### PR TITLE
refactor(backend): add BlobRef helper

### DIFF
--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -60,10 +60,10 @@ export function createApi({
       const identities = stored?.value || []
       if (identities.some((i) => i?.channelKey === channelKey || i?.driveKey === channelKey)) {
         // Backfill marker so future checks are fast
-        try { await ctx.metaDb.put(`mw-channel:${channelKey}`, { kind: 'autobase', backfilledAt: Date.now() }) } catch {}
+        try { await ctx.metaDb.put(`mw-channel:${channelKey}`, { kind: 'autobase', backfilledAt: Date.now() }) } catch { /* best effort */ }
         return true
       }
-    } catch {}
+    } catch { /* best effort */ }
 
     return false
   }
@@ -71,7 +71,7 @@ export function createApi({
   async function markAsMultiWriterChannel(channelKey) {
     try {
       await ctx.metaDb.put(`mw-channel:${channelKey}`, { kind: 'autobase', discoveredAt: Date.now() })
-    } catch {}
+    } catch { /* best effort */ }
   }
 
   /**
@@ -158,13 +158,13 @@ export function createApi({
   }
 
   function invalidateChannelCaches(driveKey) {
-    try { listVideosCache.delete(driveKey) } catch {}
-    try { channelMetaCache.delete(driveKey) } catch {}
+    try { listVideosCache.delete(driveKey) } catch { /* best effort */ }
+    try { channelMetaCache.delete(driveKey) } catch { /* best effort */ }
     try {
       for (const key of videoAvailabilityCache.keys()) {
         if (key.startsWith(`${driveKey}:`)) videoAvailabilityCache.delete(key)
       }
-    } catch {}
+    } catch { /* best effort */ }
   }
 
   // ============================================
