### PR TITLE
fix(app): stop shorts playback on tab leave

### DIFF
--- a/packages/app/app/(tabs)/discover.tsx
+++ b/packages/app/app/(tabs)/discover.tsx
@@ -17,7 +17,7 @@ import {
   View,
   ViewToken,
 } from 'react-native'
-import { useRouter } from 'expo-router'
+import { useFocusEffect, useRouter } from 'expo-router'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { Feather } from '@expo/vector-icons'
 import type { VideoData } from '@peartube/core'
@@ -250,6 +250,20 @@ export default function VerticalDiscoveryScreen() {
     if (!ready || !rpc) return
     loadFeed()
   }, [loadFeed, ready, rpc])
+
+  const stopShortsPlayback = useCallback(() => {
+    void shortsPlayerRef.current?.stop?.()
+    void shortsPlayerRef.current?.pause?.()
+    pendingPlayKeyRef.current = null
+    setShortsVideoUrl(null)
+    setShortsLoading(false)
+  }, [])
+
+  useFocusEffect(
+    useCallback(() => {
+      return stopShortsPlayback
+    }, [stopShortsPlayback])
+  )
 
   const handoffToShorts = useCallback(() => {
     if (!currentVideo || playerMode === 'hidden') return

--- a/packages/app/app/(tabs)/downloads.tsx
+++ b/packages/app/app/(tabs)/downloads.tsx
@@ -9,6 +9,7 @@ import { useDownloads, DownloadItem, DownloadStatus } from '../../lib/DownloadsC
 import { colors } from '../_layout'
 import { CastHeaderButton } from '@/components/cast'
 import { formatBytes } from '@/lib/formatters'
+import { useTabBarMetrics } from '@/lib/tabBarHeight'
 
 // Status icon component
 function StatusIcon({ status }: { status: DownloadStatus }) {
@@ -153,6 +154,8 @@ export default function DownloadsScreen() {
   const insets = useSafeAreaInsets()
   const router = useRouter()
   const { downloads, activeCount, cancelDownload, removeDownload, clearCompleted, retryDownload } = useDownloads()
+  const tabBarMetrics = useTabBarMetrics()
+  const bottomPadding = Math.max(tabBarMetrics.height + 16, insets.bottom + 16)
 
   // We need rpc for retry - get it from app context
   // For now, retry won't work without passing rpc through
@@ -223,7 +226,7 @@ export default function DownloadsScreen() {
         style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: 16,
-          paddingBottom: insets.bottom + 100
+          paddingBottom: bottomPadding
         }}
       >
         {downloads.length === 0 ? (

--- a/packages/app/app/(tabs)/index.tsx
+++ b/packages/app/app/(tabs)/index.tsx
@@ -33,6 +33,7 @@ import {
   getSnapshotChannelKeys,
   restoreFeedSnapshot,
 } from '@/lib/feed-snapshot'
+import { useTabBarMetrics } from '@/lib/tabBarHeight'
 import {
   readFeedSnapshotFromDisk,
   writeFeedSnapshotToDisk,
@@ -101,6 +102,8 @@ export default function HomeScreen() {
   const { loadAndPlayVideo } = useVideoPlayerContext()
   const { isDesktop } = usePlatform()
   const { width: screenWidth } = useWindowDimensions()
+  const tabBarMetrics = useTabBarMetrics()
+  const bottomPadding = Math.max(tabBarMetrics.height + 16, insets.bottom + 16)
 
   const gridColumns = getDesktopVideoGridColumns(isDesktop, screenWidth)
 
@@ -858,7 +861,7 @@ export default function HomeScreen() {
             </View>
           </View>
 
-          <ScrollView contentContainerStyle={{ paddingBottom: insets.bottom + 20, paddingHorizontal: isDesktop ? 24 : 0 }}>
+          <ScrollView contentContainerStyle={{ paddingBottom: bottomPadding, paddingHorizontal: isDesktop ? 24 : 0 }}>
             {loadingChannel ? (
               <View className="py-12 items-center">
                 <ActivityIndicator color={colors.primary} size="large" />
@@ -893,7 +896,7 @@ export default function HomeScreen() {
       {/* Main Feed */}
       {!viewingChannel && (
         <ScrollView
-          contentContainerStyle={{ paddingBottom: insets.bottom + 16, flexGrow: 1 }}
+          contentContainerStyle={{ paddingBottom: bottomPadding, flexGrow: 1 }}
           refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={colors.primary} />}
         >
           {/* Discover Section */}

--- a/packages/app/app/(tabs)/settings.tsx
+++ b/packages/app/app/(tabs)/settings.tsx
@@ -8,6 +8,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { Feather } from '@expo/vector-icons'
 import { useApp, colors } from '../_layout'
 import { CastHeaderButton } from '@/components/cast'
+import { useTabBarMetrics } from '@/lib/tabBarHeight'
 
 interface StorageStats {
   usedBytes: number
@@ -40,6 +41,8 @@ export default function SettingsScreen() {
   const [clearingCache, setClearingCache] = useState(false)
   const [isPublished, setIsPublished] = useState(false)
   const [publishLoading, setPublishLoading] = useState(false)
+  const tabBarMetrics = useTabBarMetrics()
+  const bottomPadding = Math.max(tabBarMetrics.height + 16, insets.bottom + 16)
 
   // Multi-device (multi-writer) channel
   const [devices, setDevices] = useState<any[]>([])
@@ -508,7 +511,7 @@ export default function SettingsScreen() {
       </View>
 
       <ScrollView
-        contentContainerStyle={{ paddingBottom: insets.bottom + 16 }}
+        contentContainerStyle={{ paddingBottom: bottomPadding }}
         showsVerticalScrollIndicator={false}
       >
         {/* Your Channel Section */}

--- a/packages/app/app/(tabs)/studio.tsx
+++ b/packages/app/app/(tabs)/studio.tsx
@@ -14,6 +14,7 @@ import { CastHeaderButton } from '@/components/cast'
 import { useVideoPlayerContext } from '@/lib/VideoPlayerContext'
 import { VideoEditModal } from '@/components/VideoEditModal'
 import { formatBytes } from '@/lib/formatters'
+import { useTabBarMetrics } from '@/lib/tabBarHeight'
 
 // Detect Pear desktop (must match index.web.tsx detection)
 const isPear = Platform.OS === 'web' && typeof window !== 'undefined' && (!!(window as any).Pear || !!(window as any).bridge)
@@ -61,6 +62,8 @@ export default function StudioScreen() {
   const [pickingVideo, setPickingVideo] = useState(false)
   const pickingVideoRef = useRef(false)
   const [editingVideo, setEditingVideo] = useState<any>(null)
+  const tabBarMetrics = useTabBarMetrics()
+  const bottomPadding = Math.max(tabBarMetrics.height + 16, insets.bottom + 16)
 
   const uploadThumbnailForVideo = useCallback(async (videoId: string, thumbPath: string) => {
     if (!rpc || !videoId || !thumbPath) return false
@@ -703,7 +706,7 @@ export default function StudioScreen() {
         ListHeaderComponent={listHeaderComponent}
         contentContainerStyle={{
           paddingHorizontal: 20,
-          paddingBottom: insets.bottom + 16,
+          paddingBottom: bottomPadding,
         }}
         ListEmptyComponent={
           <View className="flex-1 justify-center items-center py-16">

--- a/packages/app/app/(tabs)/subscriptions.tsx
+++ b/packages/app/app/(tabs)/subscriptions.tsx
@@ -8,6 +8,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { Feather } from '@expo/vector-icons'
 import { useApp, colors } from '../_layout'
 import { CastHeaderButton } from '@/components/cast'
+import { useTabBarMetrics } from '@/lib/tabBarHeight'
 
 interface Subscription {
   channelKey: string
@@ -27,6 +28,8 @@ export default function SubscriptionsScreen() {
   const [refreshing, setRefreshing] = useState(false)
   const [channelKey, setChannelKey] = useState('')
   const [loading, setLoading] = useState(false)
+  const tabBarMetrics = useTabBarMetrics()
+  const bottomPadding = Math.max(tabBarMetrics.height + 16, insets.bottom + 16)
 
   const loadSubscriptions = useCallback(async () => {
     if (!rpc) return
@@ -139,7 +142,7 @@ export default function SubscriptionsScreen() {
         contentContainerStyle={{
           paddingHorizontal: 20,
           paddingTop: 16,
-          paddingBottom: insets.bottom + 16,
+          paddingBottom: bottomPadding,
           flexGrow: 1,
         }}
         refreshControl={

--- a/packages/app/tests/vertical-discovery-regression.test.mjs
+++ b/packages/app/tests/vertical-discovery-regression.test.mjs
@@ -115,3 +115,33 @@ test('shorts player has functional playback buttons and a seekable progress bar'
   assert.match(source, /handleProgressBarPress/, 'progress bar should handle tap-to-seek')
   assert.match(source, /accessibilityLabel="Shorts progress bar"/, 'progress bar should be accessible and testable')
 })
+
+test('vertical discovery stops inline Shorts playback when the route unmounts or loses focus', () => {
+  const source = readAppFile('app/(tabs)/discover.tsx')
+
+  assert.match(source, /useFocusEffect/, 'Discover should subscribe to route focus lifecycle')
+  assert.match(source, /stopShortsPlayback/, 'Discover should centralize Shorts playback teardown')
+  assert.match(source, /shortsPlayerRef\.current\?\.stop\?\.\(\)/, 'teardown should stop the native inline player instead of merely hiding React chrome')
+  assert.match(source, /setShortsVideoUrl\(null\)/, 'teardown should detach the playback URL so the inline surface unmounts')
+  assert.match(source, /return stopShortsPlayback/, 'Discover should run teardown when tab navigation leaves the Shorts route')
+})
+
+test('bottom tab screens pad scrollable content by the measured pill tab bar height', () => {
+  const indexSource = readAppFile('app/(tabs)/index.tsx')
+  const subscriptionsSource = readAppFile('app/(tabs)/subscriptions.tsx')
+  const studioSource = readAppFile('app/(tabs)/studio.tsx')
+  const downloadsSource = readAppFile('app/(tabs)/downloads.tsx')
+  const settingsSource = readAppFile('app/(tabs)/settings.tsx')
+
+  for (const [label, source] of [
+    ['home', indexSource],
+    ['subscriptions', subscriptionsSource],
+    ['studio', studioSource],
+    ['downloads', downloadsSource],
+    ['settings', settingsSource],
+  ]) {
+    assert.match(source, /useTabBarMetrics\(/, `${label} should read measured tab bar metrics`)
+    assert.match(source, /const bottomPadding = Math\.max\(tabBarMetrics\.height \+ 16, insets\.bottom \+ 16\)/, `${label} should reserve enough space for the floating pill nav`)
+    assert.doesNotMatch(source, /paddingBottom:\s*insets\.bottom \+ (16|20|100)/, `${label} should not use hard-coded safe-area-only bottom padding`)
+  }
+})


### PR DESCRIPTION
## Summary
- stop and detach the inline Shorts player when leaving the Discover tab
- pad tab screen scroll content by measured floating pill tab bar height
- add regressions for Shorts route teardown and tab bar overlap padding

## Test Plan
- node --test packages/app/tests/vertical-discovery-regression.test.mjs
- node --test packages/app/tests/mobile-player-page-layout-regression.test.mjs packages/app/tests/vertical-discovery-regression.test.mjs
- git diff --check

Note: pre-existing local changes to release-android workflow/test and untracked sketches/ were not included.