### PR TITLE
refactor(app): define shared PlayerPort interface

### DIFF
--- a/packages/app/components/discovery/VerticalShortsPlayer.tsx
+++ b/packages/app/components/discovery/VerticalShortsPlayer.tsx
@@ -4,10 +4,11 @@ import { Feather } from '@expo/vector-icons'
 import type { VideoData } from '@peartube/core'
 import { colors } from '@/lib/colors'
 import { PearInlineVideoView } from '@/components/video-player/PearInlineVideoView'
+import type { PlayerPort } from '@/lib/video-player'
 
 type VerticalShortsPlayerProps = {
   testID?: string
-  playerRef: RefObject<any>
+  playerRef: RefObject<PlayerPort | null>
   videoUrl: string | null
   video: VideoData
   playbackSession: number

--- a/packages/app/components/video-player/DesktopMiniPlayer.tsx
+++ b/packages/app/components/video-player/DesktopMiniPlayer.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
 /**
  * DesktopMiniPlayer - Draggable mini player for Pear desktop
  *

--- a/packages/app/components/video-player/DesktopMiniPlayer.tsx
+++ b/packages/app/components/video-player/DesktopMiniPlayer.tsx
@@ -10,6 +10,7 @@ import { ActivityIndicator, Text } from 'react-native'
 import { Feather, Ionicons } from '@expo/vector-icons'
 import { colors } from '@/lib/colors'
 import { PearInlineVideoView } from './PearInlineVideoView'
+import type { PlayerPort } from '@/lib/video-player'
 import { desktopStyles } from './desktopStyles'
 import {
   DESKTOP_MINI_WIDTH,
@@ -31,7 +32,7 @@ interface DesktopMiniPlayerProps {
     id?: string
   } | null
   playbackSession: number
-  playerRef: React.RefObject<any>
+  playerRef: React.RefObject<PlayerPort | null>
   isPlaying: boolean
   progress: number
   isCasting: boolean

--- a/packages/app/components/video-player/MseVideoPlayer.web.tsx
+++ b/packages/app/components/video-player/MseVideoPlayer.web.tsx
@@ -20,17 +20,20 @@ interface Segment {
   data: Uint8Array   // moof+mdat combined
 }
 
-interface MseVideoPlayerProps {
+import { createWebMsePlayerPort, type PlayerPort } from '@/lib/video-player'
+
+type MseVideoPlayerProps = {
   videoUrl: string
   style?: any
   isPlaying: boolean
-  onLoad?: (data: { duration: number; durationMs: number }) => void
+  playbackRate?: number
   onProgress?: (data: { currentTime: number; duration: number }) => void
+  onLoad?: (data?: any) => void
   onPlaying?: () => void
   onPaused?: () => void
   onEnded?: () => void
-  onError?: (error: { message: string }) => void
-  playerRef?: React.RefObject<any>
+  onError?: (error: any) => void
+  playerRef?: React.RefObject<PlayerPort | null>
 }
 
 /** Binary search for the segment whose time is <= target */
@@ -71,15 +74,7 @@ export const MseVideoPlayer = memo(function MseVideoPlayer({
     videoElRef.current = el
 
     if (playerRef) {
-      playerRef.current = {
-        play: async () => el.play(),
-        pause: async () => el.pause(),
-        stop: async () => { el.pause(); el.currentTime = 0 },
-        destroy: async () => {},
-        seek: async (t: number) => { el.currentTime = t },
-        resume: async (p: boolean) => { if (p) el.play(); else el.pause() },
-        enterPip: () => {},
-      }
+      playerRef.current = createWebMsePlayerPort(el)
     }
 
     // Progress reporting

--- a/packages/app/components/video-player/MseVideoPlayer.web.tsx
+++ b/packages/app/components/video-player/MseVideoPlayer.web.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-empty, no-constant-condition, jsx-a11y/media-has-caption */
 /**
  * MseVideoPlayer — streaming MSE player with sliding buffer window.
  *

--- a/packages/app/components/video-player/PearInlineVideoView.tsx
+++ b/packages/app/components/video-player/PearInlineVideoView.tsx
@@ -7,11 +7,12 @@ import Video, {
   type VideoRef,
   type BufferConfig,
 } from 'react-native-video'
+import { createPlayerPort, type PlayerPort } from '@/lib/video-player'
 
 type PearInlineVideoViewProps = {
   style?: StyleProp<ViewStyle>
   testID?: string
-  playerRef: RefObject<any>
+  playerRef: RefObject<PlayerPort | null>
   videoUrl: string
   playbackSession: number
   currentVideoKey?: string
@@ -167,35 +168,45 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
   }, [])
 
   const adapter = useMemo(
-    () => ({
-      play: async () => {
-        videoRef.current?.resume?.()
-      },
-      pause: async () => {
-        videoRef.current?.pause?.()
-      },
-      stop: async () => {
-        videoRef.current?.pause?.()
-        videoRef.current?.seek(0)
-      },
-      destroy: async () => {
-        videoRef.current?.pause?.()
-        videoRef.current?.seek(0)
-      },
-      seek: async (timeSeconds: number) => {
-        videoRef.current?.seek(Math.max(0, timeSeconds))
-      },
-      resume: async (playing: boolean) => {
-        if (playing) {
+    () => createPlayerPort(
+      {
+        play: async () => {
           videoRef.current?.resume?.()
-        } else {
+        },
+        pause: async () => {
           videoRef.current?.pause?.()
-        }
+        },
+        stop: async () => {
+          videoRef.current?.pause?.()
+          videoRef.current?.seek(0)
+        },
+        destroy: async () => {
+          videoRef.current?.pause?.()
+          videoRef.current?.seek(0)
+        },
+        seek: async (timeSeconds: number) => {
+          videoRef.current?.seek(Math.max(0, timeSeconds))
+        },
+        resume: async (playing: boolean) => {
+          if (playing) {
+            videoRef.current?.resume?.()
+          } else {
+            videoRef.current?.pause?.()
+          }
+        },
+        enterPip: () => {
+          void videoRef.current?.enterPictureInPicture?.()
+        },
       },
-      enterPip: () => {
-        void videoRef.current?.enterPictureInPicture?.()
+      {
+        kind: 'native',
+        capabilities: {
+          pictureInPicture: Platform.OS === 'android',
+          playbackRate: true,
+          backgroundAudio: true,
+        },
       },
-    }),
+    ),
     [],
   )
 

--- a/packages/app/components/video-player/VideoContainer.tsx
+++ b/packages/app/components/video-player/VideoContainer.tsx
@@ -4,6 +4,7 @@ import { Feather } from '@expo/vector-icons'
 import { colors } from '@/lib/colors'
 import { styles } from './styles'
 import { PearInlineVideoView } from './PearInlineVideoView'
+import type { PlayerPort } from '@/lib/video-player'
 
 export interface VideoContainerProps {
   // Video state
@@ -17,7 +18,7 @@ export interface VideoContainerProps {
   } | null
   playbackSession: number
 
-  playerRef: RefObject<any>
+  playerRef: RefObject<PlayerPort | null>
 
   // Playback control
   isPlaying: boolean

--- a/packages/app/lib/VideoPlayerContext.tsx
+++ b/packages/app/lib/VideoPlayerContext.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-empty, no-useless-escape */
 /**
  * VideoPlayerContext - Unified Video Player State Management
  *

--- a/packages/app/lib/VideoPlayerContext.tsx
+++ b/packages/app/lib/VideoPlayerContext.tsx
@@ -9,7 +9,8 @@
 import { createContext, useContext, useState, useCallback, useRef, useEffect, useMemo, ReactNode } from 'react'
 import { Platform, AppState, AppStateStatus, DeviceEventEmitter } from 'react-native'
 import type { VideoData, VideoStats } from '@peartube/core'
-import type { PlayerMode } from './video-player'
+import type { PlayerMode, PlayerPort } from './video-player'
+import { resolvePlayerPort } from './video-player'
 import { usePlayerStateMachine } from './playerStateMachine'
 import type { ModeBeforePip, PlayerState } from './playerStateMachine'
 
@@ -72,7 +73,7 @@ interface VideoPlayerContextType {
 
   seekPosition: number | undefined
 
-  playerRef: React.MutableRefObject<any>
+  playerRef: React.MutableRefObject<PlayerPort | null>
 
   // Actions
   loadAndPlayVideo: (video: VideoData, url: string) => void
@@ -158,7 +159,8 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
 
   const [seekPosition, setSeekPosition] = useState<number | undefined>(undefined)
 
-  const playerRef = useRef<any>(null)
+  const playerRef = useRef<PlayerPort | null>(null)
+  const getPlayerPort = useCallback(() => resolvePlayerPort(playerRef.current), [])
 
   // Ref for current video - updated synchronously to avoid race conditions with stats events
   const currentVideoRef = useRef<VideoData | null>(null)
@@ -287,7 +289,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
     // transition (surface re-attach / audio focus). If JS ignores the pause event to
     // keep UI stable, we still need to *reassert* play on the native player.
     try {
-      playerRef.current?.play?.()
+      getPlayerPort()?.play?.()
     } catch (e) {
       if (__DEV__) console.warn('[VideoPlayerContext] Failed to reassert play after PiP exit:', reason, e)
     }
@@ -391,8 +393,8 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
     // The PiP window continues playing natively and we must not interfere with it.
     if (reason !== 'background-audio') {
       try {
-        playerRef.current?.stop?.()
-        playerRef.current?.pause?.()
+        getPlayerPort()?.stop?.()
+        getPlayerPort()?.pause?.()
       } catch {}
     }
 
@@ -734,8 +736,8 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
     lastPlaybackStartAtRef.current = now
 
     try {
-      playerRef.current?.stop?.()
-      playerRef.current?.pause?.()
+      getPlayerPort()?.stop?.()
+      getPlayerPort()?.pause?.()
     } catch {}
     pendingAndroidMinimizeCloseRef.current = false
     // MediaSession.clearPendingPlayerLaunchPayload removed - using react-native-video native PiP
@@ -848,7 +850,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
     console.log('[VideoPlayerContext] Pausing video')
     if (Platform.OS === 'web') {
       try {
-        playerRef.current?.pause?.()
+        getPlayerPort()?.pause?.()
       } catch {}
     }
     setDesiredPlaying(false)
@@ -871,7 +873,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
       setDesiredPlaying(true)
       if (Platform.OS === 'web') {
         try {
-          playerRef.current?.play?.()
+          getPlayerPort()?.play?.()
         } catch {}
       }
     }
@@ -944,7 +946,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
     if (wasInPip && wasPlaying) {
       pipExitExpectedPlayingRef.current = true
       pipExitResumeUntilRef.current = Date.now() + 3000
-      try { playerRef.current?.play?.() } catch {}
+      try { getPlayerPort()?.play?.() } catch {}
     }
 
     dispatch({
@@ -978,8 +980,8 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
     // cases where the native player isn't mounted/ready yet.
     let didImperativeSeek = false
     try {
-      if (typeof playerRef.current?.seek === 'function') {
-        playerRef.current.seek(clampedTime)
+      if (typeof getPlayerPort()?.seek === 'function') {
+        getPlayerPort()?.seek(clampedTime)
         didImperativeSeek = true
       }
     } catch {}
@@ -1004,8 +1006,8 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
 
     let didImperativeSeek = false
     try {
-      if (typeof playerRef.current?.seek === 'function') {
-        playerRef.current.seek(newTime)
+      if (typeof getPlayerPort()?.seek === 'function') {
+        getPlayerPort()?.seek(newTime)
         didImperativeSeek = true
       }
     } catch {}

--- a/packages/app/lib/video-player/index.ts
+++ b/packages/app/lib/video-player/index.ts
@@ -17,4 +17,20 @@ export type {
   TransitionOrigin,
   UnifiedPlayerState,
 } from './playerModeContract'
+export {
+  createPlayerPort,
+  createWebMsePlayerPort,
+  isPlayerPort,
+  resolvePlayerPort,
+} from './playerPort'
+export type {
+  LegacyPlayerRef,
+  PlayerBackendKind,
+  PlayerPort,
+  PlayerPortCapabilities,
+  PlayerPortEventHandler,
+  PlayerPortEventMap,
+  PlayerPortEventName,
+  PlayerPortMetadata,
+} from './playerPort'
 export type { VideoData, VideoStats } from './VideoMetaContext'

--- a/packages/app/lib/video-player/playerPort.ts
+++ b/packages/app/lib/video-player/playerPort.ts
@@ -1,0 +1,152 @@
+export type PlayerBackendKind = 'native' | 'web-mse' | 'cast' | 'desktop-native' | 'unknown'
+
+export type PlayerPortEventName =
+  | 'loaded'
+  | 'playing'
+  | 'paused'
+  | 'buffering'
+  | 'progress'
+  | 'ended'
+  | 'error'
+  | 'pip-change'
+  | 'cast-change'
+
+export type PlayerPortEventMap = {
+  loaded: { duration?: number; durationMs?: number }
+  playing: undefined
+  paused: undefined
+  buffering: { isBuffering: boolean }
+  progress: { currentTime: number; duration: number }
+  ended: undefined
+  error: unknown
+  'pip-change': { isInPictureInPicture: boolean; width?: number; height?: number }
+  'cast-change': { isCasting: boolean }
+}
+
+export type PlayerPortEventHandler<Name extends PlayerPortEventName = PlayerPortEventName> = (
+  event: PlayerPortEventMap[Name],
+) => void
+
+export type PlayerPortCapabilities = {
+  pictureInPicture?: boolean
+  cast?: boolean
+  playbackRate?: boolean
+  backgroundAudio?: boolean
+}
+
+export type PlayerPortMetadata = {
+  kind: PlayerBackendKind
+  capabilities: PlayerPortCapabilities
+  label?: string
+}
+
+export interface PlayerPort {
+  readonly kind: PlayerBackendKind
+  readonly capabilities: PlayerPortCapabilities
+  play(): void | Promise<void>
+  pause(): void | Promise<void>
+  stop(): void | Promise<void>
+  seek(timeSeconds: number): void | Promise<void>
+  setPlaybackRate?(rate: number): void | Promise<void>
+  destroy?(): void | Promise<void>
+  on?<Name extends PlayerPortEventName>(event: Name, handler: PlayerPortEventHandler<Name>): () => void
+  enterPictureInPicture?(): void | Promise<void>
+  exitPictureInPicture?(): void | Promise<void>
+  startCasting?(): void | Promise<void>
+  stopCasting?(): void | Promise<void>
+}
+
+export type LegacyPlayerRef = {
+  play?: () => void | Promise<void>
+  pause?: () => void | Promise<void>
+  stop?: () => void | Promise<void>
+  destroy?: () => void | Promise<void>
+  seek?: (timeSeconds: number) => void | Promise<void>
+  resume?: (playing: boolean) => void | Promise<void>
+  setPlaybackRate?: (rate: number) => void | Promise<void>
+  enterPip?: () => void | Promise<void>
+  enterPictureInPicture?: () => void | Promise<void>
+  exitPictureInPicture?: () => void | Promise<void>
+  startCasting?: () => void | Promise<void>
+  stopCasting?: () => void | Promise<void>
+}
+
+export function createPlayerPort(
+  backend: LegacyPlayerRef,
+  metadata: PlayerPortMetadata,
+): PlayerPort {
+  const port: PlayerPort = {
+    kind: metadata.kind,
+    capabilities: metadata.capabilities,
+    play: () => backend.play?.() ?? backend.resume?.(true),
+    pause: () => backend.pause?.() ?? backend.resume?.(false),
+    stop: () => {
+      if (typeof backend.stop === 'function') return backend.stop()
+      backend.pause?.()
+      return backend.seek?.(0)
+    },
+    seek: (timeSeconds: number) => backend.seek?.(Math.max(0, timeSeconds)),
+  }
+
+  if (typeof backend.setPlaybackRate === 'function') {
+    port.setPlaybackRate = (rate: number) => backend.setPlaybackRate?.(rate)
+  }
+
+  if (typeof backend.destroy === 'function') {
+    port.destroy = () => backend.destroy?.()
+  }
+
+  const enterPip = backend.enterPictureInPicture ?? backend.enterPip
+  if (typeof enterPip === 'function') {
+    port.enterPictureInPicture = () => enterPip()
+  }
+
+  if (typeof backend.exitPictureInPicture === 'function') {
+    port.exitPictureInPicture = () => backend.exitPictureInPicture?.()
+  }
+
+  if (typeof backend.startCasting === 'function') {
+    port.startCasting = () => backend.startCasting?.()
+  }
+
+  if (typeof backend.stopCasting === 'function') {
+    port.stopCasting = () => backend.stopCasting?.()
+  }
+
+  return port
+}
+
+export function isPlayerPort(value: unknown): value is PlayerPort {
+  const candidate = value as Partial<PlayerPort> | null
+  return !!candidate &&
+    typeof candidate.play === 'function' &&
+    typeof candidate.pause === 'function' &&
+    typeof candidate.stop === 'function' &&
+    typeof candidate.seek === 'function'
+}
+
+export function resolvePlayerPort(value: unknown): PlayerPort | null {
+  return isPlayerPort(value) ? value : null
+}
+
+export function createWebMsePlayerPort(video: HTMLVideoElement): PlayerPort {
+  return createPlayerPort(
+    {
+      play: () => video.play(),
+      pause: () => video.pause(),
+      stop: () => {
+        video.pause()
+        video.currentTime = 0
+      },
+      seek: (timeSeconds: number) => { video.currentTime = Math.max(0, timeSeconds) },
+      setPlaybackRate: (rate: number) => { video.playbackRate = rate },
+    },
+    {
+      kind: 'web-mse',
+      capabilities: {
+        pictureInPicture: typeof document !== 'undefined' && 'pictureInPictureEnabled' in document,
+        playbackRate: true,
+      },
+    },
+  )
+}

--- a/packages/app/tests/player-port-contract-regression.test.mjs
+++ b/packages/app/tests/player-port-contract-regression.test.mjs
@@ -1,0 +1,85 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const appRoot = path.resolve(__dirname, '..')
+
+function readAppFile(relativePath) {
+  return fs.readFileSync(path.join(appRoot, relativePath), 'utf8')
+}
+
+test('player port contract declares shared backend controls and optional capabilities', () => {
+  const source = readAppFile('lib/video-player/playerPort.ts')
+
+  assert.match(source, /export type PlayerBackendKind = 'native' \| 'web-mse' \| 'cast' \| 'desktop-native' \| 'unknown'/)
+  assert.match(source, /export interface PlayerPort \{[\s\S]*play\(\): void \| Promise<void>/)
+  assert.match(source, /export interface PlayerPort \{[\s\S]*pause\(\): void \| Promise<void>/)
+  assert.match(source, /export interface PlayerPort \{[\s\S]*stop\(\): void \| Promise<void>/)
+  assert.match(source, /export interface PlayerPort \{[\s\S]*seek\(timeSeconds: number\): void \| Promise<void>/)
+  assert.match(source, /setPlaybackRate\?\(rate: number\): void \| Promise<void>/)
+  assert.match(source, /enterPictureInPicture\?\(\): void \| Promise<void>/)
+  assert.match(source, /startCasting\?\(\): void \| Promise<void>/)
+  assert.match(source, /export type PlayerPortCapabilities = \{[\s\S]*pictureInPicture\?: boolean[\s\S]*cast\?: boolean[\s\S]*playbackRate\?: boolean/)
+})
+
+test('legacy native and web player refs are adapted behind PlayerPort', () => {
+  const source = readAppFile('lib/video-player/playerPort.ts')
+
+  assert.match(source, /export function createPlayerPort\([\s\S]*backend: LegacyPlayerRef,[\s\S]*metadata: PlayerPortMetadata,[\s\S]*\): PlayerPort/)
+  assert.match(source, /play: \(\) => backend\.play\?\.\(\) \?\? backend\.resume\?\.\(true\)/)
+  assert.match(source, /pause: \(\) => backend\.pause\?\.\(\) \?\? backend\.resume\?\.\(false\)/)
+  assert.match(source, /seek: \(timeSeconds: number\) => backend\.seek\?\.\(Math\.max\(0, timeSeconds\)\)/)
+  assert.match(source, /export function createWebMsePlayerPort\(video: HTMLVideoElement\): PlayerPort/)
+  assert.match(source, /kind: 'web-mse'/)
+})
+
+test('VideoPlayerContext talks to the resolved PlayerPort instead of raw imperative refs', () => {
+  const source = readAppFile('lib/VideoPlayerContext.tsx')
+
+  assert.match(source, /import type \{ PlayerMode, PlayerPort \} from '\.\/video-player'/)
+  assert.match(source, /playerRef: React\.MutableRefObject<PlayerPort \| null>/)
+  assert.match(source, /const playerRef = useRef<PlayerPort \| null>\(null\)/)
+  assert.match(source, /const getPlayerPort = useCallback\(\(\) => resolvePlayerPort\(playerRef\.current\), \[\]\)/)
+  assert.match(source, /getPlayerPort\(\)\?\.pause\?\.\(\)/)
+  assert.match(source, /getPlayerPort\(\)\?\.play\?\.\(\)/)
+  assert.match(source, /getPlayerPort\(\)\?\.stop\?\.\(\)/)
+  assert.doesNotMatch(source, /playerRef\.current\?\.pause\?\.\(\)/)
+  assert.doesNotMatch(source, /playerRef\.current\?\.play\?\.\(\)/)
+  assert.doesNotMatch(source, /playerRef\.current\?\.stop\?\.\(\)/)
+})
+
+test('native and web player components publish typed PlayerPort adapters', () => {
+  const pearSource = readAppFile('components/video-player/PearInlineVideoView.tsx')
+
+  assert.match(pearSource, /import \{ createPlayerPort, type PlayerPort \} from '@\/lib\/video-player'/)
+  assert.match(pearSource, /playerRef: RefObject<PlayerPort \| null>/)
+  assert.match(pearSource, /createPlayerPort\(/)
+  assert.match(pearSource, /kind: 'native'/)
+  assert.match(pearSource, /pictureInPicture: Platform\.OS === 'android'/)
+
+  const mseSource = readAppFile('components/video-player/MseVideoPlayer.web.tsx')
+  assert.match(mseSource, /import \{ createWebMsePlayerPort, type PlayerPort \} from '@\/lib\/video-player'/)
+  assert.match(mseSource, /playerRef\?: React\.RefObject<PlayerPort \| null>/)
+  assert.match(mseSource, /playerRef\.current = createWebMsePlayerPort\(el\)/)
+
+  const videoContainerSource = readAppFile('components/video-player/VideoContainer.tsx')
+  assert.match(videoContainerSource, /playerRef: RefObject<PlayerPort \| null>/)
+  const desktopMiniSource = readAppFile('components/video-player/DesktopMiniPlayer.tsx')
+  assert.match(desktopMiniSource, /playerRef: React\.RefObject<PlayerPort \| null>/)
+  const verticalShortsSource = readAppFile('components/discovery/VerticalShortsPlayer.tsx')
+  assert.match(verticalShortsSource, /playerRef: RefObject<PlayerPort \| null>/)
+})
+
+test('video-player barrel exports the PlayerPort contract for future backends', () => {
+  const source = readAppFile('lib/video-player/index.ts')
+
+  assert.match(source, /createPlayerPort/)
+  assert.match(source, /createWebMsePlayerPort/)
+  assert.match(source, /resolvePlayerPort/)
+  assert.match(source, /PlayerBackendKind/)
+  assert.match(source, /PlayerPortCapabilities/)
+})


### PR DESCRIPTION
## Summary
- Add a typed `PlayerPort` contract for native, web/MSE, cast, and future desktop/native player backends.
- Adapt native `PearInlineVideoView` and web `MseVideoPlayer` refs into typed player ports.
- Route `VideoPlayerContext` control calls through `resolvePlayerPort` while keeping session state ownership unchanged.
- Tighten player ref prop types across overlay, mini-player, and vertical shorts surfaces.

## Test plan
- `node --test packages/app/tests/player-port-contract-regression.test.mjs packages/app/tests/watch-page-mse-player-mode.test.mjs packages/app/tests/vertical-discovery-regression.test.mjs packages/app/tests/mobile-player-page-layout-regression.test.mjs`
- `git diff --check`
- `node scripts/lint-changed.mjs` (reported no changed JS/TS files to lint in this worktree)

Closes #72
