### PR TITLE
fix(android): remove stale unavailable videos after returning to feed

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -26,7 +26,39 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.x
-          cache: 'npm'
+
+      - name: Validate and init required submodules
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          declare -A EXPECTED_URLS=(
+            [packages/bare-ffmpeg]=https://github.com/ayooooo123/bare-ffmpeg.git
+            [packages/bare-mpv]=https://github.com/ayooooo123/bare-mpv.git
+          )
+
+          mapfile -t SUBMODULE_PATHS < <(git ls-files --stage | awk '$1 == "160000" {print $4}')
+          if [ "${#SUBMODULE_PATHS[@]}" -eq 0 ]; then
+            echo "::error::No git submodules found in the checked-out tree"
+            exit 1
+          fi
+
+          for path in "${SUBMODULE_PATHS[@]}"; do
+            expected="${EXPECTED_URLS[$path]:-}"
+            if [ -z "$expected" ]; then
+              echo "::error::Unexpected git submodule path in repository tree: $path"
+              exit 1
+            fi
+
+            actual=$(git config -f .gitmodules --get "submodule.$path.url" || true)
+            if [ "$actual" != "$expected" ]; then
+              echo "::error::Unexpected submodule URL for $path: $actual"
+              exit 1
+            fi
+          done
+
+          git submodule sync -- "${SUBMODULE_PATHS[@]}"
+          git submodule update --init --depth 1 -- "${SUBMODULE_PATHS[@]}"
 
       - name: Setup JDK 17
         uses: actions/setup-java@v4
@@ -39,10 +71,7 @@ jobs:
         uses: android-actions/setup-android@v3
 
       - name: Install dependencies
-        run: |
-          npm ci
-          cd packages/backend && npm ci && cd ../..
-          cd packages/app && npm ci --legacy-peer-deps && cd ../..
+        run: npm run install:all
 
       - name: Bundle backend
         working-directory: packages/app

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,14 +21,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'npm'
 
-      - name: Install root dependencies
-        run: npm ci
-
-      - name: Install backend dependencies
-        run: npm ci
-        working-directory: packages/backend
+      - name: Install dependencies
+        run: npm run install:all
 
       - name: Run backend tests
         run: npm test
@@ -48,10 +43,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22.x
-          cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm run install:all
 
       - name: Run linter
         run: npm run lint

--- a/packages/app/app/(tabs)/index.tsx
+++ b/packages/app/app/(tabs)/index.tsx
@@ -22,6 +22,8 @@ import {
   getFeedVideoLoadEntries,
   getMissingChannelMetaRequests,
   getVisibleSeededFeedEntries,
+  mergeHydratedFeedBatches,
+  mergeHydratedFeedVideos,
   shouldRenderFeedVideo,
 } from '@/lib/feed-hydration'
 
@@ -212,7 +214,9 @@ export default function HomeScreen() {
             channels: (status as any).channelsLoaded,
           })
         }