@@ -274,7 +274,7 @@ export function createApi({
             if (fullyCached) return { availability: 'playable', contiguousBlocks: totalBlocks || 0, hasHeadBlock: true }
             const headEnd = Math.min(endBlock, startBlock + Math.max(1, Math.min(32, totalBlocks || 32)))
             let initialAvailable = false
-            try { initialAvailable = await core.has(startBlock, headEnd) } catch {}
+            try { initialAvailable = await core.has(startBlock, headEnd) } catch { /* best effort */ }
             return { availability: initialAvailable ? 'playable' : 'unknown', contiguousBlocks: initialAvailable ? Math.max(1, headEnd - startBlock) : 0, hasHeadBlock: initialAvailable }
           } catch {
             return { availability: 'unknown', contiguousBlocks: 0, hasHeadBlock: false }
@@ -496,7 +496,7 @@ export function createApi({
           if (!video) return null
           if (video.id) return video.id
           if (video.path && typeof video.path === 'string') {
-            const match = video.path.match(/\/videos\/([^.\/]+)/)
+            const match = video.path.match(/\/videos\/([^./]+)/)
             if (match?.[1]) return match[1]
             const base = video.path.split('/').pop() || ''
             return base.replace(/\.[^./]+$/, '') || null
@@ -522,7 +522,7 @@ export function createApi({
             try {
               const meta = await fetcher(id)
               if (meta) metaById.set(id, meta)
-            } catch {}
+            } catch { /* best effort */ }
           }))
 
           if (metaById.size === 0) return videos
@@ -596,7 +596,7 @@ export function createApi({
                 let initialAvailable = false
                 try {
                   initialAvailable = await core.has(startBlock, headEnd)
-                } catch {}
+                } catch { /* best effort */ }
                 hasHeadBlock = initialAvailable
                 contiguousBlocks = initialAvailable ? Math.max(1, headEnd - startBlock) : 0
                 availability = initialAvailable ? 'playable' : 'unknown'
@@ -662,7 +662,7 @@ export function createApi({
                 if (!hint?.id) continue
                 peerHintsById.set(hint.id, hint)
               }
-            } catch {}
+            } catch { /* best effort */ }
           }
 
           return videos.map((video) => {
@@ -818,7 +818,7 @@ export function createApi({
             retainSwarmDiscovery(ctx, discoveryKey, {
               label: `blobs:${String(blobsCoreKey).slice(0, 16)}`
             })
-          } catch {}
+          } catch { /* best effort */ }
         }
 
         // Return URL instantly
@@ -854,7 +854,7 @@ export function createApi({
             retainSwarmDiscovery(ctx, discoveryKey, {
               label: `blobs:${String(blobsKeyHex).slice(0, 16)}`
             })
-          } catch {}
+          } catch { /* best effort */ }
         }
 
         // Return URL instantly - blob server handles fetching
@@ -887,7 +887,7 @@ export function createApi({
           retainSwarmDiscovery(ctx, discoveryKey, {
             label: `blobs:${blobsKeyHex.slice(0, 16)}`
           })
-        } catch {}
+        } catch { /* best effort */ }
       }
       console.log('[API] getVideoUrl: blobsKey:', blobsKeyHex.slice(0, 16), 'blobId:', meta.blobId);
       return getVideoUrlFromBlob(ctx, blobsKeyHex, blobEntry.blobId, {
@@ -1079,7 +1079,7 @@ export function createApi({
         await channel.deleteVideo(videoId)
 
         if (ctx.semanticFinder) {
-          try { ctx.semanticFinder.removeVideo(videoId) } catch {}
+          try { ctx.semanticFinder.removeVideo(videoId) } catch { /* best effort */ }
         }
 
         return { success: true };
@@ -1100,7 +1100,7 @@ export function createApi({
         const normalizeVideoId = (value) => {
           if (!value || typeof value !== 'string') return value
           if (value.startsWith('/videos/')) {
-            const match = value.match(/\/videos\/([^.\/]+)/)
+            const match = value.match(/\/videos\/([^./]+)/)
             if (match?.[1]) return match[1]
           }
           return value
@@ -1152,7 +1152,7 @@ export function createApi({
               })
             : null;
           resolvedPublicBeeKey = entry && typeof entry === 'object' ? (entry.publicBeeKey || null) : null;
-        } catch {}
+        } catch { /* best effort */ }
 
         let meta = null;
         const cachedMeta = getThumbnailMetaFromCachedList()
@@ -1189,7 +1189,7 @@ export function createApi({
 
           // Join swarm for thumbnail core
           if (ctx.swarm && blobsCore.discoveryKey) {
-            try { ctx.swarm.join(blobsCore.discoveryKey) } catch {}
+            try { ctx.swarm.join(blobsCore.discoveryKey) } catch { /* best effort */ }
           }
 
           try {
@@ -1197,7 +1197,7 @@ export function createApi({
               blobsCore.update({ wait: true }),
               new Promise((_, reject) => setTimeout(() => reject(new Error('thumbnail core update timeout')), 1500))
             ]);
-          } catch {}
+          } catch { /* best effort */ }
 
           const blob = normalizeBlobRefInput(meta.thumbnailBlobId) || parseBlobRef({
             blobsCoreKey: meta.thumbnailBlobsCoreKey,
@@ -1292,7 +1292,7 @@ export function createApi({
           const channel = await loadChannel(ctx, sub.driveKey)
           const meta = await channel?.getMetadata().catch(() => null)
           if (meta?.name) name = meta.name
-        } catch (e) {}
+        } catch (e) { /* best effort */ }
         enriched.push({ ...sub, name });
       }
 
@@ -1314,7 +1314,7 @@ export function createApi({
         if (!video) return null
         if (video.id) return video.id
         if (video.path && typeof video.path === 'string') {
-          const match = video.path.match(/\/videos\/([^.\/]+)/)
+          const match = video.path.match(/\/videos\/([^./]+)/)
           if (match?.[1]) return match[1]
           const base = video.path.split('/').pop() || ''
           return base.replace(/\.[^./]+$/, '') || null
@@ -1339,7 +1339,7 @@ export function createApi({
           try {
             const meta = await fetcher(id)
             if (meta) metaById.set(id, meta)
-          } catch {}
+          } catch { /* best effort */ }
         }))
 
         if (metaById.size === 0) return videos
@@ -1629,10 +1629,10 @@ export function createApi({
       const existingRanges = activeRangeRequests.get(prefetchKey)
       if (existingRanges) {
         console.log('[API] Cancelling orphaned range requests for:', videoPath)
-        existingRanges.ranges.forEach(r => { try { r?.destroy?.() } catch {} })
+        existingRanges.ranges.forEach(r => { try { r?.destroy?.() } catch { /* best effort */ } })
         if (existingRanges.core) {
-          try { existingRanges.core.off('download', existingRanges.onDownload) } catch {}
-          try { existingRanges.core.off('upload', existingRanges.onUpload) } catch {}
+          try { existingRanges.core.off('download', existingRanges.onDownload) } catch { /* best effort */ }
+          try { existingRanges.core.off('upload', existingRanges.onUpload) } catch { /* best effort */ }
         }
         activeRangeRequests.delete(prefetchKey)
       }
@@ -1744,7 +1744,7 @@ export function createApi({
               retainSwarmDiscovery(ctx, core.discoveryKey, {
                 label: `prefetch:${blobMeta.blobsCoreKey.slice(0, 16)}`
               })
-            } catch {}
+            } catch { /* best effort */ }
           }
 
           const blobId = normalizeBlobRefInput(blobMeta.blobId) || parseBlobRef(blobMeta)?.blob
@@ -2675,11 +2675,11 @@ export function createApi({
 
       // Best-effort: import replicated vectors from any loaded channels.
       if (ctx.channels && ctx.channels.size > 0) {
-        ;(async () => {
+        (async () => {
           for (const [channelKey, channel] of ctx.channels.entries()) {
             try {
               await finder.ensureGlobalIndexedFromChannelView(channelKey, channel)
-            } catch {}
+            } catch { /* best effort */ }
           }
         })()
       }
@@ -2698,14 +2698,14 @@ export function createApi({
         try {
           const video = await this.getVideoData(channelKey, r.id, meta.publicBeeKey)
           if (video) { validated.push(r); continue }
-        } catch {}
+        } catch { /* best effort */ }
         staleIds.push(r.id)
       }
 
       if (staleIds.length > 0) {
         console.log('[API] globalSearchVideos: pruning', staleIds.length, 'stale entries')
         for (const id of staleIds) {
-          try { finder.removeVideo(id) } catch {}
+          try { finder.removeVideo(id) } catch { /* best effort */ }
         }
       }
 

--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -15,6 +15,7 @@ import { SemanticFinder } from './search/semantic-finder.js';
 import { FederatedSearch } from './search/federated-search.js';
 import { Recommender } from './recommendations/recommender.js';
 import { getVideoToolboxDecodeSettings, setVideoToolboxDecodeEnabled, setVideoToolboxHwMapEnabled } from './transcode/videotoolbox-settings.mjs';
+import { buildBlobRefCacheKey, normalizeBlobsCoreKey, normalizeBlobRefInput, parseBlobRef, stringifyBlobId } from './blob-ref.js';
 import { NETWORK_TOPIC_STRING } from './types.js'
 
 /**
@@ -247,7 +248,12 @@ export function createApi({
             }
             const key = req?.driveKey || 'unknown'
             // Reuse the cheap local-only availability path shape
-            const cacheKey = `${key}:${id}:${video.blobsCoreKey}:${video.blobId}`
+            const cacheKey = buildBlobRefCacheKey({
+              driveKey: key,
+              id,
+              blobsCoreKey: video.blobsCoreKey,
+              blobId: video.blobId,
+            })
             const cachedAvailability = videoAvailabilityCache.get(cacheKey)
             if (
               cachedAvailability &&
@@ -255,17 +261,11 @@ export function createApi({
             ) {
               return { availability: cachedAvailability.value, contiguousBlocks: cachedAvailability.value === 'playable' ? 1 : 0, hasHeadBlock: cachedAvailability.value === 'playable' }
             }
-            const keyBuf = video?.blobsCoreKey ? b4a.from(video.blobsCoreKey, 'hex') : null
-            if (!keyBuf || !video?.blobId) return { availability: 'unknown', contiguousBlocks: 0, hasHeadBlock: false }
+            const keyBuf = normalizeBlobsCoreKey(video?.blobsCoreKey) ? b4a.from(normalizeBlobsCoreKey(video.blobsCoreKey), 'hex') : null
+            const blobId = normalizeBlobRefInput(video?.blobId) || parseBlobRef(video)?.blob
+            if (!keyBuf || !blobId) return { availability: 'unknown', contiguousBlocks: 0, hasHeadBlock: false }
             const core = ctx.store.get({ key: keyBuf })
             await core.ready()
-            let blobId = video.blobId
-            if (typeof blobId === 'string') {
-              const parts = blobId.split(':').map(Number)
-              if (parts.length === 4 && parts.every((n) => Number.isFinite(n))) {
-                blobId = { blockOffset: parts[0], blockLength: parts[1], byteOffset: parts[2], byteLength: parts[3] }
-              }
-            }
             const startBlock = blobId?.blockOffset
             const totalBlocks = blobId?.blockLength
             const endBlock = Number.isFinite(startBlock) && Number.isFinite(totalBlocks) ? startBlock + totalBlocks : null
@@ -551,7 +551,12 @@ export function createApi({
             return { availability: 'unknown', contiguousBlocks: 0, hasHeadBlock: false }
           }
 
-          const cacheKey = `${driveKey}:${id}:${blobsCoreKey}:${blobIdRaw}`
+          const cacheKey = buildBlobRefCacheKey({
+            driveKey,
+            id,
+            blobsCoreKey,
+            blobId: blobIdRaw,
+          })
           const cachedAvailability = videoAvailabilityCache.get(cacheKey)
           if (
             cachedAvailability &&
@@ -564,21 +569,14 @@ export function createApi({
           let contiguousBlocks = 0
           let hasHeadBlock = false
           try {
-            const keyBuf = b4a.from(blobsCoreKey, 'hex')
+            const keyBuf = b4a.from(normalizeBlobsCoreKey(blobsCoreKey) || blobsCoreKey, 'hex')
             const core = ctx.store.get({ key: keyBuf })
             await core.ready()
 
-            let blobId = blobIdRaw
-            if (typeof blobId === 'string') {
-              const parts = blobId.split(':').map(Number)
-              if (parts.length === 4 && parts.every((n) => Number.isFinite(n))) {
-                blobId = {
-                  blockOffset: parts[0],
-                  blockLength: parts[1],
-                  byteOffset: parts[2],
-                  byteLength: parts[3]
-                }
-              }
+            const blobId = normalizeBlobRefInput(blobIdRaw) || parseBlobRef({ blobsCoreKey, blobId: blobIdRaw })?.blob
+            if (!blobId) {
+              videoAvailabilityCache.set(cacheKey, { ts: Date.now(), value: availability })
+              return { availability, contiguousBlocks, hasHeadBlock }
             }
 
             const startBlock = blobId?.blockOffset
@@ -964,17 +962,10 @@ export function createApi({
           return { success: false, error: 'Video missing blobId or blobsCoreKey' };
         }
 
-        // Parse blobId
-        const parts = meta.blobId.split(':').map(Number);
-        if (parts.length !== 4) {
+        const blob = normalizeBlobRefInput(meta.blobId) || parseBlobRef(meta)?.blob
+        if (!blob) {
           return { success: false, error: 'Invalid blob ID format' };
         }
-        const blob = {
-          blockOffset: parts[0],
-          blockLength: parts[1],
-          byteOffset: parts[2],
-          byteLength: parts[3]
-        };
 
         // Load channel and get blobs core
         const channel = await loadChannel(ctx, channelKey);
@@ -1208,14 +1199,13 @@ export function createApi({
             ]);
           } catch {}
 
-          // Parse blobId string to blob object
-          const parts = meta.thumbnailBlobId.split(':').map(Number);
-          const blob = {
-            blockOffset: parts[0],
-            blockLength: parts[1],
-            byteOffset: parts[2],
-            byteLength: parts[3]
-          };
+          const blob = normalizeBlobRefInput(meta.thumbnailBlobId) || parseBlobRef({
+            blobsCoreKey: meta.thumbnailBlobsCoreKey,
+            blobId: meta.thumbnailBlobId,
+          })?.blob
+          if (!blob) {
+            return { exists: false, error: 'Invalid thumbnail blob ID format' }
+          }
 
           const thumbnailMimeType = typeof meta.thumbnailMimeType === 'string' && meta.thumbnailMimeType.length > 0
             ? meta.thumbnailMimeType
@@ -1757,17 +1747,8 @@ export function createApi({
             } catch {}
           }
 
-          let blobId = blobMeta.blobId
-          if (typeof blobId === 'string') {
-            const parts = blobId.split(':').map(Number)
-            if (parts.length !== 4) throw new Error('Invalid blob ID format')
-            blobId = {
-              blockOffset: parts[0],
-              blockLength: parts[1],
-              byteOffset: parts[2],
-              byteLength: parts[3]
-            }
-          }
+          const blobId = normalizeBlobRefInput(blobMeta.blobId) || parseBlobRef(blobMeta)?.blob
+          if (!blobId) throw new Error('Invalid blob ID format')
 
           const startBlock = blobId.blockOffset
           const endBlock = blobId.blockOffset + blobId.blockLength

--- a/packages/backend/src/blob-ref.js
+++ b/packages/backend/src/blob-ref.js
@@ -1,0 +1,81 @@
+const HEX_64 = /^[0-9a-f]{64}$/i
+
+function finiteNonNegativeInteger(value) {
+  return Number.isInteger(value) && value >= 0
+}
+
+function normalizeNumber(value) {
+  if (typeof value === 'number') return value
+  if (typeof value === 'bigint') return Number(value)
+  if (typeof value !== 'string' || value.trim() === '') return NaN
+  return Number(value)
+}
+
+export function normalizeBlobsCoreKey(value) {
+  if (typeof value !== 'string') return null
+  const key = value.trim().toLowerCase()
+  return HEX_64.test(key) ? key : null
+}
+
+export function parseBlobId(value) {
+  if (typeof value !== 'string') return null
+  const parts = value.split(':').map(normalizeNumber)
+  if (parts.length !== 4) return null
+  const [blockOffset, blockLength, byteOffset, byteLength] = parts
+  if (!finiteNonNegativeInteger(blockOffset)) return null
+  if (!Number.isInteger(blockLength) || blockLength <= 0) return null
+  if (!finiteNonNegativeInteger(byteOffset)) return null
+  if (!Number.isInteger(byteLength) || byteLength < 0) return null
+  return { blockOffset, blockLength, byteOffset, byteLength }
+}
+
+export function normalizeBlobRefInput(value) {
+  if (!value || typeof value !== 'object') return null
+  const blockOffset = normalizeNumber(value.blockOffset)
+  const blockLength = normalizeNumber(value.blockLength)
+  const byteOffset = normalizeNumber(value.byteOffset)
+  const byteLength = normalizeNumber(value.byteLength)
+  if (!finiteNonNegativeInteger(blockOffset)) return null
+  if (!Number.isInteger(blockLength) || blockLength <= 0) return null
+  if (!finiteNonNegativeInteger(byteOffset)) return null
+  if (!Number.isInteger(byteLength) || byteLength < 0) return null
+  return { blockOffset, blockLength, byteOffset, byteLength }
+}
+
+export function stringifyBlobId(value) {
+  const blob = typeof value === 'string' ? parseBlobId(value) : normalizeBlobRefInput(value)
+  if (!blob) return null
+  return `${blob.blockOffset}:${blob.blockLength}:${blob.byteOffset}:${blob.byteLength}`
+}
+
+export function parseBlobRef(value = {}) {
+  if (!value || typeof value !== 'object') return null
+  const blobsCoreKey = normalizeBlobsCoreKey(value.blobsCoreKey)
+  const blob = typeof value.blobId === 'string'
+    ? parseBlobId(value.blobId)
+    : normalizeBlobRefInput(value.blobId || value.blob)
+
+  if (!blobsCoreKey || !blob) return null
+
+  const byteLength = normalizeNumber(value.byteLength ?? blob.byteLength)
+  const normalized = {
+    blobsCoreKey,
+    blobId: stringifyBlobId(blob),
+    blob,
+  }
+
+  if (typeof value.mimeType === 'string' && value.mimeType.trim()) {
+    normalized.mimeType = value.mimeType.trim()
+  }
+  if (Number.isFinite(byteLength) && byteLength >= 0) {
+    normalized.byteLength = byteLength
+  }
+
+  return normalized
+}
+
+export function buildBlobRefCacheKey({ driveKey = 'unknown', id = 'unknown', blobsCoreKey, blobId, blob } = {}) {
+  const ref = parseBlobRef({ blobsCoreKey, blobId: blobId || blob })
+  if (!ref) return `${driveKey || 'unknown'}:${id || 'unknown'}:${blobsCoreKey || ''}:${typeof blobId === 'string' ? blobId : stringifyBlobId(blobId || blob) || ''}`
+  return `${driveKey || 'unknown'}:${id || 'unknown'}:${ref.blobsCoreKey}:${ref.blobId}`
+}

--- a/packages/backend/src/channel/multi-writer-channel.js
+++ b/packages/backend/src/channel/multi-writer-channel.js
@@ -671,7 +671,7 @@ export class MultiWriterChannel extends ReadyResource {
           const pubMeta = await this.publicBee.getMetadata().catch(() => null)
           existingKey = pubMeta?.commentsAutobaseKey || null
           existingAdminKey = existingAdminKey || pubMeta?.commentsAdminKey || null
-        } catch {}
+        } catch { /* best effort */ }
       }
 
       const isPublishingDevice = Boolean(this.publicBee?.writable)
@@ -750,49 +750,49 @@ export class MultiWriterChannel extends ReadyResource {
     }
 
     if (this.wakeupSession) {
-      try { await this.wakeupSession.destroy?.() } catch {}
-      try { await this.wakeupSession.close?.() } catch {}
+      try { await this.wakeupSession.destroy?.() } catch { /* best effort */ }
+      try { await this.wakeupSession.close?.() } catch { /* best effort */ }
       this.wakeupSession = null
     }
 
     if (this._channelDiscovery) {
-      try { this._channelDiscovery.destroy?.() } catch {}
-      try { this._channelDiscovery.close?.() } catch {}
+      try { this._channelDiscovery.destroy?.() } catch { /* best effort */ }
+      try { this._channelDiscovery.close?.() } catch { /* best effort */ }
       this._channelDiscovery = null
     }
 
     if (this.commentsAutobase) {
-      try { await this.commentsAutobase.close() } catch {}
+      try { await this.commentsAutobase.close() } catch { /* best effort */ }
       this.commentsAutobase = null
     }
 
     if (this.publicBee) {
-      try { await this.publicBee.close() } catch {}
+      try { await this.publicBee.close() } catch { /* best effort */ }
       this.publicBee = null
     }
 
     // Close pairing resources
     if (this.pairingMember) {
-      try { await this.pairingMember.close() } catch {}
+      try { await this.pairingMember.close() } catch { /* best effort */ }
       this.pairingMember = null
     }
     if (this.pairing) {
-      try { await this.pairing.close() } catch {}
+      try { await this.pairing.close() } catch { /* best effort */ }
       this.pairing = null
     }
 
     // Close blobs core
     if (this._blobsCore) {
-      try { await this._blobsCore.close() } catch {}
+      try { await this._blobsCore.close() } catch { /* best effort */ }
       this._blobsCore = null
       this.blobs = null
     }
     if (this.view) {
-      try { await this.view.close() } catch {}
+      try { await this.view.close() } catch { /* best effort */ }
       this.view = null
     }
     if (this.base) {
-      try { await this.base.close() } catch {}
+      try { await this.base.close() } catch { /* best effort */ }
       this.base = null
     }
   }

--- a/packages/backend/src/channel/multi-writer-channel.js
+++ b/packages/backend/src/channel/multi-writer-channel.js
@@ -16,6 +16,7 @@ import { ReactionsManager } from './reactions.js'
 import { WatchEventLogger } from '../recommendations/watch-events.js'
 import { applyMigrations } from './migrations.js'
 import { PublicChannelBee } from './public-channel-bee.js'
+import { normalizeBlobRefInput } from '../blob-ref.js'
 
 const BeeDiffStream = BeeDiffStreamImport?.default || BeeDiffStreamImport
 const CURRENT_SCHEMA_VERSION = 1
@@ -1604,17 +1605,8 @@ export class MultiWriterChannel extends ReadyResource {
     if (!this.blobs) throw new Error('Blobs not initialized')
 
     // Parse string ID if needed
-    let id = blobId
-    if (typeof blobId === 'string') {
-      const parts = blobId.split(':').map(Number)
-      if (parts.length !== 4) throw new Error('Invalid blob ID format')
-      id = {
-        blockOffset: parts[0],
-        blockLength: parts[1],
-        byteOffset: parts[2],
-        byteLength: parts[3]
-      }
-    }
+    const id = normalizeBlobRefInput(blobId)
+    if (!id) throw new Error('Invalid blob ID format')
 
     try {
       return await this.blobs.get(id)
@@ -1634,17 +1626,8 @@ export class MultiWriterChannel extends ReadyResource {
     if (!this.blobs) throw new Error('Blobs not initialized')
 
     // Parse string ID if needed
-    let id = blobId
-    if (typeof blobId === 'string') {
-      const parts = blobId.split(':').map(Number)
-      if (parts.length !== 4) throw new Error('Invalid blob ID format')
-      id = {
-        blockOffset: parts[0],
-        blockLength: parts[1],
-        byteOffset: parts[2],
-        byteLength: parts[3]
-      }
-    }
+    const id = normalizeBlobRefInput(blobId)
+    if (!id) throw new Error('Invalid blob ID format')
 
     return this.blobs.createReadStream(id, opts)
   }
@@ -1658,17 +1641,8 @@ export class MultiWriterChannel extends ReadyResource {
     if (!video?.blobId) return null
 
     // Parse the blobId
-    let id = video.blobId
-    if (typeof id === 'string') {
-      const parts = id.split(':').map(Number)
-      if (parts.length !== 4) return null
-      id = {
-        blockOffset: parts[0],
-        blockLength: parts[1],
-        byteOffset: parts[2],
-        byteLength: parts[3]
-      }
-    }
+    const id = normalizeBlobRefInput(video.blobId)
+    if (!id) return null
 
     // Determine which blobs core has this video
     let blobsKey = this._blobsCore?.key

--- a/packages/backend/src/storage.js
+++ b/packages/backend/src/storage.js
@@ -56,7 +56,7 @@ function describeDebugError(error) {
       extra[key] = error[key]
     }
     if (Object.keys(extra).length > 0) details.extra = extra
-  } catch {}
+  } catch { /* best effort */ }
 
   try {
     return JSON.stringify(details)
@@ -74,7 +74,7 @@ async function appendDebugLine(line) {
     const fs = fsModule?.default ?? fsModule
     if (typeof fs?.appendFileSync !== 'function') return
     fs.appendFileSync(filePath, `${new Date().toISOString()} ${line}\n`)
-  } catch {}
+  } catch { /* best effort */ }
 }
 
 const log = logger('Storage')
@@ -147,7 +147,7 @@ function createOfflineSwarm(keyPair, reason = 'unavailable') {
     },
     emit(event, ...args) {
       for (const listener of listeners.get(event) || []) {
-        try { listener(...args) } catch {}
+        try { listener(...args) } catch { /* best effort */ }
       }
       return true
     },
@@ -218,13 +218,13 @@ async function initStorageModules() {
   fs = resolveBareOrNodeFsModuleSync()
   path = resolveBareOrNodePathModuleSync()
   if (!fs) {
-    try { fs = await loadBareOrNodeFsModule(); } catch {}
+    try { fs = await loadBareOrNodeFsModule(); } catch { /* best effort */ }
   }
   if (!path) {
-    try { path = await loadBareOrNodePathModule(); } catch {}
+    try { path = await loadBareOrNodePathModule(); } catch { /* best effort */ }
   }
   if (!Hyperswarm) {
-    try { Hyperswarm = await loadHyperswarmModule(); } catch {}
+    try { Hyperswarm = await loadHyperswarmModule(); } catch { /* best effort */ }
   }
 }
 
@@ -238,7 +238,7 @@ async function migrateLegacyCorestoreLayout(storagePath) {
       await appendDebugLine('[storage] embedded migration skipped (CORESTORE exists)')
       return
     }
-  } catch {}
+  } catch { /* best effort */ }
 
   if (!fs.promises?.readdir || !fs.promises?.rename || !fs.promises?.mkdir) {
     await appendDebugLine('[storage] embedded migration skipped (fs.promises unavailable)')
@@ -272,7 +272,7 @@ async function migrateLegacyCorestoreLayout(storagePath) {
 
     try {
       await fs.promises.mkdir(path.join(storagePath, 'db'), { recursive: true })
-    } catch {}
+    } catch { /* best effort */ }
 
     try {
       await fs.promises.rename(
@@ -280,7 +280,7 @@ async function migrateLegacyCorestoreLayout(storagePath) {
         path.join(storagePath, 'db', entry)
       )
       moved++
-    } catch {}
+    } catch { /* best effort */ }
   }
 
   await appendDebugLine(`[storage] embedded migration moved=${moved}`)
@@ -365,7 +365,7 @@ export function retainSwarmDiscovery(ctx, discoveryKey, options = {}) {
           console.log(`[Storage] Swarm discovery flush failed for ${label} (non-fatal):`, err?.message)
         })
     }
-  } catch {}
+  } catch { /* best effort */ }
 
   return handle
 }
@@ -854,7 +854,7 @@ export async function loadChannel(ctx, channelKeyHex, options = {}) {
     if (!isChannelUsable(cached)) {
       console.log('[Storage] loadChannel: evicting stale cached channel:', channelKeyHex.slice(0, 16))
       ctx.channels.delete(channelKeyHex)
-      try { await cached?.close?.() } catch {}
+      try { await cached?.close?.() } catch { /* best effort */ }
     }
 
     if (ctx.channels.has(channelKeyHex)) {
@@ -867,7 +867,7 @@ export async function loadChannel(ctx, channelKeyHex, options = {}) {
               current.close(),
               new Promise((resolve) => setTimeout(resolve, 2000))
             ])
-          } catch {}
+          } catch { /* best effort */ }
           ctx.channels.delete(channelKeyHex)
         } else {
           console.log('[Storage] loadChannel: cached channel remains read-only (no writer key name):', channelKeyHex.slice(0, 16))
@@ -950,7 +950,7 @@ export async function loadChannel(ctx, channelKeyHex, options = {}) {
           new Promise((_, reject) => setTimeout(() => reject(new Error('Channel ready timeout')), readyTimeoutMs))
         ])
       } catch (err) {
-        try { await ch.close() } catch {}
+        try { await ch.close() } catch { /* best effort */ }
         throw err
       }
 
