### PR TITLE
docs(cli): add root relay compose entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,17 @@ npm run desktop:native:build
 open packages/desktop-native/build/Build/Products/Debug/PearTubeDesktop.app
 ```
 
+### Relay container
+
+Use the root-level relay Compose file to run a public PearTube CLI relay:
+
+```bash
+docker compose -f docker-compose.relay.yml up -d
+docker compose -f docker-compose.relay.yml exec relay /peartube-relay status --json
+```
+
+The relay image is `ghcr.io/ayooooo123/peartube-relay:latest` and stores persistent data in the `peartube-relay-data` volume at `/var/lib/peartube-relay`.
+
 ## Development
 
 ### Mobile

--- a/docker-compose.relay.yml
+++ b/docker-compose.relay.yml
@@ -1,0 +1,34 @@
+# PearTube relay container.
+#
+# Quick start:
+#   docker compose -f docker-compose.relay.yml up -d
+#   docker compose -f docker-compose.relay.yml exec relay /peartube-relay status --json
+#
+# The image is shell-less/distroless. Use /peartube-relay directly for status/validate.
+services:
+  relay:
+    image: ghcr.io/ayooooo123/peartube-relay:latest
+    pull_policy: always
+    restart: unless-stopped
+    environment:
+      PEARTUBE_MODE: public
+      PEARTUBE_POLICY: discovery
+      PEARTUBE_STORAGE_PATH: /var/lib/peartube-relay
+      PEARTUBE_STORAGE_MAX_BYTES: 107374182400
+      PEARTUBE_DISCOVERY_ENABLED: "true"
+      PEARTUBE_DISCOVERY_MAX_CHANNELS: 500
+      PEARTUBE_DISCOVERY_MAX_CHANNELS_PER_OWNER: 20
+      PEARTUBE_NETWORK_ANNOUNCE: "true"
+      PEARTUBE_NETWORK_BOOTSTRAP: default
+      PEARTUBE_LOG_LEVEL: info
+      # Optional allowlist keys for private or curated public mode:
+      # PEARTUBE_ADMISSION_CHANNELS: chan-key-1,chan-key-2
+      # PEARTUBE_ADMISSION_OWNERS: owner-key-1
+      # Optional retention overrides:
+      # PEARTUBE_RETENTION_PROTECT_PRIVATE: "true"
+      # PEARTUBE_RETENTION_PROTECT_ALLOWLIST: "true"
+    volumes:
+      - peartube-relay-data:/var/lib/peartube-relay
+
+volumes:
+  peartube-relay-data:

--- a/packages/cli/test/cli.test.mjs
+++ b/packages/cli/test/cli.test.mjs
@@ -117,6 +117,19 @@ test('Dockerfile final stage copies the prepared relay artifact', async (t) => {
   t.ok(content.includes('COPY --from=artifact /peartube-relay /peartube-relay'), 'final image copies the packaged relay executable from the artifact stage')
 })
 
+test('root-level relay compose file points to the packaged relay container example', async (t) => {
+  const rootComposePath = join(__dirname, '..', '..', '..', 'docker-compose.relay.yml')
+  const rootReadmePath = join(__dirname, '..', '..', '..', 'README.md')
+  const composeContent = readFileSync(rootComposePath, 'utf8')
+  const readmeContent = readFileSync(rootReadmePath, 'utf8')
+
+  t.ok(composeContent.includes('ghcr.io/ayooooo123/peartube-relay:latest'), 'root compose uses the published relay image')
+  t.ok(composeContent.includes('PEARTUBE_STORAGE_PATH: /var/lib/peartube-relay'), 'root compose persists relay storage at the container storage path')
+  t.ok(composeContent.includes('PEARTUBE_NETWORK_ANNOUNCE: "true"'), 'root compose announces relay availability to the P2P network')
+  t.ok(readmeContent.includes('docker-compose.relay.yml'), 'README links the discoverable root relay compose file')
+  t.ok(readmeContent.includes('docker compose -f docker-compose.relay.yml up -d'), 'README documents the relay compose startup command')
+})
+
 test('relay workflow prepares standalone artifacts before docker image build', async (t) => {
   const workflowPath = join(__dirname, '..', '..', '..', '.github', 'workflows', 'build-relay.yml')
   const content = readFileSync(workflowPath, 'utf8')


### PR DESCRIPTION
## Summary
- Add root-level docker-compose.relay.yml for the published PearTube relay container
- Document relay startup and status commands in README
- Add CLI regression coverage so the root compose entrypoint stays discoverable

## Test Plan
- [x] git diff --check
- [x] node --test packages/cli/test/cli.test.mjs
- [x] npm run lint:changed -- --since HEAD