### PR TITLE
chore(cli): include yt-dlp in relay container

### DIFF
--- a/packages/cli/Dockerfile
+++ b/packages/cli/Dockerfile
@@ -16,10 +16,15 @@ RUN case "${TARGETARCH}" in \
 FROM debian:12-slim AS runtime-libs
 
 ARG TARGETARCH
+ARG YT_DLP_VERSION=2026.03.17
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends libatomic1 \
+  && apt-get install -y --no-install-recommends ca-certificates curl libatomic1 \
   && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL "https://github.com/yt-dlp/yt-dlp/releases/download/${YT_DLP_VERSION}/yt-dlp" \
+    -o /usr/local/bin/yt-dlp \
+  && chmod 755 /usr/local/bin/yt-dlp
 
 RUN case "${TARGETARCH}" in \
     amd64) cp /usr/lib/x86_64-linux-gnu/libatomic.so.1 /libatomic.so.1 ;; \
@@ -40,6 +45,7 @@ WORKDIR /var/lib/peartube-relay
 
 COPY --from=artifact /peartube-relay /peartube-relay
 COPY --from=runtime-libs /libatomic.so.1 /lib/libatomic.so.1
+COPY --from=runtime-libs /usr/local/bin/yt-dlp /usr/local/bin/yt-dlp
 
 VOLUME ["/var/lib/peartube-relay"]
 

--- a/packages/cli/test/cli.test.mjs
+++ b/packages/cli/test/cli.test.mjs
@@ -95,7 +95,10 @@ test('Dockerfile packages the standalone relay executable in a minimal runtime i
 
   t.ok(content.includes('FROM busybox:1.36.1 AS artifact'), 'artifact stage selects the prebuilt standalone relay binary')
   t.ok(content.includes('FROM debian:12-slim AS runtime-libs'), 'runtime libs stage installs missing shared libraries for native addons')
-  t.ok(content.includes('libatomic1'), 'runtime libs stage installs libatomic needed by rocksdb-native in the standalone relay')
+  t.ok(content.includes('ARG YT_DLP_VERSION='), 'Dockerfile pins the yt-dlp release version as a build arg')
+  t.ok(content.includes('ca-certificates curl libatomic1'), 'runtime libs stage installs curl and CA roots to download yt-dlp')
+  t.ok(content.includes('https://github.com/yt-dlp/yt-dlp/releases/download/${YT_DLP_VERSION}/yt-dlp'), 'runtime libs stage downloads the pinned yt-dlp release')
+  t.ok(content.includes('chmod 755 /usr/local/bin/yt-dlp'), 'runtime libs stage makes yt-dlp executable')
   t.ok(content.includes('COPY packages/cli/dist/docker/ /dist/'), 'builder stage only packages prebuilt docker artifacts')
   t.ok(content.includes('cp /dist/linux-amd64/peartube-relay /peartube-relay'), 'artifact stage maps Docker amd64 to the prepared standalone binary')
   t.ok(content.includes('cp /dist/linux-arm64/peartube-relay /peartube-relay'), 'artifact stage maps Docker arm64 to the prepared standalone binary')
@@ -103,6 +106,7 @@ test('Dockerfile packages the standalone relay executable in a minimal runtime i
   t.absent(content.includes('npm run build:standalone'), 'Docker build no longer runs bare-build inside the image')
   t.ok(content.includes('COPY --from=artifact'), 'final image copies the packaged artifact from the artifact stage')
   t.ok(content.includes('COPY --from=runtime-libs /libatomic.so.1 /lib/libatomic.so.1'), 'final image copies libatomic into the runtime rootfs for rocksdb-native')
+  t.ok(content.includes('COPY --from=runtime-libs /usr/local/bin/yt-dlp /usr/local/bin/yt-dlp'), 'final image copies yt-dlp into PATH for relay CLI import workflows')
   t.ok(content.includes('ENTRYPOINT ["/peartube-relay"]'), 'final image runs the standalone relay executable directly')
 })
 


### PR DESCRIPTION
## Summary
- Download pinned yt-dlp during the relay container runtime-libs stage
- Copy /usr/local/bin/yt-dlp into the final distroless image so it is available on PATH for CLI/import workflows
- Extend the Dockerfile regression test to cover the yt-dlp download, executable bit, and final-stage copy

## Verification
- git diff --check
- Source-level Dockerfile assertions via search_files confirmed YT_DLP_VERSION=2026.03.17, curl/CA install, GitHub release download, chmod, and final image copy

## Notes
- Could not run the existing brittle test in this worktree because dependencies were absent, and npm install hit filesystem quota / write errors (errno -122). Docker is also unavailable on this runner, so no local image build was possible.