@@ -1093,7 +1093,7 @@ export async function loadPublicBee(ctx, publicBeeKeyHex) {
       return false
     },
     closeStale: async (bee) => {
-      try { await bee?.close?.() } catch {}
+      try { await bee?.close?.() } catch { /* best effort */ }
     },
     loadFresh: async () => {
       console.log('[Storage] loadPublicBee: loading:', publicBeeKeyHex.slice(0, 16))
@@ -1109,7 +1109,7 @@ export async function loadPublicBee(ctx, publicBeeKeyHex) {
         ])
       } catch (err) {
         console.error('[Storage] loadPublicBee failed:', err.message)
-        try { await bee.close() } catch {}
+        try { await bee.close() } catch { /* best effort */ }
         throw err
       }
 
@@ -1170,7 +1170,7 @@ export async function createChannel(ctx, options = {}) {
   // Persist a marker so we can reliably distinguish multi-writer channels.
   try {
     await ctx.metaDb.put(`mw-channel:${channelKeyHex}`, { kind: 'autobase', createdAt: Date.now() })
-  } catch {}
+  } catch { /* best effort */ }
 
   // Set up pairing and replication - AWAIT to ensure handlers are registered
   if (ctx.swarm) {
@@ -1223,9 +1223,9 @@ export async function deriveDeterministicChannelSeed(store, { writerKeyName, enc
       encryptionKeyHex: encrypt && bootstrapCore.encryptionKey ? b4a.toString(bootstrapCore.encryptionKey, 'hex') : null
     }
   } finally {
-    try { await bootstrapCore?.close?.() } catch {}
+    try { await bootstrapCore?.close?.() } catch { /* best effort */ }
     if (deriveSession !== store) {
-      try { await deriveSession.close?.() } catch {}
+      try { await deriveSession.close?.() } catch { /* best effort */ }
     }
   }
 }
