### PR TITLE
ci: fix Android APK build and release workflows

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -26,28 +26,32 @@ jobs:
         shell: bash
         run: |
           declare -A EXPECTED_URLS=(
-            [submodule.packages/bare-ffmpeg.url]=https://github.com/ayooooo123/bare-ffmpeg.git
-            [submodule.packages/app/vendor/react-native-vlc-media-player.url]=https://github.com/ayooooo123/react-native-vlc-media-player.git
-            [submodule.packages/bare-mpv.url]=https://github.com/ayooooo123/bare-mpv.git
+            [packages/bare-ffmpeg]=https://github.com/ayooooo123/bare-ffmpeg.git
+            [packages/bare-mpv]=https://github.com/ayooooo123/bare-mpv.git
           )
 
-          actual_count=$(git config -f .gitmodules --name-only --get-regexp '^submodule\..*\.url$' | wc -l | tr -d ' ')
-          if [ "$actual_count" != "3" ]; then
-            echo "::error::.gitmodules URL entry count changed unexpectedly"
-            git config -f .gitmodules --get-regexp '^submodule\..*\.url$' || true
+          mapfile -t SUBMODULE_PATHS < <(git ls-files --stage | awk '$1 == "160000" {print $4}')
+          if [ "${#SUBMODULE_PATHS[@]}" -eq 0 ]; then
+            echo "::error::No git submodules found in the checked-out tree"
             exit 1
           fi
 
-          for key in "${!EXPECTED_URLS[@]}"; do
-            actual=$(git config -f .gitmodules --get "$key" || true)
-            if [ "$actual" != "${EXPECTED_URLS[$key]}" ]; then
-              echo "::error::Unexpected submodule URL for $key: $actual"
+          for path in "${SUBMODULE_PATHS[@]}"; do
+            expected="${EXPECTED_URLS[$path]:-}"
+            if [ -z "$expected" ]; then
+              echo "::error::Unexpected git submodule path in repository tree: $path"
+              exit 1
+            fi
+
+            actual=$(git config -f .gitmodules --get "submodule.$path.url" || true)
+            if [ "$actual" != "$expected" ]; then
+              echo "::error::Unexpected submodule URL for $path: $actual"
               exit 1
             fi
           done
 
-          git submodule sync
-          git submodule update --init --depth 1 packages/bare-ffmpeg packages/bare-mpv packages/app/vendor/react-native-vlc-media-player
+          git submodule sync -- "${SUBMODULE_PATHS[@]}"
+          git submodule update --init --depth 1 -- "${SUBMODULE_PATHS[@]}"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -22,11 +22,37 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Validate and init required submodules
+        shell: bash
+        run: |
+          declare -A EXPECTED_URLS=(
+            [submodule.packages/bare-ffmpeg.url]=https://github.com/ayooooo123/bare-ffmpeg.git
+            [submodule.packages/app/vendor/react-native-vlc-media-player.url]=https://github.com/ayooooo123/react-native-vlc-media-player.git
+            [submodule.packages/bare-mpv.url]=https://github.com/ayooooo123/bare-mpv.git
+          )
+
+          actual_count=$(git config -f .gitmodules --name-only --get-regexp '^submodule\..*\.url$' | wc -l | tr -d ' ')
+          if [ "$actual_count" != "3" ]; then
+            echo "::error::.gitmodules URL entry count changed unexpectedly"
+            git config -f .gitmodules --get-regexp '^submodule\..*\.url$' || true
+            exit 1
+          fi
+
+          for key in "${!EXPECTED_URLS[@]}"; do
+            actual=$(git config -f .gitmodules --get "$key" || true)
+            if [ "$actual" != "${EXPECTED_URLS[$key]}" ]; then
+              echo "::error::Unexpected submodule URL for $key: $actual"
+              exit 1
+            fi
+          done
+
+          git submodule sync
+          git submodule update --init --depth 1 packages/bare-ffmpeg packages/bare-mpv packages/app/vendor/react-native-vlc-media-player
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20.x
-          cache: 'npm'
 
       - name: Setup JDK 17
         uses: actions/setup-java@v4
@@ -39,10 +65,7 @@ jobs:
         uses: android-actions/setup-android@v3
 
       - name: Install dependencies
