### PR TITLE
ci: upgrade actions to Node 24 runtime

### DIFF
--- a/.github/actions/setup-node-workspace/action.yml
+++ b/.github/actions/setup-node-workspace/action.yml
@@ -15,7 +15,7 @@ runs:
   using: composite
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6.4.0
       with:
         node-version: ${{ inputs.node-version }}
 

--- a/.github/workflows/bare-mpv-prebuilds.yml
+++ b/.github/workflows/bare-mpv-prebuilds.yml
@@ -20,12 +20,12 @@ jobs:
   build-macos:
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
         with:
           submodules: recursive
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: '20'
 
@@ -51,7 +51,7 @@ jobs:
           file prebuilds/darwin-arm64/bare-mpv.bare
 
       - name: Upload prebuild artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: prebuild-darwin-arm64
           path: packages/bare-mpv/prebuilds/darwin-arm64/bare-mpv.bare
@@ -68,13 +68,13 @@ jobs:
             docker_platform: linux/arm64
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
         with:
           submodules: recursive
 
       - name: Set up QEMU (for ARM64 emulation)
         if: matrix.arch == 'arm64'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4.0.0
 
       - name: Build in Docker container
         run: |
@@ -133,7 +133,7 @@ jobs:
             "
 
       - name: Upload prebuild artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: prebuild-${{ matrix.prebuild_dir }}
           path: packages/bare-mpv/prebuilds/${{ matrix.prebuild_dir }}/
@@ -144,12 +144,12 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download all prebuilds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           pattern: prebuild-*
           path: packages/bare-mpv/prebuilds

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: macos-14
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - uses: ./.github/actions/validate-submodules
 
@@ -29,7 +29,7 @@ jobs:
           install: 'true'
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version: 1.3.11
 
@@ -52,7 +52,7 @@ jobs:
             build/PearTube-electrobun-dev-macos-arm64.zip
 
       - name: Upload Electrobun desktop app
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: peartube-electrobun-desktop
           path: packages/app/build/PearTube-electrobun-dev-macos-arm64.zip
@@ -62,7 +62,7 @@ jobs:
     runs-on: macos-14
     timeout-minutes: 75
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - uses: ./.github/actions/validate-submodules
 
@@ -88,7 +88,7 @@ jobs:
     runs-on: macos-14
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - uses: ./.github/actions/validate-submodules
 
@@ -120,7 +120,7 @@ jobs:
             archive
 
       - name: Upload native desktop archive
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: peartube-native-desktop-archive
           path: packages/desktop-native/build/PearTubeDesktop.xcarchive

--- a/.github/workflows/build-mobile.yml
+++ b/.github/workflows/build-mobile.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - uses: ./.github/actions/validate-submodules
 
@@ -29,14 +29,14 @@ jobs:
           install: 'true'
 
       - name: Setup JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5.2.0
         with:
           distribution: temurin
           java-version: 17
           cache: gradle
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v4.0.1
 
       - uses: ./.github/actions/prepare-mobile-backend
 
@@ -49,7 +49,7 @@ jobs:
         run: ./gradlew assembleDebug --no-daemon
 
       - name: Upload debug APKs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: peartube-android-debug
           path: packages/app/android/app/build/outputs/apk/**/*.apk
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - uses: ./.github/actions/validate-submodules
 
@@ -69,14 +69,14 @@ jobs:
           install: 'true'
 
       - name: Setup JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5.2.0
         with:
           distribution: temurin
           java-version: 17
           cache: gradle
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v4.0.1
 
       - uses: ./.github/actions/prepare-mobile-backend
 
@@ -89,7 +89,7 @@ jobs:
         run: ./gradlew assembleRelease bundleRelease --no-daemon
 
       - name: Upload Android release artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: peartube-android-release-artifacts
           path: |
@@ -101,7 +101,7 @@ jobs:
     runs-on: macos-14
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - uses: ./.github/actions/setup-node-workspace
         with:
@@ -133,7 +133,7 @@ jobs:
             build
 
       - name: Upload iOS simulator app
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: peartube-ios-simulator-app
           path: packages/app/ios/build/Build/Products/Debug-iphonesimulator/PearTube.app