@@ -1253,7 +1253,7 @@ export async function pairDevice(ctx, inviteCode, options = {}) {
   // Persist marker for multi-writer channel
   try {
     await ctx.metaDb.put(`mw-channel:${channelKeyHex}`, { kind: 'autobase', createdAt: Date.now() })
-  } catch {}
+  } catch { /* best effort */ }
 
   // Set up pairing and replication - AWAIT to ensure base.replicate(conn) handlers are registered
   if (ctx.swarm) {
@@ -1332,7 +1332,7 @@ export function getVideoUrlInstant(ctx, blobsCoreKeyHex, blobId, options = {}) {
         retainSwarmDiscovery(ctx, blobsCore.discoveryKey, {
           label: `blobs:${blobsCoreKeyHex.slice(0, 16)}`
         })
-      } catch {}
+      } catch { /* best effort */ }
     }
     // Trigger update in background to find peers
     blobsCore.update().catch(() => {})
@@ -1404,7 +1404,7 @@ export async function getVideoUrlFromBlob(ctx, blobsCoreKeyHex, blobId, options 
       blobsCore.update({ wait: true }),
       new Promise((_, reject) => setTimeout(() => reject(new Error('blobs core update timeout')), 5000))
     ])
-  } catch {}
+  } catch { /* best effort */ }
 
   const mimeType = options.mimeType || 'video/mp4'
 
