### PR TITLE
ci: publish available Android APK release artifacts

### DIFF
--- a/.github/actions/setup-node-workspace/action.yml
+++ b/.github/actions/setup-node-workspace/action.yml
@@ -22,4 +22,18 @@ runs:
     - name: Install workspace dependencies
       if: ${{ inputs.install == 'true' }}
       shell: bash
-      run: npm run install:all
+      run: |
+        for attempt in 1 2 3; do
+          if npm run install:all; then
+            exit 0
+          fi
+
+          if [ "$attempt" -eq 3 ]; then
+            echo "::error::npm run install:all failed after 3 attempts"
+            exit 1
+          fi
+
+          echo "npm run install:all failed; retrying in $((attempt * 20)) seconds..."
+          npm cache verify || true
+          sleep $((attempt * 20))
+        done

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -167,7 +167,7 @@ jobs:
   publish-release:
     needs: build-release
     runs-on: ubuntu-latest
-    if: always() && (startsWith(github.ref, 'refs/tags/v') || github.event.inputs.tag != '') && contains(needs.build-release.result, 'success')
+    if: always() && (startsWith(github.ref, 'refs/tags/v') || github.event.inputs.tag != '')
     permissions:
       contents: write
 

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -167,7 +167,7 @@ jobs:
   publish-release:
     needs: build-release
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v') || github.event.inputs.tag != ''
+    if: always() && (startsWith(github.ref, 'refs/tags/v') || github.event.inputs.tag != '') && contains(needs.build-release.result, 'success')
     permissions:
       contents: write
 
@@ -177,6 +177,19 @@ jobs:
         with:
           path: apks
           merge-multiple: true
+
+      - name: Verify APK artifacts exist
+        shell: bash
+        run: |
+          mapfile -t apks < <(find apks -type f -name '*.apk' | sort)
+          if [ "${#apks[@]}" -eq 0 ]; then
+            echo "::error::No APK artifacts were downloaded for release publishing"
+            find apks -maxdepth 3 -type f -print 2>/dev/null || true
+            exit 1
+          fi
+
+          printf 'Publishing %s APK artifact(s):\n' "${#apks[@]}"
+          printf ' - %s\n' "${apks[@]}"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3.0.0

--- a/packages/app/tests/android-apk-build-pipeline-regression.test.mjs
+++ b/packages/app/tests/android-apk-build-pipeline-regression.test.mjs
@@ -43,6 +43,11 @@ test('Android GitHub workflows regenerate HRPC spec and backend bundles before A
       /npm run install:all/,
       `${name} workflow family should use the repo install:all flow instead of root npm ci`,
     )
+    assert.match(
+      setupAction,
+      /for attempt in 1 2 3/,
+      `${name} workflow family should retry transient npm install failures before failing`,
+    )
   }
 
   assert.match(

--- a/packages/app/tests/ci-lockfile-install-regression.test.mjs
+++ b/packages/app/tests/ci-lockfile-install-regression.test.mjs
@@ -38,6 +38,16 @@ test('test workflow avoids root npm cache and npm ci because the repo has no roo
     'shared Node setup should install dependencies via the repo install:all script',
   )
   assert.match(
+    setupAction,
+    /for attempt in 1 2 3/,
+    'shared Node setup should retry transient npm registry/network failures before failing the workflow',
+  )
+  assert.match(
+    setupAction,
+    /npm cache verify \|\| true/,
+    'shared Node setup should verify cache between install retries without masking the final install failure',
+  )
+  assert.match(
     rootPackage.scripts['install:all'],
     /packages\/spec/,
     'install:all should install packages/spec so schema generation can require hrpc-swift in CI',

--- a/packages/app/tests/ci-workflow-split-regression.test.mjs
+++ b/packages/app/tests/ci-workflow-split-regression.test.mjs
@@ -29,6 +29,17 @@ test('build workflows stay separate from publish workflows', () => {
     'release-android should own GitHub release publishing',
   )
 
+  assert.match(
+    releaseAndroid,
+    /if:\s*always\(\)[^\n]*contains\(needs\.build-release\.result, 'success'\)/,
+    'release-android should still publish completed APK artifacts when one matrix ABI flakes after other ABIs uploaded',
+  )
+  assert.match(
+    releaseAndroid,
+    /No APK artifacts were downloaded for release publishing/,
+    'release-android should fail loudly if no APK artifacts are available to attach to the tag release',
+  )
+
   assert.doesNotMatch(
     buildRelay,
     /docker\/login-action/,

--- a/packages/app/tests/ci-workflow-split-regression.test.mjs
+++ b/packages/app/tests/ci-workflow-split-regression.test.mjs
@@ -31,7 +31,7 @@ test('build workflows stay separate from publish workflows', () => {
 
   assert.match(
     releaseAndroid,
-    /if:\s*always\(\)[^\n]*contains\(needs\.build-release\.result, 'success'\)/,
+    /if:\s*always\(\)[^\n]*startsWith\(github\.ref, 'refs\/tags\/v'\)/,
     'release-android should still publish completed APK artifacts when one matrix ABI flakes after other ABIs uploaded',
   )
   assert.match(


### PR DESCRIPTION
## Summary
- let the Android release publish job run after successful matrix legs even if another ABI flakes
- fail loudly if no APK artifacts were downloaded before attaching release assets
- retry npm install:all in the shared Node setup action for transient registry/network failures

## Root cause
v0.1.35 had armeabi-v7a and x86_64 APK artifacts, but arm64-v8a hit an npm ECONNRESET during install. Since publish-release depended on the whole matrix, GitHub skipped release publishing entirely.

## Test Plan
- node --test packages/app/tests/ci-workflow-split-regression.test.mjs packages/app/tests/ci-lockfile-install-regression.test.mjs packages/app/tests/android-apk-build-pipeline-regression.test.mjs
- python3 YAML parse for release-android.yml and setup-node-workspace/action.yml