### PR TITLE
fix(app): use dedicated vertical shorts player

### DIFF
--- a/packages/app/app/(tabs)/discover.tsx
+++ b/packages/app/app/(tabs)/discover.tsx
@@ -28,7 +28,7 @@ import { fetchThumbnailUrlWithRetry } from '@/lib/thumbnail'
 import { getFeedPreviewVideos, getVisibleSeededFeedEntries, shouldRenderFeedVideo } from '@/lib/feed-hydration'
 import { getCachedVideoUrl, makeVideoUrlCacheKey, setCachedVideoUrl } from '@/lib/video-url-cache'
 import { formatTimeAgo } from '@/lib/formatters'
-import { VideoContainer } from '@/components/video-player/VideoContainer'
+import { VerticalShortsPlayer } from '@/components/discovery/VerticalShortsPlayer'
 
 interface FeedEntry {
   driveKey: string
@@ -406,30 +406,17 @@ export default function VerticalDiscoveryScreen() {
               >
                 <View style={styles.scrim} />
                 <View style={styles.videoStage}>
-                  {activeVideoKey === `${video.channelKey}:${video.id}` && shortsVideoUrl ? (
-                    <View style={styles.playingFrame}>
-                      <VideoContainer
-                        testID="vertical-discovery-inline-player"
-                        style={styles.shortsInlinePlayer}
-                        playerRef={shortsPlayerRef}
-                        videoUrl={shortsVideoUrl}
-                        currentVideo={video}
-                        playbackSession={shortsPlaybackSession}
-                        isPlaying
-                        playbackRate={1}
-                        isCasting={false}
-                        isInPipMode={false}
-                      />
-                    </View>
-                  ) : shortsLoading && activeVideoKey === `${video.channelKey}:${video.id}` ? (
-                    <View style={styles.playButtonShell}>
-                      <ActivityIndicator color="#fff" size="large" />
-                    </View>
-                  ) : (
-                    <View style={styles.playButtonShell}>
-                      <Feather name="play" color="#fff" size={42} />
-                    </View>
-                  )}
+                  <VerticalShortsPlayer
+                    testID="vertical-discovery-inline-player"
+                    playerRef={shortsPlayerRef}
+                    videoUrl={activeVideoKey === `${video.channelKey}:${video.id}` ? shortsVideoUrl : null}
+                    video={video}
+                    playbackSession={shortsPlaybackSession}
+                    isActive={activeVideoKey === `${video.channelKey}:${video.id}`}
+                    isLoading={shortsLoading && activeVideoKey === `${video.channelKey}:${video.id}`}
+                    thumbnailUrl={video.thumbnailUrl || null}
+                    onReplay={() => playVideo(video)}
+                  />
                 </View>
                 <View style={[styles.bottomMeta, { paddingBottom: Math.max(insets.bottom + 86, 104) }]}> 
                   <Pressable onPress={() => openDetails(video)} style={styles.metaTextBlock}>
@@ -542,42 +529,8 @@ const styles = StyleSheet.create({
     backgroundColor: 'rgba(0,0,0,0.38)',
   },
   videoStage: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingHorizontal: 24,
-  },
-  playingFrame: {
-    width: '78%',
-    aspectRatio: 9 / 16,
-    maxHeight: '66%',
-    borderRadius: 28,
-    borderWidth: 1,
-    borderColor: 'rgba(255,255,255,0.18)',
-    backgroundColor: 'rgba(0,0,0,0.34)',
-    overflow: 'hidden',
-  },
-  shortsInlinePlayer: {
-    width: '100%',
-    height: '100%',
+    ...StyleSheet.absoluteFillObject,
     backgroundColor: '#000',
-  },
-  playingText: {
-    color: colors.primary,
-    fontSize: 13,
-    fontWeight: '800',
-    textTransform: 'uppercase',
-    letterSpacing: 1.5,
-  },
-  playButtonShell: {
-    width: 86,
-    height: 86,
-    borderRadius: 43,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: 'rgba(255,255,255,0.13)',
-    borderWidth: 1,
-    borderColor: 'rgba(255,255,255,0.18)',
   },
   bottomMeta: {
     position: 'absolute',

--- a/packages/app/components/discovery/VerticalShortsPlayer.tsx
+++ b/packages/app/components/discovery/VerticalShortsPlayer.tsx
@@ -1,0 +1,170 @@
+import { memo, RefObject, useCallback, useEffect, useMemo, useState } from 'react'
+import { ActivityIndicator, ImageBackground, Pressable, StyleSheet, View } from 'react-native'
+import { Feather } from '@expo/vector-icons'
+import type { VideoData } from '@peartube/core'
+import { colors } from '@/lib/colors'
+import { PearInlineVideoView } from '@/components/video-player/PearInlineVideoView'
+
+type VerticalShortsPlayerProps = {
+  testID?: string
+  playerRef: RefObject<any>
+  videoUrl: string | null
+  video: VideoData
+  playbackSession: number
+  isActive: boolean
+  isLoading?: boolean
+  thumbnailUrl?: string | null
+  onReplay?: () => void
+}
+
+function getShortsVideoKey(video: VideoData, fallbackUrl?: string | null) {
+  return `${video.channelKey || 'channel'}:${video.id || video.path || fallbackUrl || 'video'}`
+}
+
+export const VerticalShortsPlayer = memo(function VerticalShortsPlayer({
+  testID,
+  playerRef,
+  videoUrl,
+  video,
+  playbackSession,
+  isActive,
+  isLoading = false,
+  thumbnailUrl,
+  onReplay,
+}: VerticalShortsPlayerProps) {
+  const [videoSize, setVideoSize] = useState<{ width: number; height: number } | null>(null)
+  const [hasPlaybackError, setHasPlaybackError] = useState(false)
+  const videoKey = getShortsVideoKey(video, videoUrl)
+
+  useEffect(() => {
+    setHasPlaybackError(false)
+    setVideoSize(null)
+  }, [videoKey])
+
+  const isLandscape = useMemo(() => {
+    if (!videoSize) return false
+    return videoSize.width > videoSize.height * 1.12
+  }, [videoSize])
+
+  const handleVideoStateChange = useCallback((event: any) => {
+    if (event?.type !== 'video-size') return
+    const width = Number(event.mVideoWidth || event.width)
+    const height = Number(event.mVideoHeight || event.height)
+    if (Number.isFinite(width) && Number.isFinite(height) && width > 0 && height > 0) {
+      setVideoSize({ width, height })
+    }
+  }, [])
+
+  const handleError = useCallback((error: any) => {
+    setHasPlaybackError(true)
+    console.log('[VerticalShortsPlayer] Playback failed:', error?.message || error)
+  }, [])
+
+  const showPlayer = Boolean(videoUrl && isActive && !hasPlaybackError)
+  const showPoster = !showPlayer && Boolean(thumbnailUrl)
+
+  return (
+    <View
+      testID={testID}
+      style={styles.container}
+      accessibilityRole="imagebutton"
+      accessibilityLabel={`Vertical video player for ${video.title || 'video'}`}
+    >
+      {showPoster ? (
+        <ImageBackground
+          source={{ uri: thumbnailUrl || undefined }}
+          style={StyleSheet.absoluteFill}
+          imageStyle={styles.posterImage}
+        />
+      ) : null}
+
+      {showPlayer ? (
+        <PearInlineVideoView
+          playerRef={playerRef}
+          videoUrl={videoUrl as string}
+          playbackSession={playbackSession}
+          currentVideoKey={videoKey}
+          isPlaying={isActive}
+          playbackRate={1}
+          videoTitle={video.title}
+          channelName={video.channel?.name || 'Channel'}
+          thumbnailUrl={thumbnailUrl || undefined}
+          onVideoStateChange={handleVideoStateChange}
+          onError={handleError}
+          style={[
+            styles.videoSurface,
+            isLandscape ? styles.landscapeVideoSurface : styles.verticalVideoSurface,
+          ]}
+        />
+      ) : null}
+
+      {showPlayer && isLandscape ? (
+        <View pointerEvents="none" style={styles.landscapeMatte} />
+      ) : null}
+
+      {isLoading ? (
+        <View style={styles.centerOverlay}>
+          <ActivityIndicator color="#fff" size="large" />
+        </View>
+      ) : null}
+
+      {!showPlayer && !isLoading ? (
+        <Pressable onPress={onReplay} style={styles.playButtonShell} accessibilityLabel="Play vertical video">
+          <Feather name={hasPlaybackError ? 'rotate-cw' : 'play'} color="#fff" size={42} />
+        </Pressable>
+      ) : null}
+    </View>
+  )
+})
+
+const styles = StyleSheet.create({
+  container: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: '#000',
+    overflow: 'hidden',
+  },
+  posterImage: {
+    opacity: 0.44,
+    resizeMode: 'cover',
+  },
+  videoSurface: {
+    backgroundColor: '#000',
+  },
+  verticalVideoSurface: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  landscapeVideoSurface: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    top: '25%',
+    height: '50%',
+  },
+  landscapeMatte: {
+    ...StyleSheet.absoluteFillObject,
+    borderTopWidth: 1,
+    borderBottomWidth: 1,
+    borderColor: 'rgba(255,255,255,0.08)',
+  },
+  centerOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(0,0,0,0.2)',
+  },
+  playButtonShell: {
+    position: 'absolute',
+    left: '50%',
+    top: '50%',
+    width: 86,
+    height: 86,
+    marginLeft: -43,
+    marginTop: -43,
+    borderRadius: 43,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(255,255,255,0.13)',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.18)',
+  },
+})

