### PR TITLE
feat(app): refresh mobile video UI

### DIFF
--- a/packages/app/app/channel/[key].tsx
+++ b/packages/app/app/channel/[key].tsx
@@ -8,13 +8,16 @@ import {
   ActivityIndicator,
   Pressable,
   Image,
+  StyleSheet,
   type PressableProps,
-  } from 'react-native'
+} from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
+import { useApp } from '../_layout'
 import { Feather } from '@expo/vector-icons'
 import { useLocalSearchParams, useRouter } from 'expo-router'
 import * as ImagePicker from 'expo-image-picker'
 import Animated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated'
+import { fetchThumbnailUrlWithRetry } from '@/lib/thumbnail'
 import { rpc } from '@peartube/platform/rpc'
 import { Skeleton } from '@/components/ui/skeleton'
 import { ThumbnailImage } from '@/components/video/ThumbnailImage'
@@ -39,7 +42,12 @@ type ChannelVideo = {
 
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable)
 
-function PressableFeedback({ children, className, ...props }: PressableProps) {
+function PressableFeedback({
+  children,
+  className,
+  enableMotion = true,
+  ...props
+}: PressableProps & { enableMotion?: boolean }) {
   const scale = useSharedValue(1)
   const opacity = useSharedValue(1)
 
@@ -53,17 +61,20 @@ function PressableFeedback({ children, className, ...props }: PressableProps) {
     opacity.value = withSpring(1, { damping: 15, stiffness: 400 })
   }, [opacity, scale])
 
-  const animatedStyle = useAnimatedStyle(() => ({
-    transform: [{ scale: scale.value }],
-    opacity: opacity.value,
-  }))
+  const animatedStyle = useAnimatedStyle(() => {
+    if (!enableMotion) return {}
+    return {
+      transform: [{ scale: scale.value }],
+      opacity: opacity.value,
+    }
+  })
 
   return (
     <AnimatedPressable
       {...props}
       className={className}
-      onPressIn={handlePressIn}
-      onPressOut={handlePressOut}
+      onPressIn={enableMotion ? handlePressIn : undefined}
+      onPressOut={enableMotion ? handlePressOut : undefined}
       style={animatedStyle}
     >
       {children}
@@ -93,7 +104,7 @@ function ChannelVideoCard({
   onPress: () => void
 }) {
   return (
-    <PressableFeedback className="mb-4" onPress={onPress} accessibilityRole="button">
+    <PressableFeedback className="mb-4" onPress={onPress} accessibilityRole="button" enableMotion={false}>
       <ThumbnailImage
         thumbnailUrl={video.thumbnailUrl || video.thumbnail}
         duration={video.duration}
@@ -138,8 +149,10 @@ export default function ChannelScreen() {
   const channelKey = useMemo(() => (Array.isArray(key) ? key[0] : key) || '', [key])
   const channelPublicBeeKey = useMemo(() => (Array.isArray(publicBeeKey) ? publicBeeKey[0] : publicBeeKey) || '', [publicBeeKey])
 
+  const { rpc: appRpc, blobServerPort } = useApp()
   const [channelMeta, setChannelMeta] = useState<ChannelMeta | null>(null)
   const [channelVideos, setChannelVideos] = useState<ChannelVideo[]>([])
+  const [thumbnailCache, setThumbnailCache] = useState<Record<string, string>>({})
   const [identityDriveKey, setIdentityDriveKey] = useState('')
   const [isLoading, setIsLoading] = useState(true)
   const [screenError, setScreenError] = useState('')
@@ -156,6 +169,30 @@ export default function ChannelScreen() {
   const activeAvatarUrl = avatarPreviewUrl || channelMeta?.avatar || ''
   const channelDisplayName = channelMeta?.name?.trim() || `Channel ${channelKey.slice(0, 8)}`
   const channelDescription = channelMeta?.description?.trim() || 'No channel description yet.'
+  const channelVideoCountText = `${channelVideos.length} ${channelVideos.length === 1 ? 'video' : 'videos'}`
+
+  const resolveChannelThumbnails = useCallback((videosToResolve: ChannelVideo[]) => {
+    if (!appRpc || !channelKey || videosToResolve.length === 0) return
+
+    for (const video of videosToResolve) {
+      if (!video?.id) continue
+      const cacheKey = `${channelKey}:${video.id}`
+      if (video.thumbnailUrl || video.thumbnail) continue
+
+      void fetchThumbnailUrlWithRetry({
+        rpc: appRpc,
+        channelKey,
+        videoId: video.id,
+        expectedPort: blobServerPort,
+      }).then((url) => {
+        if (!url) return
+        setThumbnailCache((prev) => {
+          if (prev[cacheKey] === url) return prev
+          return { ...prev, [cacheKey]: url }
+        })
+      })
+    }
+  }, [appRpc, blobServerPort, channelKey])
 
   const fetchChannelPage = useCallback(async () => {
     if (!channelKey) {
@@ -168,17 +205,19 @@ export default function ChannelScreen() {
       setScreenError('')
       setIsLoading(true)
       const [channelMetaResponse, channelVideosResponse] = await Promise.all([
-        rpc.getChannelMeta({ channelKey, publicBeeKey: channelPublicBeeKey || undefined }),
-        rpc.listVideos({ channelKey, publicBeeKey: channelPublicBeeKey || undefined }),
+        rpc.getChannelMeta({ channelKey, publicBeeKey: channelPublicBeeKey || undefined } as any),
+        rpc.listVideos({ channelKey, publicBeeKey: channelPublicBeeKey || undefined } as any),
       ])
+      const loadedVideos = Array.isArray(channelVideosResponse?.videos) ? channelVideosResponse.videos : []
       setChannelMeta(channelMetaResponse || null)
-      setChannelVideos(Array.isArray(channelVideosResponse?.videos) ? channelVideosResponse.videos : [])
+      setChannelVideos(loadedVideos)
+      resolveChannelThumbnails(loadedVideos)
     } catch (channelFetchError: any) {
       setScreenError(channelFetchError?.message || 'Failed to load channel page.')
     } finally {
       setIsLoading(false)
     }
-  }, [channelKey, channelPublicBeeKey])
+  }, [channelKey, channelPublicBeeKey, resolveChannelThumbnails])
 
   useEffect(() => {
     let isMounted = true
@@ -282,17 +321,17 @@ export default function ChannelScreen() {
   }, [avatarBase64, editDescription, editName, fetchChannelPage, isSaving])
 
   return (
-    <SafeAreaView className="flex-1 bg-pear-bg">
-      <View className="flex-row items-center px-5 py-4 border-b border-pear-border">
+    <SafeAreaView style={styles.screen}>
+      <View style={styles.topBar}>
         <PressableFeedback
           onPress={() => router.back()}
-          className="w-10 h-10 rounded-full bg-pear-bg-card items-center justify-center mr-3"
+          className="w-10 h-10 rounded-full items-center justify-center mr-3"
           accessibilityRole="button"
           accessibilityLabel="Go back"
         >
           <Feather name="chevron-left" size={20} color={colors.text} />
         </PressableFeedback>
-        <Text className="text-headline text-pear-text" numberOfLines={1}>Channel</Text>
+        <Text style={styles.topBarTitle} numberOfLines={1}>Channel</Text>
       </View>
 
       {isLoading ? (
@@ -312,67 +351,76 @@ export default function ChannelScreen() {
           </PressableFeedback>
         </View>
       ) : (
-        <ScrollView
-          contentInsetAdjustmentBehavior="automatic"
-          showsVerticalScrollIndicator={false}
-          contentContainerStyle={{ paddingBottom: 28 }}
-        >
-          <View className="px-5 pt-4 pb-2">
-            <View className="flex-row items-center">
-              {activeAvatarUrl ? (
-                <Image source={{ uri: activeAvatarUrl }} className="w-20 h-20 rounded-full bg-pear-bg-card" resizeMode="cover" />
-              ) : (
-                <View className="w-20 h-20 rounded-full bg-pear-primary items-center justify-center">
-                  <Text className="text-white text-title font-bold">{channelDisplayName.charAt(0).toUpperCase() || 'P'}</Text>
+            <ScrollView
+              contentInsetAdjustmentBehavior="automatic"
+              showsVerticalScrollIndicator={false}
+              contentContainerStyle={styles.scrollContent}
+            >
+              <View style={styles.hero}>
+                <View style={styles.avatarShell}>
+                  {activeAvatarUrl ? (
+                    <Image source={{ uri: activeAvatarUrl }} style={styles.avatarImage} resizeMode="cover" />
+                  ) : (
+                    <Text style={styles.avatarInitial}>{channelDisplayName.charAt(0).toUpperCase() || 'P'}</Text>
+                  )}
                 </View>
-              )}
 
-              <View className="flex-1 ml-4">
-                <Text className="text-title text-pear-text font-bold" numberOfLines={2} selectable>{channelDisplayName}</Text>
-                <Text className="text-body text-pear-text-secondary mt-1" selectable>{channelDescription}</Text>
+                <View style={styles.heroCopy}>
+                  <Text style={styles.channelTitle} numberOfLines={2} selectable>{channelDisplayName}</Text>
+                  <Text style={styles.channelDescription} numberOfLines={3} selectable>{channelDescription}</Text>
+                  <View style={styles.heroMetaRow}>
+                    <View style={styles.videoCountPill}>
+                      <Feather name="film" size={13} color={colors.textSecondary} />
+                      <Text style={styles.videoCountText}>{channelVideoCountText}</Text>
+                    </View>
+                    <Text style={styles.channelKeyText}>{channelKey.slice(0, 12)}...</Text>
+                  </View>
+                </View>
+
+                {isOwner ? (
+                  <PressableFeedback
+                    onPress={openEditModal}
+                    className="mt-5 rounded-full px-4 py-3 flex-row items-center justify-center gap-2"
+                    accessibilityRole="button"
+                  >
+                    <Feather name="edit-2" size={16} color={colors.text} />
+                    <Text style={styles.editButtonText}>Edit Channel</Text>
+                  </PressableFeedback>
+                ) : null}
               </View>
-            </View>
 
-            {isOwner ? (
-              <PressableFeedback
-                onPress={openEditModal}
-                className="mt-4 bg-pear-bg-card border border-pear-border rounded-lg px-4 py-3 flex-row items-center justify-center gap-2"
-                accessibilityRole="button"
-              >
-                <Feather name="edit-2" size={16} color={colors.text} />
-                <Text className="text-label text-pear-text">Edit Channel</Text>
-              </PressableFeedback>
-            ) : null}
-          </View>
-
-          <View className="px-5 pt-4">
+              <View style={styles.videoListSection}>
             {channelVideos.length === 0 ? (
               <View className="py-16 items-center justify-center rounded-xl bg-pear-bg-card border border-pear-border">
                 <Feather name="video-off" size={30} color={colors.textMuted} />
                 <Text className="text-body text-pear-text-secondary mt-3">No videos yet</Text>
               </View>
             ) : (
-              channelVideos.map((channelVideo) => (
-                <ChannelVideoCard
-                  key={channelVideo.id}
-                  video={channelVideo}
-                  channelName={channelDisplayName}
-                  onPress={() => router.push({
-                    pathname: '/video/[id]',
-                    params: {
-                      id: channelVideo.id,
-                      channel: channelKey,
-                      publicBeeKey: channelPublicBeeKey || undefined,
-                      videoData: JSON.stringify({
-                        ...channelVideo,
-                        channelKey,
+              channelVideos.map((channelVideo) => {
+                const thumbnailUrl = thumbnailCache[`${channelKey}:${channelVideo.id}`] || channelVideo.thumbnailUrl || channelVideo.thumbnail || null
+                return (
+                  <ChannelVideoCard
+                    key={channelVideo.id}
+                    video={{ ...channelVideo, thumbnailUrl }}
+                    channelName={channelDisplayName}
+                    onPress={() => router.push({
+                      pathname: '/video/[id]',
+                      params: {
+                        id: channelVideo.id,
+                        channel: channelKey,
                         publicBeeKey: channelPublicBeeKey || undefined,
-                        channel: { name: channelDisplayName },
-                      }),
-                    },
-                  })}
-                />
-              ))
+                        videoData: JSON.stringify({
+                          ...channelVideo,
+                          thumbnailUrl,
+                          channelKey,
+                          publicBeeKey: channelPublicBeeKey || undefined,
+                          channel: { name: channelDisplayName },
+                        }),
+                      },
+                    })}
+                  />
+                )
+              })
             )}
           </View>
         </ScrollView>
@@ -462,3 +510,108 @@ export default function ChannelScreen() {
     </SafeAreaView>
   )
 }
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: colors.bg,
+  },
+  topBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 18,
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+    backgroundColor: colors.bg,
+  },
+  topBarTitle: {
+    color: colors.text,
+    fontSize: 18,
+    fontWeight: '600',
+    letterSpacing: -0.25,
+  },
+  scrollContent: {
+    paddingHorizontal: 16,
+    paddingTop: 14,
+    paddingBottom: 34,
+  },
+  hero: {
+    borderRadius: 24,
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.surface,
+    padding: 18,
+    overflow: 'hidden',
+  },
+  avatarShell: {
+    width: 82,
+    height: 82,
+    borderRadius: 28,
+    backgroundColor: colors.primary,
+    borderWidth: 1,
+    borderColor: colors.borderLight,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 16,
+  },
+  avatarImage: {
+    width: '100%',
+    height: '100%',
+    borderRadius: 27,
+  },
+  avatarInitial: {
+    color: '#fff',
+    fontSize: 30,
+    fontWeight: '700',
+  },
+  heroCopy: {
+    gap: 8,
+  },
+  channelTitle: {
+    color: colors.text,
+    fontSize: 28,
+    lineHeight: 33,
+    fontWeight: '700',
+    letterSpacing: -0.65,
+  },
+  channelDescription: {
+    color: colors.textSecondary,
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  heroMetaRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: 8,
+    marginTop: 4,
+  },
+  videoCountPill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 999,
+    backgroundColor: colors.bgElevated,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  videoCountText: {
+    color: colors.textSecondary,
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  channelKeyText: {
+    color: colors.textMuted,
+    fontSize: 12,
+  },
+  editButtonText: {
+    color: colors.text,
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  videoListSection: {
+    paddingTop: 18,
+  },
+})

--- a/packages/app/components/video-player/Scrubber.tsx
+++ b/packages/app/components/video-player/Scrubber.tsx
@@ -386,7 +386,7 @@ export const Scrubber = memo(function Scrubber({
       borderRadius: geometry.borderRadius,
       width: shimmerWidth,
       left: Math.max(0, bufW - shimmerWidth),
-      backgroundColor: `rgba(145, 71, 255, 1)`,
+      backgroundColor: '#5e6ad2',
       opacity: bufferShimmerOpacity.value,
     }
   }, [])
@@ -422,7 +422,7 @@ export const Scrubber = memo(function Scrubber({
       transform: [{ translateX: tx }],
       // Glow ring on scrub
       borderWidth: interpolate(isScrubbingSV.value, [0, 1], [0, 2]),
-      borderColor: 'rgba(145, 71, 255, 0.50)',
+      borderColor: 'rgba(94, 106, 210, 0.50)',
       shadowOpacity: interpolate(isScrubbingSV.value, [0, 1], [0.4, 0.5]),
       shadowRadius: interpolate(isScrubbingSV.value, [0, 1], [3, 5]),
       elevation: interpolate(isScrubbingSV.value, [0, 1], [4, 6]),

--- a/packages/app/components/video-player/Scrubber.tsx
+++ b/packages/app/components/video-player/Scrubber.tsx
@@ -1,4 +1,5 @@
 import { memo, useCallback, useEffect, useMemo, useState } from 'react'
+import * as Haptics from 'expo-haptics'
 import { type LayoutChangeEvent, Platform, Text, View } from 'react-native'
 import { Gesture, GestureDetector } from 'react-native-gesture-handler'
 import Animated, {
@@ -13,8 +14,6 @@ import Animated, {
   withTiming,
   withRepeat,
 } from 'react-native-reanimated'
-let Haptics: any = null
-try { Haptics = require('expo-haptics') } catch {}
 import { styles } from './styles'
 import { formatDuration } from './formatters'
 
@@ -64,15 +63,27 @@ function getFineScrubScale(verticalDistance: number): number {
 
 // ── Haptic helpers (called from UI thread via runOnJS) ──────────────────
 function triggerLightHaptic() {
-  try { Haptics?.impactAsync?.(Haptics?.ImpactFeedbackStyle?.Light)?.catch?.(() => {}) } catch {}
+  try {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => undefined)
+  } catch {
+    // Haptics are best-effort and unavailable on some platforms.
+  }
 }
 
 function triggerMediumHaptic() {
-  try { Haptics?.impactAsync?.(Haptics?.ImpactFeedbackStyle?.Medium)?.catch?.(() => {}) } catch {}
+  try {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium).catch(() => undefined)
+  } catch {
+    // Haptics are best-effort and unavailable on some platforms.
+  }
 }
 
 function triggerHeavyHaptic() {
-  try { Haptics?.impactAsync?.(Haptics?.ImpactFeedbackStyle?.Heavy)?.catch?.(() => {}) } catch {}
+  try {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy).catch(() => undefined)
+  } catch {
+    // Haptics are best-effort and unavailable on some platforms.
+  }
 }
 
 type Props = {

--- a/packages/app/components/video-player/styles.ts
+++ b/packages/app/components/video-player/styles.ts
@@ -5,12 +5,12 @@
  */
 
 import { StyleSheet } from 'react-native'
-import { colors } from '@/lib/colors'
+import { colors } from '@peartube/core'
 import { MINI_PIP_WIDTH, MINI_PIP_HEIGHT } from './constants'
 
 const PLAYER_COLORS = {
-  brandPurple: '#9147ff',
-  brandPurpleAlpha35: 'rgba(145, 71, 255, 0.35)',
+  brandPurple: colors.primary,
+  brandPurpleAlpha35: 'rgba(94, 106, 210, 0.35)',
   whiteAlpha15: 'rgba(255, 255, 255, 0.15)',
   black: '#000',
   blackShadow: '#000000',

--- a/packages/app/components/video/ThumbnailImage.tsx
+++ b/packages/app/components/video/ThumbnailImage.tsx
@@ -8,6 +8,7 @@ import { useState, useEffect, useCallback, useMemo, memo } from 'react'
 import { View, Image, Text, StyleSheet, ActivityIndicator } from 'react-native'
 import { Ionicons } from '@expo/vector-icons'
 import { formatDuration } from '@/lib/formatters'
+import { colors } from '@/lib/colors'
 
 interface ThumbnailImageProps {
   thumbnailUrl?: string | null
@@ -92,7 +93,7 @@ function ThumbnailImageComponent({
       {/* Always show placeholder as background, image overlays on top when loaded */}
       <View style={styles.placeholder}>
         <View style={styles.playIconContainer}>
-          <Ionicons name="play" color="#9147ff" size={48} />
+          <Ionicons name="play" color={colors.primary} size={48} />
         </View>
       </View>
 
@@ -101,7 +102,7 @@ function ThumbnailImageComponent({
         <Image
           source={imageSource}
           style={styles.image}
-          resizeMode="contain"
+          resizeMode="cover"
           onError={handleError}
           onLoadStart={handleLoadStart}
           onLoadEnd={handleLoadEnd}
@@ -111,7 +112,7 @@ function ThumbnailImageComponent({
       {/* Loading indicator */}
       {imageLoading && thumbnailUrl && !imageError && (
         <View style={styles.loadingOverlay}>
-          <ActivityIndicator color="#9147ff" size="small" />
+          <ActivityIndicator color={colors.primary} size="small" />
         </View>
       )}
 
@@ -144,24 +145,24 @@ const styles = StyleSheet.create({
   container: {
     width: '100%',
     aspectRatio: 16 / 9,
-    backgroundColor: '#1f1f23',
+    backgroundColor: colors.bgElevated,
     borderRadius: 12,
     overflow: 'hidden',
     position: 'relative',
   },
   image: {
     ...StyleSheet.absoluteFillObject,
-    backgroundColor: '#0e0e10',
+    backgroundColor: colors.bg,
   },
   loadingOverlay: {
     ...StyleSheet.absoluteFillObject,
-    backgroundColor: '#1f1f23',
+    backgroundColor: colors.bgElevated,
     justifyContent: 'center',
     alignItems: 'center',
   },
   placeholder: {
     ...StyleSheet.absoluteFillObject,
-    backgroundColor: '#1f1f23',
+    backgroundColor: colors.bgElevated,
     justifyContent: 'center',
     alignItems: 'center',
   },
@@ -169,7 +170,7 @@ const styles = StyleSheet.create({
     width: 80,
     height: 80,
     borderRadius: 40,
-    backgroundColor: 'rgba(145, 71, 255, 0.15)',
+    backgroundColor: colors.primaryLight,
     justifyContent: 'center',
     alignItems: 'center',
   },

--- a/packages/app/components/video/VideoCard.tsx
+++ b/packages/app/components/video/VideoCard.tsx
@@ -6,6 +6,7 @@
  */
 import { memo, useMemo, useCallback } from 'react'
 import { View, Text, Pressable, StyleSheet } from 'react-native'
+import { colors } from '@/lib/colors'
 import Animated, { useSharedValue, useAnimatedStyle, withSpring, withTiming } from 'react-native-reanimated'
 import { ThumbnailImage } from './ThumbnailImage'
 import { formatTimeAgo } from '@/lib/formatters'
@@ -101,66 +102,66 @@ function VideoCardComponent({ video, onPress, onChannelPress, showChannelInfo = 
 
   return (
     <Pressable onPress={handlePress} style={getPressedStyle} testID={testID}>
-      {/* Thumbnail */}
-      <ThumbnailImage
-        thumbnailUrl={video.thumbnailUrl || video.thumbnail}
-        duration={video.duration}
-        channelInitial={channelInitial}
-      />
+      <View style={styles.surface}>
+        <View style={styles.thumbnailFrame}>
+          <ThumbnailImage
+            thumbnailUrl={video.thumbnailUrl || video.thumbnail}
+            duration={video.duration}
+            channelInitial={channelInitial}
+          />
+        </View>
 
-      {/* Video info row */}
-      <View style={styles.infoRow}>
-        {/* Channel avatar */}
-        {showChannelInfo && onChannelPress ? (
-          <AnimatedPressable
-            onPress={onChannelPress}
-            onPressIn={channelPressIn}
-            onPressOut={channelPressOut}
-            style={[styles.avatarContainer, channelAnimStyle]}
-            hitSlop={4}
-          >
-            <View style={styles.avatar}>
-              <Text style={styles.avatarText}>{channelInitial}</Text>
+        <View style={styles.infoRow}>
+          {showChannelInfo && onChannelPress ? (
+            <AnimatedPressable
+              onPress={onChannelPress}
+              onPressIn={channelPressIn}
+              onPressOut={channelPressOut}
+              style={[styles.avatarContainer, channelAnimStyle]}
+              hitSlop={6}
+            >
+              <View style={styles.avatar}>
+                <Text style={styles.avatarText}>{channelInitial}</Text>
+              </View>
+            </AnimatedPressable>
+          ) : showChannelInfo ? (
+            <View style={styles.avatarContainer}>
+              <View style={styles.avatar}>
+                <Text style={styles.avatarText}>{channelInitial}</Text>
+              </View>
             </View>
-          </AnimatedPressable>
-        ) : showChannelInfo ? (
-          <View style={styles.avatarContainer}>
-            <View style={styles.avatar}>
-              <Text style={styles.avatarText}>{channelInitial}</Text>
-            </View>
-          </View>
-        ) : null}
+          ) : null}
 
-        {/* Title and metadata */}
-        <View style={styles.textContainer}>
-          <Text style={styles.title} numberOfLines={2}>
-            {video.title}
-          </Text>
-          <View style={styles.metaRow}>
-            {showChannelInfo && onChannelPress ? (
-              <>
-                <AnimatedPressable
-                  onPress={onChannelPress}
-                  onPressIn={channelPressIn}
-                  onPressOut={channelPressOut}
-                  style={channelAnimStyle}
-                  hitSlop={4}
-                >
-                  <Text style={styles.channelNameLink} numberOfLines={1}>
+          <View style={styles.textContainer}>
+            <Text style={styles.title} numberOfLines={2}>
+              {video.title}
+            </Text>
+            <View style={styles.metaRow}>
+              {showChannelInfo && onChannelPress ? (
+                <>
+                  <AnimatedPressable
+                    onPress={onChannelPress}
+                    onPressIn={channelPressIn}
+                    onPressOut={channelPressOut}
+                    style={channelAnimStyle}
+                    hitSlop={6}
+                  >
+                    <Text style={styles.channelNameLink} numberOfLines={1}>
+                      {channelName}
+                    </Text>
+                  </AnimatedPressable>
+                  <Text style={styles.dot}>·</Text>
+                </>
+              ) : showChannelInfo ? (
+                <>
+                  <Text style={styles.channelName} numberOfLines={1}>
                     {channelName}
                   </Text>
-                </AnimatedPressable>
-                <Text style={styles.dot}>·</Text>
-              </>
-            ) : showChannelInfo ? (
-              <>
-                <Text style={styles.channelName} numberOfLines={1}>
-                  {channelName}
-                </Text>
-                <Text style={styles.dot}>·</Text>
-              </>
-            ) : null}
-            <Text style={styles.timeAgo}>{timeAgo}</Text>
+                  <Text style={styles.dot}>·</Text>
+                </>
+              ) : null}
+              <Text style={styles.timeAgo}>{timeAgo}</Text>
+            </View>
           </View>
         </View>
       </View>
@@ -203,66 +204,83 @@ export const VideoCard = memo(VideoCardComponent, arePropsEqual)
 const styles = StyleSheet.create({
   container: {
     width: '100%',
-    marginBottom: 16,
+    marginBottom: 18,
+    paddingHorizontal: 14,
+  },
+  surface: {
+    overflow: 'hidden',
+    borderRadius: 18,
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.08)',
+    backgroundColor: colors.surface,
+  },
+  thumbnailFrame: {
+    overflow: 'hidden',
+    borderTopLeftRadius: 17,
+    borderTopRightRadius: 17,
+    backgroundColor: colors.bg,
   },
   pressed: {
-    opacity: 0.7,
+    opacity: 0.78,
+    transform: [{ scale: 0.99 }],
   },
   infoRow: {
     flexDirection: 'row',
-    marginTop: 8,
-    paddingHorizontal: 12,
+    paddingHorizontal: 14,
+    paddingTop: 12,
+    paddingBottom: 14,
   },
   avatarContainer: {
     marginRight: 12,
   },
   avatar: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    backgroundColor: '#9147ff',
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    backgroundColor: colors.primary,
     justifyContent: 'center',
     alignItems: 'center',
   },
   avatarText: {
     color: '#ffffff',
-    fontSize: 16,
+    fontSize: 15,
     fontWeight: '600',
   },
   textContainer: {
     flex: 1,
+    minWidth: 0,
     justifyContent: 'center',
   },
   title: {
-    color: '#efeff1',
-    fontSize: 14,
-    fontWeight: '500',
-    lineHeight: 20,
-    marginBottom: 4,
+    color: colors.text,
+    fontSize: 15,
+    fontWeight: '590' as any,
+    lineHeight: 21,
+    marginBottom: 5,
+    letterSpacing: -0.18,
   },
   metaRow: {
     flexDirection: 'row',
     alignItems: 'center',
   },
   channelName: {
-    color: '#adadb8',
+    color: colors.textSecondary,
     fontSize: 12,
     maxWidth: 150,
   },
   channelNameLink: {
-    color: '#adadb8',
+    color: colors.textSecondary,
     fontSize: 12,
     maxWidth: 150,
-    textDecorationLine: 'underline',
-    textDecorationStyle: 'dotted',
+    fontWeight: '500',
   },
   dot: {
-    color: '#adadb8',
+    color: colors.textMuted,
     fontSize: 12,
-    marginHorizontal: 4,
+    marginHorizontal: 5,
   },
   timeAgo: {
-    color: '#adadb8',
+    color: colors.textMuted,
     fontSize: 12,
   },
 })

--- a/packages/app/components/video/VideoFeed.tsx
+++ b/packages/app/components/video/VideoFeed.tsx
@@ -4,6 +4,7 @@
  */
 import { FlatList, View, Text, RefreshControl, StyleSheet, ActivityIndicator } from 'react-native'
 import { VideoCard, VideoData } from './VideoCard'
+import { colors } from '@/lib/colors'
 
 interface VideoFeedProps {
   videos: VideoData[]
@@ -104,8 +105,8 @@ export function VideoFeed({
           <RefreshControl
             refreshing={refreshing}
             onRefresh={onRefresh}
-            tintColor="#9147ff"
-            colors={['#9147ff']}
+            tintColor={colors.primary}
+            colors={[colors.primary]}
           />
         ) : undefined
       }
@@ -121,7 +122,7 @@ export function VideoFeed({
       ListFooterComponent={
         loading && videos.length > 0 ? (
           <View style={styles.footer}>
-            <ActivityIndicator color="#9147ff" size="small" />
+            <ActivityIndicator color={colors.primary} size="small" />
           </View>
         ) : null
       }
@@ -132,7 +133,7 @@ export function VideoFeed({
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#0e0e10',
+    backgroundColor: colors.bg,
   },
   contentContainer: {
     paddingBottom: 20,
@@ -150,7 +151,7 @@ const skeletonStyles = StyleSheet.create({
   thumbnail: {
     width: '100%',
     aspectRatio: 16 / 9,
-    backgroundColor: '#1f1f23',
+    backgroundColor: colors.bgElevated,
     borderRadius: 12,
   },
   infoRow: {
@@ -162,7 +163,7 @@ const skeletonStyles = StyleSheet.create({
     width: 40,
     height: 40,
     borderRadius: 20,
-    backgroundColor: '#1f1f23',
+    backgroundColor: colors.bgElevated,
     marginRight: 12,
   },
   textContainer: {
@@ -170,21 +171,21 @@ const skeletonStyles = StyleSheet.create({
   },
   titleLine1: {
     height: 14,
-    backgroundColor: '#1f1f23',
+    backgroundColor: colors.bgElevated,
     borderRadius: 4,
     marginBottom: 6,
     width: '90%',
   },
   titleLine2: {
     height: 14,
-    backgroundColor: '#1f1f23',
+    backgroundColor: colors.bgElevated,
     borderRadius: 4,
     marginBottom: 8,
     width: '60%',
   },
   metaLine: {
     height: 12,
-    backgroundColor: '#1f1f23',
+    backgroundColor: colors.bgElevated,
     borderRadius: 4,
     width: '40%',
   },

--- a/packages/app/tailwind.config.js
+++ b/packages/app/tailwind.config.js
@@ -21,18 +21,18 @@ module.exports = {
       colors: {
         // PearTube brand colors mapped to Gluestack semantic colors
         primary: {
-          0: "#E8DAFF",
-          50: "#D4B8FF",
-          100: "#C099FF",
-          200: "#AB7AFF",
-          300: "#9B5CFF",
-          400: "#9147ff", // PearTube primary
-          500: "#8236E8",
-          600: "#772ce8", // hover
-          700: "#6420C7",
-          800: "#5115A6",
-          900: "#3E0A85",
-          950: "#2B0064",
+          0: "#F0F2FF",
+          50: "#E2E6FF",
+          100: "#CAD1FF",
+          200: "#AAB4F6",
+          300: "#8B95EA",
+          400: "#7170ff", // PearTube primary hover
+          500: "#5e6ad2", // PearTube primary
+          600: "#505ab7",
+          700: "#414894",
+          800: "#30356f",
+          900: "#20254f",
+          950: "#151936",
         },
         secondary: {
           0: "#FEFFFF",
@@ -192,21 +192,21 @@ module.exports = {
         },
         // PearTube legacy colors for backwards compatibility
         pear: {
-          primary: '#9147ff',
-          'primary-hover': '#772ce8',
-          'primary-muted': '#9147ff20',
-          bg: '#0e0e10',
-          'bg-elevated': '#18181b',
-          'bg-card': '#1f1f23',
-          'bg-input': '#26262c',
-          text: '#efeff1',
-          'text-secondary': '#adadb8',
-          'text-muted': '#53535f',
-          border: '#2f2f35',
-          'border-light': '#3f3f46',
-          error: '#eb0400',
-          success: '#00c853',
-          warning: '#ffb300',
+          primary: '#5e6ad2',
+          'primary-hover': '#7170ff',
+          'primary-muted': 'rgba(94, 106, 210, 0.18)',
+          bg: '#08090a',
+          'bg-elevated': '#0f1011',
+          'bg-card': 'rgba(255,255,255,0.035)',
+          'bg-input': '#191a1b',
+          text: '#f7f8f8',
+          'text-secondary': '#d0d6e0',
+          'text-muted': '#8a8f98',
+          border: 'rgba(255,255,255,0.08)',
+          'border-light': 'rgba(255,255,255,0.12)',
+          error: '#ef6262',
+          success: '#27a644',
+          warning: '#d6a243',
         },
       },
       fontFamily: {

--- a/packages/app/tamagui.config.ts
+++ b/packages/app/tamagui.config.ts
@@ -3,17 +3,17 @@ import { config as defaultConfig } from '@tamagui/config/v3'
 
 // PearTube dark theme colors
 const colors = {
-  bg: '#0e0e10',
-  bgSecondary: '#18181b',
-  bgHover: '#26262c',
-  primary: '#9147ff',
-  primaryHover: '#772ce8',
-  text: '#efeff1',
-  textSecondary: '#adadb8',
-  textMuted: '#848494',
-  border: '#2f2f35',
-  error: '#ff4444',
-  success: '#00c853',
+  bg: '#08090a',
+  bgSecondary: '#0f1011',
+  bgHover: '#191a1b',
+  primary: '#5e6ad2',
+  primaryHover: '#7170ff',
+  text: '#f7f8f8',
+  textSecondary: '#d0d6e0',
+  textMuted: '#8a8f98',
+  border: 'rgba(255,255,255,0.08)',
+  error: '#ef6262',
+  success: '#27a644',
 }
 
 const tokens = createTokens({

--- a/packages/app/tamagui.config.ts
+++ b/packages/app/tamagui.config.ts
@@ -65,6 +65,7 @@ export const tamaguiConfig = createTamagui({
 export type AppConfig = typeof tamaguiConfig
 
 declare module '@tamagui/core' {
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
   interface TamaguiCustomConfig extends AppConfig {}
 }
 

--- a/packages/app/tests/channel-view-playback-regression.test.mjs
+++ b/packages/app/tests/channel-view-playback-regression.test.mjs
@@ -1,0 +1,28 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const appRoot = path.resolve(__dirname, '..')
+
+function readApp(relativePath) {
+  return fs.readFileSync(path.join(appRoot, relativePath), 'utf8')
+}
+
+test('native channel view resolves remote thumbnails through the shared thumbnail RPC helper', () => {
+  const source = readApp('app/channel/[key].tsx')
+
+  assert.match(source, /fetchThumbnailUrlWithRetry/, 'channel view should request blob-backed thumbnail URLs instead of only trusting listVideos thumbnail fields')
+  assert.match(source, /const \{ rpc: appRpc, blobServerPort \} = useApp\(\)/, 'channel view should use app RPC/blob server state for thumbnail resolution')
+  assert.match(source, /thumbnailCache\[`\$\{channelKey\}:\$\{channelVideo\.id\}`\]/, 'rendered channel cards should use resolved thumbnail cache entries')
+})
+
+test('native channel video cards disable spring scale feedback that conflicts with route transitions', () => {
+  const source = readApp('app/channel/[key].tsx')
+
+  assert.match(source, /enableMotion\?: boolean/, 'press feedback should allow motion to be disabled')
+  assert.match(source, /enableMotion=\{false\}/, 'channel video cards should not use the spring scale press animation')
+})

--- a/packages/app/tests/channel-view-routing-regression.test.mjs
+++ b/packages/app/tests/channel-view-routing-regression.test.mjs
@@ -23,7 +23,7 @@ test('native channel page video cards navigate to the video route with channel c
 
   assert.match(
     source,
-    /router\.push\(\{\s*pathname: '\/video\/\[id\]'[\s\S]*?channel: channelKey[\s\S]*?videoData: JSON\.stringify/s,
+    /router\.(?:push|replace)\(\{\s*pathname: '\/video\/\[id\]'[\s\S]*?channel: channelKey[\s\S]*?videoData: JSON\.stringify/s,
     'native channel videos should open /video/[id] with channel and videoData params',
   )
 
@@ -96,8 +96,8 @@ test('channel view preserves publicBeeKey across native and web navigation/data 
   assert.match(nativeVideo, /const rawPublicBeeParam = params\.publicBeeKey \?\? params\.publicBee/, 'native watch route should accept both publicBeeKey and legacy publicBee route params')
   assert.match(nativeVideo, /const fetchedVideoData = result\?\.video \|\| result/, 'native watch route should unwrap backend getVideoData responses before playback')
   assert.match(nativeChannel, /const channelPublicBeeKey = useMemo/, 'native channel view should resolve publicBeeKey route params')
-  assert.match(nativeChannel, /rpc\.getChannelMeta\(\{ channelKey, publicBeeKey: channelPublicBeeKey \|\| undefined \}\)/, 'native channel metadata should pass publicBeeKey')
-  assert.match(nativeChannel, /rpc\.listVideos\(\{ channelKey, publicBeeKey: channelPublicBeeKey \|\| undefined \}\)/, 'native channel video list should pass publicBeeKey')
+  assert.match(nativeChannel, /rpc\.getChannelMeta\(\{ channelKey, publicBeeKey: channelPublicBeeKey \|\| undefined \}(?: as any)?\)/, 'native channel metadata should pass publicBeeKey')
+  assert.match(nativeChannel, /rpc\.listVideos\(\{ channelKey, publicBeeKey: channelPublicBeeKey \|\| undefined \}(?: as any)?\)/, 'native channel video list should pass publicBeeKey')
   assert.match(nativeChannel, /publicBeeKey: channelPublicBeeKey \|\| undefined/, 'native channel video navigation should preserve publicBeeKey')
 
   assert.match(webHome, /#\/channel\/\$\{encodeURIComponent\(channelKey\)\}\?publicBeeKey=\$\{encodeURIComponent\(publicBeeKey\)\}/, 'web watch channel navigation should include publicBeeKey in hash query')

--- a/packages/app/tests/mobile-player-page-layout-regression.test.mjs
+++ b/packages/app/tests/mobile-player-page-layout-regression.test.mjs
@@ -72,10 +72,15 @@ test('android fullscreen overlay does not add a second JS cutout shift on top of
     /const cutoutOffset = Platform\.OS === 'ios'\s+&& !isInPipModeShared\.value\s+&& !isLandscapeFullscreenShared\.value/,
     'video surface offset should be limited to iOS so Android does not get shifted twice',
   )
+  assert.doesNotMatch(
+    overlaySource,
+    /MediaSession\.setSurfaceViewInset\([^)]*\)/,
+    'inline Android playback should not translate the Media3 SurfaceView from JS; native playback owns surface inset handling',
+  )
   assert.match(
     overlaySource,
-    /MediaSession\.setSurfaceViewInset\(0\)\.catch\(\(\) => \{\}\)/,
-    'inline Android playback should not translate the Media3 SurfaceView down inside the fixed player-page slot',
+    /setSurfaceViewInset and setAutoPictureInPicture are no longer needed/,
+    'the overlay should document that Android surface inset handling has moved out of JS layout code',
   )
   assert.match(
     overlaySource,
@@ -144,22 +149,27 @@ test('mobile mini-player drag snaps to safe-area corners', () => {
 
   assert.match(
     overlaySource,
-    /function getMobileMiniPlayerSnapPosition\(\{\s*corner,\s*screenWidth,\s*screenHeight,\s*miniWidth,\s*topInset,\s*bottomOffset,/,
+    /function getMobileMiniPlayerSnapPosition\(\{\s*corner,\s*screenWidth,\s*screenHeight,\s*topInset,\s*rightInset,\s*bottomInset,\s*leftInset,\s*bottomOffset,\s*aspectRatio,\s*sizeMode,/,
     'mobile mini-player placement should be derived from a dedicated corner snap helper',
   )
   assert.match(
     overlaySource,
-    /const topY = topInset \+ MINI_PIP_MARGIN/,
+    /const bounds = computeMiniBounds\(\s*screenWidth,\s*screenHeight,\s*topInset,\s*rightInset,\s*bottomInset,\s*leftInset,\s*bottomOffset,\s*miniWidth,\s*miniHeight,/,
+    'mobile snap helper should derive bounds from safe-area insets, tab bar offset, and dynamic mini-player size',
+  )
+  assert.match(
+    overlaySource,
+    /topBound: insetTop \+ margin,/,
     'mobile top-corner snapping should stay below the safe-area inset',
   )
   assert.match(
     overlaySource,
-    /const bottomY = screenHeight - MINI_PIP_HEIGHT - MINI_PIP_MARGIN - bottomOffset/,
+    /bottomBound: screenHeight - bottomMargin - miniHeight,/,
     'mobile bottom-corner snapping should stay above the tab bar and bottom inset',
   )
   assert.match(
     overlaySource,
-    /const nextMiniPlayerPosition = getMobileMiniPlayerSnapPosition\(\{\s*corner: miniPlayerCorner,/,
+    /const nextPos = getMobileMiniPlayerSnapPosition\(\{\s*corner: miniPlayerCorner,/,
     'mobile mini-player relayout should reuse the selected corner instead of always resetting to bottom-right',
   )
   assert.match(
@@ -169,22 +179,22 @@ test('mobile mini-player drag snaps to safe-area corners', () => {
   )
   assert.match(
     overlaySource,
-    /const newCorner = `\$\{isBottom \? 'bottom' : 'top'\}-\$\{isRight \? 'right' : 'left'\}` as MiniPlayerCorner/,
-    'mobile mini-player drag release should snap to the nearest corner state',
+    /const snap = resolveSnapTarget\(/,
+    'mobile mini-player drag release should snap to the nearest safe-area anchor',
   )
   assert.match(
     overlaySource,
-    /runOnJS\(setMiniPlayerCorner\)\(newCorner\)/,
+    /runOnJS\(setMiniPlayerCorner\)\(snap\.corner\)/,
     'mobile mini-player drag release should persist the snapped corner in React state',
   )
   assert.match(
     overlaySource,
-    /miniPipX\.value = withSpring\(targetX, SPRING_CONFIG_TIGHT\)/,
+    /miniPipX\.value = withSpring\(snap\.x, \{ \.\.\.SPRING_CONFIG_MINI_SNAP, velocity: event\.velocityX \}\)/,
     'mobile mini-player drag release should spring the player to the snapped horizontal corner',
   )
   assert.match(
     overlaySource,
-    /miniPipY\.value = withSpring\(targetY, SPRING_CONFIG_TIGHT\)/,
+    /miniPipY\.value = withSpring\(snap\.y, \{ \.\.\.SPRING_CONFIG_MINI_SNAP, velocity: event\.velocityY \}\)/,
     'mobile mini-player drag release should spring the player to the snapped vertical corner',
   )
 })

--- a/packages/app/tests/mobile-ui-redesign-regression.test.mjs
+++ b/packages/app/tests/mobile-ui-redesign-regression.test.mjs
@@ -1,0 +1,73 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const appRoot = path.resolve(__dirname, '..')
+const repoRoot = path.resolve(appRoot, '../..')
+
+function readApp(relativePath) {
+  return fs.readFileSync(path.join(appRoot, relativePath), 'utf8')
+}
+
+function readRepo(relativePath) {
+  return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8')
+}
+
+test('mobile design tokens move away from Twitch purple toward a restrained PearTube dark system', () => {
+  const source = readRepo('packages/core/src/utils/index.ts')
+
+  assert.match(source, /primary:\s*'#5e6ad2'/, 'primary accent should use restrained indigo instead of the old saturated Twitch purple')
+  assert.match(source, /bg:\s*'#08090a'/, 'mobile surface should use near-black Linear-style base')
+  assert.match(source, /surfaceBorder:\s*'rgba\(255,255,255,0\.08\)'/, 'surface borders should use translucent dark-mode-native separators')
+  assert.doesNotMatch(source, /primary:\s*'#9147ff'/, 'old Twitch purple should not remain as the primary brand color')
+})
+
+test('native video cards use premium app-native surfaces and cover thumbnails', () => {
+  const cardSource = readApp('components/video/VideoCard.tsx')
+  const thumbnailSource = readApp('components/video/ThumbnailImage.tsx')
+
+  assert.match(cardSource, /styles\.surface/, 'native VideoCard should wrap content in a deliberate surface')
+  assert.match(cardSource, /styles\.thumbnailFrame/, 'native VideoCard should give thumbnails a controlled framed media area')
+  assert.match(cardSource, /borderColor:\s*'rgba\(255,255,255,0\.08\)'/, 'VideoCard surface should use subtle translucent borders')
+  assert.doesNotMatch(cardSource, /textDecorationLine:\s*'underline'/, 'channel labels should not look like cheap underlined web links on mobile')
+  assert.match(thumbnailSource, /resizeMode="cover"/, 'mobile thumbnails should fill their media frame instead of letterboxing with contain')
+})
+
+test('opening a channel video on mobile pushes the watch route without suppressing minimize behavior', () => {
+  const channelSource = readApp('app/channel/[key].tsx')
+  const videoSource = readApp('app/video/[id].tsx')
+
+  assert.match(
+    channelSource,
+    /router\.push\(\{\s*pathname: '\/video\/\[id\]'[\s\S]*?videoData: JSON\.stringify/,
+    'channel video taps should push the watch route with full videoData params',
+  )
+  assert.doesNotMatch(
+    channelSource,
+    /fromChannel: 'true'/,
+    'channel video taps should not mark a special navigation mode that suppresses normal player lifecycle',
+  )
+  assert.doesNotMatch(
+    videoSource,
+    /const fromChannel = params\.fromChannel === 'true'/,
+    'watch route should not branch player lifecycle for channel-origin navigation',
+  )
+  assert.match(
+    videoSource,
+    /navigation\.addListener\('beforeRemove'[\s\S]*?minimizePlayer\(\)/,
+    'leaving the watch route should use the normal shared-player minimize behavior',
+  )
+})
+
+test('channel page presents a polished mobile-native header and concise video count context', () => {
+  const source = readApp('app/channel/[key].tsx')
+
+  assert.match(source, /const channelVideoCountText =/, 'channel page should compute a concise video-count label')
+  assert.match(source, /styles\.hero/, 'channel page should use a designed hero block instead of a plain row')
+  assert.match(source, /styles\.videoCountPill/, 'channel page should show count/context in a restrained pill')
+  assert.match(source, /styles\.videoListSection/, 'channel video list should have a named composed section')
+})

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -127,47 +127,48 @@ export const RPC_METHODS = {
 
 export const colors = {
   // Brand
-  primary: '#9147ff',
-  primaryHover: '#772ce8',
-  primaryLight: 'rgba(145, 71, 255, 0.2)',
+  primary: '#5e6ad2',
+  primaryHover: '#7170ff',
+  primaryLight: 'rgba(94, 106, 210, 0.18)',
 
   // Accent
-  accent: '#00f0b5',
-  accentHover: '#00d9a4',
+  accent: '#10b981',
+  accentHover: '#34d399',
 
   // Status
-  success: '#00c853',
-  successLight: 'rgba(0, 200, 83, 0.2)',
-  warning: '#ffb300',
-  warningLight: 'rgba(255, 179, 0, 0.2)',
-  error: '#ff5252',
-  errorLight: 'rgba(255, 82, 82, 0.2)',
+  success: '#27a644',
+  successLight: 'rgba(39, 166, 68, 0.18)',
+  warning: '#d6a243',
+  warningLight: 'rgba(214, 162, 67, 0.18)',
+  error: '#ef6262',
+  errorLight: 'rgba(239, 98, 98, 0.18)',
+  red: '#ef6262',
 
   // Backgrounds
-  bg: '#0e0e10',
-  bgElevated: '#18181b',
-  bgSecondary: '#18181b', // Alias for bgElevated
-  bgHover: '#1f1f23',
-  bgActive: '#26262c',
+  bg: '#08090a',
+  bgElevated: '#0f1011',
+  bgSecondary: '#0f1011', // Alias for bgElevated
+  bgHover: '#191a1b',
+  bgActive: '#28282c',
   bgOverlay: 'rgba(0, 0, 0, 0.85)',
-  bgCard: '#1f1f23',
+  bgCard: 'rgba(255,255,255,0.035)',
 
   // Surfaces
-  surface: '#1f1f23',
-  surfaceHover: '#26262c',
-  surfaceBorder: '#303035',
+  surface: 'rgba(255,255,255,0.035)',
+  surfaceHover: 'rgba(255,255,255,0.055)',
+  surfaceBorder: 'rgba(255,255,255,0.08)',
 
   // Text
-  text: '#efeff1', // Alias for textPrimary
-  textPrimary: '#efeff1',
-  textSecondary: '#adadb8',
-  textMuted: '#7a7a85',
-  textDisabled: '#53535f',
+  text: '#f7f8f8', // Alias for textPrimary
+  textPrimary: '#f7f8f8',
+  textSecondary: '#d0d6e0',
+  textMuted: '#8a8f98',
+  textDisabled: '#62666d',
 
   // Borders
-  border: '#303035',
-  borderLight: '#404045',
-  borderFocus: '#9147ff',
+  border: 'rgba(255,255,255,0.08)',
+  borderLight: 'rgba(255,255,255,0.12)',
+  borderFocus: '#7170ff',
 } as const;
 
 export const spacing = {


### PR DESCRIPTION
## Summary
- Refresh mobile visual system with darker restrained PearTube tokens and updated NativeWind/Tamagui config
- Redesign native video cards/feed surfaces and channel page header/list presentation
- Improve mobile player controls/scrubber styling and mini-player/layout regression coverage
- Fix channel-view video taps/thumbnails: normal watch-route push, blob-backed thumbnail resolution, and no spring card animation during route transitions

## Test Plan
- [x] `git diff --check`
- [x] `node --test packages/app/tests/mobile-ui-redesign-regression.test.mjs packages/app/tests/mobile-player-page-layout-regression.test.mjs packages/app/tests/channel-view-routing-regression.test.mjs packages/app/tests/channel-view-playback-regression.test.mjs`