@@ -1497,7 +1497,7 @@ export async function shutdownBackend(ctx) {
             if (ch && typeof ch.close === 'function') {
               await ch.close()
             }
-          } catch {}
+          } catch { /* best effort */ }
         }))
       } catch (err) {
         console.log('[Backend] Shutdown: channel close batch failed (non-fatal):', err?.message)
@@ -1513,7 +1513,7 @@ export async function shutdownBackend(ctx) {
             if (bee && typeof bee.close === 'function') {
               await bee.close()
             }
-          } catch {}
+          } catch { /* best effort */ }
         }))
       } catch (err) {
         console.log('[Backend] Shutdown: publicBeeCache close batch failed (non-fatal):', err?.message)
@@ -1533,7 +1533,7 @@ export async function shutdownBackend(ctx) {
       for (const handle of ctx._swarmDiscoveryHandles.values()) {
         try {
           handle?.destroy?.()
-        } catch {}
+        } catch { /* best effort */ }
       }
       ctx._swarmDiscoveryHandles.clear()
     }
@@ -1764,7 +1764,7 @@ export async function prefetchVideoForCast(drive, filePath, signal) {
   const onAbort = () => {
     try {
       stream.destroy(abortError())
-    } catch {}
+    } catch { /* best effort */ }
   }
   if (signal) signal.addEventListener('abort', onAbort)
 
