### PR TITLE
fix(cli): resolve archive WebUI output path

### DIFF
--- a/packages/cli/src/archive-manager.js
+++ b/packages/cli/src/archive-manager.js
@@ -1,7 +1,7 @@
 import { spawn } from '#subprocess'
 import crypto from 'hypercore-crypto'
 import b4a from 'b4a'
-import { mkdirSync, rmSync } from '#fs'
+import { mkdirSync, rmSync, existsSync } from '#fs'
 import { join } from '#path'
 
 const JOBS_KEY = 'relay-archive-jobs'
@@ -114,7 +114,7 @@ export async function enqueueArchiveJob(store, input = {}) {
   })
 }
 
-export function createYtDlpDownloader({ bin = 'yt-dlp', outputDir, spawnFn = spawn, fs = { mkdirSync, rmSync }, path = { join } } = {}) {
+export function createYtDlpDownloader({ bin = 'yt-dlp', outputDir, spawnFn = spawn, fs = { mkdirSync, rmSync, existsSync }, path = { join } } = {}) {
   if (!outputDir) throw new Error('outputDir is required')
 
   return {
@@ -148,8 +148,22 @@ export function createYtDlpDownloader({ bin = 'yt-dlp', outputDir, spawnFn = spa
         })
       })
 
-      const filePath = stdout.trim().split(/\r?\n/).filter(Boolean).pop()
+      const lines = stdout.trim().split(/\r?\n/).map((line) => line.trim()).filter(Boolean)
+      let filePath = null
+      for (let i = lines.length - 1; i >= 0; i -= 1) {
+        const line = lines[i]
+        if (line === 'filepath') continue
+        if (line.startsWith('filepath ')) {
+          filePath = line.slice('filepath '.length).trim()
+          break
+        }
+        filePath = line
+        break
+      }
       if (!filePath) throw new Error('yt-dlp did not report an output file')
+      if (typeof fs.existsSync === 'function' && !fs.existsSync(filePath)) {
+        throw new Error(`yt-dlp reported output file does not exist: ${filePath}`)
+      }
 
       return {
         filePath,

--- a/packages/cli/test/archive-ui.test.mjs
+++ b/packages/cli/test/archive-ui.test.mjs
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
 import { parseArgv } from '../src/argv.js'
-import { createArchiveJobStore, enqueueArchiveJob, createArchiveManager } from '../src/archive-manager.js'
+import { createArchiveJobStore, enqueueArchiveJob, createArchiveManager, createYtDlpDownloader } from '../src/archive-manager.js'
 import { renderArchiveTui, renderArchiveWebHome } from '../src/archive-ui.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -123,4 +123,62 @@ test('archive TUI and WebUI render queue, archive form, and publish actions', as
   t.ok(web.includes('name="url"'), 'WebUI accepts video or channel URL')
   t.ok(web.includes('name="channelName"'), 'WebUI accepts anonymous channel name')
   t.ok(web.includes('Queued video'), 'WebUI renders archive queue')
+})
+
+
+test('yt-dlp downloader extracts the actual after_move filepath and verifies it exists', async (t) => {
+  const calls = []
+  const createdDirs = []
+  const existing = new Set(['/archive/tmp/arch_1/example.mp4'])
+  const downloader = createYtDlpDownloader({
+    outputDir: '/archive/tmp',
+    fs: {
+      mkdirSync(dir) { createdDirs.push(dir) },
+      rmSync() {},
+      existsSync(path) { return existing.has(path) }
+    },
+    path: {
+      join(...parts) { return parts.join('/').replace(/\/+/g, '/') }
+    },
+    spawnFn(binary, args) {
+      calls.push({ binary, args })
+      return {
+        stdout: { on(event, cb) { if (event === 'data') cb('filepath\n/archive/tmp/arch_1/example.mp4\n') } },
+        stderr: { on() {} },
+        on(event, cb) { if (event === 'close') cb(0) }
+      }
+    }
+  })
+
+  const result = await downloader.download({ id: 'arch_1', url: 'https://www.youtube.com/watch?v=abc' })
+
+  t.is(result.filePath, '/archive/tmp/arch_1/example.mp4')
+  t.alike(createdDirs, ['/archive/tmp/arch_1'])
+  t.ok(calls[0].args.includes('after_move:filepath'), 'keeps yt-dlp after_move filepath print')
+})
+
+test('yt-dlp downloader fails with useful context when reported output file is missing', async (t) => {
+  const downloader = createYtDlpDownloader({
+    outputDir: '/archive/tmp',
+    fs: {
+      mkdirSync() {},
+      rmSync() {},
+      existsSync() { return false }
+    },
+    path: {
+      join(...parts) { return parts.join('/').replace(/\/+/g, '/') }
+    },
+    spawnFn() {
+      return {
+        stdout: { on(event, cb) { if (event === 'data') cb('filepath\n/archive/tmp/arch_2/missing.mp4\n') } },
+        stderr: { on() {} },
+        on(event, cb) { if (event === 'close') cb(0) }
+      }
+    }
+  })
+
+  await t.exception(
+    () => downloader.download({ id: 'arch_2', url: 'https://youtu.be/abc' }),
+    /yt-dlp reported output file does not exist: \/archive\/tmp\/arch_2\/missing\.mp4/
+  )
 })


### PR DESCRIPTION
## Summary
- parse yt-dlp's `after_move:filepath` output as a label plus actual path
- verify the reported output file exists before import, producing a specific error instead of a vague ENOENT
- add downloader regressions for valid and missing yt-dlp output paths

## Root cause
`--print after_move:filepath` prints a label line followed by the actual file path. The archive WebUI downloader was using the last non-empty stdout line blindly, so the import path could be wrong or unverified and collapse later into `no such file or directory`.

## Test Plan
- node --test packages/cli/test/archive-ui.test.mjs
- node --test packages/cli/test/archive-ui.test.mjs packages/cli/test/archive.test.mjs packages/cli/test/cli.test.mjs
- npm test --prefix packages/cli
- git diff --check
