### PR TITLE
feat(app): improve vertical shorts controls

### DIFF
--- a/packages/app/app/(tabs)/discover.tsx
+++ b/packages/app/app/(tabs)/discover.tsx
@@ -108,12 +108,34 @@ export default function VerticalDiscoveryScreen() {
   const [shortsVideoUrl, setShortsVideoUrl] = useState<string | null>(null)
   const [shortsPlaybackSession, setShortsPlaybackSession] = useState(0)
   const [shortsLoading, setShortsLoading] = useState(false)
+  const [shortsChromeVisible, setShortsChromeVisible] = useState(true)
   const shortsPlayerRef = useRef<any>(null)
   const pendingPlayKeyRef = useRef<string | null>(null)
   const hydratedChannelsRef = useRef<Set<string>>(new Set())
 
   const activeVideo = videos[activeIndex]
   const activeVideoKey = activeVideo ? `${activeVideo.channelKey}:${activeVideo.id}` : null
+
+  const makePlaybackRequest = useCallback((video: VideoData) => {
+    const videoRef = getVideoRef(video)
+    const videoAny = video as any
+    const cacheKey = makeVideoUrlCacheKey(
+      video.channelKey,
+      videoRef,
+      videoAny.blobId || undefined,
+      videoAny.blobsCoreKey || undefined,
+    )
+    const playbackRequest = {
+      channelKey: video.channelKey,
+      videoId: videoRef,
+      publicBeeKey: videoAny.publicBeeKey || undefined,
+      blobId: videoAny.blobId || undefined,
+      blobsCoreKey: videoAny.blobsCoreKey || undefined,
+      mimeType: videoAny.mimeType || undefined,
+    }
+
+    return { cacheKey, playbackRequest }
+  }, [])
 
   const fetchThumbnailsForVideos = useCallback(async (items: VideoData[]) => {
     if (!rpc || !blobServerPort) return
@@ -170,14 +192,16 @@ export default function VerticalDiscoveryScreen() {
     if (!rpc) return
     const channelKey = entry.channelKey || entry.driveKey
     if (!channelKey || hydratedChannelsRef.current.has(channelKey)) return
-    hydratedChannelsRef.current.add(channelKey)
 
     try {
+      const timeoutToken = Symbol('vertical-channel-timeout')
       const result = await withTimeout(
         rpc.listVideos({ channelKey, publicBeeKey: entry.publicBeeKey || undefined }),
         3500,
-        { videos: [] } as any,
+        timeoutToken as any,
       )
+      if (result === timeoutToken) return
+      hydratedChannelsRef.current.add(channelKey)
       const channelVideos = Array.isArray((result as any)?.videos) ? (result as any).videos : []
       const mapped = channelVideos
         .filter((video: any) => shouldRenderFeedVideo({
@@ -212,7 +236,7 @@ export default function VerticalDiscoveryScreen() {
       const entries = Array.isArray((result as any)?.entries) ? (result as any).entries : []
       setFeedEntries(entries)
       seedFromFeedEntries(entries)
-      for (const entry of entries.slice(0, 8)) {
+      for (const entry of entries.slice(0, 24)) {
         void hydrateChannelVideos(entry)
       }
     } catch (err) {
@@ -235,26 +259,10 @@ export default function VerticalDiscoveryScreen() {
 
   const playVideo = useCallback(async (video: VideoData) => {
     if (!rpc) return
-    const videoRef = getVideoRef(video)
-    const videoAny = video as any
-    const cacheKey = makeVideoUrlCacheKey(
-      video.channelKey,
-      videoRef,
-      videoAny.blobId || undefined,
-      videoAny.blobsCoreKey || undefined,
-    )
+    const { cacheKey, playbackRequest } = makePlaybackRequest(video)
     const playKey = `${video.channelKey}:${video.id}`
     if (pendingPlayKeyRef.current === playKey) return
     pendingPlayKeyRef.current = playKey
-
-    const playbackRequest = {
-      channelKey: video.channelKey,
-      videoId: videoRef,
-      publicBeeKey: videoAny.publicBeeKey || undefined,
-      blobId: videoAny.blobId || undefined,
-      blobsCoreKey: videoAny.blobsCoreKey || undefined,
-      mimeType: videoAny.mimeType || undefined,
-    }
 
     try {
       handoffToShorts()
@@ -279,29 +287,27 @@ export default function VerticalDiscoveryScreen() {
       pendingPlayKeyRef.current = null
       setShortsLoading(false)
     }
-  }, [handoffToShorts, rpc])
+  }, [handoffToShorts, makePlaybackRequest, rpc])
 
   useEffect(() => {
     if (!activeVideo || !ready) return
+    setShortsChromeVisible(true)
     void playVideo(activeVideo)
   }, [activeVideo, playVideo, ready])
 
   useEffect(() => {
-    const nextVideos = videos.slice(activeIndex + 1, activeIndex + 3)
-    for (const video of nextVideos) {
-      const videoAny = video as any
-      const videoRef = getVideoRef(video)
-      const playbackRequest = {
-        channelKey: video.channelKey,
-        videoId: videoRef,
-        publicBeeKey: videoAny.publicBeeKey || undefined,
-        blobId: videoAny.blobId || undefined,
-        blobsCoreKey: videoAny.blobsCoreKey || undefined,
-        mimeType: videoAny.mimeType || undefined,
-      }
-      void rpc?.preparePlayback?.(playbackRequest).catch(() => undefined)
+    const warmPlaybackUrl = async (video: VideoData) => {
+      const { cacheKey, playbackRequest } = makePlaybackRequest(video)
+      if (cacheKey && getCachedVideoUrl(cacheKey)) return
+      const result = await rpc?.preparePlayback?.(playbackRequest)
+      if (result?.url && cacheKey) setCachedVideoUrl(cacheKey, result.url)
     }
-  }, [activeIndex, rpc, videos])
+
+    const nextVideos = videos.slice(activeIndex + 1, activeIndex + 5)
+    for (const video of nextVideos) {
+      void warmPlaybackUrl(video).catch(() => undefined)
+    }
+  }, [activeIndex, makePlaybackRequest, rpc, videos])
 
   const onRefresh = useCallback(async () => {
     setRefreshing(true)
@@ -429,34 +435,38 @@ export default function VerticalDiscoveryScreen() {
                     isActive={activeVideoKey === `${video.channelKey}:${video.id}`}
                     isLoading={shortsLoading && activeVideoKey === `${video.channelKey}:${video.id}`}
                     thumbnailUrl={video.thumbnailUrl || null}
+                    controlsVisible={shortsChromeVisible}
+                    onControlsVisibleChange={setShortsChromeVisible}
                     onReplay={() => playVideo(video)}
                   />
                 </View>
-                <View style={[styles.bottomMeta, { paddingBottom: Math.max(insets.bottom + 86, 104) }]}> 
-                  <Pressable onPress={() => openDetails(video)} style={styles.metaTextBlock}>
-                    <Text style={styles.videoTitle} numberOfLines={2}>{video.title || 'Untitled'}</Text>
-                    <Text style={styles.videoMeta} numberOfLines={1}>
-                      {video.channel?.name || 'Channel'} · {formatTimeAgo(video.uploadedAt || Date.now())}
-                    </Text>
-                    {video.description ? (
-                      <Text style={styles.videoDescription} numberOfLines={2}>{video.description}</Text>
-                    ) : null}
-                  </Pressable>
-                  <View style={styles.sideRail}>
-                    <Pressable onPress={() => openChannel(video)} style={styles.sideButton}>
-                      <Feather name="user" color="#fff" size={24} />
-                      <Text style={styles.sideLabel}>Channel</Text>
+                {shortsChromeVisible ? (
+                  <View style={[styles.bottomMeta, { paddingBottom: Math.max(insets.bottom + 116, 134) }]}>
+                    <Pressable onPress={() => openDetails(video)} style={styles.metaTextBlock}>
+                      <Text style={styles.videoTitle} numberOfLines={2}>{video.title || 'Untitled'}</Text>
+                      <Text style={styles.videoMeta} numberOfLines={1}>
+                        {video.channel?.name || 'Channel'} · {formatTimeAgo(video.uploadedAt || Date.now())}
+                      </Text>
+                      {video.description ? (
+                        <Text style={styles.videoDescription} numberOfLines={2}>{video.description}</Text>
+                      ) : null}
                     </Pressable>
-                    <Pressable onPress={() => openDetails(video)} style={styles.sideButton}>
-                      <Feather name="message-circle" color="#fff" size={24} />
-                      <Text style={styles.sideLabel}>Details</Text>
-                    </Pressable>
-                    <Pressable onPress={() => playVideo(video)} style={styles.sideButton}>
-                      <Feather name="rotate-cw" color="#fff" size={24} />
-                      <Text style={styles.sideLabel}>Replay</Text>
-                    </Pressable>
+                    <View style={styles.sideRail}>
+                      <Pressable onPress={() => openChannel(video)} style={styles.sideButton}>
+                        <Feather name="user" color="#fff" size={24} />
+                        <Text style={styles.sideLabel}>Channel</Text>
+                      </Pressable>
+                      <Pressable onPress={() => openDetails(video)} style={styles.sideButton}>
+                        <Feather name="message-circle" color="#fff" size={24} />
+                        <Text style={styles.sideLabel}>Details</Text>
+                      </Pressable>
+                      <Pressable onPress={() => playVideo(video)} style={styles.sideButton}>
+                        <Feather name="rotate-cw" color="#fff" size={24} />
+                        <Text style={styles.sideLabel}>Replay</Text>
+                      </Pressable>
+                    </View>
                   </View>
-                </View>
+                ) : null}
               </ImageBackground>
             </View>
           )}

--- a/packages/app/components/discovery/VerticalShortsPlayer.tsx
+++ b/packages/app/components/discovery/VerticalShortsPlayer.tsx
@@ -1,5 +1,5 @@
 import { memo, RefObject, useCallback, useEffect, useMemo, useState } from 'react'
-import { ActivityIndicator, ImageBackground, Pressable, StyleSheet, View } from 'react-native'
+import { ActivityIndicator, ImageBackground, LayoutChangeEvent, Pressable, StyleSheet, View } from 'react-native'
 import { Feather } from '@expo/vector-icons'
 import type { VideoData } from '@peartube/core'
 import { colors } from '@/lib/colors'
@@ -15,11 +15,18 @@ type VerticalShortsPlayerProps = {
   isActive: boolean
   isLoading?: boolean
   thumbnailUrl?: string | null
+  controlsVisible?: boolean
+  onControlsVisibleChange?: (visible: boolean) => void
   onReplay?: () => void
 }
 
 function getShortsVideoKey(video: VideoData, fallbackUrl?: string | null) {
   return `${video.channelKey || 'channel'}:${video.id || video.path || fallbackUrl || 'video'}`
+}
+
+function clampProgress(value: number) {
+  if (!Number.isFinite(value)) return 0
+  return Math.max(0, Math.min(1, value))
 }
 
 export const VerticalShortsPlayer = memo(function VerticalShortsPlayer({
@@ -31,15 +38,24 @@ export const VerticalShortsPlayer = memo(function VerticalShortsPlayer({
   isActive,
   isLoading = false,
   thumbnailUrl,
+  controlsVisible = true,
+  onControlsVisibleChange,
   onReplay,
 }: VerticalShortsPlayerProps) {
   const [videoSize, setVideoSize] = useState<{ width: number; height: number } | null>(null)
   const [hasPlaybackError, setHasPlaybackError] = useState(false)
+  const [isPaused, setIsPaused] = useState(false)
+  const [seekPosition, setSeekPosition] = useState<number | undefined>(undefined)
+  const [progressBarWidth, setProgressBarWidth] = useState(0)
+  const [playbackProgress, setPlaybackProgress] = useState({ currentTime: 0, duration: 0 })
   const videoKey = getShortsVideoKey(video, videoUrl)
 
   useEffect(() => {
     setHasPlaybackError(false)
     setVideoSize(null)
+    setIsPaused(false)
+    setSeekPosition(undefined)
+    setPlaybackProgress({ currentTime: 0, duration: 0 })
   }, [videoKey])
 
   const isLandscape = useMemo(() => {
@@ -56,20 +72,69 @@ export const VerticalShortsPlayer = memo(function VerticalShortsPlayer({
     }
   }, [])
 
+  const handleProgress = useCallback((event: any) => {
+    const currentTime = Math.max(0, Number(event?.currentTime || 0))
+    const duration = Math.max(0, Number(event?.duration || 0))
+    setPlaybackProgress({ currentTime, duration })
+    if (duration > 0 && seekPosition !== undefined && Math.abs(currentTime - seekPosition) < 900) {
+      setSeekPosition(undefined)
+    }
+  }, [seekPosition])
+
   const handleError = useCallback((error: any) => {
     setHasPlaybackError(true)
     console.log('[VerticalShortsPlayer] Playback failed:', error?.message || error)
   }, [])
 
+  const toggleControlsVisibility = useCallback(() => {
+    onControlsVisibleChange?.(!controlsVisible)
+  }, [controlsVisible, onControlsVisibleChange])
+
+  const pauseShorts = useCallback(() => {
+    setIsPaused(true)
+    void playerRef.current?.pause?.()
+  }, [playerRef])
+
+  const playShorts = useCallback(() => {
+    setIsPaused(false)
+    void playerRef.current?.play?.()
+  }, [playerRef])
+
+  const restartShorts = useCallback(() => {
+    setIsPaused(false)
+    setSeekPosition(0)
+    setPlaybackProgress((prev) => ({ ...prev, currentTime: 0 }))
+    void playerRef.current?.seek?.(0)
+    void playerRef.current?.play?.()
+  }, [playerRef])
+
+  const handleProgressBarLayout = useCallback((event: LayoutChangeEvent) => {
+    setProgressBarWidth(event.nativeEvent.layout.width)
+  }, [])
+
+  const handleProgressBarPress = useCallback((event: any) => {
+    if (progressBarWidth <= 0 || playbackProgress.duration <= 0) return
+    const locationX = Number(event?.nativeEvent?.locationX || 0)
+    const progress = clampProgress(locationX / progressBarWidth)
+    const nextTime = progress * playbackProgress.duration
+    setSeekPosition(nextTime / 1000)
+    setPlaybackProgress((prev) => ({ ...prev, currentTime: nextTime }))
+    void playerRef.current?.seek?.(nextTime / 1000)
+  }, [playbackProgress.duration, playerRef, progressBarWidth])
+
   const showPlayer = Boolean(videoUrl && isActive && !hasPlaybackError)
   const showPoster = !showPlayer && Boolean(thumbnailUrl)
+  const effectiveProgress = playbackProgress.duration > 0
+    ? clampProgress(playbackProgress.currentTime / playbackProgress.duration)
+    : 0
 
   return (
-    <View
+    <Pressable
       testID={testID}
       style={styles.container}
       accessibilityRole="imagebutton"
       accessibilityLabel={`Vertical video player for ${video.title || 'video'}`}
+      onPress={toggleControlsVisibility}
     >
       {showPoster ? (
         <ImageBackground
@@ -85,12 +150,16 @@ export const VerticalShortsPlayer = memo(function VerticalShortsPlayer({
           videoUrl={videoUrl as string}
           playbackSession={playbackSession}
           currentVideoKey={videoKey}
-          isPlaying={isActive}
+          isPlaying={isActive && !isPaused}
           playbackRate={1}
+          seekPosition={seekPosition}
           videoTitle={video.title}
           channelName={video.channel?.name || 'Channel'}
           thumbnailUrl={thumbnailUrl || undefined}
           onVideoStateChange={handleVideoStateChange}
+          onProgress={handleProgress}
+          onPlaying={() => setIsPaused(false)}
+          onEnded={restartShorts}
           onError={handleError}
           style={[
             styles.videoSurface,
@@ -114,7 +183,33 @@ export const VerticalShortsPlayer = memo(function VerticalShortsPlayer({
           <Feather name={hasPlaybackError ? 'rotate-cw' : 'play'} color="#fff" size={42} />
         </Pressable>
       ) : null}
-    </View>
+
+      {showPlayer && controlsVisible ? (
+        <View style={styles.controlsOverlay} pointerEvents="box-none">
+          <View style={styles.controlButtons}>
+            <Pressable
+              onPress={isPaused ? playShorts : pauseShorts}
+              style={styles.controlButton}
+              accessibilityLabel={isPaused ? 'Play Shorts video' : 'Pause Shorts video'}
+            >
+              <Feather name={isPaused ? 'play' : 'pause'} color="#fff" size={24} />
+            </Pressable>
+            <Pressable onPress={restartShorts} style={styles.controlButton} accessibilityLabel="Restart Shorts video">
+              <Feather name="rotate-cw" color="#fff" size={22} />
+            </Pressable>
+          </View>
+          <Pressable
+            onPress={handleProgressBarPress}
+            onLayout={handleProgressBarLayout}
+            style={styles.progressTrack}
+            accessibilityRole="adjustable"
+            accessibilityLabel="Shorts progress bar"
+          >
+            <View style={[styles.progressFill, { width: `${effectiveProgress * 100}%` }]} />
+          </Pressable>
+        </View>
+      ) : null}
+    </Pressable>
   )
 })
 
@@ -152,6 +247,39 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     backgroundColor: 'rgba(0,0,0,0.2)',
+  },
+  controlsOverlay: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    paddingHorizontal: 18,
+    paddingBottom: 18,
+  },
+  controlButtons: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    marginBottom: 12,
+  },
+  controlButton: {
+    width: 46,
+    height: 46,
+    borderRadius: 23,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(0,0,0,0.42)',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.18)',
+  },
+  progressTrack: {
+    height: 18,
+    justifyContent: 'center',
+  },
+  progressFill: {
+    height: 3,
+    borderRadius: 999,
+    backgroundColor: colors.primary,
   },
   playButtonShell: {
     position: 'absolute',

--- a/packages/app/tests/vertical-discovery-regression.test.mjs
+++ b/packages/app/tests/vertical-discovery-regression.test.mjs
@@ -68,3 +68,50 @@ test('vertical discovery keeps channel navigation and detail escape hatches', ()
   assert.match(source, /Feather name="message-circle"/, 'vertical player should include a comments/details affordance')
   assert.match(source, /Feather name="user"/, 'vertical player should include a channel affordance')
 })
+
+test('vertical discovery hydrates beyond sparse previews without permanently poisoning timed-out channels', () => {
+  const source = readAppFile('app/(tabs)/discover.tsx')
+  const hydrateBlock = source.slice(source.indexOf('const hydrateChannelVideos'), source.indexOf('const loadFeed'))
+
+  assert.doesNotMatch(source, /entries\.slice\(0, 8\)/, 'shorts should not cap channel hydration to the first few feed entries')
+  assert.match(source, /entries\.slice\(0, 24\)/, 'shorts should fan out across enough feed channels to expose more than preview videos')
+  assert.doesNotMatch(hydrateBlock, /hydratedChannelsRef\.current\.add\(channelKey\)[\s\S]*?const result = await withTimeout/, 'timed-out channel list calls must remain retryable')
+  assert.match(hydrateBlock, /const timeoutToken = Symbol\('vertical-channel-timeout'\)/, 'channel hydration should distinguish timeout from an authoritative empty video list')
+  assert.match(hydrateBlock, /if \(result === timeoutToken\) return[\s\S]*hydratedChannelsRef\.current\.add\(channelKey\)/, 'channel hydration should only mark the channel hydrated after a real response')
+})
+
+test('vertical discovery preloads the next few videos into the playback URL cache', () => {
+  const source = readAppFile('app/(tabs)/discover.tsx')
+
+  assert.match(source, /const nextVideos = videos\.slice\(activeIndex \+ 1, activeIndex \+ 5\)/, 'shorts should warm the next few videos, not only one or two')
+  assert.match(source, /const warmPlaybackUrl = async \(video: VideoData\)/, 'preload should use a named URL warming helper')
+  assert.match(source, /const result = await rpc\?\.preparePlayback\?\.\(playbackRequest\)/, 'preload should await preparePlayback so it can keep the resolved URL')
+  assert.match(source, /if \(result\?\.url && cacheKey\) setCachedVideoUrl\(cacheKey, result\.url\)/, 'preload should populate the playback URL cache for instant swipe playback')
+})
+
+
+test('vertical discovery lets the shorts player hide card chrome', () => {
+  const source = readAppFile('app/(tabs)/discover.tsx')
+  const playerSource = readAppFile('components/discovery/VerticalShortsPlayer.tsx')
+
+  assert.match(source, /const \[shortsChromeVisible, setShortsChromeVisible\] = useState\(true\)/, 'Discover should track whether Shorts chrome/buttons are visible')
+  assert.match(source, /controlsVisible=\{shortsChromeVisible\}/, 'Discover should pass shared chrome visibility to the Shorts player')
+  assert.match(source, /onControlsVisibleChange=\{setShortsChromeVisible\}/, 'Shorts player taps should update route chrome visibility')
+  assert.match(source, /\{shortsChromeVisible \? \([\s\S]*styles\.bottomMeta/, 'channel/details/replay buttons should hide when Shorts controls are hidden')
+  assert.match(playerSource, /toggleControlsVisibility/, 'Shorts player should toggle controls on tap')
+  assert.match(playerSource, /onControlsVisibleChange\?\.\(!controlsVisible\)/, 'Shorts player should notify the parent when controls are toggled')
+})
+
+test('shorts player has functional playback buttons and a seekable progress bar', () => {
+  const source = readAppFile('components/discovery/VerticalShortsPlayer.tsx')
+
+  assert.match(source, /const \[isPaused, setIsPaused\] = useState\(false\)/, 'Shorts player should own local pause state')
+  assert.match(source, /const \[playbackProgress, setPlaybackProgress\]/, 'Shorts player should track current time and duration')
+  assert.match(source, /onProgress=\{handleProgress\}/, 'Shorts player should receive native progress events')
+  assert.match(source, /seekPosition=\{seekPosition\}/, 'Shorts player should pass seek requests to the native inline player')
+  assert.match(source, /playerRef\.current\?\.pause\?\.\(\)/, 'pause button should call the player port')
+  assert.match(source, /playerRef\.current\?\.play\?\.\(\)/, 'play button should call the player port')
+  assert.match(source, /playerRef\.current\?\.seek\?\.\(0\)/, 'restart button should seek to the beginning')
+  assert.match(source, /handleProgressBarPress/, 'progress bar should handle tap-to-seek')
+  assert.match(source, /accessibilityLabel="Shorts progress bar"/, 'progress bar should be accessible and testable')
+})


### PR DESCRIPTION
## Summary
- Expand vertical Shorts feed hydration and cache preloaded playback URLs for upcoming videos
- Add tap-to-hide Shorts chrome and hide channel/details/replay controls with it
- Add functional Shorts play/pause, restart, and tap-to-seek progress bar controls

## Test Plan
- [x] git diff --check
- [x] node --test packages/app/tests/vertical-discovery-regression.test.mjs

Note: npm run lint:changed -- --since HEAD currently reports no changed JS/TS files to lint in this worktree.