--- a/.github/workflows/build-relay.yml
+++ b/.github/workflows/build-relay.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - uses: ./.github/actions/setup-node-workspace
         with:
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - uses: ./.github/actions/setup-node-workspace
         with:
@@ -74,13 +74,13 @@ jobs:
         run: npm run prepare:docker-artifacts --prefix packages/cli
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4.0.0
 
       - name: Build relay image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7.1.0
         with:
           context: .
           file: packages/cli/Dockerfile
@@ -97,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - uses: ./.github/actions/setup-node-workspace
         with:
@@ -114,7 +114,7 @@ jobs:
         run: npm run build:standalone:${{ matrix.host }} --prefix packages/cli
 
       - name: Upload relay standalone artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: peartube-relay-${{ matrix.host }}
           path: packages/cli/dist/standalone/${{ matrix.host }}/peartube-relay

--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
 
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - uses: ./.github/actions/setup-node-workspace
         with:
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - uses: ./.github/actions/setup-node-workspace
         with:
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - uses: ./.github/actions/setup-node-workspace
         with:

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Validate release input and signing config
         id: prep
@@ -75,14 +75,14 @@ jobs:
           install: 'true'
 
       - name: Setup JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5.2.0
         with:
           distribution: temurin
           java-version: 17
           cache: gradle
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v4.0.1
 
       - uses: ./.github/actions/prepare-mobile-backend
 
@@ -158,7 +158,7 @@ jobs:
           fi
 
       - name: Upload APK artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: peartube-${{ matrix.abi }}
           path: packages/app/android/app/build/outputs/apk/release/peartube-*.apk