--- a/packages/app/tests/vertical-discovery-regression.test.mjs
+++ b/packages/app/tests/vertical-discovery-regression.test.mjs
@@ -29,13 +29,24 @@ test('vertical discovery uses paged full-screen feed and plays inline in the sho
   assert.match(source, /snapToInterval=\{pageHeight\}/, 'vertical discovery should snap to full-screen item height')
   assert.match(source, /onViewableItemsChanged/, 'vertical discovery should track the active page')
   assert.match(source, /viewabilityConfig/, 'vertical discovery should use explicit viewability thresholds')
-  assert.match(source, /<VideoContainer[\s\S]*testID="vertical-discovery-inline-player"/, 'active vertical item should render the video inside the shorts surface')
+  assert.match(source, /<VerticalShortsPlayer[\s\S]*testID="vertical-discovery-inline-player"/, 'active vertical item should render through the dedicated shorts player surface')
+  assert.doesNotMatch(source, /<VideoContainer/, 'vertical discovery must not embed the normal watch player container')
   assert.doesNotMatch(source, /loadAndPlayVideo\(/, 'vertical playback must not open the normal mobile playback overlay')
   assert.doesNotMatch(source, /useVideoPlayerContext\(/, 'vertical playback should not depend on the global overlay player context')
   assert.match(source, /preparePlayback\(playbackRequest\)/, 'vertical player should resolve playback through backend preparePlayback')
   assert.match(source, /getCachedVideoUrl\(cacheKey\)/, 'vertical player should use the short playback URL cache')
   assert.match(source, /setShortsVideoUrl\(/, 'vertical player should keep playback URL in local shorts-player state')
   assert.match(source, /testID=\{index === 0 \? 'vertical-discovery-first-video' : undefined\}/, 'first vertical card should keep a stable test hook')
+})
+
+test('vertical discovery uses a dedicated shorts player surface instead of the watch player frame', () => {
+  const source = readAppFile('components/discovery/VerticalShortsPlayer.tsx')
+
+  assert.match(source, /PearInlineVideoView/, 'shorts player should paint the native inline video surface directly')
+  assert.doesNotMatch(source, /VideoContainer/, 'shorts player must not wrap the normal watch player container')
+  assert.match(source, /\.\.\.StyleSheet\.absoluteFillObject/, 'shorts player should own the full vertical card surface')
+  assert.match(source, /landscapeVideoSurface/, 'shorts player should have a landscape-specific presentation mode')
+  assert.match(source, /onVideoStateChange=\{handleVideoStateChange\}/, 'shorts player should react to loaded video dimensions')
 })
 
 test('vertical discovery keeps channel navigation and detail escape hatches', () => {


### PR DESCRIPTION
## Summary

- Replaces the normal watch `VideoContainer` embed in vertical Discover with a dedicated `VerticalShortsPlayer` surface.
- Keeps Shorts playback local to the Discover card, but paints the native inline video surface directly instead of nesting a phone-shaped watch player frame.
- Adds landscape-aware presentation inside the Shorts surface so wide videos use a clean horizontal player band without an extra portrait border/card.
- Preserves thumbnail poster, replay/loading states, local playback URL/session state, and the existing channel/details escape hatches.

## Test plan

```bash
node --test packages/app/tests/vertical-discovery-regression.test.mjs packages/app/tests/mobile-player-page-layout-regression.test.mjs && git diff --check && npm run lint:changed
```

Result: 12 passed / 0 failed. `lint:changed` exited 0 with repo message `No changed JS/TS files to lint`.
