### PR TITLE
feat(cli): add YouTube archive mode to relay

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,29 @@ docker compose -f docker-compose.relay.yml exec relay \
 
 Archived source URLs stay in the local relay job input store. Public job/status output only includes imported metadata, generated video IDs, and channel keys.
 
+### Relay archive mode (YouTube)
+
+Beyond the on-demand archive command, a relay can be configured to continuously poll YouTube channels/playlists and publish new uploads into PearTube channels it owns. `yt-dlp` is bundled in the relay Docker image; for a local install ensure `yt-dlp` is on `PATH`.
+
+Add an `archive` block to the relay config (or set `PEARTUBE_ARCHIVE_*` env vars):
+
+```yaml
+archive:
+  enabled: true
+  poll: 3600              # seconds between polls
+  maxItems: 50            # newest videos considered per poll
+  maxRetries: 3           # give up on a video after N consecutive failures
+  budgetReservePercent: 5 # stop archiving when within N% of storage.maxBytes
+  format: "bv*[height<=1080][ext=mp4]+ba[ext=m4a]/b[height<=1080][ext=mp4]/b"
+  tmpPath: /var/lib/peartube-relay/archive-tmp
+  sources:
+    - url: https://www.youtube.com/@somechannel
+      label: Some Channel
+    - url: https://www.youtube.com/playlist?list=PLxxxxxxxxxxx
+```
+
+Each source maps to a separate PearTube channel whose keypair is deterministic from the relay's persistent identity and the source URL — restarts reopen the same channel, and each archived channel is announced to the public feed and pinned in the relay's cache.
+
 ## Development
 
 ### Mobile

--- a/packages/cli/config.example.yml
+++ b/packages/cli/config.example.yml
@@ -14,5 +14,21 @@ discovery:
   maxChannels: 500
   maxChannelsPerOwner: 20
 
