### PR TITLE
fix(cli): package executable yt-dlp for relay archive

### DIFF
--- a/packages/cli/Dockerfile
+++ b/packages/cli/Dockerfile
@@ -22,9 +22,15 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates curl libatomic1 \
   && rm -rf /var/lib/apt/lists/*
 
-RUN curl -fsSL "https://github.com/yt-dlp/yt-dlp/releases/download/${YT_DLP_VERSION}/yt-dlp" \
+RUN case "${TARGETARCH}" in \
+    amd64) YT_DLP_ASSET=yt-dlp_linux ;; \
+    arm64) YT_DLP_ASSET=yt-dlp_linux_aarch64 ;; \
+    *) echo "Unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+  esac \
+  && curl -fsSL "https://github.com/yt-dlp/yt-dlp/releases/download/${YT_DLP_VERSION}/${YT_DLP_ASSET}" \
     -o /usr/local/bin/yt-dlp \
-  && chmod 755 /usr/local/bin/yt-dlp
+  && chmod 755 /usr/local/bin/yt-dlp \
+  && /usr/local/bin/yt-dlp --version
 
 RUN case "${TARGETARCH}" in \
     amd64) cp /usr/lib/x86_64-linux-gnu/libatomic.so.1 /libatomic.so.1 ;; \
@@ -40,6 +46,8 @@ ENV PEARTUBE_POLICY=discovery
 ENV PEARTUBE_STORAGE_PATH=/var/lib/peartube-relay
 ENV PEARTUBE_STORAGE_MAX_BYTES=107374182400
 ENV PEARTUBE_LOG_LEVEL=info
+ENV PEARTUBE_ARCHIVE_YT_DLP_PATH=/usr/local/bin/yt-dlp
+ENV PATH="/usr/local/bin:/usr/bin:${PATH}"
 
 WORKDIR /var/lib/peartube-relay
 

--- a/packages/cli/src/service.js
+++ b/packages/cli/src/service.js
@@ -13,7 +13,10 @@ export async function createRelayService({
   logger = createCliLogger(config?.logging?.level || 'info'),
   catalog = null,
   setIntervalFn = setInterval,
-  clearIntervalFn = clearInterval
+  clearIntervalFn = clearInterval,
+  fsModule = null,
+  pathModule = null,
+  spawnFn = null
 }) {
   if (!config) throw new Error('config is required')
   if (typeof runtimeFactory !== 'function') throw new Error('runtimeFactory is required')
@@ -187,24 +190,26 @@ export async function createRelayService({
       })
 
       if (config.archive?.uiEnabled) {
-        const fsModule = await import('#fs')
-        const pathModule = await import('#path')
+        const runtimeFsModule = fsModule || await import('#fs')
+        const runtimePathModule = pathModule || await import('#path')
         archiveConsole = await createArchiveConsole({
           service,
           logger,
           host: config.archive.uiHost || '127.0.0.1',
           port: config.archive.uiPort || 8174,
           downloader: createYtDlpDownloader({
+            bin: config.archive.ytDlpPath,
             outputDir: config.archive.tmpPath,
-            fs: fsModule,
-            path: pathModule
+            spawnFn: spawnFn || undefined,
+            fs: runtimeFsModule,
+            path: runtimePathModule
           }),
           publisher: createArchivePublisher({
             identityManager: runtime.identityManager,
             uploadManager: runtime.uploadManager,
             api: runtime.api,
             runtime,
-            fs: fsModule
+            fs: runtimeFsModule
           })
         })
         await archiveConsole.start()
@@ -235,23 +240,25 @@ export async function createRelayService({
     },
     async enqueueArchiveJob(input, { runNow = false } = {}) {
       if (!runtime.ctx?.metaDb) throw new Error('archive jobs require relay runtime metadata storage')
-      const fsModule = await import('#fs')
-      const pathModule = await import('#path')
+      const runtimeFsModule = fsModule || await import('#fs')
+      const runtimePathModule = pathModule || await import('#path')
       const store = createArchiveJobStore({ metaDb: runtime.ctx.metaDb })
       const manager = createArchiveManager({
         store,
         logger,
         downloader: createYtDlpDownloader({
+          bin: config.archive?.ytDlpPath,
           outputDir: config.archive?.tmpPath || './peartube-relay/archive-tmp',
-          fs: fsModule,
-          path: pathModule
+          spawnFn: spawnFn || undefined,
+          fs: runtimeFsModule,
+          path: runtimePathModule
         }),
         publisher: createArchivePublisher({
           identityManager: runtime.identityManager,
           uploadManager: runtime.uploadManager,
           api: runtime.api,
           runtime,
-          fs: fsModule
+          fs: runtimeFsModule
         })
       })
       const job = await manager.enqueue(input)

--- a/packages/cli/test/cli.test.mjs
+++ b/packages/cli/test/cli.test.mjs
@@ -104,8 +104,11 @@ test('Dockerfile packages the standalone relay executable in a minimal runtime i
   t.ok(content.includes('FROM debian:12-slim AS runtime-libs'), 'runtime libs stage installs missing shared libraries for native addons')
   t.ok(content.includes('ARG YT_DLP_VERSION='), 'Dockerfile pins the yt-dlp release version as a build arg')
   t.ok(content.includes('ca-certificates curl libatomic1'), 'runtime libs stage installs curl and CA roots to download yt-dlp')
-  t.ok(content.includes('https://github.com/yt-dlp/yt-dlp/releases/download/${YT_DLP_VERSION}/yt-dlp'), 'runtime libs stage downloads the pinned yt-dlp release')
+  t.ok(content.includes('YT_DLP_ASSET=yt-dlp_linux'), 'runtime libs stage selects the Linux standalone yt-dlp binary for amd64')
+  t.ok(content.includes('YT_DLP_ASSET=yt-dlp_linux_aarch64'), 'runtime libs stage selects the Linux standalone yt-dlp binary for arm64')
+  t.ok(content.includes('https://github.com/yt-dlp/yt-dlp/releases/download/${YT_DLP_VERSION}/${YT_DLP_ASSET}'), 'runtime libs stage downloads the pinned standalone yt-dlp release asset')
   t.ok(content.includes('chmod 755 /usr/local/bin/yt-dlp'), 'runtime libs stage makes yt-dlp executable')
+  t.ok(content.includes('/usr/local/bin/yt-dlp --version'), 'Docker build fails early if the packaged yt-dlp binary cannot execute')
   t.ok(content.includes('COPY packages/cli/dist/docker/ /dist/'), 'builder stage only packages prebuilt docker artifacts')
   t.ok(content.includes('cp /dist/linux-amd64/peartube-relay /peartube-relay'), 'artifact stage maps Docker amd64 to the prepared standalone binary')
   t.ok(content.includes('cp /dist/linux-arm64/peartube-relay /peartube-relay'), 'artifact stage maps Docker arm64 to the prepared standalone binary')
@@ -130,4 +133,15 @@ test('relay workflow prepares standalone artifacts before docker image build', a
 
   t.ok(content.includes('npm run build:standalone:linux-x64 --prefix packages/cli'), 'workflow builds linux x64 standalone artifacts before docker packaging')
   t.ok(content.includes('npm run prepare:docker-artifacts --prefix packages/cli'), 'workflow stages prepared docker artifacts before docker packaging')
+})
+
+test('Dockerfile packages executable standalone yt-dlp in the distroless relay image', async (t) => {
+  const dockerfilePath = join(__dirname, '..', 'Dockerfile')
+  const content = readFileSync(dockerfilePath, 'utf8')
+
+  t.ok(content.includes('YT_DLP_ASSET=yt-dlp_linux'), 'amd64 uses the standalone Linux yt-dlp binary instead of the Python script')
+  t.ok(content.includes('YT_DLP_ASSET=yt-dlp_linux_aarch64'), 'arm64 uses the standalone Linux yt-dlp binary instead of the Python script')
+  t.ok(content.includes('/usr/local/bin/yt-dlp --version'), 'Docker build verifies the packaged yt-dlp binary executes')
+  t.ok(content.includes('ENV PATH="/usr/local/bin:/usr/bin:${PATH}"'), 'final image PATH includes the packaged yt-dlp location')
+  t.ok(content.includes('PEARTUBE_ARCHIVE_YT_DLP_PATH=/usr/local/bin/yt-dlp'), 'relay archive config uses the absolute packaged yt-dlp path')
 })

--- a/packages/cli/test/service.test.mjs
+++ b/packages/cli/test/service.test.mjs
@@ -11,6 +11,7 @@ function makeTempDir(prefix) {
 
 function createFakeRuntime() {
   let candidateHandler = null
+  const metaDbMap = new Map()
 
   return {
     async start() {},
@@ -34,14 +35,30 @@ function createFakeRuntime() {
     getNetworkStats() {
       return { peers: 3, connections: 2 }
     },
-    async close() {}
+    async close() {},
+    ctx: {
+      metaDb: {
+        async get(key) { return metaDbMap.has(key) ? { value: metaDbMap.get(key) } : null },
+        async put(key, value) { metaDbMap.set(key, value) }
+      }
+    },
+    identityManager: {
+      getActiveIdentity() { return { driveKey: 'drive-key' } },
+      getActiveChannel() { return { blobs: true, publicBeeKey: 'public-bee' } }
+    },
+    uploadManager: {
+      async uploadFromPath() { return { success: true, videoId: 'video-1' } }
+    },
+    api: {
+      async submitToFeed() { return { success: true } }
+    }
   }
 }
 
 function createFakeLogger() {
   const entries = []
   const levels = ['debug', 'info', 'warn', 'error']
-  const components = ['relay', 'runtime', 'admission', 'status', 'mirror', 'peer', 'cache', 'feed', 'download']
+  const components = ['relay', 'runtime', 'admission', 'status', 'mirror', 'peer', 'cache', 'feed', 'download', 'archive']
   const logger = { entries }
 
   for (const component of components) {
@@ -277,6 +294,72 @@ test('createRelayService installs and clears a heartbeat interval', async (t) =>
 
     await service.close()
     t.alike(cleared, [scheduled.timer])
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('archive job uses configured yt-dlp binary when started from the WebUI relay service', async (t) => {
+  const dir = makeTempDir('peartube-relay-service-archive-bin-')
+  const runtime = createFakeRuntime()
+  const logger = createFakeLogger()
+  const videoPath = join(dir, 'downloaded.mp4')
+  const spawned = []
+
+  try {
+    const service = await createRelayService({
+      config: {
+        mode: 'public',
+        policy: 'discovery',
+        storage: { path: dir, maxBytes: 10_000 },
+        paths: {
+          catalog: join(dir, 'relay-catalog.json'),
+          status: join(dir, 'relay-status.json')
+        },
+        admission: {
+          channels: [],
+          owners: []
+        },
+        discovery: {
+          enabled: true,
+          maxChannels: 5,
+          maxChannelsPerOwner: 2
+        },
+        archive: {
+          uiEnabled: false,
+          ytDlpPath: '/usr/local/bin/yt-dlp',
+          tmpPath: join(dir, 'archive-tmp')
+        }
+      },
+      logger,
+      runtimeFactory: async () => runtime,
+      mirrorChannel: async () => ({ bytesDownloaded: 0, videosFound: 0, videosDownloaded: 0 }),
+      writeStatusFile: async () => {},
+      fsModule: {
+        mkdirSync() {},
+        rmSync() {},
+        existsSync(path) { return path === videoPath }
+      },
+      pathModule: {
+        join(...parts) { return join(...parts) }
+      },
+      spawnFn(binary, args) {
+        spawned.push({ binary, args })
+        return {
+          stdout: { on(event, cb) { if (event === 'data') cb(`filepath\n${videoPath}\n`) } },
+          stderr: { on() {} },
+          on(event, cb) { if (event === 'close') cb(0) }
+        }
+      }
+    })
+
+    await service.start()
+    const result = await service.enqueueArchiveJob({ url: 'https://youtu.be/archive-test', channelName: 'Archive Test' }, { runNow: true })
+
+    t.is(result.status, 'completed')
+    t.is(spawned[0]?.binary, '/usr/local/bin/yt-dlp')
+    t.ok(spawned[0]?.args.includes('--print'), 'archive job invokes yt-dlp through the real downloader wrapper')
+    await service.close()
   } finally {
     rmSync(dir, { recursive: true, force: true })
   }


### PR DESCRIPTION
## Summary
- package the standalone Linux yt-dlp binaries in the relay Docker image instead of the Python script
- verify yt-dlp executes during Docker build so broken images fail before publish
- set the relay container archive binary path explicitly and thread configured ytDlpPath into archive jobs
- add tests for Docker packaging and the service archive job path using the real downloader wrapper

## Tests
- git diff --check
- node --test packages/cli/test/cli.test.mjs packages/cli/test/service.test.mjs packages/cli/test/archive-ui.test.mjs
- npm test --prefix packages/cli → 49/49 tests, 263/263 asserts