### PR TITLE
fix(ci): generate HRPC spec for desktop release

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -34,6 +34,9 @@ jobs:
         with:
           bun-version: 1.3.11
 
+      - name: Generate HRPC schema
+        run: npm run schema
+
       - name: Build desktop app
         working-directory: packages/app
         run: |
@@ -83,6 +86,9 @@ jobs:
 
       - name: Install native desktop dependencies
         run: npm install --prefix packages/desktop-native
+
+      - name: Generate HRPC schema
+        run: npm run schema:full
 
       - name: Install xcodegen
         run: brew install xcodegen

--- a/packages/desktop-native/scripts/bare-pack-host-flags.test.mjs
+++ b/packages/desktop-native/scripts/bare-pack-host-flags.test.mjs
@@ -104,3 +104,48 @@ test('native host sidecar bundler stages a temp bundle tree with app node_module
     'ensure-host-sidecar-bundle should stage a temporary bundle root',
   )
 })
+
+test('native host sidecar bundler regenerates missing HRPC spec before staging temp tree', () => {
+  const absolutePath = path.join(packageRoot, 'scripts/ensure-host-sidecar-bundle.mjs')
+  const source = fs.readFileSync(absolutePath, 'utf8')
+
+  assert.match(
+    source,
+    /function ensureGeneratedSpec\(/,
+    'ensure-host-sidecar-bundle should explicitly guard generated spec outputs',
+  )
+  assert.match(
+    source,
+    /packages', 'spec', 'spec', 'hrpc', 'index\.js'/,
+    'ensure-host-sidecar-bundle should require generated HRPC entry before bare-pack traversal',
+  )
+  assert.match(
+    source,
+    /packages', 'spec', 'schema\.cjs'/,
+    'ensure-host-sidecar-bundle should run the canonical schema generator when generated files are absent',
+  )
+  assert.match(
+    source,
+    /spawnSync\(process\.execPath, \[schemaScript\]/,
+    'ensure-host-sidecar-bundle should invoke schema.cjs with the current Node runtime',
+  )
+  assert.match(
+    source,
+    /ensureGeneratedSpec\(\)\s*\n\s*for \(const sourcePath of sourceRoots\)/,
+    'ensure-host-sidecar-bundle should generate spec before staging sourceRoots into the temp bundle root',
+  )
+})
+
+test('desktop release workflow generates HRPC schema before desktop release builds', () => {
+  const workflowPath = path.resolve(packageRoot, '..', '..', '.github', 'workflows', 'release-desktop.yml')
+  const source = fs.readFileSync(workflowPath, 'utf8')
+  const electrobunSchemaIndex = source.indexOf('Generate HRPC schema')
+  const electrobunBuildIndex = source.indexOf('Build desktop app')
+  const nativeSchemaIndex = source.indexOf('Generate HRPC schema', electrobunBuildIndex)
+  const nativeProjectIndex = source.indexOf('Generate native desktop project')
+
+  assert.ok(electrobunSchemaIndex >= 0, 'electrobun release job should generate HRPC schema')
+  assert.ok(electrobunSchemaIndex < electrobunBuildIndex, 'electrobun release schema generation should run before web bundling')
+  assert.ok(nativeSchemaIndex >= 0, 'native desktop release job should generate full HRPC/Swift schema')
+  assert.ok(nativeSchemaIndex < nativeProjectIndex, 'native release schema generation should run before native project generation')
+})

--- a/packages/desktop-native/scripts/ensure-host-sidecar-bundle.mjs
+++ b/packages/desktop-native/scripts/ensure-host-sidecar-bundle.mjs
@@ -130,6 +130,27 @@ function stageDirectory(tempRoot, sourcePath) {
   linkDirectory(sourcePath, path.join(tempRoot, relativePath))
 }
 
+function ensureGeneratedSpec() {
+  const generatedHrpcEntry = path.join(repoRoot, 'packages', 'spec', 'spec', 'hrpc', 'index.js')
+  if (fs.existsSync(generatedHrpcEntry)) return
+
+  const schemaScript = path.join(repoRoot, 'packages', 'spec', 'schema.cjs')
+  console.log('[bundle:native-sidecar:ensure] Generated HRPC spec missing; running schema.cjs')
+  const result = spawnSync(process.execPath, [schemaScript], {
+    cwd: path.dirname(schemaScript),
+    stdio: 'inherit',
+    env: process.env,
+  })
+
+  if (result.status !== 0) {
+    throw new Error(`Failed to generate HRPC spec with ${schemaScript}`)
+  }
+
+  if (!fs.existsSync(generatedHrpcEntry)) {
+    throw new Error(`HRPC spec generation completed but ${generatedHrpcEntry} is still missing`)
+  }
+}
+
 function linkPackageNodeModules(tempRoot, packageName) {
   const realNmPath = path.join(repoRoot, 'packages', packageName, 'node_modules')
   const targetNmPath = path.join(tempRoot, 'packages', packageName, 'node_modules')
@@ -208,6 +229,7 @@ function stagePackageJson(tempRoot, packageName) {
 function createTempBundleRoot() {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'peartube-native-sidecar-'))
 
+  ensureGeneratedSpec()
   for (const sourcePath of sourceRoots) {
     stageDirectory(tempRoot, sourcePath)
   }


### PR DESCRIPTION
## Summary
- generate HRPC schema in the desktop release workflow before Electrobun web bundling
- generate full HRPC/Swift schema before native desktop project generation
- make the native sidecar bundler self-heal if generated `packages/spec/spec/hrpc/index.js` is missing before staging its temp bare-pack tree

## Root cause
The v0.1.36 desktop release checked out a clean tree where generated spec outputs are gitignored. The release workflow skipped schema generation, so both Electrobun Metro and native sidecar bare-pack could not resolve `@peartube/spec` / `../../spec/spec/hrpc/index.js`.

## Verification
```bash
node --test packages/app/tests/ci-generated-schema-workflow-regression.test.mjs packages/desktop-native/scripts/bare-pack-host-flags.test.mjs
python - <<'PY'
import yaml, pathlib
for p in ['.github/workflows/release-desktop.yml', '.github/workflows/build-desktop.yml']:
    yaml.safe_load(pathlib.Path(p).read_text())
print('workflow yaml parse ok')
PY
git diff --check
npm run lint:changed
```

Result: 8 node tests passed, workflow YAML parsed, diff check passed, lint changed passed.

Note: I also smoke-tested the missing-generated-spec path far enough to verify `ensure-host-sidecar-bundle.mjs` detects the missing HRPC entry and runs `schema.cjs`; local disk quota blocked the later temp copy step, not schema generation.