### PR TITLE
feat(app): add vertical discovery feed

### DIFF
--- a/packages/app/app/(tabs)/_layout.tsx
+++ b/packages/app/app/(tabs)/_layout.tsx
@@ -36,6 +36,7 @@ export default function TabLayout() {
         tabBar={() => <PillTabBar />}
       >
         <Tabs.Screen name="index" />
+        <Tabs.Screen name="discover" />
         <Tabs.Screen name="subscriptions" />
         <Tabs.Screen name="studio" />
         <Tabs.Screen name="downloads" />

--- a/packages/app/app/(tabs)/discover.tsx
+++ b/packages/app/app/(tabs)/discover.tsx
@@ -1,0 +1,625 @@
+/**
+ * Vertical Discovery - Twitter-style full-screen video doomscroll mode.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  ActivityIndicator,
+  FlatList,
+  ImageBackground,
+  NativeScrollEvent,
+  NativeSyntheticEvent,
+  Platform,
+  Pressable,
+  RefreshControl,
+  StyleSheet,
+  Text,
+  useWindowDimensions,
+  View,
+  ViewToken,
+} from 'react-native'
+import { useRouter } from 'expo-router'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { Feather } from '@expo/vector-icons'
+import type { VideoData } from '@peartube/core'
+import { useApp } from '../_layout'
+import { usePlatform } from '@/lib/PlatformProvider'
+import { useVideoPlayerContext } from '@/lib/VideoPlayerContext'
+import { colors } from '@/lib/colors'
+import { fetchThumbnailUrlWithRetry } from '@/lib/thumbnail'
+import { getFeedPreviewVideos, getVisibleSeededFeedEntries, shouldRenderFeedVideo } from '@/lib/feed-hydration'
+import { getCachedVideoUrl, makeVideoUrlCacheKey, setCachedVideoUrl } from '@/lib/video-url-cache'
+import { formatTimeAgo } from '@/lib/formatters'
+
+interface FeedEntry {
+  driveKey: string
+  channelKey?: string
+  publicBeeKey?: string
+  channelName?: string | null
+  previewVideos?: Array<{
+    id: string
+    title?: string
+    uploadedAt?: number
+    duration?: number
+    thumbnail?: string | null
+    blobId?: string | null
+    blobsCoreKey?: string | null
+    mimeType?: string | null
+    availability?: 'playable' | 'unavailable' | 'unknown'
+    thumbnailBlobId?: string | null
+    thumbnailBlobsCoreKey?: string | null
+    thumbnailMimeType?: string | null
+  }>
+}
+
+function withTimeout<T>(promise: Promise<T>, ms: number, fallback: T): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<T>((resolve) => setTimeout(() => resolve(fallback), ms)),
+  ])
+}
+
+function getVideoRef(video: VideoData) {
+  return video.path && typeof video.path === 'string' && video.path.startsWith('/')
+    ? video.path
+    : video.id
+}
+
+function makeRouteVideoData(video: VideoData) {
+  return JSON.stringify({
+    id: video.id,
+    title: video.title,
+    description: video.description,
+    channelKey: video.channelKey,
+    publicBeeKey: (video as any).publicBeeKey || undefined,
+    path: video.path,
+    size: video.size,
+    duration: video.duration,
+    uploadedAt: video.uploadedAt,
+    thumbnail: (video as any).thumbnail,
+    thumbnailUrl: video.thumbnailUrl,
+    blobId: (video as any).blobId || undefined,
+    blobsCoreKey: (video as any).blobsCoreKey || undefined,
+    mimeType: (video as any).mimeType || undefined,
+    channel: video.channel,
+  })
+}
+
+export default function VerticalDiscoveryScreen() {
+  const router = useRouter()
+  const insets = useSafeAreaInsets()
+  const { height: screenHeight, width: screenWidth } = useWindowDimensions()
+  const { isDesktop } = usePlatform()
+  const { ready, identity, rpc, blobServerPort, backendError, startupStatus } = useApp()
+  const { currentVideo, videoUrl, isLoading, loadAndPlayVideo } = useVideoPlayerContext()
+
+  const pageHeight = Math.max(1, screenHeight - insets.top)
+  const [refreshing, setRefreshing] = useState(false)
+  const [feedLoading, setFeedLoading] = useState(false)
+  const [feedEntries, setFeedEntries] = useState<FeedEntry[]>([])
+  const [videos, setVideos] = useState<VideoData[]>([])
+  const [thumbnailCache, setThumbnailCache] = useState<Record<string, string>>({})
+  const [activeIndex, setActiveIndex] = useState(0)
+  const pendingPlayKeyRef = useRef<string | null>(null)
+  const hydratedChannelsRef = useRef<Set<string>>(new Set())
+
+  const activeVideo = videos[activeIndex]
+  const activeVideoKey = activeVideo ? `${activeVideo.channelKey}:${activeVideo.id}` : null
+  const currentVideoKey = currentVideo ? `${currentVideo.channelKey}:${currentVideo.id}` : null
+
+  const fetchThumbnailsForVideos = useCallback(async (items: VideoData[]) => {
+    if (!rpc || !blobServerPort) return
+    const targets = items.slice(0, 12)
+    for (const video of targets) {
+      const cacheKey = `${video.channelKey}:${video.id}`
+      if (thumbnailCache[cacheKey]) continue
+      try {
+        const url = await fetchThumbnailUrlWithRetry({
+          rpc,
+          channelKey: video.channelKey,
+          videoId: video.id,
+          expectedPort: blobServerPort,
+        })
+        if (url) {
+          setThumbnailCache((prev) => ({ ...prev, [cacheKey]: url }))
+        }
+      } catch (err) {
+        console.log('[VerticalDiscovery] Thumbnail resolve failed:', (err as any)?.message || err)
+      }
+    }
+  }, [blobServerPort, rpc, thumbnailCache])
+
+  const seedFromFeedEntries = useCallback((entries: FeedEntry[]) => {
+    const visibleEntries = getVisibleSeededFeedEntries(entries as any)
+    const previewVideos = getFeedPreviewVideos(visibleEntries as any, {
+      identityDriveKey: identity?.driveKey || undefined,
+      channelMeta: {},
+    }) as VideoData[]
+
+    const renderable = previewVideos
+      .filter((video) => shouldRenderFeedVideo({
+        video,
+        identityDriveKey: identity?.driveKey || undefined,
+      }))
+      .slice(0, 40)
+
+    if (renderable.length > 0) {
+      setVideos((prev) => {
+        const seen = new Set<string>()
+        const merged = [...prev, ...renderable].filter((video) => {
+          const key = `${video.channelKey}:${video.id}`
+          if (seen.has(key)) return false
+          seen.add(key)
+          return true
+        })
+        return merged
+      })
+      void fetchThumbnailsForVideos(renderable)
+    }
+  }, [fetchThumbnailsForVideos, identity?.driveKey])
+
+  const hydrateChannelVideos = useCallback(async (entry: FeedEntry) => {
+    if (!rpc) return
+    const channelKey = entry.channelKey || entry.driveKey
+    if (!channelKey || hydratedChannelsRef.current.has(channelKey)) return
+    hydratedChannelsRef.current.add(channelKey)
+
+    try {
+      const result = await withTimeout(
+        rpc.listVideos({ channelKey, publicBeeKey: entry.publicBeeKey || undefined }),
+        3500,
+        { videos: [] } as any,
+      )
+      const channelVideos = Array.isArray((result as any)?.videos) ? (result as any).videos : []
+      const mapped = channelVideos
+        .filter((video: any) => shouldRenderFeedVideo({
+          video: { ...video, channelKey },
+          identityDriveKey: identity?.driveKey || undefined,
+        }))
+        .map((video: any) => ({
+          ...video,
+          channelKey,
+          publicBeeKey: entry.publicBeeKey || undefined,
+          channel: { name: entry.channelName || 'Channel' },
+        }))
+
+      if (mapped.length > 0) {
+        setVideos((prev) => {
+          const byKey = new Map<string, VideoData>()
+          for (const video of [...prev, ...mapped]) byKey.set(`${video.channelKey}:${video.id}`, video)
+          return Array.from(byKey.values()).slice(0, 80)
+        })
+        void fetchThumbnailsForVideos(mapped)
+      }
+    } catch (err) {
+      console.log('[VerticalDiscovery] Channel hydration failed:', (err as any)?.message || err)
+    }
+  }, [fetchThumbnailsForVideos, identity?.driveKey, rpc])
+
+  const loadFeed = useCallback(async () => {
+    if (!rpc) return
+    setFeedLoading(true)
+    try {
+      const result = await withTimeout(rpc.getPublicFeed({}), 4000, { entries: [] } as any)
+      const entries = Array.isArray((result as any)?.entries) ? (result as any).entries : []
+      setFeedEntries(entries)
+      seedFromFeedEntries(entries)
+      for (const entry of entries.slice(0, 8)) {
+        void hydrateChannelVideos(entry)
+      }
+    } catch (err) {
+      console.log('[VerticalDiscovery] Feed load failed:', (err as any)?.message || err)
+    } finally {
+      setFeedLoading(false)
+    }
+  }, [hydrateChannelVideos, rpc, seedFromFeedEntries])
+
+  useEffect(() => {
+    if (!ready || !rpc) return
+    loadFeed()
+  }, [loadFeed, ready, rpc])
+
+  const playVideo = useCallback(async (video: VideoData) => {
+    if (!rpc) return
+    const videoRef = getVideoRef(video)
+    const videoAny = video as any
+    const cacheKey = makeVideoUrlCacheKey(
+      video.channelKey,
+      videoRef,
+      videoAny.blobId || undefined,
+      videoAny.blobsCoreKey || undefined,
+    )
+    const playKey = `${video.channelKey}:${video.id}`
+    if (pendingPlayKeyRef.current === playKey) return
+    pendingPlayKeyRef.current = playKey
+
+    const playbackRequest = {
+      channelKey: video.channelKey,
+      videoId: videoRef,
+      publicBeeKey: videoAny.publicBeeKey || undefined,
+      blobId: videoAny.blobId || undefined,
+      blobsCoreKey: videoAny.blobsCoreKey || undefined,
+      mimeType: videoAny.mimeType || undefined,
+    }
+
+    try {
+      const cachedUrl = cacheKey ? getCachedVideoUrl(cacheKey) : null
+      if (cachedUrl) {
+        void rpc.preparePlayback(playbackRequest).catch(() => undefined)
+        loadAndPlayVideo(video, cachedUrl)
+        return
+      }
+      const result = await rpc.preparePlayback(playbackRequest)
+      if (result?.url) {
+        if (cacheKey) setCachedVideoUrl(cacheKey, result.url)
+        loadAndPlayVideo(video, result.url)
+      }
+    } catch (err) {
+      console.log('[VerticalDiscovery] Playback failed:', (err as any)?.message || err)
+    } finally {
+      pendingPlayKeyRef.current = null
+    }
+  }, [loadAndPlayVideo, rpc])
+
+  useEffect(() => {
+    if (!activeVideo || !ready) return
+    void playVideo(activeVideo)
+  }, [activeVideo, playVideo, ready])
+
+  useEffect(() => {
+    const nextVideos = videos.slice(activeIndex + 1, activeIndex + 3)
+    for (const video of nextVideos) {
+      const videoAny = video as any
+      const videoRef = getVideoRef(video)
+      const playbackRequest = {
+        channelKey: video.channelKey,
+        videoId: videoRef,
+        publicBeeKey: videoAny.publicBeeKey || undefined,
+        blobId: videoAny.blobId || undefined,
+        blobsCoreKey: videoAny.blobsCoreKey || undefined,
+        mimeType: videoAny.mimeType || undefined,
+      }
+      void rpc?.preparePlayback?.(playbackRequest).catch(() => undefined)
+    }
+  }, [activeIndex, rpc, videos])
+
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true)
+    hydratedChannelsRef.current.clear()
+    try {
+      await rpc?.refreshFeed?.({})
+      await loadFeed()
+    } finally {
+      setRefreshing(false)
+    }
+  }, [loadFeed, rpc])
+
+  const onMomentumScrollEnd = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    const nextIndex = Math.max(0, Math.round(event.nativeEvent.contentOffset.y / pageHeight))
+    setActiveIndex(nextIndex)
+  }, [pageHeight])
+
+  const onViewableItemsChanged = useRef(({ viewableItems }: { viewableItems: ViewToken[] }) => {
+    const firstVisible = viewableItems.find((item) => item.index !== null)
+    if (typeof firstVisible?.index === 'number') {
+      setActiveIndex(firstVisible.index)
+    }
+  }).current
+
+  const viewabilityConfig = useRef({
+    itemVisiblePercentThreshold: 70,
+    minimumViewTime: 120,
+  }).current
+
+  const openChannel = useCallback((video: VideoData) => {
+    if (!video.channelKey) return
+    router.push({
+      pathname: '/channel/[key]',
+      params: { key: video.channelKey, publicBeeKey: (video as any).publicBeeKey || undefined },
+    })
+  }, [router])
+
+  const openDetails = useCallback((video: VideoData) => {
+    router.push({
+      pathname: '/video/[id]',
+      params: {
+        id: video.id,
+        channel: video.channelKey,
+        publicBeeKey: (video as any).publicBeeKey || undefined,
+        videoData: makeRouteVideoData(video),
+      },
+    })
+  }, [router])
+
+  const verticalVideos = useMemo(() => videos.map((video) => {
+    const cacheKey = `${video.channelKey}:${video.id}`
+    return {
+      ...video,
+      thumbnailUrl: thumbnailCache[cacheKey] || video.thumbnailUrl || (video as any).thumbnail || null,
+    }
+  }), [thumbnailCache, videos])
+
+  if (isDesktop) {
+    return (
+      <View style={styles.centerState}>
+        <Text style={styles.centerTitle}>Vertical discovery is mobile-first.</Text>
+        <Text style={styles.centerBody}>Use Home on desktop for the grid feed.</Text>
+      </View>
+    )
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={[styles.topChrome, { paddingTop: Math.max(insets.top, 10) }]}> 
+        <View>
+          <Text style={styles.eyebrow}>PearTube</Text>
+          <Text style={styles.title}>Discover</Text>
+        </View>
+        <View style={styles.topActions}>
+          {feedEntries.length > 0 ? (
+            <View style={styles.feedPill}>
+              <Feather name="radio" color={colors.primary} size={12} />
+              <Text style={styles.feedPillText}>{feedEntries.length}</Text>
+            </View>
+          ) : null}
+          <Pressable onPress={onRefresh} style={styles.roundButton} disabled={refreshing || feedLoading}>
+            <Feather name="refresh-cw" color={colors.text} size={18} />
+          </Pressable>
+        </View>
+      </View>
+
+      {verticalVideos.length === 0 ? (
+        <View style={styles.centerState}>
+          {feedLoading || !ready ? <ActivityIndicator color={colors.primary} size="large" /> : null}
+          <Text style={styles.centerTitle}>
+            {backendError ? 'Backend error' : ready ? 'No videos discovered yet' : (startupStatus || 'Connecting to P2P network…')}
+          </Text>
+          <Text style={styles.centerBody}>
+            {backendError || 'Pull down to refresh, or wait for peers to announce channels.'}
+          </Text>
+        </View>
+      ) : (
+        <FlatList
+          data={verticalVideos}
+          keyExtractor={(item) => `${item.channelKey}:${item.id}`}
+          pagingEnabled
+          snapToInterval={pageHeight}
+          decelerationRate="fast"
+          showsVerticalScrollIndicator={false}
+          onMomentumScrollEnd={onMomentumScrollEnd}
+          onViewableItemsChanged={onViewableItemsChanged}
+          viewabilityConfig={viewabilityConfig}
+          refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={colors.primary} />}
+          getItemLayout={(_, index) => ({ length: pageHeight, offset: pageHeight * index, index })}
+          renderItem={({ item: video, index }) => (
+            <View style={[styles.page, { height: pageHeight, width: screenWidth }]} testID={index === 0 ? 'vertical-discovery-first-video' : undefined}>
+              <ImageBackground
+                source={video.thumbnailUrl ? { uri: video.thumbnailUrl } : undefined}
+                style={styles.backdrop}
+                imageStyle={styles.backdropImage}
+              >
+                <View style={styles.scrim} />
+                <View style={styles.videoStage}>
+                  {activeVideoKey === `${video.channelKey}:${video.id}` && currentVideoKey === activeVideoKey && videoUrl && !isLoading ? (
+                    <View style={styles.playingFrame}>
+                      <Text style={styles.playingText}>Playing</Text>
+                    </View>
+                  ) : (
+                    <View style={styles.playButtonShell}>
+                      <Feather name="play" color="#fff" size={42} />
+                    </View>
+                  )}
+                </View>
+                <View style={[styles.bottomMeta, { paddingBottom: Math.max(insets.bottom + 86, 104) }]}> 
+                  <Pressable onPress={() => openDetails(video)} style={styles.metaTextBlock}>
+                    <Text style={styles.videoTitle} numberOfLines={2}>{video.title || 'Untitled'}</Text>
+                    <Text style={styles.videoMeta} numberOfLines={1}>
+                      {video.channel?.name || 'Channel'} · {formatTimeAgo(video.uploadedAt || Date.now())}
+                    </Text>
+                    {video.description ? (
+                      <Text style={styles.videoDescription} numberOfLines={2}>{video.description}</Text>
+                    ) : null}
+                  </Pressable>
+                  <View style={styles.sideRail}>
+                    <Pressable onPress={() => openChannel(video)} style={styles.sideButton}>
+                      <Feather name="user" color="#fff" size={24} />
+                      <Text style={styles.sideLabel}>Channel</Text>
+                    </Pressable>
+                    <Pressable onPress={() => openDetails(video)} style={styles.sideButton}>
+                      <Feather name="message-circle" color="#fff" size={24} />
+                      <Text style={styles.sideLabel}>Details</Text>
+                    </Pressable>
+                    <Pressable onPress={() => playVideo(video)} style={styles.sideButton}>
+                      <Feather name="rotate-cw" color="#fff" size={24} />
+                      <Text style={styles.sideLabel}>Replay</Text>
+                    </Pressable>
+                  </View>
+                </View>
+              </ImageBackground>
+            </View>
+          )}
+        />
+      )}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#050607',
+  },
+  topChrome: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    zIndex: 10,
+    paddingHorizontal: 18,
+    paddingBottom: 12,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  eyebrow: {
+    color: colors.primary,
+    fontSize: 12,
+    fontWeight: '700',
+    letterSpacing: 1.8,
+    textTransform: 'uppercase',
+  },
+  title: {
+    color: '#fff',
+    fontSize: 28,
+    fontWeight: '800',
+    letterSpacing: -0.8,
+  },
+  topActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+  },
+  feedPill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 5,
+    paddingHorizontal: 10,
+    paddingVertical: 7,
+    borderRadius: 999,
+    backgroundColor: 'rgba(255,255,255,0.1)',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.14)',
+  },
+  feedPillText: {
+    color: '#fff',
+    fontSize: 12,
+    fontWeight: '700',
+  },
+  roundButton: {
+    width: 38,
+    height: 38,
+    borderRadius: 19,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(255,255,255,0.1)',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.14)',
+  },
+  page: {
+    backgroundColor: '#050607',
+  },
+  backdrop: {
+    flex: 1,
+    justifyContent: 'center',
+  },
+  backdropImage: {
+    opacity: 0.48,
+    resizeMode: 'cover',
+  },
+  scrim: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0,0,0,0.38)',
+  },
+  videoStage: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+  },
+  playingFrame: {
+    width: '78%',
+    aspectRatio: 9 / 16,
+    maxHeight: '66%',
+    borderRadius: 28,
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.18)',
+    backgroundColor: 'rgba(0,0,0,0.34)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  playingText: {
+    color: colors.primary,
+    fontSize: 13,
+    fontWeight: '800',
+    textTransform: 'uppercase',
+    letterSpacing: 1.5,
+  },
+  playButtonShell: {
+    width: 86,
+    height: 86,
+    borderRadius: 43,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(255,255,255,0.13)',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.18)',
+  },
+  bottomMeta: {
+    position: 'absolute',
+    left: 18,
+    right: 16,
+    bottom: 0,
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    gap: 14,
+  },
+  metaTextBlock: {
+    flex: 1,
+    paddingRight: 4,
+  },
+  videoTitle: {
+    color: '#fff',
+    fontSize: 22,
+    fontWeight: '800',
+    letterSpacing: -0.5,
+    textShadowColor: 'rgba(0,0,0,0.45)',
+    textShadowOffset: { width: 0, height: 1 },
+    textShadowRadius: 6,
+  },
+  videoMeta: {
+    color: 'rgba(255,255,255,0.78)',
+    fontSize: 13,
+    fontWeight: '600',
+    marginTop: 8,
+  },
+  videoDescription: {
+    color: 'rgba(255,255,255,0.72)',
+    fontSize: 14,
+    lineHeight: 19,
+    marginTop: 8,
+  },
+  sideRail: {
+    width: 72,
+    alignItems: 'center',
+    gap: 20,
+  },
+  sideButton: {
+    alignItems: 'center',
+    gap: 6,
+  },
+  sideLabel: {
+    color: 'rgba(255,255,255,0.82)',
+    fontSize: 11,
+    fontWeight: '700',
+  },
+  centerState: {
+    flex: 1,
+    backgroundColor: '#050607',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 28,
+  },
+  centerTitle: {
+    color: '#fff',
+    fontSize: 18,
+    fontWeight: '800',
+    marginTop: 14,
+    textAlign: 'center',
+  },
+  centerBody: {
+    color: colors.textMuted,
+    fontSize: 14,
+    lineHeight: 20,
+    marginTop: 8,
+    textAlign: 'center',
+  },
+})

--- a/packages/app/components/PillTabBar.tsx
+++ b/packages/app/components/PillTabBar.tsx
@@ -35,6 +35,7 @@ interface TabItem {
 
 const TABS: TabItem[] = [
   { name: 'index', path: '/', icon: 'home', label: 'Home' },
+  { name: 'discover', path: '/discover', icon: 'zap', label: 'Discover' },
   { name: 'subscriptions', path: '/subscriptions', icon: 'users', label: 'Subs' },
   { name: 'studio', path: '/studio', icon: 'plus-circle', label: 'Studio', emphasized: true },
   { name: 'downloads', path: '/downloads', icon: 'download', label: 'Downloads' },

--- a/packages/app/tests/vertical-discovery-regression.test.mjs
+++ b/packages/app/tests/vertical-discovery-regression.test.mjs
@@ -1,0 +1,45 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const appRoot = path.resolve(__dirname, '..')
+
+function readAppFile(relativePath) {
+  return fs.readFileSync(path.join(appRoot, relativePath), 'utf8')
+}
+
+test('native tabs expose a vertical discovery doomscroll surface', () => {
+  const tabsLayout = readAppFile('app/(tabs)/_layout.tsx')
+  const tabBar = readAppFile('components/PillTabBar.tsx')
+
+  assert.match(tabsLayout, /<Tabs\.Screen name="discover"/, 'discover tab route should be registered')
+  assert.match(tabBar, /path:\s*'\/discover'/, 'bottom nav should link to vertical discovery')
+  assert.match(tabBar, /icon:\s*'zap'/, 'vertical discovery should have a fast-mode tab icon')
+})
+
+test('vertical discovery uses paged full-screen feed and opens current item through shared player path', () => {
+  const source = readAppFile('app/(tabs)/discover.tsx')
+
+  assert.match(source, /FlatList/, 'vertical discovery should use FlatList for a swipe feed')
+  assert.match(source, /pagingEnabled/, 'vertical discovery should page one video at a time')
+  assert.match(source, /snapToInterval=\{pageHeight\}/, 'vertical discovery should snap to full-screen item height')
+  assert.match(source, /onViewableItemsChanged/, 'vertical discovery should track the active page')
+  assert.match(source, /viewabilityConfig/, 'vertical discovery should use explicit viewability thresholds')
+  assert.match(source, /loadAndPlayVideo\(video, result\.url\)/, 'current vertical item should use shared player context')
+  assert.match(source, /preparePlayback\(playbackRequest\)/, 'vertical player should resolve playback through backend preparePlayback')
+  assert.match(source, /getCachedVideoUrl\(cacheKey\)/, 'vertical player should use the short playback URL cache')
+  assert.match(source, /testID=\{index === 0 \? 'vertical-discovery-first-video' : undefined\}/, 'first vertical card should keep a stable test hook')
+})
+
+test('vertical discovery keeps channel navigation and detail escape hatches', () => {
+  const source = readAppFile('app/(tabs)/discover.tsx')
+
+  assert.match(source, /router\.push\(\{\s*pathname:\s*'\/channel\/\[key\]'/, 'vertical cards should open channel pages')
+  assert.match(source, /router\.push\(\{\s*pathname:\s*'\/video\/\[id\]'/, 'vertical cards should expose full watch/details route')
+  assert.match(source, /Feather name="message-circle"/, 'vertical player should include a comments/details affordance')
+  assert.match(source, /Feather name="user"/, 'vertical player should include a channel affordance')
+})


### PR DESCRIPTION
## Summary

- Add a mobile-first vertical Discover tab for Twitter-style video doomscrolling.
- Uses a paged full-screen `FlatList` with one video per screen.
- Seeds the vertical feed from public-feed preview videos, then hydrates channel videos in the background.
- Auto-plays the active page through the existing shared player path and `preparePlayback`.
- Uses the short playback URL cache and warms the next two videos.
- Keeps channel and full watch/details escape hatches on each vertical card.

## Verification

```bash
node --test packages/app/tests/vertical-discovery-regression.test.mjs packages/app/tests/mobile-ui-redesign-regression.test.mjs packages/app/tests/channel-view-playback-regression.test.mjs
```

Result: 9 passed / 0 failed.

Also ran:

```bash
npm run lint:changed
```

Note: local `lint:changed` reported no changed files because this worktree's merge-base matched the pushed branch state after staging, so targeted source regression tests were the main verification path.