@@ -173,13 +173,13 @@ jobs:
 
     steps:
       - name: Download all APK artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           path: apks
           merge-multiple: true
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3.0.0
         with:
           tag_name: ${{ github.event.inputs.tag || github.ref_name }}
           files: apks/*.apk

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
 
@@ -30,7 +30,7 @@ jobs:
           install: 'true'
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version: 1.3.11
 
@@ -61,7 +61,7 @@ jobs:
             build/PearTube-electrobun-${VERSION}.zip
 
       - name: Upload Electrobun release artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: peartube-electrobun-release
           path: packages/app/build/PearTube-electrobun-*.zip
@@ -72,7 +72,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
 
@@ -124,7 +124,7 @@ jobs:
             build/PearTube-native-desktop-${VERSION}.zip
 
       - name: Upload native desktop release artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: peartube-native-desktop-release
           path: packages/desktop-native/build/PearTube-native-desktop-*.zip
@@ -140,13 +140,13 @@ jobs:
       contents: write
     steps:
       - name: Download desktop release artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           path: release
           merge-multiple: true
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3.0.0
         with:
           tag_name: ${{ github.event.inputs.tag || github.ref_name }}
           files: release/*.zip

--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 75
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
 
@@ -74,7 +74,7 @@ jobs:
             build/PearTube-ios-simulator-${VERSION}.zip
 
       - name: Upload iOS release artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: peartube-ios-release-artifact
           path: packages/app/ios/build/PearTube-ios-simulator-*.zip
@@ -82,7 +82,7 @@ jobs:
 
       - name: Create GitHub Release
         if: startsWith(github.ref, 'refs/tags/v') || github.event.inputs.tag != ''
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3.0.0
         with:
           tag_name: ${{ github.event.inputs.tag || github.ref_name }}
           files: packages/app/ios/build/PearTube-ios-simulator-*.zip

--- a/.github/workflows/release-relay.yml
+++ b/.github/workflows/release-relay.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Validate release input
         shell: bash
@@ -99,20 +99,20 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Upload relay release artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: peartube-relay-release
           path: packages/cli/dist/release/*.tar.gz
           retention-days: 30
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4.0.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -136,7 +136,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Publish relay image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7.1.0
         with:
           context: .
           file: packages/cli/Dockerfile
@@ -146,7 +146,7 @@ jobs:
 
       - name: Create GitHub Release
         if: ${{ steps.package.outputs.release_tag != '' }}
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3.0.0
         with:
           tag_name: ${{ steps.package.outputs.release_tag }}
           files: packages/cli/dist/release/*.tar.gz

--- a/packages/app/tests/ci-workflow-split-regression.test.mjs
+++ b/packages/app/tests/ci-workflow-split-regression.test.mjs
@@ -25,7 +25,7 @@ test('build workflows stay separate from publish workflows', () => {
   )
   assert.match(
     releaseAndroid,
-    /softprops\/action-gh-release@v2/,
+    /softprops\/action-gh-release@v3\.0\.0/,
     'release-android should own GitHub release publishing',
   )
 
@@ -36,7 +36,7 @@ test('build workflows stay separate from publish workflows', () => {
   )
   assert.match(
     releaseRelay,
-    /docker\/login-action@v3/,
+    /docker\/login-action@v4\.1\.0/,
     'release-relay should own GHCR publishing',
   )
   assert.match(
@@ -49,4 +49,32 @@ test('build workflows stay separate from publish workflows', () => {
     /packages:\s*write/,
     'build-relay should not request package publish permissions',
   )
+})
+
+test('GitHub Actions references use Node 24-compatible action majors', () => {
+  const files = [
+    ...fs.readdirSync(path.join(repoRoot, '.github/workflows')).map((name) => `.github/workflows/${name}`),
+    ...fs.readdirSync(path.join(repoRoot, '.github/actions')).map((name) => `.github/actions/${name}/action.yml`),
+  ].filter((relativePath) => /\.ya?ml$/.test(relativePath))
+
+  const legacyActionRefs = [
+    /actions\/checkout@v[1-5](\D|$)/,
+    /actions\/setup-node@v[1-5](\D|$)/,
+    /actions\/setup-java@v[1-4](\D|$)/,
+    /actions\/upload-artifact@v[1-6](\D|$)/,
+    /actions\/download-artifact@v[1-7](\D|$)/,
+    /android-actions\/setup-android@v[1-3](\D|$)/,
+    /softprops\/action-gh-release@v[1-2](\D|$)/,
+    /docker\/setup-qemu-action@v[1-3](\D|$)/,
+    /docker\/setup-buildx-action@v[1-3](\D|$)/,
+    /docker\/login-action@v[1-3](\D|$)/,
+    /docker\/build-push-action@v[1-6](\D|$)/,
+  ]
+
+  for (const relativePath of files) {
+    const source = readFile(relativePath)
+    for (const pattern of legacyActionRefs) {
+      assert.doesNotMatch(source, pattern, `${relativePath} should not use ${pattern}`)
+    }
+  }
 })


### PR DESCRIPTION
## Summary

- Upgrade GitHub Actions references that emitted Node.js 20 deprecation warnings to Node 24-compatible releases.
- Covers core Actions, Android setup, release publishing, Docker actions, and Bun setup.
- Add regression coverage that blocks old action majors known to run on deprecated Node runtimes.

## Upgraded action families

- `actions/checkout` v4 → v6.0.2
- `actions/setup-node` v4 → v6.4.0
- `actions/setup-java` v4 → v5.2.0
- `actions/upload-artifact` v4 → v7.0.1
- `actions/download-artifact` v4 → v8.0.1
- `android-actions/setup-android` v3 → v4.0.1
- `softprops/action-gh-release` v2 → v3.0.0
- Docker setup/login/build actions to Node 24-compatible majors
- `oven-sh/setup-bun` pinned to v2.2.0

## Verification

```bash
node --test packages/app/tests/ci-workflow-split-regression.test.mjs packages/app/tests/android-apk-build-pipeline-regression.test.mjs packages/app/tests/ci-lockfile-install-regression.test.mjs packages/app/tests/ci-generated-schema-workflow-regression.test.mjs
python3 - <<'PY'
from pathlib import Path
import yaml
for path in sorted(Path('.github/workflows').glob('*.yml')) + sorted(Path('.github/actions').glob('*/action.yml')):
    with path.open() as f:
        yaml.safe_load(f)
print('workflow yaml parse ok')
PY
git diff --check
npm run lint:changed
```

Result: workflow/source regressions passed, YAML parse passed, diff check passed.
