### PR TITLE
fix(backend): accept string blob refs in playback

### DIFF
--- a/packages/backend/src/blob-ref.js
+++ b/packages/backend/src/blob-ref.js
@@ -30,6 +30,7 @@ export function parseBlobId(value) {
 }
 
 export function normalizeBlobRefInput(value) {
+  if (typeof value === 'string') return parseBlobId(value)
   if (!value || typeof value !== 'object') return null
   const blockOffset = normalizeNumber(value.blockOffset)
   const blockLength = normalizeNumber(value.blockLength)

--- a/packages/backend/test/blob-ref.test.mjs
+++ b/packages/backend/test/blob-ref.test.mjs
@@ -56,6 +56,15 @@ test('parseBlobRef fails closed for partial or invalid refs', (t) => {
   t.is(parseBlobRef({ blobsCoreKey: 'a'.repeat(64), blobId: '1:2:3' }), null)
 })
 
+test('normalizeBlobRefInput accepts persisted hyperblob range strings', (t) => {
+  t.alike(normalizeBlobRefInput('10:4:128:4096'), {
+    blockOffset: 10,
+    blockLength: 4,
+    byteOffset: 128,
+    byteLength: 4096,
+  })
+})
+
 test('stringifyBlobId and cache key use normalized identity', (t) => {
   const blob = { blockOffset: 1, blockLength: 2, byteOffset: 3, byteLength: 4 }
   t.is(stringifyBlobId(blob), '1:2:3:4')


### PR DESCRIPTION
## Summary
- allow `normalizeBlobRefInput` to normalize persisted hyperblob range strings like `0:8:0:1024`
- keep object blob refs working unchanged
- add regression coverage for string blob refs

## Root cause
The Discover screenshot shows `HRPC request failed (12): Invalid blob ID format`. The playback/thumbnail fast paths pass persisted blob IDs as strings, but the shared BlobRef helper only accepted object-shaped refs in `normalizeBlobRefInput`. Call sites like `getVideoUrlFromBlob` and prefetch used that helper directly, so valid persisted string refs were rejected.

## Verification
```bash
node --test packages/backend/test/blob-ref.test.mjs packages/backend/test/playback-api.test.mjs packages/backend/test/public-feed-api.test.mjs
git diff --check
npm run lint:changed
```

Result: backend targeted tests passed, diff check passed, changed-file lint passed.