### PR TITLE
feat(app): restore cached feed on startup

### DIFF
--- a/packages/app/app/(tabs)/index.tsx
+++ b/packages/app/app/(tabs)/index.tsx
@@ -25,8 +25,18 @@ import {
   isConfirmedFeedHydrationResult,
   mergeHydratedFeedVideos,
   mergePreviewFeedVideos,
+  shouldKeepFeedVideoForVisibleEntries,
   shouldRenderFeedVideo,
 } from '@/lib/feed-hydration'
+import {
+  createFeedSnapshot,
+  getSnapshotChannelKeys,
+  restoreFeedSnapshot,
+} from '@/lib/feed-snapshot'
+import {
+  readFeedSnapshotFromDisk,
+  writeFeedSnapshotToDisk,
+} from '@/lib/feed-snapshot-storage'
 
 // Public feed types
 interface FeedEntry {
@@ -70,6 +80,17 @@ function withTimeout<T>(promise: Promise<T>, ms: number, fallback: T): Promise<T
   ])
 }
 
+function nowMs() {
+  return Date.now()
+}
+
+function logTiming(label: string, startMs: number, details: Record<string, any> = {}) {
+  console.log(`[HomeTiming] ${label}`, {
+    ms: Date.now() - startMs,
+    ...details,
+  })
+}
+
 // Detect Pear desktop vs mobile
 const isPear = Platform.OS === 'web' && typeof window !== 'undefined' && (!!(window as any).PearWorkerClient || !!(window as any).bridge)
 