@@ -1801,7 +1801,7 @@ export async function prefetchVideoForCast(drive, filePath, signal) {
   } finally {
     if (signal) signal.removeEventListener('abort', onAbort)
     if (!settled) {
-      try { stream.destroy() } catch {}
+      try { stream.destroy() } catch { /* best effort */ }
     }
   }
 }

--- a/packages/backend/src/storage.js
+++ b/packages/backend/src/storage.js
@@ -24,6 +24,7 @@ import {
   resolveBareOrNodePathModuleSync,
 } from './runtime-modules.js'
 import { NETWORK_TOPIC_STRING } from './types.js'
+import { normalizeBlobRefInput } from './blob-ref.js'
 
 function resolveDebugLogPath() {
   return globalThis?.process?.env?.PEARTUBE_NATIVE_WORKLET_DEBUG_LOG || null
@@ -1310,15 +1311,9 @@ export function getVideoUrlInstant(ctx, blobsCoreKeyHex, blobId, options = {}) {
   const mimeType = options.mimeType || 'video/mp4'
 
   // Parse blobId string to object if needed
-  let blob = blobId
-  if (typeof blobId === 'string') {
-    const parts = blobId.split(':').map(Number)
-    blob = {
-      blockOffset: parts[0],
-      blockLength: parts[1],
-      byteOffset: parts[2],
-      byteLength: parts[3]
-    }
+  const blob = normalizeBlobRefInput(blobId)
+  if (!blob) {
+    throw new Error('Invalid blob ID format')
   }
 
   // Generate URL immediately - blob server fetches data on-demand
@@ -1415,15 +1410,9 @@ export async function getVideoUrlFromBlob(ctx, blobsCoreKeyHex, blobId, options 
 
   // Parse blobId string to object if needed
   // blobId can be a string like "0:28174:0:1846355808" or an object
-  let blob = blobId
-  if (typeof blobId === 'string') {
-    const parts = blobId.split(':').map(Number)
-    blob = {
-      blockOffset: parts[0],
-      blockLength: parts[1],
-      byteOffset: parts[2],
-      byteLength: parts[3]
-    }
+  const blob = normalizeBlobRefInput(blobId)
+  if (!blob) {
+    throw new Error('Invalid blob ID format')
   }
 
   // Generate direct blob URL

--- a/packages/backend/test/blob-ref.test.mjs
+++ b/packages/backend/test/blob-ref.test.mjs
@@ -1,0 +1,63 @@
+import test from 'brittle'
+
+import {
+  buildBlobRefCacheKey,
+  normalizeBlobRefInput,
+  parseBlobId,
+  parseBlobRef,
+  stringifyBlobId,
+} from '../src/blob-ref.js'
+
+test('parseBlobId accepts hyperblob range strings', (t) => {
+  t.alike(parseBlobId('10:4:128:4096'), {
+    blockOffset: 10,
+    blockLength: 4,
+    byteOffset: 128,
+    byteLength: 4096,
+  })
+})
+
+test('parseBlobId rejects malformed ranges', (t) => {
+  t.is(parseBlobId(null), null)
+  t.is(parseBlobId(''), null)
+  t.is(parseBlobId('1:2:3'), null)
+  t.is(parseBlobId('1:2:3:NaN'), null)
+  t.is(parseBlobId('1:2:3:-4'), null)
+  t.is(parseBlobId('1:0:3:4'), null)
+  t.is(parseBlobId({ blockOffset: 1, blockLength: 2, byteOffset: 0, byteLength: 10 }), null)
+})
+
+test('normalizeBlobRefInput preserves valid object blob ranges', (t) => {
+  const blob = { blockOffset: 1, blockLength: 2, byteOffset: 3, byteLength: 4 }
+  t.alike(normalizeBlobRefInput(blob), blob)
+})
+
+test('parseBlobRef normalizes key, id, mime, and byte length', (t) => {
+  const ref = parseBlobRef({
+    blobsCoreKey: 'ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789',
+    blobId: '1:2:3:4',
+    mimeType: 'video/mp4',
+    byteLength: '4',
+  })
+
+  t.alike(ref, {
+    blobsCoreKey: 'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789',
+    blobId: '1:2:3:4',
+    blob: { blockOffset: 1, blockLength: 2, byteOffset: 3, byteLength: 4 },
+    mimeType: 'video/mp4',
+    byteLength: 4,
+  })
+})
+
+test('parseBlobRef fails closed for partial or invalid refs', (t) => {
+  t.is(parseBlobRef({ blobsCoreKey: 'abc', blobId: '1:2:3:4' }), null)
+  t.is(parseBlobRef({ blobsCoreKey: 'a'.repeat(64) }), null)
+  t.is(parseBlobRef({ blobId: '1:2:3:4' }), null)
+  t.is(parseBlobRef({ blobsCoreKey: 'a'.repeat(64), blobId: '1:2:3' }), null)
+})
+
+test('stringifyBlobId and cache key use normalized identity', (t) => {
+  const blob = { blockOffset: 1, blockLength: 2, byteOffset: 3, byteLength: 4 }
+  t.is(stringifyBlobId(blob), '1:2:3:4')
+  t.is(buildBlobRefCacheKey({ driveKey: 'drive', id: 'vid', blobsCoreKey: 'A'.repeat(64), blobId: blob }), 'drive:vid:' + 'a'.repeat(64) + ':1:2:3:4')
+})


### PR DESCRIPTION
## Summary

- Adds a backend `BlobRef` helper for normalizing blob IDs, blob ranges, core keys, and cache keys.
- Replaces repeated ad hoc `blobId.split(':').map(Number)` parsing in backend playback, availability, storage URL generation, downloads, thumbnails, prefetch, and multi-writer channel blob helpers.
- Adds focused regression coverage for valid/invalid/partial/legacy blob metadata behavior.

Closes #69

## Test plan

```bash
node --test packages/backend/test/blob-ref.test.mjs packages/backend/test/playback-api.test.mjs packages/app/tests/playback-url-instant-regression.test.mjs packages/app/tests/feed-hydration.test.mjs packages/app/tests/feed-snapshot.test.mjs && git diff --check
npm run lint:changed
```

Result: 20 passed / 0 failed. `lint:changed` exited 0 with repo message `No changed JS/TS files to lint`.
