### PR TITLE
fix(app): keep watch action buttons onscreen

### DIFF
--- a/packages/app/app/video/[id].tsx
+++ b/packages/app/app/video/[id].tsx
@@ -220,7 +220,7 @@ function ActionButton({ icon: Icon, label, onPress, active }: {
   return (
     <Pressable style={styles.actionButton} onPress={onPress}>
       <Icon color={active ? colors.primary : colors.text} size={22} />
-      <Text style={[styles.actionLabel, active && styles.actionLabelActive]}>{label}</Text>
+      <Text numberOfLines={1} ellipsizeMode="tail" style={[styles.actionLabel, active && styles.actionLabelActive]}>{label}</Text>
     </Pressable>
   )
 }
@@ -883,7 +883,8 @@ const styles = StyleSheet.create({
   },
   actions: {
     flexDirection: 'row',
-    justifyContent: 'space-around',
+    flexWrap: 'wrap',
+    justifyContent: 'space-between',
     paddingVertical: 12,
     paddingHorizontal: 8,
     borderTopWidth: 1,
@@ -891,14 +892,19 @@ const styles = StyleSheet.create({
     borderColor: colors.border,
   },
   actionButton: {
+    width: '16.66%',
+    minWidth: 56,
     alignItems: 'center',
-    paddingHorizontal: 12,
+    paddingHorizontal: 4,
     paddingVertical: 8,
   },
   actionLabel: {
     color: colors.text,
-    fontSize: 11,
+    fontSize: 10,
     marginTop: 4,
+    maxWidth: '100%',
+    textAlign: 'center',
+    numberOfLines: 1,
   },
   actionLabelActive: {
     color: colors.primary,

--- a/packages/app/components/video-player/ActionButton.tsx
+++ b/packages/app/components/video-player/ActionButton.tsx
@@ -32,7 +32,7 @@ export const ActionButton = memo(function ActionButton({
       ) : (
         Icon({ color: active ? colors.primary : colors.text, size: 22 })
       )}
-      <Text style={[styles.actionLabel, active && styles.actionLabelActive]}>{label}</Text>
+      <Text numberOfLines={1} ellipsizeMode="tail" style={[styles.actionLabel, active && styles.actionLabelActive]}>{label}</Text>
     </Pressable>
   )
 })

--- a/packages/app/components/video-player/styles.ts
+++ b/packages/app/components/video-player/styles.ts
@@ -577,7 +577,8 @@ export const styles = StyleSheet.create({
   },
   actions: {
     flexDirection: 'row',
-    justifyContent: 'space-around',
+    flexWrap: 'wrap',
+    justifyContent: 'space-between',
     paddingVertical: 12,
     backgroundColor: PLAYER_COLORS.black,
     paddingHorizontal: 8,
@@ -586,14 +587,19 @@ export const styles = StyleSheet.create({
     borderColor: colors.border,
   },
   actionButton: {
+    width: '16.66%',
+    minWidth: 56,
     alignItems: 'center',
-    paddingHorizontal: 12,
+    paddingHorizontal: 4,
     paddingVertical: 8,
   },
   actionLabel: {
     color: colors.text,
-    fontSize: 11,
+    fontSize: 10,
     marginTop: 4,
+    maxWidth: '100%',
+    textAlign: 'center',
+    numberOfLines: 1,
   },
   actionLabelActive: {
     color: colors.primary,

--- a/packages/app/tests/mobile-action-row-overflow-regression.test.mjs
+++ b/packages/app/tests/mobile-action-row-overflow-regression.test.mjs
@@ -1,0 +1,41 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const appRoot = path.resolve(__dirname, '..')
+
+function readAppFile(relativePath) {
+  return fs.readFileSync(path.join(appRoot, relativePath), 'utf8')
+}
+
+test('mobile watch action rows wrap instead of pushing More off screen when labels grow', () => {
+  const watchRouteSource = readAppFile('app/video/[id].tsx')
+  const sharedStylesSource = readAppFile('components/video-player/styles.ts')
+  const sharedActionButtonSource = readAppFile('components/video-player/ActionButton.tsx')
+
+  for (const [name, source] of [
+    ['watch route', watchRouteSource],
+    ['shared player styles', sharedStylesSource],
+  ]) {
+    assert.match(source, /actions:\s*\{[\s\S]*flexWrap:\s*'wrap'/, `${name} action row should wrap`) 
+    assert.match(source, /actions:\s*\{[\s\S]*justifyContent:\s*'space-between'/, `${name} action row should distribute wrapped buttons`) 
+    assert.match(source, /actionButton:\s*\{[\s\S]*width:\s*'16\.66%'/, `${name} action buttons should have six-up percentage slots`) 
+    assert.match(source, /actionButton:\s*\{[\s\S]*minWidth:\s*56/, `${name} action buttons should keep a tappable minimum`) 
+    assert.match(source, /actionLabel:\s*\{[\s\S]*numberOfLines/, `${name} action labels should be clamped through Text props or style marker`) 
+  }
+
+  assert.match(
+    watchRouteSource,
+    /<Text\s+numberOfLines=\{1\}\s+ellipsizeMode="tail"\s+style=\{\[styles\.actionLabel, active && styles\.actionLabelActive\]\}>/,
+    'watch route action labels should truncate long labels like Like (123) instead of widening the row',
+  )
+  assert.match(
+    sharedActionButtonSource,
+    /<Text\s+numberOfLines=\{1\}\s+ellipsizeMode="tail"\s+style=\{\[styles\.actionLabel, active && styles\.actionLabelActive\]\}>/,
+    'shared action labels should truncate long labels like Like (123) instead of widening the row',
+  )
+})


### PR DESCRIPTION
## Summary

- Fix mobile watch-page action row overflow when reaction labels grow, e.g. `Like (3)`.
- Give each action a six-up percentage slot with a tappable minimum width.
- Allow the row to wrap instead of pushing `More` off the right edge.
- Clamp action labels to one line with tail ellipsis.
- Apply the fix to both the watch route local action button and the shared player action button/styles.

## Verification

```bash
node --test packages/app/tests/mobile-action-row-overflow-regression.test.mjs packages/app/tests/mobile-player-page-layout-regression.test.mjs && git diff --check
npm run lint:changed
```

Result: 9 passed / 0 failed. Diff check passed. `lint:changed` reported no changed files in this worktree, so targeted source regression tests are the main verification.