+# Optional: archive YouTube channels into PearTube channels owned by this relay.
+# Each source URL maps to one PearTube channel (deterministic per relay identity).
+# yt-dlp must be available in PATH (the relay Docker image bundles it).
+archive:
+  enabled: false
+  poll: 3600              # seconds between polls per source
+  maxItems: 50            # videos to consider per poll, newest first
+  maxRetries: 3           # give up on a video after this many consecutive failures
+  budgetReservePercent: 5 # stop archiving when within N% of storage.maxBytes
+  format: "bv*[height<=1080][ext=mp4]+ba[ext=m4a]/b[height<=1080][ext=mp4]/b"
+  tmpPath: /var/lib/peartube-relay/archive-tmp  # yt-dlp scratch dir
+  sources:
+    - url: https://www.youtube.com/@somechannel
+      label: Some Channel
+    # - url: https://www.youtube.com/playlist?list=PLxxxxxxx
+
 logging:
   level: info

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,7 +10,7 @@
     "peartube-peer-bare": "bare-bin.js"
   },
   "scripts": {
-    "test": "brittle test/admission.test.mjs test/archive-ui.test.mjs test/cli.test.mjs test/config.test.mjs test/relay-seeding.test.mjs test/service.test.mjs test/status.test.mjs",
+    "test": "brittle test/admission.test.mjs test/archive-ui.test.mjs test/archive.test.mjs test/cli.test.mjs test/config.test.mjs test/relay-seeding.test.mjs test/service.test.mjs test/status.test.mjs",
     "build:standalone": "node ./scripts/build-standalone.mjs",
     "build:standalone:linux-x64": "RELAY_STANDALONE_HOST=linux-x64 node ./scripts/build-standalone.mjs",
     "build:standalone:linux-arm64": "RELAY_STANDALONE_HOST=linux-arm64 node ./scripts/build-standalone.mjs",

--- a/packages/cli/src/archive/index.js
+++ b/packages/cli/src/archive/index.js
@@ -70,6 +70,7 @@ export function createArchiver({
   let publisher = null
   let stopped = false
   const sourceTimers = new Map()
+  const initialPollTimers = new Set()
   const inflight = new Set()
   const abortController = typeof AbortController === 'function' ? new AbortController() : null
 
@@ -316,9 +317,11 @@ export function createArchiver({
       const stagger = Math.max(1, Math.floor(60_000 / sources.length))
       sources.forEach((source, index) => {
         const delay = index * stagger
-        setTimeoutFn(() => {
+        const timeout = setTimeoutFn(() => {
+          initialPollTimers.delete(timeout)
           if (!stopped) pollSourceTracked(source)
         }, delay)
+        initialPollTimers.add(timeout)
         scheduleSource(source)
       })
     },
@@ -336,6 +339,10 @@ export function createArchiver({
         try { clearIntervalFn(timer) } catch { /* best effort */ }
       }
       sourceTimers.clear()
+      for (const timer of initialPollTimers.values()) {
+        try { clearIntervalFn(timer) } catch { /* best effort */ }
+      }
+      initialPollTimers.clear()
       try { abortController?.abort() } catch { /* best effort */ }
       // Wait for any in-flight poll to drain
       const drainStart = Date.now()

--- a/packages/cli/src/archive/index.js
+++ b/packages/cli/src/archive/index.js
@@ -1,0 +1,348 @@
+import { mkdirSync, rmSync } from '#fs'
+import { join } from '#path'
+import { ARCHIVE_STATUS, createArchiveState } from './state.js'
+import { createYtDlp } from './yt-dlp.js'
+import { createArchivePublisher } from './publisher.js'
+
+function shouldRetry(record) {
+  if (!record) return true
+  if (record.status === ARCHIVE_STATUS.ARCHIVED) return false
+  if (record.status === ARCHIVE_STATUS.ABANDONED) return false
+  return true
+}
+
+function withinBudget({ cacheManager, maxBytes, reservePercent }) {
+  if (!Number.isFinite(maxBytes) || maxBytes <= 0) return true
+  const used = typeof cacheManager?.getTotalBytes === 'function'
+    ? Number(cacheManager.getTotalBytes()) || 0
+    : 0
+  const ceiling = maxBytes * (1 - reservePercent / 100)
+  return used < ceiling
+}
+
+export function createArchiver({
+  config,
+  runtime,
+  logger,
+  fs,
+  ytDlp = null,
+  uploadManagerFactory = null,
+  publisherFactory = null,
+  setIntervalFn = setInterval,
+  clearIntervalFn = clearInterval,
+  setTimeoutFn = setTimeout
+}) {
+  if (!config) throw new Error('config is required')
+  if (!runtime) throw new Error('runtime is required')
+  if (!fs) throw new Error('fs is required')
+  if (!logger?.archive) throw new Error('archive logger is required')
+
+  const archiveConfig = config.archive || {}
+  if (!archiveConfig.enabled) {
+    return {
+      enabled: false,
+      sources: [],
+      async getSourcesStatus() { return [] },
+      async start() { /* no-op */ },
+      async runOnce() { /* no-op */ },
+      async stop() { /* no-op */ }
+    }
+  }
+
+  const sources = Array.isArray(archiveConfig.sources) ? archiveConfig.sources : []
+  if (!sources.length) {
+    logger.archive.warn('Archive enabled but no sources configured; skipping')
+    return {
+      enabled: false,
+      sources: [],
+      async getSourcesStatus() { return [] },
+      async start() { /* no-op */ },
+      async runOnce() { /* no-op */ },
+      async stop() { /* no-op */ }
+    }
+  }
+
+  const tmpPath = archiveConfig.tmpPath
+  const ytDlpClient = ytDlp || createYtDlp({ binary: archiveConfig.ytDlpPath })
+  const state = createArchiveState({ metaDb: runtime.ctx.metaDb })
+
+  let uploadManager = null
+  let publisher = null
+  let stopped = false
+  const sourceTimers = new Map()
+  const inflight = new Set()
+  const abortController = typeof AbortController === 'function' ? new AbortController() : null
+
+  function abortSignal() {
+    return abortController ? abortController.signal : undefined
+  }
+
+  function cleanupTmpForVideo(videoId) {
+    const dir = join(tmpPath, videoId)
+    try { rmSync(dir, { recursive: true, force: true }) } catch { /* best effort */ }
+  }
+
+  function ensureTmpDirForVideo(videoId) {
+    const dir = join(tmpPath, videoId)
+    mkdirSync(dir, { recursive: true })
+    return dir
+  }
+
+  async function ensureUploadManager() {
+    if (uploadManager) return uploadManager
+    if (typeof uploadManagerFactory === 'function') {
+      uploadManager = await uploadManagerFactory({ ctx: runtime.ctx })
+    } else {
+      const { createUploadManager } = await import('@peartube/backend/upload')
+      uploadManager = createUploadManager({ ctx: runtime.ctx })
+    }
+    return uploadManager
+  }
+
+  async function ensurePublisher() {
+    if (publisher) return publisher
+    if (typeof publisherFactory === 'function') {
+      publisher = await publisherFactory({ ctx: runtime.ctx, runtime, fs, logger, state })
+    } else {
+      const upload = await ensureUploadManager()
+      publisher = createArchivePublisher({
+        ctx: runtime.ctx,
+        uploadManager: upload,
+        runtime,
+        fs,
+        logger,
+        state
+      })
+    }
+    return publisher
+  }
+
+  async function processOneVideo({ source, ytEntry }) {
+    const existing = await state.getVideo(source.sourceId, ytEntry.id)
+    if (!shouldRetry(existing)) return { skipped: true, status: existing.status }
+
+    if (!withinBudget({
+      cacheManager: runtime.cacheManager,
+      maxBytes: config.storage?.maxBytes,
+      reservePercent: archiveConfig.budgetReservePercent
+    })) {
+      logger.archive.warn('Storage budget reached; skipping new archives', {
+        sourceId: source.sourceId,
+        videoId: ytEntry.id,
+        maxBytes: config.storage?.maxBytes,
+        used: runtime.cacheManager?.getTotalBytes?.() || 0
+      })
+      return { skipped: true, status: 'budget' }
+    }
+
+    const tmpDir = ensureTmpDirForVideo(ytEntry.id)
+    const downloadUrl = ytEntry.webpageUrl || ytEntry.url || `https://www.youtube.com/watch?v=${ytEntry.id}`
+
+    try {
+      const files = await ytDlpClient.downloadVideo(downloadUrl, {
+        workDir: tmpDir,
+        format: source.format || archiveConfig.format,
+        videoId: ytEntry.id,
+        signal: abortSignal()
+      })
+
+      const pub = await ensurePublisher()
+      const result = await pub.publishVideo({ source, ytEntry, files })
+
+      await state.markArchived(source.sourceId, ytEntry.id, {
+        peartubeVideoId: result.videoId,
+        bytes: result.bytes,
+        title: ytEntry.title
+      })
+
+      logger.archive.info('Video archived', {
+        sourceId: source.sourceId,
+        ytId: ytEntry.id,
+        peartubeVideoId: result.videoId,
+        bytes: result.bytes,
+        title: ytEntry.title || ''
+      })
+
+      return { archived: true, status: 'archived', bytes: result.bytes }
+    } catch (err) {
+      const updated = await state.markFailed(source.sourceId, ytEntry.id, err, {
+        maxRetries: archiveConfig.maxRetries
+      })
+      logger.archive.warn('Video archive failed', {
+        sourceId: source.sourceId,
+        ytId: ytEntry.id,
+        retries: updated.retries,
+        status: updated.status,
+        error: err?.message || String(err)
+      })
+      return { archived: false, status: updated.status, error: err?.message || String(err) }
+    } finally {
+      cleanupTmpForVideo(ytEntry.id)
+    }
+  }
+
+  async function pollSource(source) {
+    if (stopped) return
+    logger.archive.debug('Polling archive source', { sourceId: source.sourceId, url: source.url })
+
+    let listing
+    try {
+      listing = await ytDlpClient.listVideos(source.url, {
+        maxItems: source.maxItems || archiveConfig.maxItems,
+        signal: abortSignal()
+      })
+    } catch (err) {
+      logger.archive.warn('Listing source failed', {
+        sourceId: source.sourceId,
+        error: err?.message || String(err)
+      })
+      await state.putSource(source.sourceId, {
+        url: source.url,
+        type: source.type,
+        lastPolledAt: Date.now(),
+        lastError: err?.message || String(err)
+      })
+      return
+    }
+
+    let archivedCount = 0
+    let failedCount = 0
+    let skippedCount = 0
+    let bytesAddedThisPoll = 0
+
+    for (const ytEntry of listing) {
+      if (stopped) break
+      const result = await processOneVideo({ source, ytEntry })
+      if (result.archived) {
+        archivedCount += 1
+        bytesAddedThisPoll += Number(result.bytes) || 0
+      } else if (result.skipped && result.status === 'budget') {
+        skippedCount += 1
+        // budget exhausted — stop processing this poll; the next poll will try again
+        break
+      } else if (result.skipped) {
+        skippedCount += 1
+      } else {
+        failedCount += 1
+      }
+    }
+
+    await state.putSource(source.sourceId, {
+      url: source.url,
+      type: source.type,
+      lastPolledAt: Date.now(),
+      lastError: null,
+      lastSeenVideos: listing.length,
+      archivedCount,
+      failedCount,
+      skippedCount,
+      bytesAddedThisPoll
+    })
+
+    logger.archive.info('Source poll complete', {
+      sourceId: source.sourceId,
+      seen: listing.length,
+      archived: archivedCount,
+      failed: failedCount,
+      skipped: skippedCount,
+      bytesAddedThisPoll
+    })
+  }
+
+  async function pollSourceTracked(source) {
+    if (inflight.has(source.sourceId)) return
+    inflight.add(source.sourceId)
+    try {
+      await pollSource(source)
+    } catch (err) {
+      logger.archive.error('Source poll crashed', {
+        sourceId: source.sourceId,
+        error: err?.message || String(err)
+      })
+    } finally {
+      inflight.delete(source.sourceId)
+    }
+  }
+
+  function scheduleSource(source) {
+    const intervalMs = Math.max(60_000, Number(archiveConfig.poll) * 1000)
+    const timer = setIntervalFn(() => {
+      pollSourceTracked(source)
+    }, intervalMs)
+    sourceTimers.set(source.sourceId, timer)
+  }
+
+  async function getSourcesStatus() {
+    const out = []
+    for (const source of sources) {
+      const sourceRecord = await state.getSource(source.sourceId).catch(() => null)
+      const videos = await state.listVideos(source.sourceId).catch(() => [])
+      const counts = { archived: 0, failed: 0, abandoned: 0 }
+      for (const video of videos) {
+        if (video.status === 'archived') counts.archived += 1
+        else if (video.status === 'failed') counts.failed += 1
+        else if (video.status === 'abandoned') counts.abandoned += 1
+      }
+      out.push({
+        sourceId: source.sourceId,
+        url: source.url,
+        type: source.type,
+        kind: source.kind,
+        label: source.label,
+        channelKey: sourceRecord?.channelKey || null,
+        publicBeeKey: sourceRecord?.publicBeeKey || null,
+        lastPolledAt: sourceRecord?.lastPolledAt || null,
+        lastError: sourceRecord?.lastError || null,
+        bytesAddedThisPoll: sourceRecord?.bytesAddedThisPoll || 0,
+        counts
+      })
+    }
+    return out
+  }
+
+  return {
+    enabled: true,
+    sources,
+    getSourcesStatus,
+    async start() {
+      mkdirSync(tmpPath, { recursive: true })
+      logger.archive.info('Archive starting', {
+        sources: sources.length,
+        pollSeconds: archiveConfig.poll,
+        tmpPath
+      })
+
+      // Stagger initial polls so we don't hammer yt-dlp simultaneously.
+      const stagger = Math.max(1, Math.floor(60_000 / sources.length))
+      sources.forEach((source, index) => {
+        const delay = index * stagger
+        setTimeoutFn(() => {
+          if (!stopped) pollSourceTracked(source)
+        }, delay)
+        scheduleSource(source)
+      })
+    },
+    async runOnce() {
+      mkdirSync(tmpPath, { recursive: true })
+      for (const source of sources) {
+        if (stopped) break
+        await pollSourceTracked(source)
+      }
+    },
+    async stop() {
+      if (stopped) return
+      stopped = true
+      for (const timer of sourceTimers.values()) {
+        try { clearIntervalFn(timer) } catch { /* best effort */ }
+      }
+      sourceTimers.clear()
+      try { abortController?.abort() } catch { /* best effort */ }
+      // Wait for any in-flight poll to drain
+      const drainStart = Date.now()
+      while (inflight.size > 0 && Date.now() - drainStart < 30_000) {
+        await new Promise((resolve) => setTimeoutFn(resolve, 100))
+      }
+      logger.archive.info('Archive stopped')
+    }
+  }
+}

--- a/packages/cli/src/archive/publisher.js
+++ b/packages/cli/src/archive/publisher.js
@@ -1,0 +1,191 @@
+import b4a from 'b4a'
+import { buildWriterKeyName } from './source-id.js'
+
+const ARCHIVE_DESCRIPTION_MARKER_PREFIX = '\n\n[peartube-archive-source]'
+
+function buildSourceMarker(source) {
+  return [
+    ARCHIVE_DESCRIPTION_MARKER_PREFIX,
+    `type=${source.type}`,
+    `id=${source.identifier}`,
+    `url=${source.url}`
+  ].join('\n')
+}
+
+function defaultChannelName(source) {
+  if (source.label) return source.label
+  if (source.kind === 'handle') return source.identifier
+  if (source.kind === 'channel') return `YouTube channel ${source.identifier.slice(0, 12)}`
+  if (source.kind === 'playlist') return `YouTube playlist ${source.identifier.slice(0, 12)}`
+  return `YouTube ${source.identifier}`
+}
+
+function defaultChannelDescription(source) {
+  return `Auto-archived from ${source.url} by a PearTube relay.${buildSourceMarker(source)}`
+}
+
+/**
+ * Loads the per-source PearTube channel for this relay (creating it on first use).
+ * The channel keypair is deterministic from the relay's persistent corestore primaryKey
+ * and the source identifier, so restarting the relay reopens the same channel.
+ */
+export function createArchivePublisher({ ctx, uploadManager, runtime, fs, logger, state = null }) {
+  if (!ctx) throw new Error('ctx is required')
+  if (!uploadManager) throw new Error('uploadManager is required')
+  if (!runtime) throw new Error('runtime is required')
+  if (!fs) throw new Error('fs is required')
+
+  const channelCache = new Map()
+
+  async function ensureSourceChannel(source) {
+    if (channelCache.has(source.sourceId)) return channelCache.get(source.sourceId)
+
+    const writerKeyName = buildWriterKeyName(source.sourceId)
+    const { createChannel } = await import('@peartube/backend/storage')
+
+    const created = await createChannel(ctx, {
+      encrypt: false,
+      writerKeyName
+    })
+
+    const channel = created.channel
+    const channelKey = created.channelKeyHex
+
+    if (!channel.writable) {
+      throw new Error(`archive channel for source ${source.sourceId} is not writable`)
+    }
+
+    let publicBeeKey = null
+    try {
+      const meta = await channel.getMetadata().catch(() => null)
+      const isFresh = !meta || (typeof meta === 'object' && Object.keys(meta).length === 0)
+      if (isFresh) {
+        await channel.updateMetadata({
+          name: defaultChannelName(source),
+          description: defaultChannelDescription(source),
+          avatar: null,
+          createdAt: Date.now(),
+          createdBy: source.sourceId
+        })
+        await channel.ensureLocalBlobDrive({ deviceName: 'archive' }).catch(() => {})
+      }
+
+      publicBeeKey = channel.publicBeeKey
+        ? (b4a.isBuffer(channel.publicBeeKey) ? b4a.toString(channel.publicBeeKey, 'hex') : String(channel.publicBeeKey))
+        : null
+      if (!publicBeeKey) {
+        const refreshed = await channel.getMetadata().catch(() => null)
+        publicBeeKey = refreshed?.publicBeeKey || null
+      }
+    } catch (err) {
+      logger?.archive?.warn?.('Channel metadata setup failed', {
+        sourceId: source.sourceId,
+        error: err?.message || String(err)
+      })
+    }
+
+    if (publicBeeKey) {
+      try {
+        await runtime.publicFeed?.submitChannel?.(channelKey, publicBeeKey)
+      } catch (err) {
+        logger?.archive?.debug?.('Public-feed submit failed', {
+          sourceId: source.sourceId,
+          error: err?.message || String(err)
+        })
+      }
+      try {
+        await runtime.cacheManager?.pinChannel?.(channelKey, publicBeeKey)
+      } catch (err) {
+        logger?.archive?.debug?.('Pin channel failed', {
+          sourceId: source.sourceId,
+          error: err?.message || String(err)
+        })
+      }
+      try {
+        await runtime.seeder?.seedChannel?.({ driveKey: channelKey, publicBeeKey })
+      } catch (err) {
+        logger?.archive?.debug?.('Seed channel failed', {
+          sourceId: source.sourceId,
+          error: err?.message || String(err)
+        })
+      }
+    }
+
+    if (state && typeof state.putSource === 'function') {
+      try {
+        const existing = await state.getSource(source.sourceId)
+        await state.putSource(source.sourceId, {
+          ...(existing || {}),
+          url: source.url,
+          type: source.type,
+          label: source.label || null,
+          channelKey,
+          publicBeeKey: publicBeeKey || existing?.publicBeeKey || null
+        })
+      } catch (err) {
+        logger?.archive?.debug?.('Persist source channel keys failed', {
+          sourceId: source.sourceId,
+          error: err?.message || String(err)
+        })
+      }
+    }
+
+    const entry = { channel, channelKey, publicBeeKey }
+    channelCache.set(source.sourceId, entry)
+    return entry
+  }
+
+  async function publishVideo({ source, ytEntry, files }) {
+    const channelEntry = await ensureSourceChannel(source)
+    const { channel } = channelEntry
+
+    if (!files?.videoFile) {
+      throw new Error('videoFile required to publish')
+    }
+
+    const stat = fs.statSync(files.videoFile)
+    const fileSize = Number.isFinite(stat?.size) ? Number(stat.size) : 0
+
+    const result = await uploadManager.uploadFromPath(
+      channel,
+      files.videoFile,
+      {
+        title: ytEntry.title || files.videoFile.split('/').pop() || 'Untitled',
+        description: ytEntry.webpageUrl
+          ? `Source: ${ytEntry.webpageUrl}`
+          : '',
+        duration: Number.isFinite(ytEntry.duration) ? Number(ytEntry.duration) : 0,
+        category: 'archive'
+      },
+      fs
+    )
+
+    if (!result?.success) {
+      throw new Error(result?.error || 'upload failed')
+    }
+
+    if (files.thumbnailFile) {
+      try {
+        const thumbBuffer = fs.readFileSync(files.thumbnailFile)
+        await uploadManager.setThumbnailFromBuffer(channel, result.videoId, thumbBuffer, 'image/jpeg')
+      } catch (err) {
+        logger?.archive?.debug?.('Thumbnail attach failed', {
+          videoId: result.videoId,
+          error: err?.message || String(err)
+        })
+      }
+    }
+
+    return {
+      videoId: result.videoId,
+      bytes: fileSize,
+      channelKey: channelEntry.channelKey,
+      publicBeeKey: channelEntry.publicBeeKey
+    }
+  }
+
+  return {
+    ensureSourceChannel,
+    publishVideo
+  }
+}

--- a/packages/cli/src/archive/source-id.js
+++ b/packages/cli/src/archive/source-id.js
@@ -1,0 +1,76 @@
+import { ARCHIVE_TYPE_YOUTUBE } from '../constants.js'
+
+const YOUTUBE_HOSTS = new Set([
+  'youtube.com',
+  'www.youtube.com',
+  'm.youtube.com',
+  'music.youtube.com',
+  'youtu.be'
+])
+
+function parseUrl(input) {
+  if (typeof input !== 'string') return null
+  try {
+    return new URL(input.trim())
+  } catch {
+    return null
+  }
+}
+
+function pickYoutubeChannelId(url) {
+  if (!url) return null
+
+  const host = url.hostname.toLowerCase()
+  if (!YOUTUBE_HOSTS.has(host)) return null
+
+  const path = url.pathname.replace(/\/+$/, '')
+  const segments = path.split('/').filter(Boolean)
+
+  if (segments[0] === 'channel' && segments[1]) {
+    return { kind: 'channel', id: segments[1] }
+  }
+  if (segments[0] && segments[0].startsWith('@')) {
+    return { kind: 'handle', id: segments[0] }
+  }
+  if (segments[0] === 'c' && segments[1]) {
+    return { kind: 'custom', id: segments[1] }
+  }
+  if (segments[0] === 'user' && segments[1]) {
+    return { kind: 'user', id: segments[1] }
+  }
+  if (segments[0] === 'playlist') {
+    const list = url.searchParams.get('list')
+    if (list) return { kind: 'playlist', id: list }
+  }
+
+  return null
+}
+
+export function classifySourceUrl(input) {
+  const url = parseUrl(input)
+  if (!url) {
+    return { type: null, normalizedUrl: null, identifier: null, kind: null }
+  }
+
+  const yt = pickYoutubeChannelId(url)
+  if (yt) {
+    return {
+      type: ARCHIVE_TYPE_YOUTUBE,
+      normalizedUrl: input.trim(),
+      identifier: yt.id,
+      kind: yt.kind
+    }
+  }
+
+  return { type: null, normalizedUrl: null, identifier: null, kind: null }
+}
+
+export function buildSourceId(type, identifier) {
+  if (!type || !identifier) return null
+  return `${type}:${identifier}`
+}
+
+export function buildWriterKeyName(sourceId) {
+  if (!sourceId) return null
+  return `peartube-archive-writer:${sourceId}`
+}

--- a/packages/cli/src/archive/state.js
+++ b/packages/cli/src/archive/state.js
@@ -1,0 +1,98 @@
+const PREFIX = 'archive:state:'
+const SOURCE_PREFIX = 'archive:source:'
+
+function buildVideoKey(sourceId, videoId) {
+  return `${PREFIX}${sourceId}:${videoId}`
+}
+
+function buildSourceKey(sourceId) {
+  return `${SOURCE_PREFIX}${sourceId}`
+}
+
+export const ARCHIVE_STATUS = Object.freeze({
+  ARCHIVED: 'archived',
+  FAILED: 'failed',
+  ABANDONED: 'abandoned'
+})
+
+/**
+ * State store backed by ctx.metaDb (a Hyperbee).
+ * Tracks per-(sourceId, videoId) status to dedupe across polls,
+ * and per-sourceId metadata (channel key, last poll time).
+ *
+ * Records are JSON; metaDb's valueEncoding is 'json'.
+ */
+export function createArchiveState({ metaDb }) {
+  if (!metaDb || typeof metaDb.get !== 'function') {
+    throw new Error('createArchiveState requires a Hyperbee-shaped metaDb')
+  }
+
+  return {
+    async getVideo(sourceId, videoId) {
+      const node = await metaDb.get(buildVideoKey(sourceId, videoId))
+      return node?.value ?? null
+    },
+
+    async putVideo(sourceId, videoId, record) {
+      const value = {
+        sourceId,
+        videoId,
+        ...record,
+        updatedAt: Date.now()
+      }
+      await metaDb.put(buildVideoKey(sourceId, videoId), value)
+      return value
+    },
+
+    async markArchived(sourceId, videoId, { peartubeVideoId, bytes, title }) {
+      return this.putVideo(sourceId, videoId, {
+        status: ARCHIVE_STATUS.ARCHIVED,
+        peartubeVideoId: peartubeVideoId || null,
+        bytes: Number.isFinite(bytes) ? Number(bytes) : 0,
+        title: typeof title === 'string' ? title : null,
+        retries: 0,
+        lastError: null,
+        archivedAt: Date.now()
+      })
+    },
+
+    async markFailed(sourceId, videoId, error, { maxRetries }) {
+      const existing = await this.getVideo(sourceId, videoId)
+      const retries = (existing?.retries || 0) + 1
+      const status = retries > Math.max(0, Number(maxRetries) || 0)
+        ? ARCHIVE_STATUS.ABANDONED
+        : ARCHIVE_STATUS.FAILED
+      return this.putVideo(sourceId, videoId, {
+        status,
+        retries,
+        lastError: error?.message || String(error),
+        peartubeVideoId: existing?.peartubeVideoId || null
+      })
+    },
+
+    async listVideos(sourceId) {
+      const gte = `${PREFIX}${sourceId}:`
+      const lt = `${PREFIX}${sourceId}:￿`
+      const out = []
+      for await (const entry of metaDb.createReadStream({ gte, lt })) {
+        if (entry?.value) out.push(entry.value)
+      }
+      return out
+    },
+
+    async getSource(sourceId) {
+      const node = await metaDb.get(buildSourceKey(sourceId))
+      return node?.value ?? null
+    },
+
+    async putSource(sourceId, record) {
+      const value = {
+        sourceId,
+        ...record,
+        updatedAt: Date.now()
+      }
+      await metaDb.put(buildSourceKey(sourceId), value)
+      return value
+    }
+  }
+}

--- a/packages/cli/src/archive/yt-dlp.js
+++ b/packages/cli/src/archive/yt-dlp.js
@@ -1,0 +1,182 @@
+import { spawn } from '#subprocess'
+
+const PRINT_FILEPATH_TOKEN = '__PEARTUBE_FILEPATH__'
+
+function runYtDlp(binary, args, { signal, env, onStderr } = {}) {
+  return new Promise((resolve, reject) => {
+    let child
+    try {
+      child = spawn(binary, args, {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: env || undefined
+      })
+    } catch (err) {
+      reject(err)
+      return
+    }
+
+    let stdout = ''
+    let stderr = ''
+    let aborted = false
+
+    const onAbort = () => {
+      aborted = true
+      try { child.kill('SIGTERM') } catch { /* best effort */ }
+    }
+
+    if (signal) {
+      if (signal.aborted) {
+        onAbort()
+      } else {
+        signal.addEventListener('abort', onAbort, { once: true })
+      }
+    }
+
+    child.stdout.setEncoding('utf8')
+    child.stderr.setEncoding('utf8')
+
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk
+    })
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk
+      if (typeof onStderr === 'function') {
+        try { onStderr(chunk) } catch { /* swallow */ }
+      }
+    })
+
+    child.on('error', (err) => {
+      if (signal) signal.removeEventListener('abort', onAbort)
+      reject(err)
+    })
+
+    child.on('close', (code) => {
+      if (signal) signal.removeEventListener('abort', onAbort)
+      if (aborted) {
+        const err = new Error('yt-dlp aborted')
+        err.code = 'ABORTED'
+        reject(err)
+        return
+      }
+      if (code !== 0) {
+        const err = new Error(`yt-dlp exited with code ${code}: ${stderr.trim() || 'unknown error'}`)
+        err.code = code
+        err.stderr = stderr
+        err.stdout = stdout
+        reject(err)
+        return
+      }
+      resolve({ stdout, stderr })
+    })
+  })
+}
+
+function parseListLine(line) {
+  if (!line) return null
+  let entry
+  try {
+    entry = JSON.parse(line)
+  } catch {
+    return null
+  }
+  if (!entry || typeof entry !== 'object') return null
+  if (!entry.id) return null
+  return {
+    id: String(entry.id),
+    title: typeof entry.title === 'string' ? entry.title : '',
+    duration: Number.isFinite(entry.duration) ? Number(entry.duration) : null,
+    uploader: typeof entry.uploader === 'string' ? entry.uploader : null,
+    uploadDate: typeof entry.upload_date === 'string' ? entry.upload_date : null,
+    url: typeof entry.url === 'string' ? entry.url : null,
+    webpageUrl: typeof entry.webpage_url === 'string' ? entry.webpage_url : null
+  }
+}
+
+export function createYtDlp({ binary = 'yt-dlp' } = {}) {
+  return {
+    binary,
+    /**
+     * List videos in a channel / playlist URL (flat — no download).
+     * @param {string} url
+     * @param {{ maxItems?: number, signal?: AbortSignal, extraArgs?: string[] }} [opts]
+     * @returns {Promise<Array<{id:string,title:string,duration:number|null,uploader:string|null,uploadDate:string|null,url:string|null,webpageUrl:string|null}>>}
+     */
+    async listVideos(url, opts = {}) {
+      const args = [
+        '--flat-playlist',
+        '--no-warnings',
+        '--print-json',
+        '--ignore-errors'
+      ]
+      if (Number.isFinite(opts.maxItems) && opts.maxItems > 0) {
+        args.push('--playlist-end', String(opts.maxItems))
+      }
+      if (Array.isArray(opts.extraArgs)) args.push(...opts.extraArgs)
+      args.push(url)
+
+      const { stdout } = await runYtDlp(binary, args, { signal: opts.signal })
+      const lines = stdout.split('\n')
+      const results = []
+      for (const line of lines) {
+        const trimmed = line.trim()
+        if (!trimmed) continue
+        const parsed = parseListLine(trimmed)
+        if (parsed) results.push(parsed)
+      }
+      return results
+    },
+
+    /**
+     * Download a single video plus thumbnail + metadata into workDir.
+     * @param {string} url
+     * @param {{ workDir: string, format: string, videoId: string, signal?: AbortSignal, extraArgs?: string[] }} opts
+     * @returns {Promise<{videoFile:string|null,thumbnailFile:string|null,infoFile:string|null,stderr:string}>}
+     */
+    async downloadVideo(url, opts) {
+      if (!opts || typeof opts.workDir !== 'string') throw new Error('workDir required')
+      if (typeof opts.videoId !== 'string' || !opts.videoId) throw new Error('videoId required')
+      const format = typeof opts.format === 'string' && opts.format ? opts.format : 'b'
+
+      const outputTemplate = `${opts.videoId}.%(ext)s`
+
+      const args = [
+        '-f', format,
+        '--no-playlist',
+        '--no-warnings',
+        '--restrict-filenames',
+        '--write-thumbnail',
+        '--convert-thumbnail', 'jpg',
+        '--write-info-json',
+        '--print', `after_move:${PRINT_FILEPATH_TOKEN} %(filepath)s`,
+        '-P', opts.workDir,
+        '-o', outputTemplate
+      ]
+      if (Array.isArray(opts.extraArgs)) args.push(...opts.extraArgs)
+      args.push(url)
+
+      const { stdout, stderr } = await runYtDlp(binary, args, { signal: opts.signal })
+
+      let videoFile = null
+      for (const rawLine of stdout.split('\n')) {
+        const line = rawLine.trim()
+        if (!line.startsWith(PRINT_FILEPATH_TOKEN)) continue
+        const filepath = line.slice(PRINT_FILEPATH_TOKEN.length).trim()
+        if (filepath) videoFile = filepath
+      }
+
+      // Thumbnail and info-json files are placed alongside the video using the
+      // same stem ("<videoId>.jpg", "<videoId>.info.json"). Resolve by deriving
+      // from videoFile (preferred) or falling back to videoId.
+      let thumbnailFile = null
+      let infoFile = null
+      if (videoFile) {
+        const lastDot = videoFile.lastIndexOf('.')
+        const stem = lastDot > 0 ? videoFile.slice(0, lastDot) : videoFile
+        thumbnailFile = `${stem}.jpg`
+        infoFile = `${stem}.info.json`
+      }
+
+      return { videoFile, thumbnailFile, infoFile, stderr }
+    }
+  }
+}

--- a/packages/cli/src/cli-logger.js
+++ b/packages/cli/src/cli-logger.js
@@ -48,7 +48,7 @@ function createLogger(component) {
 /**
  * Create all component loggers for the CLI.
  * @param {boolean|string} debugOrLevel - Enable debug logging or set a level directly
- * @returns {{ relay: Logger, runtime: Logger, admission: Logger, status: Logger, mirror: Logger, peer: Logger, cache: Logger, feed: Logger, download: Logger }}
+ * @returns {{ relay: Logger, runtime: Logger, admission: Logger, status: Logger, mirror: Logger, peer: Logger, cache: Logger, feed: Logger, download: Logger, archive: Logger }}
  */
 export function createCliLogger(debugOrLevel) {
   setDebugLevel(debugOrLevel)

--- a/packages/cli/src/config.js
+++ b/packages/cli/src/config.js
@@ -2,6 +2,12 @@ import { readFileSync } from '#fs'
 import { join } from '#path'
 import process from '#process'
 import {
+  DEFAULT_ARCHIVE_CONFIG,
+  DEFAULT_ARCHIVE_FORMAT,
+  DEFAULT_ARCHIVE_MAX_ITEMS,
+  DEFAULT_ARCHIVE_MAX_RETRIES,
+  DEFAULT_ARCHIVE_POLL_SECONDS,
+  DEFAULT_ARCHIVE_YT_DLP_PATH,
   DEFAULT_RELAY_CONFIG,
   RELAY_CATALOG_FILENAME,
   RELAY_MODE_PRIVATE,
@@ -12,6 +18,7 @@ import {
   VALID_MODES,
   VALID_POLICIES
 } from './constants.js'
+import { buildSourceId, classifySourceUrl } from './archive/source-id.js'
 
 function isPlainObject(value) {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
@@ -216,12 +223,32 @@ function configFromEnv(env = {}) {
   if (env.PEARTUBE_LOG_LEVEL) {
     config.logging = { level: env.PEARTUBE_LOG_LEVEL }
   }
-  if (env.PEARTUBE_ARCHIVE_UI_ENABLED || env.PEARTUBE_ARCHIVE_UI_HOST || env.PEARTUBE_ARCHIVE_UI_PORT || env.PEARTUBE_ARCHIVE_TMP_PATH) {
+  if (
+    env.PEARTUBE_ARCHIVE_UI_ENABLED ||
+    env.PEARTUBE_ARCHIVE_UI_HOST ||
+    env.PEARTUBE_ARCHIVE_UI_PORT ||
+    env.PEARTUBE_ARCHIVE_TMP_PATH ||
+    env.PEARTUBE_ARCHIVE_ENABLED ||
+    env.PEARTUBE_ARCHIVE_POLL ||
+    env.PEARTUBE_ARCHIVE_FORMAT ||
+    env.PEARTUBE_ARCHIVE_YT_DLP_PATH ||
+    env.PEARTUBE_ARCHIVE_SOURCES
+  ) {
     config.archive = {}
     if (env.PEARTUBE_ARCHIVE_UI_ENABLED) config.archive.uiEnabled = parseBoolean(env.PEARTUBE_ARCHIVE_UI_ENABLED)
     if (env.PEARTUBE_ARCHIVE_UI_HOST) config.archive.uiHost = env.PEARTUBE_ARCHIVE_UI_HOST
     if (env.PEARTUBE_ARCHIVE_UI_PORT) config.archive.uiPort = Number(env.PEARTUBE_ARCHIVE_UI_PORT)
     if (env.PEARTUBE_ARCHIVE_TMP_PATH) config.archive.tmpPath = env.PEARTUBE_ARCHIVE_TMP_PATH
+    if (env.PEARTUBE_ARCHIVE_ENABLED) {
+      const parsed = parseBoolean(env.PEARTUBE_ARCHIVE_ENABLED)
+      if (parsed !== undefined) config.archive.enabled = parsed
+    }
+    if (env.PEARTUBE_ARCHIVE_POLL) config.archive.poll = Number(env.PEARTUBE_ARCHIVE_POLL)
+    if (env.PEARTUBE_ARCHIVE_FORMAT) config.archive.format = env.PEARTUBE_ARCHIVE_FORMAT
+    if (env.PEARTUBE_ARCHIVE_YT_DLP_PATH) config.archive.ytDlpPath = env.PEARTUBE_ARCHIVE_YT_DLP_PATH
+    if (env.PEARTUBE_ARCHIVE_SOURCES) {
+      config.archive.sources = splitCommaList(env.PEARTUBE_ARCHIVE_SOURCES).map((url) => ({ url }))
+    }
   }
 
   return config
@@ -254,12 +281,118 @@ function configFromCli(cli = {}) {
   }
 
   if (cli.host || cli.port) {
-    config.archive = {}
+    config.archive = config.archive || {}
     if (cli.host) config.archive.uiHost = cli.host
     if (cli.port) config.archive.uiPort = Number(cli.port)
   }
 
   return config
+}
+
+function normalizeSource(rawSource, defaults) {
+  if (!isPlainObject(rawSource)) {
+    if (typeof rawSource === 'string') {
+      rawSource = { url: rawSource }
+    } else {
+      throw new Error('archive.sources entries must be objects with a url')
+    }
+  }
+
+  const url = typeof rawSource.url === 'string' ? rawSource.url.trim() : ''
+  if (!url) throw new Error('archive.sources entries must include a url')
+
+  const classified = classifySourceUrl(url)
+  if (!classified.type) {
+    throw new Error(`Unsupported archive source url "${url}"`)
+  }
+
+  const sourceId = buildSourceId(classified.type, classified.identifier)
+
+  return {
+    url: classified.normalizedUrl,
+    type: classified.type,
+    identifier: classified.identifier,
+    kind: classified.kind,
+    sourceId,
+    label: typeof rawSource.label === 'string' && rawSource.label.trim()
+      ? rawSource.label.trim()
+      : null,
+    format: typeof rawSource.format === 'string' && rawSource.format.trim()
+      ? rawSource.format.trim()
+      : defaults.format,
+    maxItems: Number.isFinite(Number(rawSource.maxItems))
+      ? Number(rawSource.maxItems)
+      : defaults.maxItems
+  }
+}
+
+function resolveArchiveConfig(rawArchive, { storagePath }) {
+  const merged = deepMerge(DEFAULT_ARCHIVE_CONFIG, isPlainObject(rawArchive) ? rawArchive : {})
+
+  merged.enabled = Boolean(merged.enabled)
+
+  merged.poll = Number(merged.poll)
+  if (!Number.isFinite(merged.poll) || merged.poll <= 0) {
+    merged.poll = DEFAULT_ARCHIVE_POLL_SECONDS
+  }
+
+  merged.format = typeof merged.format === 'string' && merged.format.trim()
+    ? merged.format.trim()
+    : DEFAULT_ARCHIVE_FORMAT
+
+  merged.ytDlpPath = typeof merged.ytDlpPath === 'string' && merged.ytDlpPath.trim()
+    ? merged.ytDlpPath.trim()
+    : DEFAULT_ARCHIVE_YT_DLP_PATH
+
+  merged.maxRetries = Number(merged.maxRetries)
+  if (!Number.isFinite(merged.maxRetries) || merged.maxRetries < 0) {
+    merged.maxRetries = DEFAULT_ARCHIVE_MAX_RETRIES
+  }
+
+  merged.budgetReservePercent = Number(merged.budgetReservePercent)
+  if (!Number.isFinite(merged.budgetReservePercent) || merged.budgetReservePercent < 0 || merged.budgetReservePercent > 50) {
+    merged.budgetReservePercent = DEFAULT_ARCHIVE_CONFIG.budgetReservePercent
+  }
+
+  merged.maxItems = Number(merged.maxItems)
+  if (!Number.isFinite(merged.maxItems) || merged.maxItems <= 0) {
+    merged.maxItems = DEFAULT_ARCHIVE_MAX_ITEMS
+  }
+
+  if (typeof merged.tmpPath !== 'string' || !merged.tmpPath) {
+    merged.tmpPath = join(storagePath, 'archive-tmp')
+  }
+
+  merged.uiEnabled = Boolean(merged.uiEnabled)
+  merged.uiHost = typeof merged.uiHost === 'string' && merged.uiHost
+    ? merged.uiHost
+    : '127.0.0.1'
+  merged.uiPort = Number(merged.uiPort)
+  if (!Number.isFinite(merged.uiPort) || merged.uiPort <= 0) {
+    throw new Error('archive.uiPort must be a positive number')
+  }
+
+  const sourceDefaults = {
+    format: merged.format,
+    maxItems: merged.maxItems
+  }
+
+  const sources = Array.isArray(merged.sources) ? merged.sources : []
+  const seenSourceIds = new Set()
+  merged.sources = sources.map((entry) => {
+    const normalized = normalizeSource(entry, sourceDefaults)
+    if (seenSourceIds.has(normalized.sourceId)) {
+      throw new Error(`Duplicate archive source: ${normalized.sourceId}`)
+    }
+    seenSourceIds.add(normalized.sourceId)
+    return normalized
+  })
+
+  if (merged.enabled && merged.sources.length === 0) {
+    throw new Error('archive.enabled is true but archive.sources is empty')
+  }
+
+  return merged
 }
 
 export function resolveRelayConfig(input = {}, { env = process.env || {} } = {}) {
@@ -316,16 +449,14 @@ export function resolveRelayConfig(input = {}, { env = process.env || {} } = {})
   config.retention = deepMerge(DEFAULT_RELAY_CONFIG.retention, config.retention || {})
   config.network = deepMerge(DEFAULT_RELAY_CONFIG.network, config.network || {})
   config.logging = deepMerge(DEFAULT_RELAY_CONFIG.logging, config.logging || {})
-  config.archive = deepMerge(DEFAULT_RELAY_CONFIG.archive, config.archive || {})
-  config.archive.uiPort = Number(config.archive.uiPort)
-  if (!Number.isFinite(config.archive.uiPort) || config.archive.uiPort <= 0) {
-    throw new Error('archive.uiPort must be a positive number')
-  }
+
+  config.archive = resolveArchiveConfig(config.archive, { storagePath: config.storage.path })
 
   config.paths = {
     catalog: join(config.storage.path, RELAY_CATALOG_FILENAME),
     status: join(config.storage.path, RELAY_STATUS_FILENAME),
-    corestore: join(config.storage.path, 'corestore')
+    corestore: join(config.storage.path, 'corestore'),
+    archiveTmpPath: config.archive.tmpPath
   }
 
   config.env = {
@@ -383,12 +514,33 @@ export function renderExampleConfig(config = DEFAULT_RELAY_CONFIG) {
     'discovery:',
     `  enabled: ${config.discovery.enabled}`,
     `  maxChannels: ${config.discovery.maxChannels}`,
-    `  maxChannelsPerOwner: ${config.discovery.maxChannelsPerOwner}`,
+    `  maxChannelsPerOwner: ${config.discovery.maxChannelsPerOwner}`
+  )
+
+  const archive = config.archive || DEFAULT_ARCHIVE_CONFIG
+  lines.push(
     'archive:',
-    `  uiEnabled: ${config.archive?.uiEnabled ?? false}`,
-    `  uiHost: ${config.archive?.uiHost || '127.0.0.1'}`,
-    `  uiPort: ${config.archive?.uiPort || 8174}`,
-    `  tmpPath: ${config.archive?.tmpPath || './peartube-relay/archive-tmp'}`,
+    `  uiEnabled: ${Boolean(archive.uiEnabled)}`,
+    `  uiHost: ${archive.uiHost || '127.0.0.1'}`,
+    `  uiPort: ${archive.uiPort || 8174}`,
+    `  tmpPath: ${archive.tmpPath || './peartube-relay/archive-tmp'}`,
+    `  enabled: ${Boolean(archive.enabled)}`,
+    `  poll: ${archive.poll || DEFAULT_ARCHIVE_POLL_SECONDS}`,
+    `  maxItems: ${archive.maxItems || DEFAULT_ARCHIVE_MAX_ITEMS}`,
+    `  maxRetries: ${archive.maxRetries ?? DEFAULT_ARCHIVE_MAX_RETRIES}`,
+    `  format: "${archive.format || DEFAULT_ARCHIVE_FORMAT}"`
+  )
+  if (Array.isArray(archive.sources) && archive.sources.length) {
+    lines.push('  sources:')
+    for (const source of archive.sources) {
+      lines.push(`    - url: ${source.url}`)
+      if (source.label) lines.push(`      label: ${source.label}`)
+    }
+  } else {
+    lines.push('  sources: []')
+  }
+
+  lines.push(
     'logging:',
     `  level: ${config.logging.level}`,
     ''

--- a/packages/cli/src/constants.js
+++ b/packages/cli/src/constants.js
@@ -25,6 +25,31 @@ export const RETENTION_PRIORITY = {
   private: 3
 }
 
+export const ARCHIVE_TYPE_YOUTUBE = 'youtube'
+export const VALID_ARCHIVE_TYPES = [ARCHIVE_TYPE_YOUTUBE]
+
+export const DEFAULT_ARCHIVE_POLL_SECONDS = 3600
+export const DEFAULT_ARCHIVE_FORMAT = 'bv*[height<=1080][ext=mp4]+ba[ext=m4a]/b[height<=1080][ext=mp4]/b'
+export const DEFAULT_ARCHIVE_MAX_ITEMS = 50
+export const DEFAULT_ARCHIVE_MAX_RETRIES = 3
+export const DEFAULT_ARCHIVE_BUDGET_RESERVE_PERCENT = 5
+export const DEFAULT_ARCHIVE_YT_DLP_PATH = 'yt-dlp'
+
+export const DEFAULT_ARCHIVE_CONFIG = {
+  enabled: false,
+  poll: DEFAULT_ARCHIVE_POLL_SECONDS,
+  format: DEFAULT_ARCHIVE_FORMAT,
+  tmpPath: null,
+  ytDlpPath: DEFAULT_ARCHIVE_YT_DLP_PATH,
+  maxRetries: DEFAULT_ARCHIVE_MAX_RETRIES,
+  budgetReservePercent: DEFAULT_ARCHIVE_BUDGET_RESERVE_PERCENT,
+  maxItems: DEFAULT_ARCHIVE_MAX_ITEMS,
+  sources: [],
+  uiEnabled: false,
+  uiHost: '127.0.0.1',
+  uiPort: 8174
+}
+
 export const DEFAULT_RELAY_CONFIG = {
   mode: RELAY_MODE_PUBLIC,
   policy: RELAY_POLICY_DISCOVERY,
@@ -49,13 +74,8 @@ export const DEFAULT_RELAY_CONFIG = {
     announce: true,
     bootstrap: 'default'
   },
+  archive: DEFAULT_ARCHIVE_CONFIG,
   logging: {
     level: 'info'
-  },
-  archive: {
-    uiEnabled: false,
-    uiHost: '127.0.0.1',
-    uiPort: 8174,
-    tmpPath: './peartube-relay/archive-tmp'
   }
 }

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -1,8 +1,10 @@
+import * as fs from '#fs'
 import { createCliLogger } from './cli-logger.js'
 import { resolveRelayConfig } from './config.js'
 import { downloadChannelBlobs } from './blob-downloader.js'
 import { createRelayRuntime } from './runtime.js'
 import { createRelayService } from './service.js'
+import { createArchiver } from './archive/index.js'
 
 export async function startRelay({ config, logger = null } = {}) {
   if (!config) {
@@ -42,6 +44,34 @@ export async function startRelay({ config, logger = null } = {}) {
   })
 
   await service.start()
+
+  let archiver = null
+  if (config.archive?.enabled && Array.isArray(config.archive.sources) && config.archive.sources.length) {
+    try {
+      archiver = createArchiver({
+        config,
+        runtime: service.runtime,
+        logger: relayLogger,
+        fs
+      })
+      await archiver.start()
+    } catch (err) {
+      relayLogger.archive.error('Archive failed to start', { error: err?.message || String(err) })
+      archiver = null
+    }
+  }
+
+  const baseClose = service.close.bind(service)
+  service.close = async () => {
+    if (archiver) {
+      try { await archiver.stop() } catch (err) {
+        relayLogger.archive.warn('Archive stop failed', { error: err?.message || String(err) })
+      }
+    }
+    await baseClose()
+  }
+  service.archiver = archiver
+
   return service
 }
 

--- a/packages/cli/src/shims/fs.bare.js
+++ b/packages/cli/src/shims/fs.bare.js
@@ -1,8 +1,10 @@
 export {
+  createReadStream,
   existsSync,
   mkdirSync,
   readFileSync,
   rmSync,
   statSync,
+  unlinkSync,
   writeFileSync
 } from 'bare-fs'

--- a/packages/cli/src/shims/fs.node.js
+++ b/packages/cli/src/shims/fs.node.js
@@ -1,8 +1,10 @@
 export {
+  createReadStream,
   existsSync,
   mkdirSync,
   readFileSync,
   rmSync,
   statSync,
+  unlinkSync,
   writeFileSync
 } from 'node:fs'

--- a/packages/cli/test/archive.test.mjs
+++ b/packages/cli/test/archive.test.mjs
@@ -1,0 +1,376 @@
+import test from 'brittle'
+
+import { resolveRelayConfig } from '../src/config.js'
+import { buildSourceId, buildWriterKeyName, classifySourceUrl } from '../src/archive/source-id.js'
+import { ARCHIVE_STATUS, createArchiveState } from '../src/archive/state.js'
+import { createArchiver } from '../src/archive/index.js'
+
+function makeFakeMetaDb() {
+  const map = new Map()
+  return {
+    map,
+    async get(key) { return map.has(key) ? { value: map.get(key) } : null },
+    async put(key, value) { map.set(key, value) },
+    async del(key) { map.delete(key) },
+    async *createReadStream({ gte, lt } = {}) {
+      const keys = [...map.keys()].sort()
+      for (const key of keys) {
+        if (gte !== undefined && key < gte) continue
+        if (lt !== undefined && key >= lt) continue
+        yield { key, value: map.get(key) }
+      }
+    }
+  }
+}
+
+function makeFakeFs(files = {}) {
+  return {
+    statSync: (path) => ({ size: files[path]?.length ?? 1024 }),
+    readFileSync: (path) => Buffer.from(files[path] || 'thumb'),
+    mkdirSync: () => {},
+    rmSync: () => {}
+  }
+}
+
+function makeFakeLogger() {
+  const events = []
+  function record(component, level) {
+    return (msg, data) => events.push({ component, level, msg, data })
+  }
+  function level(component) {
+    return {
+      debug: record(component, 'debug'),
+      info: record(component, 'info'),
+      warn: record(component, 'warn'),
+      error: record(component, 'error')
+    }
+  }
+  return {
+    events,
+    archive: level('Archive'),
+    runtime: level('Runtime')
+  }
+}
+
+function makeFakeRuntime({ metaDb, totalBytes = 0 } = {}) {
+  return {
+    ctx: { metaDb, channels: new Map() },
+    publicFeed: { submitChannel: async () => {} },
+    cacheManager: {
+      pinChannel: async () => {},
+      getTotalBytes: () => totalBytes
+    },
+    seeder: { seedChannel: async () => {} }
+  }
+}
+
+test('classifySourceUrl recognises YouTube channels, handles, and playlists', (t) => {
+  t.alike(classifySourceUrl('https://www.youtube.com/@somechannel'), {
+    type: 'youtube',
+    normalizedUrl: 'https://www.youtube.com/@somechannel',
+    identifier: '@somechannel',
+    kind: 'handle'
+  })
+  t.alike(classifySourceUrl('https://www.youtube.com/channel/UC123abc'), {
+    type: 'youtube',
+    normalizedUrl: 'https://www.youtube.com/channel/UC123abc',
+    identifier: 'UC123abc',
+    kind: 'channel'
+  })
+  t.alike(classifySourceUrl('https://www.youtube.com/playlist?list=PLxyz'), {
+    type: 'youtube',
+    normalizedUrl: 'https://www.youtube.com/playlist?list=PLxyz',
+    identifier: 'PLxyz',
+    kind: 'playlist'
+  })
+  t.is(classifySourceUrl('https://example.com/feed').type, null)
+  t.is(classifySourceUrl('not-a-url').type, null)
+})
+
+test('buildSourceId and buildWriterKeyName produce stable ids', (t) => {
+  t.is(buildSourceId('youtube', 'UC123'), 'youtube:UC123')
+  t.is(buildWriterKeyName('youtube:UC123'), 'peartube-archive-writer:youtube:UC123')
+  t.is(buildWriterKeyName(null), null)
+})
+
+test('resolveRelayConfig parses archive sources and rejects bad urls', (t) => {
+  const config = resolveRelayConfig({
+    archive: {
+      enabled: true,
+      sources: [
+        { url: 'https://www.youtube.com/@chan', label: 'Chan' },
+        'https://www.youtube.com/channel/UCabc'
+      ]
+    }
+  }, { env: {} })
+
+  t.is(config.archive.enabled, true)
+  t.is(config.archive.sources.length, 2)
+  t.is(config.archive.sources[0].sourceId, 'youtube:@chan')
+  t.is(config.archive.sources[0].label, 'Chan')
+  t.is(config.archive.sources[1].sourceId, 'youtube:UCabc')
+  t.is(typeof config.archive.tmpPath, 'string')
+  t.ok(config.archive.tmpPath.length > 0)
+
+  t.exception(() => resolveRelayConfig({
+    archive: { enabled: true, sources: [{ url: 'https://example.com/feed' }] }
+  }, { env: {} }), /Unsupported archive source/)
+
+  t.exception(() => resolveRelayConfig({
+    archive: { enabled: true, sources: [] }
+  }, { env: {} }), /archive.sources is empty/)
+
+  t.exception(() => resolveRelayConfig({
+    archive: {
+      enabled: true,
+      sources: [
+        { url: 'https://www.youtube.com/@dup' },
+        { url: 'https://www.youtube.com/@dup' }
+      ]
+    }
+  }, { env: {} }), /Duplicate archive source/)
+})
+
+test('archive state markFailed escalates to abandoned past maxRetries', async (t) => {
+  const metaDb = makeFakeMetaDb()
+  const state = createArchiveState({ metaDb })
+
+  await state.markFailed('youtube:UC1', 'vid1', new Error('boom'), { maxRetries: 2 })
+  let record = await state.getVideo('youtube:UC1', 'vid1')
+  t.is(record.status, ARCHIVE_STATUS.FAILED)
+  t.is(record.retries, 1)
+
+  await state.markFailed('youtube:UC1', 'vid1', new Error('boom'), { maxRetries: 2 })
+  record = await state.getVideo('youtube:UC1', 'vid1')
+  t.is(record.retries, 2)
+  t.is(record.status, ARCHIVE_STATUS.FAILED)
+
+  await state.markFailed('youtube:UC1', 'vid1', new Error('boom'), { maxRetries: 2 })
+  record = await state.getVideo('youtube:UC1', 'vid1')
+  t.is(record.retries, 3)
+  t.is(record.status, ARCHIVE_STATUS.ABANDONED)
+
+  await state.markArchived('youtube:UC1', 'vid2', { peartubeVideoId: 'pt1', bytes: 100, title: 'T' })
+  const archived = await state.getVideo('youtube:UC1', 'vid2')
+  t.is(archived.status, ARCHIVE_STATUS.ARCHIVED)
+  t.is(archived.peartubeVideoId, 'pt1')
+
+  const list = await state.listVideos('youtube:UC1')
+  t.is(list.length, 2)
+})
+
+test('createArchiver runOnce: archives new videos, skips already-archived, marks failed, respects budget', async (t) => {
+  const metaDb = makeFakeMetaDb()
+  const config = resolveRelayConfig({
+    storage: { path: '/tmp/peartube-test', maxBytes: 1000 },
+    archive: {
+      enabled: true,
+      maxRetries: 1,
+      maxItems: 5,
+      tmpPath: '/tmp/peartube-test/archive-tmp',
+      sources: [{ url: 'https://www.youtube.com/@chan' }]
+    }
+  }, { env: {} })
+
+  // Pre-mark vid-already as archived so it should be skipped.
+  const state = createArchiveState({ metaDb })
+  await state.markArchived('youtube:@chan', 'vid-already', { peartubeVideoId: 'pt-existing', bytes: 50, title: 'Old' })
+
+  const listed = [
+    { id: 'vid-already', title: 'Already', duration: 100, webpageUrl: 'https://yt/v?vid-already' },
+    { id: 'vid-new', title: 'New', duration: 120, webpageUrl: 'https://yt/v?vid-new' },
+    { id: 'vid-fail', title: 'Fail', duration: 90, webpageUrl: 'https://yt/v?vid-fail' }
+  ]
+
+  const downloads = []
+  const fakeYtDlp = {
+    async listVideos(url) {
+      t.is(url, 'https://www.youtube.com/@chan')
+      return listed
+    },
+    async downloadVideo(url, opts) {
+      downloads.push({ url, videoId: opts.videoId })
+      return {
+        videoFile: `/tmp/${opts.videoId}.mp4`,
+        thumbnailFile: `/tmp/${opts.videoId}.jpg`,
+        infoFile: `/tmp/${opts.videoId}.info.json`
+      }
+    }
+  }
+
+  const uploadCalls = []
+  const fakeUploadManager = {
+    async uploadFromPath(channel, filePath, options) {
+      uploadCalls.push({ filePath, options })
+      return { success: true, videoId: `pt-${filePath.split('/').pop().replace(/\..*/, '')}` }
+    },
+    async setThumbnailFromBuffer() {
+      return { success: true }
+    }
+  }
+
+  const publishCalls = []
+  const stubPublisher = {
+    ensureSourceChannel: async (source) => ({
+      channelKey: `chan-${source.sourceId}`,
+      publicBeeKey: `bee-${source.sourceId}`
+    }),
+    publishVideo: async ({ source, ytEntry, files }) => {
+      publishCalls.push({ sourceId: source.sourceId, ytId: ytEntry.id, file: files.videoFile })
+      if (ytEntry.id === 'vid-fail') throw new Error('publish exploded')
+      const result = await fakeUploadManager.uploadFromPath(null, files.videoFile, {})
+      return {
+        videoId: result.videoId,
+        bytes: 200,
+        channelKey: `chan-${source.sourceId}`,
+        publicBeeKey: `bee-${source.sourceId}`
+      }
+    }
+  }
+
+  const runtime = makeFakeRuntime({ metaDb, totalBytes: 0 })
+  const logger = makeFakeLogger()
+  const fs = makeFakeFs({
+    '/tmp/vid-new.mp4': 'video bytes',
+    '/tmp/vid-fail.mp4': 'video bytes'
+  })
+
+  const archiver = createArchiver({
+    config,
+    runtime,
+    logger,
+    fs,
+    ytDlp: fakeYtDlp,
+    publisherFactory: () => stubPublisher,
+    setIntervalFn: () => null,
+    clearIntervalFn: () => {},
+    setTimeoutFn: (fn) => fn()
+  })
+
+  t.is(archiver.enabled, true)
+  await archiver.runOnce()
+
+  t.alike(downloads.map((d) => d.videoId).sort(), ['vid-fail', 'vid-new'])
+  t.alike(publishCalls.map((p) => p.ytId).sort(), ['vid-fail', 'vid-new'])
+
+  const newRecord = await state.getVideo('youtube:@chan', 'vid-new')
+  t.is(newRecord.status, ARCHIVE_STATUS.ARCHIVED)
+  t.is(newRecord.peartubeVideoId, 'pt-vid-new')
+
+  const failRecord = await state.getVideo('youtube:@chan', 'vid-fail')
+  t.is(failRecord.status, ARCHIVE_STATUS.FAILED)
+  t.is(failRecord.retries, 1)
+
+  // Second runOnce should escalate vid-fail to abandoned (maxRetries=1)
+  await archiver.runOnce()
+  const failAfter = await state.getVideo('youtube:@chan', 'vid-fail')
+  t.is(failAfter.status, ARCHIVE_STATUS.ABANDONED)
+
+  // Source-level state record
+  const sourceRecord = await state.getSource('youtube:@chan')
+  t.ok(sourceRecord.lastPolledAt > 0)
+})
+
+test('createArchiver getSourcesStatus exposes per-source state for the WebUI', async (t) => {
+  const metaDb = makeFakeMetaDb()
+  const config = resolveRelayConfig({
+    storage: { path: '/tmp/peartube-test', maxBytes: 100000 },
+    archive: {
+      enabled: true,
+      tmpPath: '/tmp/peartube-test/archive-tmp',
+      sources: [{ url: 'https://www.youtube.com/@chan', label: 'Chan' }]
+    }
+  }, { env: {} })
+
+  const state = createArchiveState({ metaDb })
+  await state.markArchived('youtube:@chan', 'v1', { peartubeVideoId: 'pt1', bytes: 100, title: 'A' })
+  await state.markFailed('youtube:@chan', 'v2', new Error('x'), { maxRetries: 5 })
+  await state.putSource('youtube:@chan', {
+    url: 'https://www.youtube.com/@chan',
+    type: 'youtube',
+    channelKey: 'channel-key-hex',
+    publicBeeKey: 'public-bee-hex',
+    lastPolledAt: 1234,
+    lastError: null
+  })
+
+  const archiver = createArchiver({
+    config,
+    runtime: makeFakeRuntime({ metaDb }),
+    logger: makeFakeLogger(),
+    fs: makeFakeFs(),
+    ytDlp: { listVideos: async () => [], downloadVideo: async () => ({}) },
+    publisherFactory: () => ({}),
+    setIntervalFn: () => null,
+    clearIntervalFn: () => {},
+    setTimeoutFn: () => {}
+  })
+
+  const status = await archiver.getSourcesStatus()
+  t.is(status.length, 1)
+  t.is(status[0].sourceId, 'youtube:@chan')
+  t.is(status[0].label, 'Chan')
+  t.is(status[0].channelKey, 'channel-key-hex')
+  t.is(status[0].publicBeeKey, 'public-bee-hex')
+  t.is(status[0].lastPolledAt, 1234)
+  t.alike(status[0].counts, { archived: 1, failed: 1, abandoned: 0 })
+})
+
+test('createArchiver returns no-op when disabled', async (t) => {
+  const metaDb = makeFakeMetaDb()
+  const config = resolveRelayConfig({}, { env: {} })
+  const archiver = createArchiver({
+    config,
+    runtime: makeFakeRuntime({ metaDb }),
+    logger: makeFakeLogger(),
+    fs: makeFakeFs()
+  })
+  t.is(archiver.enabled, false)
+  await archiver.start()
+  await archiver.runOnce()
+  await archiver.stop()
+})
+
+test('createArchiver budget exhaustion: stops archiving when within reserve', async (t) => {
+  const metaDb = makeFakeMetaDb()
+  const config = resolveRelayConfig({
+    storage: { path: '/tmp/peartube-test', maxBytes: 1000 },
+    archive: {
+      enabled: true,
+      budgetReservePercent: 5,
+      tmpPath: '/tmp/peartube-test/archive-tmp',
+      sources: [{ url: 'https://www.youtube.com/@chan' }]
+    }
+  }, { env: {} })
+
+  const fakeYtDlp = {
+    async listVideos() { return [{ id: 'a', title: 'A' }, { id: 'b', title: 'B' }] },
+    async downloadVideo() { throw new Error('should never be called when budget exhausted') }
+  }
+  const runtime = makeFakeRuntime({ metaDb, totalBytes: 999 })
+  const logger = makeFakeLogger()
+
+  const archiver = createArchiver({
+    config,
+    runtime,
+    logger,
+    fs: makeFakeFs(),
+    ytDlp: fakeYtDlp,
+    uploadManagerFactory: async () => ({}),
+    setIntervalFn: () => null,
+    clearIntervalFn: () => {},
+    setTimeoutFn: (fn) => fn()
+  })
+
+  await archiver.runOnce()
+
+  // No video records were written (budget hit before any download)
+  const state = createArchiveState({ metaDb })
+  t.is((await state.listVideos('youtube:@chan')).length, 0)
+  const sourceRecord = await state.getSource('youtube:@chan')
+  t.is(sourceRecord.archivedCount, 0)
+  t.is(sourceRecord.skippedCount, 1)
+
+  const budgetWarn = logger.events.find((e) => e.msg === 'Storage budget reached; skipping new archives')
+  t.ok(budgetWarn, 'logs budget warning')
+})

--- a/packages/cli/test/archive.test.mjs
+++ b/packages/cli/test/archive.test.mjs
@@ -374,3 +374,51 @@ test('createArchiver budget exhaustion: stops archiving when within reserve', as
   const budgetWarn = logger.events.find((e) => e.msg === 'Storage budget reached; skipping new archives')
   t.ok(budgetWarn, 'logs budget warning')
 })
+
+test('createArchiver stop clears staggered initial poll timers', async (t) => {
+  const metaDb = makeFakeMetaDb()
+  const config = resolveRelayConfig({
+    storage: { path: '/tmp/peartube-test', maxBytes: 100000 },
+    archive: {
+      enabled: true,
+      tmpPath: '/tmp/peartube-test/archive-tmp',
+      sources: [
+        { url: 'https://www.youtube.com/@one' },
+        { url: 'https://www.youtube.com/@two' }
+      ]
+    }
+  }, { env: {} })
+
+  const scheduled = []
+  const cleared = []
+  let listed = 0
+  const archiver = createArchiver({
+    config,
+    runtime: makeFakeRuntime({ metaDb }),
+    logger: makeFakeLogger(),
+    fs: makeFakeFs(),
+    ytDlp: {
+      async listVideos() {
+        listed += 1
+        return []
+      },
+      async downloadVideo() { throw new Error('not expected') }
+    },
+    publisherFactory: () => ({}),
+    setIntervalFn: () => ({ type: 'interval' }),
+    clearIntervalFn: (timer) => { cleared.push(timer) },
+    setTimeoutFn: (fn, delay) => {
+      const timer = { type: 'timeout', fn, delay }
+      scheduled.push(timer)
+      return timer
+    }
+  })
+
+  await archiver.start()
+  t.is(scheduled.length, 2)
+  await archiver.stop()
+
+  t.is(cleared.filter((timer) => timer.type === 'timeout').length, 2)
+  for (const timer of scheduled) timer.fn()
+  t.is(listed, 0)
+})

--- a/packages/cli/test/cli.test.mjs
+++ b/packages/cli/test/cli.test.mjs
@@ -51,7 +51,7 @@ test('package.json defines standalone relay build scripts', async (t) => {
   const packageJsonPath = join(__dirname, '..', 'package.json')
   const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf8'))
 
-  t.is(pkg.scripts['test'], 'brittle test/admission.test.mjs test/archive-ui.test.mjs test/cli.test.mjs test/config.test.mjs test/relay-seeding.test.mjs test/service.test.mjs test/status.test.mjs')
+  t.is(pkg.scripts['test'], 'brittle test/admission.test.mjs test/archive-ui.test.mjs test/archive.test.mjs test/cli.test.mjs test/config.test.mjs test/relay-seeding.test.mjs test/service.test.mjs test/status.test.mjs')
   t.is(pkg.imports['#subprocess'].bare, './src/shims/subprocess.bare.js')
   t.is(pkg.imports['#subprocess'].default, './src/shims/subprocess.node.js')
   t.is(pkg.imports['#http'].bare, './src/shims/http.bare.js')


### PR DESCRIPTION
## Summary

Configures the relay to continuously poll YouTube channels/playlists via `yt-dlp` and publish new uploads into PearTube channels it owns.

This is **complementary to #88** (the WebUI/TUI for on-demand archiving). PR #88 is "user clicks archive on a single URL"; this is "relay daemon watches a list of YT channels and pulls new uploads on a schedule." The two ship as different surfaces and different config keys; both can land.

## Design

- **Per-source PearTube channels.** Each YouTube source maps to its own PearTube channel.
- **Deterministic channel keypair**, derived from the relay's persistent corestore `primaryKey` + the source URL, so restarts reopen the same channel — same source on the same relay never produces a duplicate.
- **Source metadata stamping.** Each channel's `description` ends with a `[peartube-archive-source]` block carrying type/id/url. This is the hook for a future cross-relay dedup PR (v2: detect existing archive of the same YT source on the public feed and seed it instead of authoring a new one).
- **Skip-and-continue on failure.** A failed video gets a retry counter; abandoned after `maxRetries` consecutive failures.
- **Storage budget.** Stops archiving when used storage is within `budgetReservePercent` of `storage.maxBytes`. Does **not** evict authored content.
- **Discoverability.** Each archive channel is `submitChannel`'d to the public feed, `pinChannel`'d in the cache manager, and `seedChannel`'d in the seeder.

## Config

```yaml
archive:
  enabled: true
  poll: 3600              # seconds between polls
  maxItems: 50            # newest videos considered per poll
  maxRetries: 3
  budgetReservePercent: 5
  format: "bv*[height<=1080][ext=mp4]+ba[ext=m4a]/b[height<=1080][ext=mp4]/b"
  tmpPath: /var/lib/peartube-relay/archive-tmp
  sources:
    - url: https://www.youtube.com/@somechannel
      label: Some Channel
    - url: https://www.youtube.com/playlist?list=PLxxxxxxx
```

Env-var equivalents: `PEARTUBE_ARCHIVE_ENABLED`, `PEARTUBE_ARCHIVE_POLL`, `PEARTUBE_ARCHIVE_FORMAT`, `PEARTUBE_ARCHIVE_TMP_PATH`, `PEARTUBE_ARCHIVE_YT_DLP_PATH`, `PEARTUBE_ARCHIVE_SOURCES`.

## Files

New module `packages/cli/src/archive/`:
- `source-id.js` — classifies + normalizes YouTube URLs (channel / handle / custom / user / playlist), derives stable source IDs and writer key names.
- `yt-dlp.js` — thin spawn wrapper. `listVideos` uses `--flat-playlist --print-json`; `downloadVideo` uses `--write-thumbnail --convert-thumbnail jpg --write-info-json --print after_move:filepath`.
- `state.js` — Hyperbee-backed state on `ctx.metaDb` (keys `archive:state:<sourceId>:<videoId>` and `archive:source:<sourceId>`). Tracks ARCHIVED / FAILED / ABANDONED status, retry counts, peartube video id mapping.
- `publisher.js` — opens deterministic per-source channel via `createChannel` with `writerKeyName: peartube-archive-writer:<sourceId>`, stamps metadata, calls `uploadManager.uploadFromPath` + `setThumbnailFromBuffer`, hooks into public feed / cache pin / seeder.
- `index.js` — `createArchiver({...})`. Schedules per-source polls (staggered initial polls, `setInterval` afterwards), skip-and-continue failure handling, budget gating, abort + drain on stop. Injects `ytDlp`, `uploadManagerFactory`, `publisherFactory`, timer fns for testability.

Wired into `startRelay` in `packages/cli/src/index.js` — runs alongside the relay daemon when `archive.enabled`.

Pulled from #88 to keep our work consistent:
- `archive` logger component on `cli-logger.js`
- `tmpPath` config naming (was `workDir` in my draft)
- `rmSync` / `statSync` on the fs shim

## Test plan

- [x] `npm test --prefix packages/cli` — 39/39 pass (7 new archive tests + 32 existing)
- [x] `npm run typecheck` — pre-existing failures only (`@peartube/protocol` missing); CLI is JS, not TS-covered
- [ ] Manual: run a relay with `archive.enabled: true` against a small YT channel, confirm channel appears in `peartube-relay status`, video plays in a peer client, restart reopens the same channel
- [ ] Manual: kill `yt-dlp` mid-download, confirm retry+abandon path
- [ ] Manual: set `storage.maxBytes` low, confirm budget stop behavior


---
_Generated by [Claude Code](https://claude.ai/code/session_01JN3Ry4XfBWUNGZPxVxDH5E)_