### PR TITLE
fix(app): play vertical discovery videos inline

### DIFF
--- a/packages/app/app/(tabs)/discover.tsx
+++ b/packages/app/app/(tabs)/discover.tsx
@@ -23,12 +23,12 @@ import { Feather } from '@expo/vector-icons'
 import type { VideoData } from '@peartube/core'
 import { useApp } from '../_layout'
 import { usePlatform } from '@/lib/PlatformProvider'
-import { useVideoPlayerContext } from '@/lib/VideoPlayerContext'
 import { colors } from '@/lib/colors'
 import { fetchThumbnailUrlWithRetry } from '@/lib/thumbnail'
 import { getFeedPreviewVideos, getVisibleSeededFeedEntries, shouldRenderFeedVideo } from '@/lib/feed-hydration'
 import { getCachedVideoUrl, makeVideoUrlCacheKey, setCachedVideoUrl } from '@/lib/video-url-cache'
 import { formatTimeAgo } from '@/lib/formatters'
+import { VideoContainer } from '@/components/video-player/VideoContainer'
 
 interface FeedEntry {
   driveKey: string
@@ -90,7 +90,6 @@ export default function VerticalDiscoveryScreen() {
   const { height: screenHeight, width: screenWidth } = useWindowDimensions()
   const { isDesktop } = usePlatform()
   const { ready, identity, rpc, blobServerPort, backendError, startupStatus } = useApp()
-  const { currentVideo, videoUrl, isLoading, loadAndPlayVideo } = useVideoPlayerContext()
 
   const pageHeight = Math.max(1, screenHeight - insets.top)
   const [refreshing, setRefreshing] = useState(false)
@@ -99,12 +98,15 @@ export default function VerticalDiscoveryScreen() {
   const [videos, setVideos] = useState<VideoData[]>([])
   const [thumbnailCache, setThumbnailCache] = useState<Record<string, string>>({})
   const [activeIndex, setActiveIndex] = useState(0)
+  const [shortsVideoUrl, setShortsVideoUrl] = useState<string | null>(null)
+  const [shortsPlaybackSession, setShortsPlaybackSession] = useState(0)
+  const [shortsLoading, setShortsLoading] = useState(false)
+  const shortsPlayerRef = useRef<any>(null)
   const pendingPlayKeyRef = useRef<string | null>(null)
   const hydratedChannelsRef = useRef<Set<string>>(new Set())
 
   const activeVideo = videos[activeIndex]
   const activeVideoKey = activeVideo ? `${activeVideo.channelKey}:${activeVideo.id}` : null
-  const currentVideoKey = currentVideo ? `${currentVideo.channelKey}:${currentVideo.id}` : null
 
   const fetchThumbnailsForVideos = useCallback(async (items: VideoData[]) => {
     if (!rpc || !blobServerPort) return
@@ -245,20 +247,25 @@ export default function VerticalDiscoveryScreen() {
       const cachedUrl = cacheKey ? getCachedVideoUrl(cacheKey) : null
       if (cachedUrl) {
         void rpc.preparePlayback(playbackRequest).catch(() => undefined)
-        loadAndPlayVideo(video, cachedUrl)
+        setShortsVideoUrl(cachedUrl)
+        setShortsPlaybackSession((prev) => prev + 1)
+        setShortsLoading(false)
         return
       }
+      setShortsLoading(true)
       const result = await rpc.preparePlayback(playbackRequest)
       if (result?.url) {
         if (cacheKey) setCachedVideoUrl(cacheKey, result.url)
-        loadAndPlayVideo(video, result.url)
+        setShortsVideoUrl(result.url)
+        setShortsPlaybackSession((prev) => prev + 1)
       }
     } catch (err) {
       console.log('[VerticalDiscovery] Playback failed:', (err as any)?.message || err)
     } finally {
       pendingPlayKeyRef.current = null
+      setShortsLoading(false)
     }
-  }, [loadAndPlayVideo, rpc])
+  }, [rpc])
 
   useEffect(() => {
     if (!activeVideo || !ready) return
@@ -399,9 +406,24 @@ export default function VerticalDiscoveryScreen() {
               >
                 <View style={styles.scrim} />
                 <View style={styles.videoStage}>
-                  {activeVideoKey === `${video.channelKey}:${video.id}` && currentVideoKey === activeVideoKey && videoUrl && !isLoading ? (
+                  {activeVideoKey === `${video.channelKey}:${video.id}` && shortsVideoUrl ? (
                     <View style={styles.playingFrame}>
-                      <Text style={styles.playingText}>Playing</Text>
+                      <VideoContainer
+                        testID="vertical-discovery-inline-player"
+                        style={styles.shortsInlinePlayer}
+                        playerRef={shortsPlayerRef}
+                        videoUrl={shortsVideoUrl}
+                        currentVideo={video}
+                        playbackSession={shortsPlaybackSession}
+                        isPlaying
+                        playbackRate={1}
+                        isCasting={false}
+                        isInPipMode={false}
+                      />
+                    </View>
+                  ) : shortsLoading && activeVideoKey === `${video.channelKey}:${video.id}` ? (
+                    <View style={styles.playButtonShell}>
+                      <ActivityIndicator color="#fff" size="large" />
                     </View>
                   ) : (
                     <View style={styles.playButtonShell}>
@@ -533,8 +555,12 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: 'rgba(255,255,255,0.18)',
     backgroundColor: 'rgba(0,0,0,0.34)',
-    alignItems: 'center',
-    justifyContent: 'center',
+    overflow: 'hidden',
+  },
+  shortsInlinePlayer: {
+    width: '100%',
+    height: '100%',
+    backgroundColor: '#000',
   },
   playingText: {
     color: colors.primary,

--- a/packages/app/components/video-player/PearInlineVideoView.tsx
+++ b/packages/app/components/video-player/PearInlineVideoView.tsx
@@ -10,6 +10,7 @@ import Video, {
 
 type PearInlineVideoViewProps = {
   style?: StyleProp<ViewStyle>
+  testID?: string
   playerRef: RefObject<any>
   videoUrl: string
   playbackSession: number
@@ -71,6 +72,7 @@ function getEventDurationMs(data: any) {
 
 export const PearInlineVideoView = memo(function PearInlineVideoView({
   style,
+  testID,
   playerRef,
   videoUrl,
   playbackSession,
@@ -365,7 +367,7 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
   }, [onPictureInPictureChanged])
 
   return (
-    <View style={[styles.container, style]}>
+    <View testID={testID} style={[styles.container, style]}>
       <Video
         key={`rnv-${playbackSession}:${currentVideoKey || ''}:${sourceKey}`}
         ref={videoRef}

--- a/packages/app/components/video-player/VideoContainer.tsx
+++ b/packages/app/components/video-player/VideoContainer.tsx
@@ -48,6 +48,7 @@ export interface VideoContainerProps {
 
   // Style override
   style?: any
+  testID?: string
 }
 
 export const VideoContainer = memo(
@@ -77,13 +78,14 @@ export const VideoContainer = memo(
       onError,
       onVideoStateChange,
       style,
+      testID,
     },
     ref
   ) {
     // Casting placeholder
     if (isCasting) {
       return (
-        <View style={[styles.castPlaceholder, style]}>
+        <View testID={testID} style={[styles.castPlaceholder, style]}>
           <Feather name="cast" size={40} color={colors.primary} />
           <Text style={styles.castPlaceholderTitle}>
             Casting to {castDeviceName || 'device'}
@@ -98,7 +100,7 @@ export const VideoContainer = memo(
     // No video URL - show placeholder
     if (!videoUrl) {
       return (
-        <View style={[styles.videoPlaceholder, style]}>
+        <View testID={testID} style={[styles.videoPlaceholder, style]}>
           <Text style={styles.placeholderText}>
             {currentVideo?.title?.charAt(0).toUpperCase() || '?'}
           </Text>
@@ -108,6 +110,7 @@ export const VideoContainer = memo(
 
     return (
       <PearInlineVideoView
+        testID={testID}
         style={style}
         playerRef={playerRef}
         videoUrl={videoUrl}

--- a/packages/app/tests/vertical-discovery-regression.test.mjs
+++ b/packages/app/tests/vertical-discovery-regression.test.mjs
@@ -21,7 +21,7 @@ test('native tabs expose a vertical discovery doomscroll surface', () => {
   assert.match(tabBar, /icon:\s*'zap'/, 'vertical discovery should have a fast-mode tab icon')
 })
 
-test('vertical discovery uses paged full-screen feed and opens current item through shared player path', () => {
+test('vertical discovery uses paged full-screen feed and plays inline in the shorts surface', () => {
   const source = readAppFile('app/(tabs)/discover.tsx')
 
   assert.match(source, /FlatList/, 'vertical discovery should use FlatList for a swipe feed')
@@ -29,9 +29,12 @@ test('vertical discovery uses paged full-screen feed and opens current item thro
   assert.match(source, /snapToInterval=\{pageHeight\}/, 'vertical discovery should snap to full-screen item height')
   assert.match(source, /onViewableItemsChanged/, 'vertical discovery should track the active page')
   assert.match(source, /viewabilityConfig/, 'vertical discovery should use explicit viewability thresholds')
-  assert.match(source, /loadAndPlayVideo\(video, result\.url\)/, 'current vertical item should use shared player context')
+  assert.match(source, /<VideoContainer[\s\S]*testID="vertical-discovery-inline-player"/, 'active vertical item should render the video inside the shorts surface')
+  assert.doesNotMatch(source, /loadAndPlayVideo\(/, 'vertical playback must not open the normal mobile playback overlay')
+  assert.doesNotMatch(source, /useVideoPlayerContext\(/, 'vertical playback should not depend on the global overlay player context')
   assert.match(source, /preparePlayback\(playbackRequest\)/, 'vertical player should resolve playback through backend preparePlayback')
   assert.match(source, /getCachedVideoUrl\(cacheKey\)/, 'vertical player should use the short playback URL cache')
+  assert.match(source, /setShortsVideoUrl\(/, 'vertical player should keep playback URL in local shorts-player state')
   assert.match(source, /testID=\{index === 0 \? 'vertical-discovery-first-video' : undefined\}/, 'first vertical card should keep a stable test hook')
 })
 


### PR DESCRIPTION
## Summary
- Fix vertical Discover/Shorts playback so it renders inside the Shorts card instead of opening the normal mobile playback overlay.
- Replace the global `useVideoPlayerContext().loadAndPlayVideo(...)` path in `app/(tabs)/discover.tsx` with local Shorts playback URL/session state.
- Render the active item with `VideoContainer` inside the 9:16 Shorts frame.
- Thread a `testID` through `VideoContainer` and `PearInlineVideoView` for stable regression coverage.

## Root cause
The first vertical Discover implementation still used the shared global player context. Calling `loadAndPlayVideo(video, url)` dispatches `LOAD_VIDEO`, which puts the normal mobile overlay into fullscreen mode. The Shorts UI only showed a placeholder/"Playing" shell while the actual video lived in the regular playback surface.

## Verification
```bash
node --test packages/app/tests/vertical-discovery-regression.test.mjs packages/app/tests/mobile-player-page-layout-regression.test.mjs && git diff --check && npm run lint:changed
```

Result: 11 passed / 0 failed. `lint:changed` exited 0; repo script reported no changed JS/TS files to lint.

Note: broader mobile inline tests currently need installed Expo config plugin deps in this worktree and have unrelated existing source-test drift around `useTextureView`, so I kept verification to the vertical Discover regression plus mobile player layout regressions.