-        run: |
-          npm ci
-          cd packages/backend && npm ci && cd ../..
-          cd packages/app && npm ci --legacy-peer-deps && cd ../..
+        run: npm run install:all
 
       - name: Bundle backend
         working-directory: packages/app
@@ -56,9 +79,9 @@ jobs:
         working-directory: packages/app/android
         run: ./gradlew assembleDebug --no-daemon
 
-      - name: Upload debug APK
+      - name: Upload debug APKs
         uses: actions/upload-artifact@v4
         with:
           name: peartube-debug-apks
-          path: packages/app/android/app/build/outputs/apk/debug/*.apk
+          path: packages/app/android/app/build/outputs/apk/**/*.apk
           retention-days: 7

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -69,28 +69,32 @@ jobs:
         shell: bash
         run: |
           declare -A EXPECTED_URLS=(
-            [submodule.packages/bare-ffmpeg.url]=https://github.com/ayooooo123/bare-ffmpeg.git
-            [submodule.packages/app/vendor/react-native-vlc-media-player.url]=https://github.com/ayooooo123/react-native-vlc-media-player.git
-            [submodule.packages/bare-mpv.url]=https://github.com/ayooooo123/bare-mpv.git
+            [packages/bare-ffmpeg]=https://github.com/ayooooo123/bare-ffmpeg.git
+            [packages/bare-mpv]=https://github.com/ayooooo123/bare-mpv.git
           )
 
-          actual_count=$(git config -f .gitmodules --name-only --get-regexp '^submodule\..*\.url$' | wc -l | tr -d ' ')
-          if [ "$actual_count" != "3" ]; then
-            echo "::error::.gitmodules URL entry count changed unexpectedly"
-            git config -f .gitmodules --get-regexp '^submodule\..*\.url$' || true
+          mapfile -t SUBMODULE_PATHS < <(git ls-files --stage | awk '$1 == "160000" {print $4}')
+          if [ "${#SUBMODULE_PATHS[@]}" -eq 0 ]; then
+            echo "::error::No git submodules found in the checked-out tree"
             exit 1
           fi
 
-          for key in "${!EXPECTED_URLS[@]}"; do
-            actual=$(git config -f .gitmodules --get "$key" || true)
-            if [ "$actual" != "${EXPECTED_URLS[$key]}" ]; then
-              echo "::error::Unexpected submodule URL for $key: $actual"
+          for path in "${SUBMODULE_PATHS[@]}"; do
+            expected="${EXPECTED_URLS[$path]:-}"
+            if [ -z "$expected" ]; then
+              echo "::error::Unexpected git submodule path in repository tree: $path"
+              exit 1
+            fi
+
+            actual=$(git config -f .gitmodules --get "submodule.$path.url" || true)
+            if [ "$actual" != "$expected" ]; then
+              echo "::error::Unexpected submodule URL for $path: $actual"
               exit 1
             fi
           done
 