-      } catch {}
+      } catch {
+        // Ignore delayed/failed swarm status refresh; public feed data is enough for UI hydration.
+      }
     } catch (err) {
       console.error('[Home] Failed to load public feed:', err)
     } finally {
@@ -309,29 +313,24 @@ export default function HomeScreen() {
     const initialEntries = entries.slice(0, 6)
     const laterEntries = entries.slice(6)
 
-    const mergeVideos = (incoming: VideoData[]) => {
-      if (!incoming.length || feedLoadRunIdRef.current !== runId) return
-      setFeedVideos((prev) => {
-        const byKey = new Map<string, VideoData>()
-        for (const video of prev) {
-          const key = `${video.channelKey || ''}:${video.id || video.path || ''}`
-          byKey.set(key, video)
-        }
-        for (const video of incoming) {
-          const key = `${video.channelKey || ''}:${video.id || video.path || ''}`
-          byKey.set(key, video)
-        }
-        return Array.from(byKey.values())
-          .sort((a, b) => (b.uploadedAt || 0) - (a.uploadedAt || 0))
-          .slice(0, 50)
-      })
-      fetchThumbnailsForVideos(incoming)
+    const mergeBatches = (incomingBatches: Array<{ channelKey: string, confirmed: boolean, videos: VideoData[] }>) => {
+      if (feedLoadRunIdRef.current !== runId) return
+      setFeedVideos((prev) => mergeHydratedFeedBatches({
+        previousVideos: prev,
+        incomingBatches,
+        identityDriveKey: identity?.driveKey || null,
+        limit: 50,
+      }))
+      const incomingVideos = incomingBatches.flatMap((batch) => batch.videos || [])
+      if (incomingVideos.length > 0) {
+        fetchThumbnailsForVideos(incomingVideos)
+      }
     }
 
     const loadEntry = async (entry: any, { attemptTimeout, attempts }: { attemptTimeout: number, attempts: number }) => {
       const channelKey = entry.channelKey || entry.driveKey
       const publicBeeKey = entry.publicBeeKey || undefined
-      if (!channelKey) return [] as VideoData[]
+      if (!channelKey) return { channelKey: '', confirmed: false, videos: [] as VideoData[] }
 
       console.log('[Home] loadEntry start', {
         channelKey,
@@ -349,12 +348,16 @@ export default function HomeScreen() {
       // enough to know we already own the videos locally.
       if (identity?.driveKey && channelKey === identity.driveKey) {
         console.log('[Home] loadEntry using local fast path', { channelKey, localVideos: videos?.length || 0 })
-        return (videos || []).map((v: any) => ({
-          ...v,
+        return {
           channelKey,
-          publicBeeKey: publicBeeKey || undefined,
-          channel: { name: channelMetaRef.current[channelKey]?.name || 'Your channel' }
-        }))
+          confirmed: true,
+          videos: (videos || []).map((v: any) => ({
+            ...v,
+            channelKey,
+            publicBeeKey: publicBeeKey || undefined,
+            channel: { name: channelMetaRef.current[channelKey]?.name || 'Your channel' }
+          })),
+        }
       }
 
       try {
@@ -362,30 +365,50 @@ export default function HomeScreen() {
           await withTimeout(rpc.joinChannel({ channelKey }), PER_CHANNEL_TIMEOUT, { success: false })
         }
 
-        let videos: any[] = []
+        let listedVideos: any[] = []
+        let confirmed = false
         for (let attempt = 0; attempt < attempts; attempt++) {
-          const result = await withTimeout(rpc.listVideos({ channelKey, publicBeeKey }), attemptTimeout, { videos: [] } as any)
-          videos = (result as any)?.videos || []
-          if (Array.isArray(videos) && videos.length > 0) break
-          if (hydrationMode === 'network' && attempt < attempts - 1) {
+          const result = await withTimeout(
+            rpc.listVideos({ channelKey, publicBeeKey }),
+            attemptTimeout,
+            { timedOut: true, videos: null } as any,
+          )
+          if ((result as any)?.timedOut) {
+            continue
+          }
+          if (!Array.isArray((result as any)?.videos)) {
+            continue
+          }
+          listedVideos = (result as any).videos
+          confirmed = true
+          if (listedVideos.length > 0 || attempt === attempts - 1) break
+          if (hydrationMode === 'network') {
             await new Promise((resolve) => setTimeout(resolve, LIST_RETRY_DELAY_MS))
           }
         }
 
-        return (videos || [])
-          .filter((v: any) => shouldRenderFeedVideo({
-            video: { ...v, channelKey },
-            identityDriveKey: identity?.driveKey || null,
-          }))
-          .map((v: any) => ({
-          ...v,
+        if (!confirmed) {
+          return { channelKey, confirmed: false, videos: [] as VideoData[] }
+        }
+
+        return {
           channelKey,
-          publicBeeKey: publicBeeKey || undefined,
-          channel: { name: channelMetaRef.current[channelKey]?.name || 'Unknown' }
-        }))
+          confirmed: true,
+          videos: (listedVideos || [])
+            .filter((v: any) => shouldRenderFeedVideo({
+              video: { ...v, channelKey },
+              identityDriveKey: identity?.driveKey || null,
+            }))
+            .map((v: any) => ({
+              ...v,
+              channelKey,
+              publicBeeKey: publicBeeKey || undefined,
+              channel: { name: channelMetaRef.current[channelKey]?.name || 'Unknown' }
+            })),
+        }
       } catch (err: any) {
         console.log('[Home] Failed to load videos from channel:', channelKey, '-', err?.message || err)
-        return [] as VideoData[]
+        return { channelKey, confirmed: false, videos: [] as VideoData[] }
       }
     }
 
@@ -395,18 +418,18 @@ export default function HomeScreen() {
         attempts: FIRST_PASS_ATTEMPTS,
       })))
       if (feedLoadRunIdRef.current === runId) {
-        mergeVideos(firstPassResults.flat())
+        mergeBatches(firstPassResults)
       }
 
       // Background-fill the remaining channels without blocking first paint.
       void (async () => {
         for (const entry of laterEntries) {
           if (feedLoadRunIdRef.current !== runId) break
-          const videos = await loadEntry(entry, {
+          const result = await loadEntry(entry, {
             attemptTimeout: LATER_PASS_ATTEMPT_TIMEOUT,
             attempts: LATER_PASS_ATTEMPTS,
           })
-          mergeVideos(videos)
+          mergeBatches([result])
         }
         if (feedLoadRunIdRef.current === runId) setLoadingFeedVideos(false)
       })()
@@ -425,15 +448,16 @@ export default function HomeScreen() {
   useEffect(() => {
     if (!identity?.driveKey) return
     if (!Array.isArray(videos) || videos.length === 0) return
-    const hasOwnFeedEntry = feedEntries.some((e) => (e.channelKey || e.driveKey) === identity.driveKey)
+    const identityDriveKey = identity.driveKey
+    const hasOwnFeedEntry = feedEntries.some((e) => (e.channelKey || e.driveKey) === identityDriveKey)
     if (!hasOwnFeedEntry) return
 
     setFeedVideos((prev) => {
       if (prev.length > 0) return prev
       return videos.map((v: any) => ({
         ...v,
-        channelKey: identity.driveKey,
-        channel: { name: channelMetaRef.current[identity.driveKey]?.name || 'Your channel' },
+        channelKey: identityDriveKey,
+        channel: { name: channelMetaRef.current[identityDriveKey]?.name || 'Your channel' },
       }))
     })
   }, [feedEntries, videos, identity?.driveKey])
@@ -447,21 +471,19 @@ export default function HomeScreen() {
       identity?.driveKey || null,
       18
     ) as VideoData[]
+
     if (previewVideos.length === 0) return
 
     setFeedVideos((prev) => {
-      const byKey = new Map<string, VideoData>()
-      for (const video of prev) {
-        const key = `${video.channelKey || ''}:${video.id || video.path || ''}`
-        byKey.set(key, video)
-      }
-      for (const video of previewVideos) {
-        const key = `${video.channelKey || ''}:${video.id || video.path || ''}`
-        byKey.set(key, video)
-      }
-      return Array.from(byKey.values())
-        .sort((a, b) => (b.uploadedAt || 0) - (a.uploadedAt || 0))
-        .slice(0, 50)
+      const existingChannelKeys = new Set(prev.map((video) => video.channelKey).filter(Boolean))
+      const previewVideosToAdd = previewVideos.filter((video) => !existingChannelKeys.has(video.channelKey))
+      return mergeHydratedFeedVideos({
+        previousVideos: prev,
+        incomingVideos: previewVideosToAdd,
+        refreshedChannelKeys: [],
+        identityDriveKey: identity?.driveKey || null,
+        limit: 50,
+      })
     })
 
     fetchThumbnailsForVideos(previewVideos)
@@ -673,6 +695,10 @@ export default function HomeScreen() {
 
   const feedVideosWithThumbs: VideoData[] = feedVideos
     .filter(v => seededFeedChannelKeys.has(v.channelKey))
+    .filter(v => shouldRenderFeedVideo({
+      video: v,
+      identityDriveKey: identity?.driveKey || null,
+    }))
     .map(v => {
       const cacheKey = `${v.channelKey}:${v.id}`
       return {

--- a/packages/app/lib/feed-hydration.js
+++ b/packages/app/lib/feed-hydration.js
@@ -1,3 +1,5 @@
+/** @typedef {import('@peartube/core').VideoData} VideoData */
+
 function getFeedEntryPriority(entry) {
   if (entry?.source === 'local') return 0
   if ((entry?.peerCount ?? 0) > 0) return 1
@@ -125,4 +127,88 @@ export function shouldRenderFeedVideo({ video, identityDriveKey }) {
   const channelKey = video?.channelKey || video?.driveKey || null
   if (identityDriveKey && channelKey === identityDriveKey) return true
   return video?.availability === 'playable'
+}
+
+/**
+ * @param {{
+ *   previousVideos?: VideoData[],
+ *   incomingVideos?: VideoData[],
+ *   refreshedChannelKeys?: string[],
+ *   identityDriveKey?: string | null,
+ *   limit?: number,
+ * }} params
+ * @returns {VideoData[]}
+ */
+export function mergeHydratedFeedVideos({
+  previousVideos = [],
+  incomingVideos = [],
+  refreshedChannelKeys = [],
+  identityDriveKey = null,
+  limit = 50,
+}) {
+  const refreshed = new Set((refreshedChannelKeys || []).filter(Boolean))
+  const byKey = new Map()
+
+  for (const video of previousVideos || []) {
+    if (!video) continue
+    const channelKey = video?.channelKey || video?.driveKey || null
+    if (channelKey && refreshed.has(channelKey)) continue
+    const identifier = video?.id || video?.path || ''
+    if (!identifier) continue
+    const key = `${channelKey || ''}:${identifier}`
+    byKey.set(key, video)
+  }
+
+  for (const video of incomingVideos || []) {
+    if (!video) continue
+    if (!shouldRenderFeedVideo({ video, identityDriveKey })) continue
+    const channelKey = video?.channelKey || video?.driveKey || null
+    const identifier = video?.id || video?.path || ''
+    if (!identifier) continue
+    const key = `${channelKey || ''}:${identifier}`
+    byKey.set(key, video)
+  }
+
+  return Array.from(byKey.values())
+    .filter(Boolean)
+    .sort((a, b) => (b?.uploadedAt || 0) - (a?.uploadedAt || 0))
+    .slice(0, limit)
+}
+
+/**
+ * @param {{
+ *   previousVideos?: VideoData[],
+ *   incomingBatches?: Array<{ channelKey?: string | null, confirmed?: boolean, videos?: VideoData[] }>,
+ *   identityDriveKey?: string | null,
+ *   limit?: number,
+ * }} params
+ * @returns {VideoData[]}
+ */
+export function mergeHydratedFeedBatches({
+  previousVideos = [],
+  incomingBatches = [],
+  identityDriveKey = null,
+  limit = 50,
+}) {
+  const refreshedChannelKeys = []
+  const incomingVideos = []
+
+  for (const batch of incomingBatches || []) {
+    if (!batch) continue
+    const channelKey = batch?.channelKey || null
+    if (batch?.confirmed && channelKey) {
+      refreshedChannelKeys.push(channelKey)
+    }
+    for (const video of batch?.videos || []) {
+      incomingVideos.push(video)
+    }
+  }
+
+  return mergeHydratedFeedVideos({
+    previousVideos,
+    incomingVideos,
+    refreshedChannelKeys,
+    identityDriveKey,
+    limit,
+  })
 }

--- a/packages/app/tests/feed-hydration.test.mjs
+++ b/packages/app/tests/feed-hydration.test.mjs
@@ -7,6 +7,8 @@ import {
   getFeedVideoLoadEntries,
   getMissingChannelMetaRequests,
   getVisibleSeededFeedEntries,
+  mergeHydratedFeedBatches,
+  mergeHydratedFeedVideos,
   shouldRenderFeedVideo,
 } from '../lib/feed-hydration.js'
 
@@ -158,4 +160,74 @@ test('shouldRenderFeedVideo only accepts proven-playable remote videos but keeps
     video: { channelKey: 'local', availability: 'unknown' },
     identityDriveKey: 'local',
   }), true)
+})
+
+test('mergeHydratedFeedVideos replaces stale channel cards when a refreshed channel no longer has watchable videos', () => {
+  const merged = mergeHydratedFeedVideos({
+    previousVideos: [
+      { id: 'stale-remote', channelKey: 'remote-a', uploadedAt: 30, availability: 'playable' },
+      { id: 'keep-remote', channelKey: 'remote-b', uploadedAt: 20, availability: 'playable' },
+    ],
+    incomingVideos: [],
+    refreshedChannelKeys: ['remote-a'],
+    identityDriveKey: 'local',
+    limit: 50,
+  })
+
+  assert.deepEqual(merged.map((video) => ({ id: video.id, channelKey: video.channelKey })), [
+    { id: 'keep-remote', channelKey: 'remote-b' },
+  ])
+})
+
+test('mergeHydratedFeedVideos keeps prior cards when a channel refresh fails and cannot prove a replacement set', () => {
+  const merged = mergeHydratedFeedVideos({
+    previousVideos: [
+      { id: 'stale-remote', channelKey: 'remote-a', uploadedAt: 30, availability: 'playable' },
+    ],
+    incomingVideos: [],
+    refreshedChannelKeys: [],
+    identityDriveKey: 'local',
+    limit: 50,
+  })
+
+  assert.deepEqual(merged.map((video) => ({ id: video.id, channelKey: video.channelKey })), [
+    { id: 'stale-remote', channelKey: 'remote-a' },
+  ])
+})
+
+test('mergeHydratedFeedBatches removes stale cards when a channel refresh is confirmed empty', () => {
+  const merged = mergeHydratedFeedBatches({
+    previousVideos: [
+      { id: 'stale-remote', channelKey: 'remote-a', uploadedAt: 30, availability: 'playable' },
+      { id: 'keep-remote', channelKey: 'remote-b', uploadedAt: 20, availability: 'playable' },
+    ],
+    incomingBatches: [
+      { channelKey: 'remote-a', confirmed: true, videos: [] },
+    ],
+    identityDriveKey: 'local',
+    limit: 50,
+  })
+
+  assert.deepEqual(merged.map((video) => ({ id: video.id, channelKey: video.channelKey })), [
+    { id: 'keep-remote', channelKey: 'remote-b' },
+  ])
+})
+
+test('mergeHydratedFeedBatches preserves stale cards when an empty refresh was not confirmed', () => {
+  const merged = mergeHydratedFeedBatches({
+    previousVideos: [
+      { id: 'stale-remote', channelKey: 'remote-a', uploadedAt: 30, availability: 'playable' },
+      { id: 'keep-remote', channelKey: 'remote-b', uploadedAt: 20, availability: 'playable' },
+    ],
+    incomingBatches: [
+      { channelKey: 'remote-a', confirmed: false, videos: [] },
+    ],
+    identityDriveKey: 'local',
+    limit: 50,
+  })
+
+  assert.deepEqual(merged.map((video) => ({ id: video.id, channelKey: video.channelKey })), [
+    { id: 'stale-remote', channelKey: 'remote-a' },
+    { id: 'keep-remote', channelKey: 'remote-b' },
+  ])
 })


### PR DESCRIPTION
## Summary
- treat per-channel feed hydration as a confirmed refresh only when listVideos actually returns a real payload
- drop stale cards when a channel refresh is confirmed empty, but preserve prior cards on timeout/error
- add regression coverage for confirmed-empty vs unconfirmed-empty hydration batches

## Testing
- node --test packages/app/tests/feed-hydration.test.mjs
- ./node_modules/.bin/eslint packages/app/app/'(tabs)'/index.tsx packages/app/lib/feed-hydration.js packages/app/tests/feed-hydration.test.mjs --quiet
- ./node_modules/.bin/tsc --noEmit -p packages/app/tsconfig.json 2>&1 | grep "packages/app/app/(tabs)/index.tsx" || true