@@ -106,7 +127,11 @@ export default function HomeScreen() {
   // Aggregated feed videos from all discovered channels
   const [feedVideos, setFeedVideos] = useState<VideoData[]>([])
   const [loadingFeedVideos, setLoadingFeedVideos] = useState(false)
+  const [snapshotChannelKeys, setSnapshotChannelKeys] = useState<Set<string>>(new Set())
+  const [snapshotRestoredOnly, setSnapshotRestoredOnly] = useState(false)
   const feedLoadRunIdRef = useRef(0)
+  const feedSnapshotRestoredRef = useRef(false)
+  const feedSnapshotWriteTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   // Category filter state
   const categories = ['All', 'Music', 'Gaming', 'Tech', 'Education', 'Entertainment', 'Vlog', 'Other']
@@ -182,6 +207,7 @@ export default function HomeScreen() {
   // Load public feed from backend
   const loadPublicFeed = useCallback(async () => {
     if (!rpc) return
+    const startedAt = nowMs()
     try {
       setFeedLoading(true)
       // Add timeout to prevent infinite spinner if RPC hangs
@@ -204,6 +230,10 @@ export default function HomeScreen() {
       if (result?.stats) {
         setPeerCount(result.stats.peerCount || 0)
       }
+      logTiming('publicFeed', startedAt, {
+        entries: result?.entries?.length || 0,
+        timedOut: !result,
+      })
       setLastFeedRefresh(Date.now())
       try {
         const statusPromise = rpc.getSwarmStatus()
@@ -240,6 +270,63 @@ export default function HomeScreen() {
       fetchThumbnailsForVideos(vidsWithKey as VideoData[])
     }
   }, [videos, identity?.driveKey, fetchThumbnailsForVideos])
+
+  // Restore the last renderable Discover cards before P2P/feed hydration finishes.
+  useEffect(() => {
+    if (!ready || feedSnapshotRestoredRef.current) return
+    let cancelled = false
+    void (async () => {
+      const snapshotStartedAt = nowMs()
+      const snapshot = await readFeedSnapshotFromDisk()
+      const restored = restoreFeedSnapshot(snapshot) as VideoData[]
+      logTiming('feedSnapshotRestore', snapshotStartedAt, { videos: restored.length })
+      if (cancelled || restored.length === 0) return
+      feedSnapshotRestoredRef.current = true
+
+      const restoredChannelKeys = getSnapshotChannelKeys(restored)
+      console.log('[Home] restored feed snapshot', {
+        videos: restored.length,
+        channels: restoredChannelKeys.length,
+      })
+      setSnapshotChannelKeys(new Set(restoredChannelKeys))
+      setFeedVideos((prev) => {
+        if (prev.length > 0) return prev
+        setSnapshotRestoredOnly(true)
+        return restored
+      })
+      fetchThumbnailsForVideos(restored)
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [ready, fetchThumbnailsForVideos])
+
+  // Persist the last known good renderable feed so the next launch can paint instantly.
+  useEffect(() => {
+    if (!ready || feedVideos.length === 0 || snapshotRestoredOnly) return
+    if (feedSnapshotWriteTimerRef.current) {
+      clearTimeout(feedSnapshotWriteTimerRef.current)
+    }
+
+    feedSnapshotWriteTimerRef.current = setTimeout(() => {
+      const snapshot = createFeedSnapshot({
+        videos: feedVideos,
+        channelMeta,
+        identityDriveKey: identity?.driveKey || undefined,
+        limit: 50,
+      })
+      if (snapshot.videos.length > 0) {
+        void writeFeedSnapshotToDisk(snapshot)
+      }
+    }, 1000)
+
+    return () => {
+      if (feedSnapshotWriteTimerRef.current) {
+        clearTimeout(feedSnapshotWriteTimerRef.current)
+        feedSnapshotWriteTimerRef.current = null
+      }
+    }
+  }, [ready, feedVideos, channelMeta, identity?.driveKey, snapshotRestoredOnly])
 
   // Load public feed on mount
   useEffect(() => {
@@ -296,6 +383,7 @@ export default function HomeScreen() {
     if (!rpc || hydrationMode === 'off') return
 
     const runId = feedLoadRunIdRef.current + 1
+    const startedAt = nowMs()
     feedLoadRunIdRef.current = runId
     setLoadingFeedVideos(true)
     // Keep existing Discover cards visible during background refresh/hydration.
@@ -318,7 +406,7 @@ export default function HomeScreen() {
         previousVideos: prev,
         incomingVideos: incoming,
         refreshedChannelKeys,
-        identityDriveKey: identity?.driveKey || null,
+        identityDriveKey: identity?.driveKey || undefined,
         limit: 50,
       }))
       if (incoming.length > 0) {
@@ -387,7 +475,7 @@ export default function HomeScreen() {
         const filteredVideos = (loadedVideos || [])
           .filter((v: any) => shouldRenderFeedVideo({
             video: { ...v, channelKey },
-            identityDriveKey: identity?.driveKey || null,
+            identityDriveKey: identity?.driveKey || undefined,
           }))
           .map((v: any) => ({
             ...v,
@@ -416,9 +504,18 @@ export default function HomeScreen() {
         attemptTimeout: FIRST_PASS_ATTEMPT_TIMEOUT,
         attempts: FIRST_PASS_ATTEMPTS,
       })))
+      const firstPassVideos = firstPassResults.flatMap((result) => result.videos)
+      if (firstPassVideos.length > 0) {
+        setSnapshotRestoredOnly(false)
+      }
       if (feedLoadRunIdRef.current === runId) {
+        logTiming('feedHydrationFirstPass', startedAt, {
+          mode: hydrationMode,
+          entries: initialEntries.length,
+          videos: firstPassVideos.length,
+        })
         mergeVideos(
-          firstPassResults.flatMap((result) => result.videos),
+          firstPassVideos,
           firstPassResults.filter((result) => result.confirmed).map((result) => result.channelKey).filter(Boolean)
         )
       }
@@ -448,17 +545,19 @@ export default function HomeScreen() {
   // channel appears in the feed. This avoids an empty Discover section while
   // remote/public-bee hydration is still catching up.
   useEffect(() => {
-    if (!identity?.driveKey) return
+    const identityDriveKey = identity?.driveKey
+    if (!identityDriveKey) return
     if (!Array.isArray(videos) || videos.length === 0) return
-    const hasOwnFeedEntry = feedEntries.some((e) => (e.channelKey || e.driveKey) === identity.driveKey)
+    const hasOwnFeedEntry = feedEntries.some((e) => (e.channelKey || e.driveKey) === identityDriveKey)
     if (!hasOwnFeedEntry) return
 
     setFeedVideos((prev) => {
       if (prev.length > 0) return prev
+      setSnapshotRestoredOnly(false)
       return videos.map((v: any) => ({
         ...v,
-        channelKey: identity.driveKey,
-        channel: { name: channelMetaRef.current[identity.driveKey]?.name || 'Your channel' },
+        channelKey: identityDriveKey,
+        channel: { name: channelMetaRef.current[identityDriveKey]?.name || 'Your channel' },
       }))
     })
   }, [feedEntries, videos, identity?.driveKey])
@@ -469,7 +568,7 @@ export default function HomeScreen() {
     const previewVideos = getFeedPreviewVideos(
       feedEntries,
       channelMeta,
-      identity?.driveKey || null,
+      identity?.driveKey || undefined,
       18
     ) as VideoData[]
     const previewManifestResolved = feedEntries.some((entry) => (
@@ -478,6 +577,7 @@ export default function HomeScreen() {
     ))
 
     if (previewVideos.length > 0 || previewManifestResolved) {
+      setSnapshotRestoredOnly(false)
       setFeedVideos((prev) => mergePreviewFeedVideos({
         previousVideos: prev,
         previewVideos,
@@ -528,7 +628,7 @@ export default function HomeScreen() {
           const videosWithChannel = videoList
             .filter((v: any) => shouldRenderFeedVideo({
               video: { ...v, channelKey: driveKey },
-              identityDriveKey: identity?.driveKey || null,
+              identityDriveKey: identity?.driveKey || undefined,
             }))
             .map((v: any) => ({
             ...v,
@@ -695,10 +795,14 @@ export default function HomeScreen() {
   const seededFeedChannelKeys = new Set(visibleSeededFeedEntries.map((entry) => entry.channelKey || entry.driveKey).filter(Boolean))
 
   const feedVideosWithThumbs: VideoData[] = feedVideos
-    .filter(v => seededFeedChannelKeys.has(v.channelKey))
+    .filter(v => shouldKeepFeedVideoForVisibleEntries({
+      video: v,
+      seededFeedChannelKeys,
+      snapshotChannelKeys,
+    }))
     .filter(v => shouldRenderFeedVideo({
       video: v,
-      identityDriveKey: identity?.driveKey || null,
+      identityDriveKey: identity?.driveKey || undefined,
     }))
     .map(v => {
       const cacheKey = `${v.channelKey}:${v.id}`

--- a/packages/app/app/(tabs)/index.tsx
+++ b/packages/app/app/(tabs)/index.tsx
@@ -245,7 +245,9 @@ export default function HomeScreen() {
             channels: (status as any).channelsLoaded,
           })
         }
-      } catch {}
+      } catch (err) {
+        console.log('[Home] Failed to load swarm status:', (err as any)?.message || err)
+      }
     } catch (err) {
       console.error('[Home] Failed to load public feed:', err)
     } finally {

--- a/packages/app/lib/feed-hydration.d.ts
+++ b/packages/app/lib/feed-hydration.d.ts
@@ -1,0 +1,25 @@
+export function getMissingChannelMetaRequests(feedEntries: any[], channelMeta: Record<string, any>, limit?: number): any[]
+export function getVisibleSeededFeedEntries(feedEntries: any[], limit?: number): any[]
+export function getFeedVideoLoadEntries(feedEntries: any[], limit?: number): any[]
+export function getFeedPreviewVideos(feedEntries: any[], channelMeta: Record<string, any>, identityDriveKey?: string | null, limit?: number): any[]
+export function getFeedVideoHydrationMode(options: { feedEntries?: any[]; swarmStatus?: any }): 'off' | 'local-only' | 'network'
+export function shouldAutoLoadFeedVideos(options: { feedEntries?: any[]; swarmStatus?: any }): boolean
+export function shouldKeepFeedVideoForVisibleEntries(options: {
+  video?: any
+  seededFeedChannelKeys?: Set<string>
+  snapshotChannelKeys?: Set<string>
+}): boolean
+export function shouldRenderFeedVideo(options: { video?: any; identityDriveKey?: string | null }): boolean
+export function isConfirmedFeedHydrationResult(options: { entry?: any; resolved?: boolean; videos?: any[] }): boolean
+export function mergeHydratedFeedVideos(options: {
+  previousVideos?: any[]
+  incomingVideos?: any[]
+  refreshedChannelKeys?: string[]
+  identityDriveKey?: string | null
+  limit?: number
+}): any[]
+export function mergePreviewFeedVideos(options: {
+  previousVideos?: any[]
+  previewVideos?: any[]
+  limit?: number
+}): any[]

--- a/packages/app/lib/feed-hydration.js
+++ b/packages/app/lib/feed-hydration.js
@@ -136,10 +136,10 @@ export function isConfirmedFeedHydrationResult({ entry, resolved, videos = [] })
 }
 
 export function mergeHydratedFeedVideos({
-  previousVideos = [],
-  incomingVideos = [],
-  refreshedChannelKeys = [],
-  identityDriveKey = null,
+  previousVideos = /** @type {any[]} */ ([]),
+  incomingVideos = /** @type {any[]} */ ([]),
+  refreshedChannelKeys = /** @type {string[]} */ ([]),
+  identityDriveKey = undefined,
   limit = 50,
 }) {
   const refreshed = new Set((refreshedChannelKeys || []).filter(Boolean))
@@ -172,6 +172,14 @@ export function mergeHydratedFeedVideos({
     .filter(Boolean)
     .sort((a, b) => (b?.uploadedAt || 0) - (a?.uploadedAt || 0))
     .slice(0, limit)
+}
+
+export function shouldKeepFeedVideoForVisibleEntries({ video, seededFeedChannelKeys, snapshotChannelKeys }) {
+  const channelKey = video?.channelKey || video?.driveKey || null
+  if (!channelKey) return false
+  if (!seededFeedChannelKeys || seededFeedChannelKeys.size === 0) return true
+  if (seededFeedChannelKeys.has(channelKey)) return true
+  return video?.__feedSource === 'snapshot' && snapshotChannelKeys?.has(channelKey)
 }
 
 export function mergePreviewFeedVideos({

--- a/packages/app/lib/feed-snapshot-storage.ts
+++ b/packages/app/lib/feed-snapshot-storage.ts
@@ -1,0 +1,56 @@
+import { Platform } from 'react-native'
+
+const SNAPSHOT_FILE = 'peartube-feed-snapshot.json'
+
+function normalizeFsModule(mod: any): any {
+  return mod?.default ?? mod
+}
+
+async function getFileSystem(): Promise<any | null> {
+  if (Platform.OS === 'web') return null
+  try {
+    const legacy = await import('expo-file-system/legacy')
+    return normalizeFsModule(legacy)
+  } catch {
+    try {
+      const fs = await import('expo-file-system')
+      return normalizeFsModule(fs)
+    } catch {
+      return null
+    }
+  }
+}
+
+function getSnapshotUri(fs: any): string | null {
+  const base = fs?.documentDirectory || fs?.Paths?.document?.uri || fs?.cacheDirectory || fs?.Paths?.cache?.uri
+  if (typeof base !== 'string' || base.length === 0) return null
+  return `${base.replace(/\/?$/, '/')}${SNAPSHOT_FILE}`
+}
+
+export async function readFeedSnapshotFromDisk(): Promise<any | null> {
+  const fs = await getFileSystem()
+  if (!fs || typeof fs.readAsStringAsync !== 'function') return null
+  const uri = getSnapshotUri(fs)
+  if (!uri) return null
+
+  try {
+    const text = await fs.readAsStringAsync(uri, { encoding: 'utf8' })
+    return JSON.parse(text)
+  } catch {
+    return null
+  }
+}
+
+export async function writeFeedSnapshotToDisk(snapshot: any): Promise<boolean> {
+  const fs = await getFileSystem()
+  if (!fs || typeof fs.writeAsStringAsync !== 'function') return false
+  const uri = getSnapshotUri(fs)
+  if (!uri) return false
+
+  try {
+    await fs.writeAsStringAsync(uri, JSON.stringify(snapshot), { encoding: 'utf8' })
+    return true
+  } catch {
+    return false
+  }
+}

--- a/packages/app/lib/feed-snapshot.d.ts
+++ b/packages/app/lib/feed-snapshot.d.ts
@@ -1,0 +1,15 @@
+export function createFeedSnapshot(options?: {
+  videos?: any[]
+  channelMeta?: Record<string, any>
+  identityDriveKey?: string | null | undefined
+  now?: number
+  limit?: number
+}): { version: number; savedAt: number; videos: any[] }
+
+export function restoreFeedSnapshot(snapshot: any, options?: {
+  now?: number
+  maxAgeMs?: number
+  limit?: number
+}): any[]
+
+export function getSnapshotChannelKeys(videos?: any[]): string[]

--- a/packages/app/lib/feed-snapshot.js
+++ b/packages/app/lib/feed-snapshot.js
@@ -1,0 +1,113 @@
+// @ts-nocheck
+const FEED_SNAPSHOT_VERSION = 1
+const DEFAULT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
+const DEFAULT_LIMIT = 50
+
+const VIDEO_FIELDS = [
+  'id',
+  'path',
+  'title',
+  'description',
+  'duration',
+  'uploadedAt',
+  'thumbnail',
+  'thumbnailUrl',
+  'thumbnailBlobId',
+  'thumbnailBlobsCoreKey',
+  'thumbnailMimeType',
+  'blobId',
+  'blobsCoreKey',
+  'mimeType',
+  'availability',
+  'channelKey',
+  'driveKey',
+  'publicBeeKey',
+]
+
+function copyDefinedFields(source, fields) {
+  const out = {}
+  for (const field of fields) {
+    if (source?.[field] !== undefined) out[field] = source[field]
+  }
+  return out
+}
+
+function snapshotKeyForVideo(video) {
+  const channelKey = video?.channelKey || video?.driveKey || ''
+  const identifier = video?.id || video?.path || ''
+  if (!identifier) return null
+  return `${channelKey}:${identifier}`
+}
+
+export function createFeedSnapshot({
+  videos = [],
+  channelMeta = {},
+  identityDriveKey = undefined,
+  now = Date.now(),
+  limit = DEFAULT_LIMIT,
+} = {}) {
+  const seen = new Set()
+  const snapshotVideos = []
+
+  for (const video of videos || []) {
+    if (!video) continue
+    const key = snapshotKeyForVideo(video)
+    if (!key || seen.has(key)) continue
+    seen.add(key)
+
+    const channelKey = video.channelKey || video.driveKey || null
+    const playable = video.availability === 'playable' || (identityDriveKey && channelKey === identityDriveKey)
+    if (!playable) continue
+
+    const safeVideo = copyDefinedFields(video, VIDEO_FIELDS)
+    safeVideo.channelKey = channelKey || safeVideo.channelKey
+    safeVideo.driveKey = video.driveKey || channelKey || safeVideo.driveKey
+    safeVideo.availability = playable ? 'playable' : video.availability
+
+    const channelName = video.channel?.name || channelMeta?.[channelKey]?.name || null
+    if (channelName) safeVideo.channel = { name: channelName }
+
+    snapshotVideos.push(safeVideo)
+    if (snapshotVideos.length >= limit) break
+  }
+
+  return {
+    version: FEED_SNAPSHOT_VERSION,
+    savedAt: now,
+    videos: snapshotVideos,
+  }
+}
+
+export function restoreFeedSnapshot(snapshot, {
+  now = Date.now(),
+  maxAgeMs = DEFAULT_MAX_AGE_MS,
+  limit = DEFAULT_LIMIT,
+} = {}) {
+  if (!snapshot || snapshot.version !== FEED_SNAPSHOT_VERSION) return []
+  const savedAt = Number(snapshot.savedAt || 0)
+  if (!savedAt || now - savedAt > maxAgeMs) return []
+  if (!Array.isArray(snapshot.videos)) return []
+
+  const seen = new Set()
+  const restored = []
+  for (const video of snapshot.videos) {
+    if (!video) continue
+    const key = snapshotKeyForVideo(video)
+    if (!key || seen.has(key)) continue
+    seen.add(key)
+    restored.push({
+      ...video,
+      __feedSource: 'snapshot',
+    })
+    if (restored.length >= limit) break
+  }
+  return restored
+}
+
+export function getSnapshotChannelKeys(videos = []) {
+  return Array.from(new Set(
+    (videos || [])
+      .map((video) => video?.channelKey || video?.driveKey)
+      .filter(Boolean)
+  ))
+}

--- a/packages/app/lib/feed-snapshot.js
+++ b/packages/app/lib/feed-snapshot.js
@@ -1,4 +1,3 @@
-// @ts-nocheck
 const FEED_SNAPSHOT_VERSION = 1
 const DEFAULT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
 const DEFAULT_LIMIT = 50

--- a/packages/app/tests/feed-hydration.test.mjs
+++ b/packages/app/tests/feed-hydration.test.mjs
@@ -10,6 +10,7 @@ import {
   isConfirmedFeedHydrationResult,
   mergeHydratedFeedVideos,
   mergePreviewFeedVideos,
+  shouldKeepFeedVideoForVisibleEntries,
   shouldRenderFeedVideo,
 } from '../lib/feed-hydration.js'
 
@@ -144,6 +145,29 @@ test('getFeedPreviewVideos only uses local or live-peer manifest previews', () =
       channelName: 'Live channel',
     },
   ])
+})
+
+test('shouldKeepFeedVideoForVisibleEntries keeps restored snapshot cards until their channels are refreshed', () => {
+  const seededFeedChannelKeys = new Set(['live-channel'])
+  const snapshotChannelKeys = new Set(['cached-channel'])
+
+  assert.equal(shouldKeepFeedVideoForVisibleEntries({
+    video: { id: 'cached', channelKey: 'cached-channel', __feedSource: 'snapshot' },
+    seededFeedChannelKeys,
+    snapshotChannelKeys,
+  }), true)
+
+  assert.equal(shouldKeepFeedVideoForVisibleEntries({
+    video: { id: 'live', channelKey: 'live-channel', __feedSource: 'hydrated' },
+    seededFeedChannelKeys,
+    snapshotChannelKeys,
+  }), true)
+
+  assert.equal(shouldKeepFeedVideoForVisibleEntries({
+    video: { id: 'other', channelKey: 'other-channel', __feedSource: 'hydrated' },
+    seededFeedChannelKeys,
+    snapshotChannelKeys,
+  }), false)
 })
 
 test('shouldRenderFeedVideo only accepts proven-playable remote videos but keeps the local channel visible', () => {

--- a/packages/app/tests/feed-snapshot.test.mjs
+++ b/packages/app/tests/feed-snapshot.test.mjs
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  createFeedSnapshot,
+  getSnapshotChannelKeys,
+  restoreFeedSnapshot,
+} from '../lib/feed-snapshot.js'
+
+test('createFeedSnapshot stores only safe renderable feed card fields', () => {
+  const snapshot = createFeedSnapshot({
+    now: 1000,
+    identityDriveKey: 'local-channel',
+    channelMeta: {
+      remote: { name: 'Remote channel' },
+    },
+    videos: [
+      {
+        id: 'remote-playable',
+        title: 'Remote playable',
+        channelKey: 'remote',
+        uploadedAt: 20,
+        availability: 'playable',
+        blobId: 'blob-a',
+        blobsCoreKey: 'core-a',
+        url: 'http://do-not-store.example/video.mp4',
+      },
+      {
+        id: 'remote-unknown',
+        channelKey: 'remote',
+        uploadedAt: 30,
+        availability: 'unknown',
+      },
+      {
+        id: 'local-draft',
+        title: 'Local draft',
+        channelKey: 'local-channel',
+        uploadedAt: 10,
+        availability: 'unknown',
+        channel: { name: 'Me' },
+      },
+    ],
+  })
+
+  assert.equal(snapshot.version, 1)
+  assert.equal(snapshot.savedAt, 1000)
+  assert.deepEqual(snapshot.videos.map((video) => ({
+    id: video.id,
+    channelKey: video.channelKey,
+    availability: video.availability,
+    channelName: video.channel?.name,
+    hasUrl: Object.hasOwn(video, 'url'),
+  })), [
+    {
+      id: 'remote-playable',
+      channelKey: 'remote',
+      availability: 'playable',
+      channelName: 'Remote channel',
+      hasUrl: false,
+    },
+    {
+      id: 'local-draft',
+      channelKey: 'local-channel',
+      availability: 'playable',
+      channelName: 'Me',
+      hasUrl: false,
+    },
+  ])
+})
+
+test('restoreFeedSnapshot rejects stale or unsupported snapshots', () => {
+  assert.deepEqual(restoreFeedSnapshot(null), [])
+  assert.deepEqual(restoreFeedSnapshot({ version: 999, savedAt: 1000, videos: [] }, { now: 1000 }), [])
+  assert.deepEqual(restoreFeedSnapshot({ version: 1, savedAt: 1000, videos: [{ id: 'old' }] }, {
+    now: 1000 + 100,
+    maxAgeMs: 99,
+  }), [])
+})
+
+test('restoreFeedSnapshot dedupes and marks restored cards as snapshot sourced', () => {
+  const restored = restoreFeedSnapshot({
+    version: 1,
+    savedAt: 1000,
+    videos: [
+      { id: 'a', channelKey: 'remote', uploadedAt: 20, availability: 'playable' },
+      { id: 'a', channelKey: 'remote', uploadedAt: 10, availability: 'playable' },
+      { id: 'b', driveKey: 'remote-b', uploadedAt: 5, availability: 'playable', __feedSource: 'hydrated' },
+    ],
+  }, { now: 1200 })
+
+  assert.deepEqual(restored.map((video) => ({
+    id: video.id,
+    channelKey: video.channelKey,
+    driveKey: video.driveKey,
+    source: video.__feedSource,
+  })), [
+    { id: 'a', channelKey: 'remote', driveKey: undefined, source: 'snapshot' },
+    { id: 'b', channelKey: undefined, driveKey: 'remote-b', source: 'snapshot' },
+  ])
+})
+
+test('getSnapshotChannelKeys returns unique channel keys for restored cards', () => {
+  assert.deepEqual(getSnapshotChannelKeys([
+    { id: 'a', channelKey: 'remote-a' },
+    { id: 'b', driveKey: 'remote-b' },
+    { id: 'c', channelKey: 'remote-a' },
+    { id: 'd' },
+  ]), ['remote-a', 'remote-b'])
+})


### PR DESCRIPTION
## Summary
- Restore the last known renderable Discover feed snapshot on mobile startup so cached videos can paint before P2P/feed hydration completes
- Persist safe feed-card metadata after fresh local/preview/hydrated data arrives, without storing transient playback URLs
- Keep restored snapshot cards visible while public-feed entries are still incomplete, and add timing logs for snapshot restore/public feed/hydration
- Add regression coverage for snapshot serialization/restore and snapshot-card retention

## Test Plan
- [x] `git diff --cached --check`
- [x] `node --test packages/app/tests/feed-snapshot.test.mjs packages/app/tests/feed-hydration.test.mjs`

## Notes
- Full app `tsc --noEmit` still has unrelated pre-existing errors outside this change set, so targeted tests are the clean validation signal here.
