### PR TITLE
feat(cli): persist relay seeding discovery

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,7 +10,7 @@
     "peartube-peer-bare": "bare-bin.js"
   },
   "scripts": {
-    "test": "brittle test/*.test.mjs",
+    "test": "brittle test/admission.test.mjs test/cli.test.mjs test/config.test.mjs test/relay-seeding.test.mjs test/service.test.mjs test/status.test.mjs",
     "build:standalone": "node ./scripts/build-standalone.mjs",
     "build:standalone:linux-x64": "RELAY_STANDALONE_HOST=linux-x64 node ./scripts/build-standalone.mjs",
     "build:standalone:linux-arm64": "RELAY_STANDALONE_HOST=linux-arm64 node ./scripts/build-standalone.mjs",

--- a/packages/cli/src/runtime.js
+++ b/packages/cli/src/runtime.js
@@ -3,11 +3,13 @@ export async function createRelayRuntime({ config, logger }) {
     { initializeStorage, loadChannel, loadPublicBee },
     { PublicFeedManager },
     { CacheManager },
+    { createRelaySeeder },
     { readPrimaryKeyFile, writePrimaryKeyFile }
   ] = await Promise.all([
     import('@peartube/backend/storage'),
     import('@peartube/backend/public-feed'),
     import('./cache-manager.js'),
+    import('./seeding.js'),
     import('../../backend/src/identity-key-file.js')
   ])
 
@@ -52,6 +54,11 @@ export async function createRelayRuntime({ config, logger }) {
 
   const publicFeed = new PublicFeedManager(ctx.swarm, ctx.metaDb)
   const cacheManager = new CacheManager(ctx.store, ctx.metaDb, config?.storage?.maxBytes || 0)
+  const seeder = createRelaySeeder({
+    ctx,
+    loadPublicBee,
+    logger: logger.runtime || logger.relay || logger
+  })
   let candidateHandler = null
 
   function emitFeedEntries() {
@@ -88,6 +95,7 @@ export async function createRelayRuntime({ config, logger }) {
     ctx,
     publicFeed,
     cacheManager,
+    seeder,
     setCandidateHandler(handler) {
       candidateHandler = handler
     },
@@ -108,6 +116,7 @@ export async function createRelayRuntime({ config, logger }) {
         try {
           await loadPublicBee(ctx, channel.publicBeeKey)
           await publicFeed.submitChannel(channel.driveKey, channel.publicBeeKey)
+          await seeder.seedChannel(channel)
         } catch (err) {
           logger.runtime?.debug('Failed to restore cached mirrored channel', {
             channelKey: channel.driveKey,
@@ -117,6 +126,9 @@ export async function createRelayRuntime({ config, logger }) {
       }
 
       logger.runtime?.info('Relay runtime started', this.getNetworkStats())
+      await seeder.seedCachedChannels(cacheManager).catch((err) => {
+        logger.runtime?.warn('Relay seeding refresh failed', { error: err?.message || String(err) })
+      })
       emitFeedEntries()
     },
     requestFeedSync() {
@@ -184,11 +196,18 @@ export async function createRelayRuntime({ config, logger }) {
         connections: ctx.swarm?.connections?.size || 0,
         feedPeers: feedStats.peerCount || 0,
         feedConnections: publicFeed.feedConnections?.size || 0,
-        feedEntries: feedStats.totalEntries || 0
+        feedEntries: feedStats.totalEntries || 0,
+        dht: {
+          bootstrapped: ctx.swarm?.dht?.bootstrapped ?? null,
+          firewalled: ctx.swarm?.dht?.firewalled ?? null,
+          online: ctx.swarm?.dht?.online ?? null
+        },
+        seeding: seeder.getStats()
       }
     },
     async close() {
       try { publicFeed.stop() } catch {}
+      try { await seeder.close() } catch {}
       try { await ctx.swarm.destroy() } catch {}
       try { ctx.blobServer?.close?.() } catch {}
       try { await ctx.store.close() } catch {}

--- a/packages/cli/src/runtime.js
+++ b/packages/cli/src/runtime.js
@@ -206,11 +206,11 @@ export async function createRelayRuntime({ config, logger }) {
       }
     },
     async close() {
-      try { publicFeed.stop() } catch {}
-      try { await seeder.close() } catch {}
-      try { await ctx.swarm.destroy() } catch {}
-      try { ctx.blobServer?.close?.() } catch {}
-      try { await ctx.store.close() } catch {}
+      try { publicFeed.stop() } catch (err) { logger.runtime?.debug('Public feed close failed', { error: err?.message || String(err) }) }
+      try { await seeder.close() } catch (err) { logger.runtime?.debug('Relay seeder close failed', { error: err?.message || String(err) }) }
+      try { await ctx.swarm.destroy() } catch (err) { logger.runtime?.debug('Swarm close failed', { error: err?.message || String(err) }) }
+      try { ctx.blobServer?.close?.() } catch (err) { logger.runtime?.debug('Blob server close failed', { error: err?.message || String(err) }) }
+      try { await ctx.store.close() } catch (err) { logger.runtime?.debug('Store close failed', { error: err?.message || String(err) }) }
     }
   }
 }

--- a/packages/cli/src/seeding.js
+++ b/packages/cli/src/seeding.js
@@ -1,0 +1,187 @@
+import b4a from 'b4a'
+
+function isValidHexKey(value) {
+  return typeof value === 'string' && /^[a-f0-9]{64}$/i.test(value)
+}
+
+function emptyStats() {
+  return {
+    channels: 0,
+    videos: 0,
+    publicBeeCores: 0,
+    blobCores: 0,
+    discoveryHandles: 0,
+    lastSeededAt: null,
+    lastError: null
+  }
+}
+
+function cloneStats(stats) {
+  return { ...stats }
+}
+
+function addCoreKey(set, value) {
+  if (!isValidHexKey(value)) return false
+  set.add(value.toLowerCase())
+  return true
+}
+
+export function createRelaySeeder({ ctx, loadPublicBee, logger = {} }) {
+  if (!ctx) throw new Error('ctx is required')
+  if (typeof loadPublicBee !== 'function') throw new Error('loadPublicBee is required')
+
+  const handles = new Map()
+  const seededChannels = new Map()
+  const logInfo = typeof logger.info === 'function' ? logger.info.bind(logger) : () => {}
+  const logWarn = typeof logger.warn === 'function' ? logger.warn.bind(logger) : () => {}
+  const logDebug = typeof logger.debug === 'function' ? logger.debug.bind(logger) : () => {}
+
+  function retainDiscovery(discoveryKey, label) {
+    if (!ctx.swarm || ctx.swarm.destroyed || !discoveryKey) return null
+    const discoveryKeyHex = Buffer.isBuffer(discoveryKey) || b4a.isBuffer(discoveryKey)
+      ? b4a.toString(discoveryKey, 'hex')
+      : String(discoveryKey)
+    if (handles.has(discoveryKeyHex)) return handles.get(discoveryKeyHex)
+
+    try {
+      const handle = ctx.swarm.join(discoveryKey, { server: true, client: true })
+      handles.set(discoveryKeyHex, handle)
+      try {
+        const flushed = handle?.flushed?.()
+        if (flushed && typeof flushed.then === 'function') {
+          flushed
+            .then(() => logDebug('[relay-seeder] discovery flushed', { label, discoveryKey: discoveryKeyHex.slice(0, 16) }))
+            .catch((err) => logDebug('[relay-seeder] discovery flush failed', { label, error: err?.message || String(err) }))
+        }
+      } catch {}
+      return handle
+    } catch (err) {
+      logWarn('[relay-seeder] failed to join discovery', { label, error: err?.message || String(err) })
+      return null
+    }
+  }
+
+  async function resolveBlobCore(keyHex) {
+    if (!isValidHexKey(keyHex) || !ctx.store || typeof ctx.store.get !== 'function') return null
+    try {
+      const core = ctx.store.get(b4a.from(keyHex, 'hex'))
+      await core?.ready?.()
+      return core || null
+    } catch (err) {
+      logDebug('[relay-seeder] failed to resolve blob core', { key: keyHex.slice(0, 16), error: err?.message || String(err) })
+      return null
+    }
+  }
+
+  async function seedChannel(channel) {
+    const driveKey = channel?.driveKey || channel?.channelKey
+    const publicBeeKey = channel?.publicBeeKey || null
+    const stats = emptyStats()
+
+    if (!driveKey || !publicBeeKey) return stats
+
+    try {
+      const bee = await loadPublicBee(ctx, publicBeeKey)
+      if (bee?.core?.discoveryKey) {
+        retainDiscovery(bee.core.discoveryKey, `publicBee:${String(publicBeeKey).slice(0, 16)}`)
+        stats.publicBeeCores = 1
+      }
+
+      const videos = await bee?.listVideos?.().catch(() => [])
+      const blobCoreKeys = new Set()
+      if (Array.isArray(videos)) {
+        stats.videos = videos.length
+        for (const video of videos) {
+          addCoreKey(blobCoreKeys, video?.blobsCoreKey)
+          addCoreKey(blobCoreKeys, video?.thumbnailBlobsCoreKey)
+        }
+      }
+
+      for (const keyHex of blobCoreKeys) {
+        const core = await resolveBlobCore(keyHex)
+        if (core?.discoveryKey) {
+          retainDiscovery(core.discoveryKey, `blob:${keyHex.slice(0, 16)}`)
+          stats.blobCores += 1
+        }
+      }
+
+      stats.channels = 1
+      stats.discoveryHandles = handles.size
+      stats.lastSeededAt = Date.now()
+      seededChannels.set(driveKey, {
+        driveKey,
+        publicBeeKey,
+        videos: stats.videos,
+        publicBeeCores: stats.publicBeeCores,
+        blobCores: stats.blobCores,
+        lastSeededAt: stats.lastSeededAt,
+        lastError: null
+      })
+      logInfo('[relay-seeder] channel seeded', {
+        driveKey,
+        videos: stats.videos,
+        blobCores: stats.blobCores,
+        discoveryHandles: handles.size
+      })
+      return stats
+    } catch (err) {
+      stats.lastError = err?.message || String(err)
+      seededChannels.set(driveKey, {
+        driveKey,
+        publicBeeKey,
+        videos: 0,
+        publicBeeCores: 0,
+        blobCores: 0,
+        lastSeededAt: null,
+        lastError: stats.lastError
+      })
+      logWarn('[relay-seeder] channel seed failed', { driveKey, error: stats.lastError })
+      return stats
+    }
+  }
+
+  async function seedCachedChannels(cacheManager) {
+    const channels = cacheManager?.getChannels?.() || []
+    const seen = new Set()
+    for (const channel of channels) {
+      const driveKey = channel?.driveKey || channel?.channelKey
+      if (!driveKey || seen.has(driveKey)) continue
+      seen.add(driveKey)
+      await seedChannel(channel)
+    }
+    return getStats()
+  }
+
+  function getStats() {
+    const stats = emptyStats()
+    stats.channels = seededChannels.size
+    stats.discoveryHandles = handles.size
+    for (const channel of seededChannels.values()) {
+      stats.videos += Number(channel.videos || 0)
+      stats.publicBeeCores += Number(channel.publicBeeCores || 0)
+      stats.blobCores += Number(channel.blobCores || 0)
+      if (channel.lastSeededAt && (!stats.lastSeededAt || channel.lastSeededAt > stats.lastSeededAt)) {
+        stats.lastSeededAt = channel.lastSeededAt
+      }
+      if (channel.lastError) stats.lastError = channel.lastError
+    }
+    return cloneStats(stats)
+  }
+
+  async function close() {
+    for (const handle of handles.values()) {
+      try { await handle?.destroy?.() } catch {}
+      try { await handle?.close?.() } catch {}
+    }
+    handles.clear()
+    seededChannels.clear()
+  }
+
+  return {
+    retainDiscovery,
+    seedChannel,
+    seedCachedChannels,
+    getStats,
+    close
+  }
+}

--- a/packages/cli/src/seeding.js
+++ b/packages/cli/src/seeding.js
@@ -53,7 +53,9 @@ export function createRelaySeeder({ ctx, loadPublicBee, logger = {} }) {
             .then(() => logDebug('[relay-seeder] discovery flushed', { label, discoveryKey: discoveryKeyHex.slice(0, 16) }))
             .catch((err) => logDebug('[relay-seeder] discovery flush failed', { label, error: err?.message || String(err) }))
         }
-      } catch {}
+      } catch (err) {
+        logDebug('[relay-seeder] discovery flush setup failed', { label, error: err?.message || String(err) })
+      }
       return handle
     } catch (err) {
       logWarn('[relay-seeder] failed to join discovery', { label, error: err?.message || String(err) })
@@ -170,8 +172,16 @@ export function createRelaySeeder({ ctx, loadPublicBee, logger = {} }) {
 
   async function close() {
     for (const handle of handles.values()) {
-      try { await handle?.destroy?.() } catch {}
-      try { await handle?.close?.() } catch {}
+      try {
+        await handle?.destroy?.()
+      } catch (err) {
+        logDebug('[relay-seeder] discovery handle destroy failed', { error: err?.message || String(err) })
+      }
+      try {
+        await handle?.close?.()
+      } catch (err) {
+        logDebug('[relay-seeder] discovery handle close failed', { error: err?.message || String(err) })
+      }
     }
     handles.clear()
     seededChannels.clear()

--- a/packages/cli/src/service.js
+++ b/packages/cli/src/service.js
@@ -107,6 +107,10 @@ export async function createRelayService({
       if (resolved.publicBeeKey) {
         await runtime.cacheManager?.addChannel?.(resolved.channelKey, resolved.publicBeeKey, 'discovered').catch(() => {})
         await runtime.publicFeed?.submitChannel?.(resolved.channelKey, resolved.publicBeeKey).catch(() => {})
+        await runtime.seeder?.seedChannel?.({
+          driveKey: resolved.channelKey,
+          publicBeeKey: resolved.publicBeeKey
+        }).catch(() => {})
       }
 
       logger.mirror.info('Channel mirrored', {

--- a/packages/cli/src/status.js
+++ b/packages/cli/src/status.js
@@ -30,7 +30,21 @@ export function buildRelayStatus({ config, catalog, runtimeStats = {} }) {
       connections: runtimeStats.connections || 0,
       feedPeers: runtimeStats.feedPeers || 0,
       feedConnections: runtimeStats.feedConnections || 0,
-      feedEntries: runtimeStats.feedEntries || 0
+      feedEntries: runtimeStats.feedEntries || 0,
+      dht: {
+        bootstrapped: runtimeStats.dht?.bootstrapped ?? null,
+        firewalled: runtimeStats.dht?.firewalled ?? null,
+        online: runtimeStats.dht?.online ?? null
+      },
+      seeding: {
+        channels: runtimeStats.seeding?.channels || 0,
+        videos: runtimeStats.seeding?.videos || 0,
+        publicBeeCores: runtimeStats.seeding?.publicBeeCores || 0,
+        blobCores: runtimeStats.seeding?.blobCores || 0,
+        discoveryHandles: runtimeStats.seeding?.discoveryHandles || 0,
+        lastSeededAt: runtimeStats.seeding?.lastSeededAt || null,
+        lastError: runtimeStats.seeding?.lastError || null
+      }
     },
     evictionCandidates: sortEvictionCandidates(channels).map((channel) => ({
       channelKey: channel.channelKey,
@@ -64,7 +78,9 @@ export function formatRelayStatus(status) {
     `connections: ${status.runtime.connections}`,
     `feedPeers: ${status.runtime.feedPeers}`,
     `feedConnections: ${status.runtime.feedConnections}`,
-    `feedEntries: ${status.runtime.feedEntries}`
+    `feedEntries: ${status.runtime.feedEntries}`,
+    `dht: bootstrapped=${status.runtime.dht.bootstrapped} firewalled=${status.runtime.dht.firewalled} online=${status.runtime.dht.online}`,
+    `seeding: channels=${status.runtime.seeding.channels} videos=${status.runtime.seeding.videos} publicBeeCores=${status.runtime.seeding.publicBeeCores} blobCores=${status.runtime.seeding.blobCores} discoveryHandles=${status.runtime.seeding.discoveryHandles}`
   ]
 
   if (status.evictionCandidates.length > 0) {

--- a/packages/cli/test/relay-seeding.test.mjs
+++ b/packages/cli/test/relay-seeding.test.mjs
@@ -1,0 +1,170 @@
+import test from 'brittle'
+import { createRelaySeeder } from '../src/seeding.js'
+import { buildRelayStatus, formatRelayStatus } from '../src/status.js'
+
+function createCore(keyHex, discoveryKey = `discovery:${keyHex}`) {
+  return {
+    key: Buffer.from(keyHex.padEnd(64, '0').slice(0, 64), 'hex'),
+    discoveryKey,
+    readyCalls: 0,
+    async ready() {
+      this.readyCalls += 1
+    }
+  }
+}
+
+function createSwarm() {
+  return {
+    joins: [],
+    join(discoveryKey, opts) {
+      this.joins.push({ discoveryKey, opts })
+      return {
+        discoveryKey,
+        opts,
+        flushed() {
+          return Promise.resolve()
+        },
+        destroy() {}
+      }
+    }
+  }
+}
+
+test('relay seeder retains PublicBee and blob-core discovery handles for mirrored channels', async (t) => {
+  const publicBeeCore = createCore('11')
+  const videoCore = createCore('22')
+  const thumbnailCore = createCore('33')
+  const swarm = createSwarm()
+  const store = {
+    getCalls: [],
+    get(key) {
+      const keyHex = Buffer.isBuffer(key) ? key.toString('hex') : String(key)
+      this.getCalls.push(keyHex)
+      if (keyHex.startsWith('22')) return videoCore
+      if (keyHex.startsWith('33')) return thumbnailCore
+      throw new Error(`unexpected core key ${keyHex}`)
+    }
+  }
+  const ctx = { swarm, store }
+  const publicBee = {
+    core: publicBeeCore,
+    async listVideos() {
+      return [
+        {
+          id: 'video-1',
+          blobsCoreKey: '22'.padEnd(64, '0'),
+          thumbnailBlobsCoreKey: '33'.padEnd(64, '0'),
+          blobId: '0:1:0:10',
+          thumbnailBlobId: '1:1:0:5'
+        }
+      ]
+    }
+  }
+  const seeder = createRelaySeeder({
+    ctx,
+    loadPublicBee: async () => publicBee,
+    logger: { info() {}, warn() {}, debug() {} }
+  })
+
+  const stats = await seeder.seedChannel({
+    driveKey: 'aa'.padEnd(64, '0'),
+    publicBeeKey: 'bb'.padEnd(64, '0')
+  })
+
+  t.is(stats.channels, 1)
+  t.is(stats.videos, 1)
+  t.is(stats.publicBeeCores, 1)
+  t.is(stats.blobCores, 2)
+  t.alike(swarm.joins.map((join) => join.discoveryKey), [
+    publicBeeCore.discoveryKey,
+    videoCore.discoveryKey,
+    thumbnailCore.discoveryKey
+  ])
+  t.alike(swarm.joins.map((join) => join.opts), [
+    { server: true, client: true },
+    { server: true, client: true },
+    { server: true, client: true }
+  ])
+
+  const snapshot = seeder.getStats()
+  t.is(snapshot.channels, 1)
+  t.is(snapshot.videos, 1)
+  t.is(snapshot.publicBeeCores, 1)
+  t.is(snapshot.blobCores, 2)
+  t.is(snapshot.discoveryHandles, 3)
+})
+
+test('relay seeder refreshes all cached channels and deduplicates retained joins', async (t) => {
+  const publicBeeCore = createCore('44')
+  const blobCore = createCore('55')
+  const swarm = createSwarm()
+  const ctx = {
+    swarm,
+    store: {
+      get() { return blobCore }
+    }
+  }
+  const seeder = createRelaySeeder({
+    ctx,
+    loadPublicBee: async () => ({
+      core: publicBeeCore,
+      async listVideos() {
+        return [{ id: 'video-1', blobsCoreKey: '55'.padEnd(64, '0'), blobId: '0:1:0:10' }]
+      }
+    }),
+    logger: { info() {}, warn() {}, debug() {} }
+  })
+  const cacheManager = {
+    getChannels() {
+      return [
+        { driveKey: 'aa'.padEnd(64, '0'), publicBeeKey: 'bb'.padEnd(64, '0') },
+        { driveKey: 'aa'.padEnd(64, '0'), publicBeeKey: 'bb'.padEnd(64, '0') }
+      ]
+    }
+  }
+
+  const stats = await seeder.seedCachedChannels(cacheManager)
+
+  t.is(stats.channels, 1)
+  t.is(stats.videos, 1)
+  t.is(stats.discoveryHandles, 2)
+  t.is(swarm.joins.length, 2)
+})
+
+test('relay status surfaces DHT and seeding stats for phone connectivity diagnostics', async (t) => {
+  const status = buildRelayStatus({
+    config: {
+      mode: 'public',
+      policy: 'discovery',
+      storage: { path: '/tmp/relay', maxBytes: 1000 }
+    },
+    catalog: {
+      getChannels() { return [] },
+      getSummary() { return { totalChannels: 0, protectedChannels: 0, usedBytes: 0 } }
+    },
+    runtimeStats: {
+      peers: 2,
+      connections: 1,
+      feedPeers: 1,
+      feedConnections: 1,
+      feedEntries: 3,
+      dht: { bootstrapped: true, firewalled: false, online: true },
+      seeding: { channels: 2, videos: 5, publicBeeCores: 2, blobCores: 8, discoveryHandles: 10 }
+    }
+  })
+
+  t.alike(status.runtime.dht, { bootstrapped: true, firewalled: false, online: true })
+  t.alike(status.runtime.seeding, {
+    channels: 2,
+    videos: 5,
+    publicBeeCores: 2,
+    blobCores: 8,
+    discoveryHandles: 10,
+    lastSeededAt: null,
+    lastError: null
+  })
+
+  const formatted = formatRelayStatus(status)
+  t.ok(formatted.includes('dht: bootstrapped=true firewalled=false online=true'))
+  t.ok(formatted.includes('seeding: channels=2 videos=5 publicBeeCores=2 blobCores=8 discoveryHandles=10'))
+})


### PR DESCRIPTION
## Summary
- Adds a relay seeder that keeps PublicBee and blob-core discovery handles retained for mirrored channels
- Seeds cached relay channels at startup and after mirroring so phones can discover stable serving peers
- Expands relay status with DHT and seeding diagnostics for phone connectivity debugging

## Test Plan
- node --test packages/cli/test/relay-seeding.test.mjs packages/cli/test/cli.test.mjs
- git diff --check
- npm run lint:changed