-          git submodule sync
-          git submodule update --init --depth 1 packages/bare-ffmpeg packages/bare-mpv packages/app/vendor/react-native-vlc-media-player
+          git submodule sync -- "${SUBMODULE_PATHS[@]}"
+          git submodule update --init --depth 1 -- "${SUBMODULE_PATHS[@]}"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -24,14 +24,78 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Validate release input and signing config
+        id: prep
+        shell: bash
+        env:
+          REQUESTED_TAG: ${{ github.event.inputs.tag }}
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          if [ -n "$REQUESTED_TAG" ]; then
+            case "$REQUESTED_TAG" in
+              v*) ;;
+              *)
+                echo "::error::workflow_dispatch tag must look like v1.2.3"
+                exit 1
+                ;;
+            esac
+
+            git fetch --force --tags origin
+            if ! git rev-parse -q --verify "refs/tags/$REQUESTED_TAG" >/dev/null; then
+              echo "::error::Tag '$REQUESTED_TAG' does not exist on origin"
+              exit 1
+            fi
+          fi
+
+          HAS_KEYSTORE=false
+          if [ -n "$ANDROID_KEYSTORE_BASE64" ] && [ -n "$ANDROID_KEYSTORE_PASSWORD" ] && [ -n "$ANDROID_KEY_ALIAS" ] && [ -n "$ANDROID_KEY_PASSWORD" ]; then
+            HAS_KEYSTORE=true
+          fi
+          echo "has_keystore=$HAS_KEYSTORE" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout requested release tag
+        if: ${{ github.event.inputs.tag != '' }}
+        shell: bash
+        env:
+          REQUESTED_TAG: ${{ github.event.inputs.tag }}
+        run: |
+          git checkout --detach "refs/tags/$REQUESTED_TAG"
+
+      - name: Validate and init required submodules
+        shell: bash
+        run: |
+          declare -A EXPECTED_URLS=(
+            [submodule.packages/bare-ffmpeg.url]=https://github.com/ayooooo123/bare-ffmpeg.git
+            [submodule.packages/app/vendor/react-native-vlc-media-player.url]=https://github.com/ayooooo123/react-native-vlc-media-player.git
+            [submodule.packages/bare-mpv.url]=https://github.com/ayooooo123/bare-mpv.git
+          )
+
+          actual_count=$(git config -f .gitmodules --name-only --get-regexp '^submodule\..*\.url$' | wc -l | tr -d ' ')
+          if [ "$actual_count" != "3" ]; then
+            echo "::error::.gitmodules URL entry count changed unexpectedly"
+            git config -f .gitmodules --get-regexp '^submodule\..*\.url$' || true
+            exit 1
+          fi
+
+          for key in "${!EXPECTED_URLS[@]}"; do
+            actual=$(git config -f .gitmodules --get "$key" || true)
+            if [ "$actual" != "${EXPECTED_URLS[$key]}" ]; then
+              echo "::error::Unexpected submodule URL for $key: $actual"
+              exit 1
+            fi
+          done
+
+          git submodule sync
+          git submodule update --init --depth 1 packages/bare-ffmpeg packages/bare-mpv packages/app/vendor/react-native-vlc-media-player
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20.x
-          cache: 'npm'
 
       - name: Setup JDK 17
         uses: actions/setup-java@v4
@@ -44,10 +108,7 @@ jobs:
         uses: android-actions/setup-android@v3
 
       - name: Install dependencies
-        run: |
-          npm ci
-          cd packages/backend && npm ci && cd ../..
-          cd packages/app && npm ci --legacy-peer-deps && cd ../..
+        run: npm run install:all
 
       - name: Bundle backend
         working-directory: packages/app
@@ -58,45 +119,69 @@ jobs:
         run: npm run android:prebuild
 
       - name: Decode release keystore
-        if: ${{ env.HAS_KEYSTORE == 'true' }}
+        if: ${{ steps.prep.outputs.has_keystore == 'true' }}
         working-directory: packages/app/android/app
-        run: echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 -d > release.keystore
         env:
-          HAS_KEYSTORE: ${{ secrets.ANDROID_KEYSTORE_BASE64 != '' }}
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: printf '%s' "$ANDROID_KEYSTORE_BASE64" | base64 -d > release.keystore
+
+      - name: Configure Gradle release signing
+        if: ${{ steps.prep.outputs.has_keystore == 'true' }}
+        shell: bash
+        env:
+          KEYSTORE_PATH: ${{ github.workspace }}/packages/app/android/app/release.keystore
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          mkdir -p "$HOME/.gradle"
+          printf '%s\n' \
+            "android.injected.signing.store.file=$KEYSTORE_PATH" \
+            "android.injected.signing.store.password=$ANDROID_KEYSTORE_PASSWORD" \
+            "android.injected.signing.key.alias=$ANDROID_KEY_ALIAS" \
+            "android.injected.signing.key.password=$ANDROID_KEY_PASSWORD" \
+            >> "$HOME/.gradle/gradle.properties"
 
       - name: Build release APK (${{ matrix.abi }})
         working-directory: packages/app/android
         env:
-          HAS_KEYSTORE: ${{ secrets.ANDROID_KEYSTORE_BASE64 != '' }}
+          HAS_KEYSTORE: ${{ steps.prep.outputs.has_keystore }}
         run: |
