### PR TITLE
fix(cli): include yt-dlp runtime libraries

### DIFF
--- a/packages/cli/Dockerfile
+++ b/packages/cli/Dockerfile
@@ -19,7 +19,7 @@ ARG TARGETARCH
 ARG YT_DLP_VERSION=2026.03.17
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends ca-certificates curl libatomic1 \
+  && apt-get install -y --no-install-recommends ca-certificates curl libatomic1 zlib1g \
   && rm -rf /var/lib/apt/lists/*
 
 RUN case "${TARGETARCH}" in \
@@ -32,12 +32,17 @@ RUN case "${TARGETARCH}" in \
   && chmod 755 /usr/local/bin/yt-dlp \
   && /usr/local/bin/yt-dlp --version
 
-RUN case "${TARGETARCH}" in \
-    amd64) cp /usr/lib/x86_64-linux-gnu/libatomic.so.1 /libatomic.so.1 ;; \
-    arm64) cp /usr/lib/aarch64-linux-gnu/libatomic.so.1 /libatomic.so.1 ;; \
+RUN mkdir -p /runtime-libs \
+  && case "${TARGETARCH}" in \
+    amd64) archTriplet=x86_64-linux-gnu; loader=ld-linux-x86-64.so.2; loaderDir=/lib64 ;; \
+    arm64) archTriplet=aarch64-linux-gnu; loader=ld-linux-aarch64.so.1; loaderDir=/lib ;; \
     *) echo "Unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
   esac \
-  && chmod 755 /libatomic.so.1
+  && cp /usr/lib/${archTriplet}/libatomic.so.1 /runtime-libs/libatomic.so.1 \
+  && cp /lib/${archTriplet}/libz.so.1 /runtime-libs/libz.so.1 \
+  && cp /lib/${archTriplet}/${loader} /runtime-libs/${loader} \
+  && printf '%s' "${loaderDir}" > /runtime-libs/loader-dir \
+  && chmod 755 /runtime-libs/libatomic.so.1 /runtime-libs/libz.so.1 /runtime-libs/${loader}
 
 FROM gcr.io/distroless/cc-debian12
 
@@ -52,7 +57,10 @@ ENV PATH="/usr/local/bin:/usr/bin:${PATH}"
 WORKDIR /var/lib/peartube-relay
 
 COPY --from=artifact /peartube-relay /peartube-relay
-COPY --from=runtime-libs /libatomic.so.1 /lib/libatomic.so.1
+COPY --from=runtime-libs /runtime-libs/libatomic.so.1 /lib/libatomic.so.1
+COPY --from=runtime-libs /runtime-libs/libz.so.1 /lib/libz.so.1
+COPY --from=runtime-libs /runtime-libs/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+COPY --from=runtime-libs /runtime-libs/ld-linux-aarch64.so.1 /lib/ld-linux-aarch64.so.1
 COPY --from=runtime-libs /usr/local/bin/yt-dlp /usr/local/bin/yt-dlp
 
 VOLUME ["/var/lib/peartube-relay"]

--- a/packages/cli/test/cli.test.mjs
+++ b/packages/cli/test/cli.test.mjs
@@ -115,7 +115,7 @@ test('Dockerfile packages the standalone relay executable in a minimal runtime i
   t.ok(content.includes('gcr.io/distroless/cc-debian12'), 'final image uses the distroless C runtime needed by the standalone relay binary')
   t.absent(content.includes('npm run build:standalone'), 'Docker build no longer runs bare-build inside the image')
   t.ok(content.includes('COPY --from=artifact'), 'final image copies the packaged artifact from the artifact stage')
-  t.ok(content.includes('COPY --from=runtime-libs /libatomic.so.1 /lib/libatomic.so.1'), 'final image copies libatomic into the runtime rootfs for rocksdb-native')
+  t.ok(content.includes('COPY --from=runtime-libs /runtime-libs/libatomic.so.1 /lib/libatomic.so.1'), 'final image copies libatomic into the runtime rootfs for rocksdb-native')
   t.ok(content.includes('COPY --from=runtime-libs /usr/local/bin/yt-dlp /usr/local/bin/yt-dlp'), 'final image copies yt-dlp into PATH for relay CLI import workflows')
   t.ok(content.includes('ENTRYPOINT ["/peartube-relay"]'), 'final image runs the standalone relay executable directly')
 })
@@ -144,4 +144,16 @@ test('Dockerfile packages executable standalone yt-dlp in the distroless relay i
   t.ok(content.includes('/usr/local/bin/yt-dlp --version'), 'Docker build verifies the packaged yt-dlp binary executes')
   t.ok(content.includes('ENV PATH="/usr/local/bin:/usr/bin:${PATH}"'), 'final image PATH includes the packaged yt-dlp location')
   t.ok(content.includes('PEARTUBE_ARCHIVE_YT_DLP_PATH=/usr/local/bin/yt-dlp'), 'relay archive config uses the absolute packaged yt-dlp path')
+})
+
+test('Dockerfile copies yt-dlp shared libraries required by the distroless runtime', async (t) => {
+  const dockerfilePath = join(__dirname, '..', 'Dockerfile')
+  const content = readFileSync(dockerfilePath, 'utf8')
+
+  t.ok(content.includes('zlib1g'), 'runtime libs stage installs libz provider for standalone yt-dlp')
+  t.ok(content.includes('cp /lib/${archTriplet}/libz.so.1 /runtime-libs/libz.so.1'), 'runtime libs stage stages libz for the final image')
+  t.ok(content.includes('cp /lib/${archTriplet}/${loader} /runtime-libs/${loader}'), 'runtime libs stage stages the architecture dynamic loader')
+  t.ok(content.includes('COPY --from=runtime-libs /runtime-libs/libz.so.1 /lib/libz.so.1'), 'final image copies libz into the distroless runtime')
+  t.ok(content.includes('COPY --from=runtime-libs /runtime-libs/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2'), 'final image copies the amd64 dynamic loader path')
+  t.ok(content.includes('COPY --from=runtime-libs /runtime-libs/ld-linux-aarch64.so.1 /lib/ld-linux-aarch64.so.1'), 'final image copies the arm64 dynamic loader path')
 })


### PR DESCRIPTION
## Summary
- copy standalone yt-dlp shared runtime dependencies into the distroless relay image
- include `libz.so.1` plus architecture dynamic loader paths for amd64 and arm64
- keep the existing Docker build-time `yt-dlp --version` check and add source regression assertions for required copied libraries

## Root cause
`v0.1.40` switched the relay image to the standalone yt-dlp Linux binary, but that binary still dynamically loads `libz.so.1`. The distroless final image did not include it, so archive jobs failed with:

```text
/usr/local/bin/yt-dlp: error while loading shared libraries: libz.so.1: cannot open shared object file: No such file or directory
```

## Tests
- `git diff --check`
- `node --test packages/cli/test/cli.test.mjs packages/cli/test/service.test.mjs packages/cli/test/archive-ui.test.mjs`
- `npm test --prefix packages/cli` → 50/50 tests, 269/269 asserts
