### PR TITLE
fix(app): preserve vertical discovery feed cards

### DIFF
--- a/packages/app/app/(tabs)/discover.tsx
+++ b/packages/app/app/(tabs)/discover.tsx
@@ -28,6 +28,7 @@ import { colors } from '@/lib/colors'
 import { fetchThumbnailUrlWithRetry } from '@/lib/thumbnail'
 import { getFeedPreviewVideos, getVisibleSeededFeedEntries, shouldRenderFeedVideo } from '@/lib/feed-hydration'
 import { getCachedVideoUrl, makeVideoUrlCacheKey, setCachedVideoUrl } from '@/lib/video-url-cache'
+import { readDiscoverFeedCache, writeDiscoverFeedCache } from '@/lib/discover-feed-cache'
 import { formatTimeAgo } from '@/lib/formatters'
 
 interface FeedEntry {
@@ -91,12 +92,13 @@ export default function VerticalDiscoveryScreen() {
   const { isDesktop } = usePlatform()
   const { ready, identity, rpc, blobServerPort, backendError, startupStatus } = useApp()
   const { currentVideo, videoUrl, isLoading, loadAndPlayVideo } = useVideoPlayerContext()
+  const cachedFeed = useMemo(() => readDiscoverFeedCache(), [])
 
   const pageHeight = Math.max(1, screenHeight - insets.top)
   const [refreshing, setRefreshing] = useState(false)
   const [feedLoading, setFeedLoading] = useState(false)
-  const [feedEntries, setFeedEntries] = useState<FeedEntry[]>([])
-  const [videos, setVideos] = useState<VideoData[]>([])
+  const [feedEntries, setFeedEntries] = useState<FeedEntry[]>(() => cachedFeed.feedEntries as FeedEntry[])
+  const [videos, setVideos] = useState<VideoData[]>(() => cachedFeed.videos as VideoData[])
   const [thumbnailCache, setThumbnailCache] = useState<Record<string, string>>({})
   const [activeIndex, setActiveIndex] = useState(0)
   const pendingPlayKeyRef = useRef<string | null>(null)
@@ -161,14 +163,15 @@ export default function VerticalDiscoveryScreen() {
     if (!rpc) return
     const channelKey = entry.channelKey || entry.driveKey
     if (!channelKey || hydratedChannelsRef.current.has(channelKey)) return
-    hydratedChannelsRef.current.add(channelKey)
 
     try {
       const result = await withTimeout(
         rpc.listVideos({ channelKey, publicBeeKey: entry.publicBeeKey || undefined }),
         3500,
-        { videos: [] } as any,
+        null as any,
       )
+      if (!result) return
+      hydratedChannelsRef.current.add(channelKey)
       const channelVideos = Array.isArray((result as any)?.videos) ? (result as any).videos : []
       const mapped = channelVideos
         .filter((video: any) => shouldRenderFeedVideo({
@@ -199,7 +202,9 @@ export default function VerticalDiscoveryScreen() {
     if (!rpc) return
     setFeedLoading(true)
     try {
-      const result = await withTimeout(rpc.getPublicFeed({}), 4000, { entries: [] } as any)
+      const timeoutToken = Symbol('getPublicFeedTimeout')
+      const result = await withTimeout(rpc.getPublicFeed({}), 4000, timeoutToken as any)
+      if (result === timeoutToken) return
       const entries = Array.isArray((result as any)?.entries) ? (result as any).entries : []
       setFeedEntries(entries)
       seedFromFeedEntries(entries)
@@ -217,6 +222,15 @@ export default function VerticalDiscoveryScreen() {
     if (!ready || !rpc) return
     loadFeed()
   }, [loadFeed, ready, rpc])
+
+  useEffect(() => {
+    if (feedEntries.length === 0 && videos.length === 0) return
+    writeDiscoverFeedCache({
+      feedEntries,
+      videos,
+      savedAt: Date.now(),
+    })
+  }, [feedEntries, videos])
 
   const playVideo = useCallback(async (video: VideoData) => {
     if (!rpc) return

--- a/packages/app/lib/discover-feed-cache.ts
+++ b/packages/app/lib/discover-feed-cache.ts
@@ -1,0 +1,37 @@
+import type { VideoData } from '@peartube/core'
+
+interface DiscoverFeedCacheSnapshot {
+  feedEntries: any[]
+  videos: VideoData[]
+  savedAt: number
+}
+
+let discoverFeedCache: DiscoverFeedCacheSnapshot = {
+  feedEntries: [],
+  videos: [],
+  savedAt: 0,
+}
+
+export function readDiscoverFeedCache(): DiscoverFeedCacheSnapshot {
+  return {
+    feedEntries: Array.isArray(discoverFeedCache.feedEntries) ? discoverFeedCache.feedEntries : [],
+    videos: Array.isArray(discoverFeedCache.videos) ? discoverFeedCache.videos : [],
+    savedAt: discoverFeedCache.savedAt || 0,
+  }
+}
+
+export function writeDiscoverFeedCache(snapshot: Partial<DiscoverFeedCacheSnapshot>) {
+  discoverFeedCache = {
+    feedEntries: Array.isArray(snapshot.feedEntries) ? snapshot.feedEntries : discoverFeedCache.feedEntries,
+    videos: Array.isArray(snapshot.videos) ? snapshot.videos : discoverFeedCache.videos,
+    savedAt: typeof snapshot.savedAt === 'number' ? snapshot.savedAt : Date.now(),
+  }
+}
+
+export function clearDiscoverFeedCache() {
+  discoverFeedCache = {
+    feedEntries: [],
+    videos: [],
+    savedAt: 0,
+  }
+}

--- a/packages/app/tests/vertical-discovery-feed-state-regression.test.mjs
+++ b/packages/app/tests/vertical-discovery-feed-state-regression.test.mjs
@@ -1,0 +1,52 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  mergeHydratedFeedVideos,
+  mergePreviewFeedVideos,
+} from '../lib/feed-hydration.js'
+
+test('vertical discovery keeps cached hydrated videos when a refresh returns no previews yet', () => {
+  const previousVideos = [
+    { id: 'cached-a', channelKey: 'remote-a', uploadedAt: 30, availability: 'playable', __feedSource: 'hydrated' },
+    { id: 'cached-b', channelKey: 'remote-b', uploadedAt: 20, availability: 'playable', __feedSource: 'hydrated' },
+  ]
+
+  const afterHydration = mergeHydratedFeedVideos({
+    previousVideos,
+    incomingVideos: [],
+    refreshedChannelKeys: [],
+    identityDriveKey: 'local',
+    limit: 50,
+  })
+
+  const afterPreviewReconcile = mergePreviewFeedVideos({
+    previousVideos: afterHydration,
+    previewVideos: [],
+    limit: 50,
+  })
+
+  assert.deepEqual(afterPreviewReconcile.map((video) => video.id), ['cached-a', 'cached-b'])
+})
+
+test('vertical discovery can replace one live channel without dropping unrelated cached videos', () => {
+  const previousVideos = [
+    { id: 'old-live', channelKey: 'live-a', uploadedAt: 10, availability: 'playable', __feedSource: 'hydrated' },
+    { id: 'cached-b', channelKey: 'remote-b', uploadedAt: 20, availability: 'playable', __feedSource: 'hydrated' },
+  ]
+
+  const merged = mergeHydratedFeedVideos({
+    previousVideos,
+    incomingVideos: [
+      { id: 'fresh-live', channelKey: 'live-a', uploadedAt: 40, availability: 'playable' },
+    ],
+    refreshedChannelKeys: ['live-a'],
+    identityDriveKey: 'local',
+    limit: 50,
+  })
+
+  assert.deepEqual(merged.map((video) => ({ id: video.id, channelKey: video.channelKey })), [
+    { id: 'fresh-live', channelKey: 'live-a' },
+    { id: 'cached-b', channelKey: 'remote-b' },
+  ])
+})

--- a/packages/app/tests/vertical-discovery-regression.test.mjs
+++ b/packages/app/tests/vertical-discovery-regression.test.mjs
@@ -43,3 +43,13 @@ test('vertical discovery keeps channel navigation and detail escape hatches', ()
   assert.match(source, /Feather name="message-circle"/, 'vertical player should include a comments/details affordance')
   assert.match(source, /Feather name="user"/, 'vertical player should include a channel affordance')
 })
+
+test('vertical discovery preserves known-good cards across remount and sparse feed refreshes', () => {
+  const source = readAppFile('app/(tabs)/discover.tsx')
+
+  assert.match(source, /readDiscoverFeedCache\(\)/, 'vertical discovery should initialize from its last known-good in-memory cache')
+  assert.match(source, /writeDiscoverFeedCache\(\{/, 'vertical discovery should snapshot entries/videos while mounted')
+  assert.match(source, /const timeoutToken = Symbol\('getPublicFeedTimeout'\)/, 'feed loading should distinguish timeout from authoritative empty feed')
+  assert.match(source, /if \(result === timeoutToken\)/, 'timeout refreshes must not replace current feed entries with []')
+  assert.doesNotMatch(source, /hydratedChannelsRef\.current\.add\(channelKey\)[\s\S]{0,500}rpc\.listVideos/, 'channels must not be marked hydrated before listVideos returns usable videos')
+})


### PR DESCRIPTION
## Summary
- Preserve the vertical Discover feed from its last known-good in-memory state across tab remounts/app returns.
- Stop treating `getPublicFeed` timeouts as authoritative empty feeds.
- Only mark a channel hydrated after `listVideos` actually returns, so transient hydrate timeouts can retry instead of silently freezing a sparse feed.
- Add regressions for sparse refresh/remount behavior and cached hydrated-card preservation.

## Why
Vertical Discover had a different state model than Home Discover. Home had snapshot/merge safeguards, but the new vertical feed started empty on remount and could rebuild from a sparse or timed-out P2P refresh. That made videos appear to mysteriously disappear depending on timing, app background/return, or feed hydration order.

## Verification
```bash
node --test packages/app/tests/vertical-discovery-regression.test.mjs packages/app/tests/vertical-discovery-feed-state-regression.test.mjs packages/app/tests/feed-hydration.test.mjs && git diff --check
npm run lint:changed
```

Result: 17 passed / 0 failed. `lint:changed` exited 0; repo script reported no changed JS/TS files to lint.