-          SIGNING_ARGS=""
-          if [ "$HAS_KEYSTORE" = "true" ]; then
-            SIGNING_ARGS="-PRELEASE_STORE_FILE=release.keystore"
-            SIGNING_ARGS="$SIGNING_ARGS -PRELEASE_STORE_PASSWORD=${{ secrets.ANDROID_KEYSTORE_PASSWORD }}"
-            SIGNING_ARGS="$SIGNING_ARGS -PRELEASE_KEY_ALIAS=${{ secrets.ANDROID_KEY_ALIAS }}"
-            SIGNING_ARGS="$SIGNING_ARGS -PRELEASE_KEY_PASSWORD=${{ secrets.ANDROID_KEY_PASSWORD }}"
+          GRADLE_ARGS=(
+            assembleRelease
+            "-PtargetAbis=${{ matrix.abi }}"
+            "-PreactNativeArchitectures=${{ matrix.abi }}"
+            --no-daemon
+          )
+
+          if [ "$HAS_KEYSTORE" != "true" ]; then
+            echo "No Android release keystore secrets configured; building with the project's default release signing config."
           fi
 
-          ./gradlew assembleRelease \
-            -PtargetAbis=${{ matrix.abi }} \
-            -PreactNativeArchitectures=${{ matrix.abi }} \
-            $SIGNING_ARGS \
-            --no-daemon
+          ./gradlew "${GRADLE_ARGS[@]}"
 
       - name: Rename APK
+        env:
+          REQUESTED_TAG: ${{ github.event.inputs.tag }}
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          if [ -z "$VERSION" ] || [ "$VERSION" = "$GITHUB_REF_NAME" ]; then
-            VERSION="dev"
+          RELEASE_TAG="$REQUESTED_TAG"
+          if [ -z "$RELEASE_TAG" ] && [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            RELEASE_TAG="$GITHUB_REF_NAME"
           fi
+
+          if [ -n "$RELEASE_TAG" ]; then
+            VERSION="${RELEASE_TAG#v}"
+          else
+            VERSION="dev-${GITHUB_SHA::7}"
+          fi
+
           APK_DIR="packages/app/android/app/build/outputs/apk/release"
-          # Find the APK for this ABI (pattern: app-<abi>-release.apk)
-          APK_FILE=$(find "$APK_DIR" -name "app-${{ matrix.abi }}-release*.apk" -o -name "app-release*.apk" | head -1)
+          APK_FILE=$(find "$APK_DIR" \( -name "app-${{ matrix.abi }}-release*.apk" -o -name "app-release*.apk" \) | head -1)
           if [ -n "$APK_FILE" ]; then
             mv "$APK_FILE" "$APK_DIR/peartube-${VERSION}-${{ matrix.abi }}.apk"
           else
             echo "::error::No APK found for ABI ${{ matrix.abi }}"
-            ls -la "$APK_DIR"/ 2>/dev/null || echo "APK directory does not exist"
+            find "$APK_DIR" -maxdepth 2 -type f -name '*.apk' -print 2>/dev/null || echo "APK directory does not exist"
             exit 1
           fi
 
@@ -110,7 +195,7 @@ jobs:
   publish-release:
     needs: build-release
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') || github.event.inputs.tag != ''
     permissions:
       contents: write
 
@@ -127,7 +212,8 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ github.event.inputs.tag || github.ref_name }}
           files: apks/*.apk
           generate_release_notes: true
           draft: false
-          prerelease: ${{ contains(github.ref_name, '-') }}
+          prerelease: ${{ contains(github.event.inputs.tag || github.ref_name, '-') }}


### PR DESCRIPTION
## Summary
- fix Android CI checkout/install so APK workflows can actually reach Gradle
- validate and initialize only the expected submodules before Android builds
- fix release publishing flow, including manual tag validation and optional signing via Gradle properties

## Why
Current Android build/release runs fail before the build starts because setup-node expects a root lockfile and checkout skips required submodules. The release workflow also had malformed signing interpolation and did not support manual tagged releases safely.

## Validation
- reproduced current GH Actions failures from logs (`setup-node` lockfile error)
- reproduced local prebuild failure until submodules were initialized (`bare-ffmpeg` missing)
- `npm run install:all`
- `npm run android:prebuild`
- parsed both workflow YAML files successfully
- `bash -n` sanity check on embedded shell blocks
- independent reviewer pass in fresh context
