### PR TITLE
fix(cli): stage relay loader placeholders

### DIFF
--- a/packages/cli/Dockerfile
+++ b/packages/cli/Dockerfile
@@ -41,8 +41,10 @@ RUN mkdir -p /runtime-libs \
   && cp /usr/lib/${archTriplet}/libatomic.so.1 /runtime-libs/libatomic.so.1 \
   && cp /lib/${archTriplet}/libz.so.1 /runtime-libs/libz.so.1 \
   && cp /lib/${archTriplet}/${loader} /runtime-libs/${loader} \
+  && test -e /runtime-libs/ld-linux-x86-64.so.2 || cp /runtime-libs/${loader} /runtime-libs/ld-linux-x86-64.so.2 \
+  && test -e /runtime-libs/ld-linux-aarch64.so.1 || cp /runtime-libs/${loader} /runtime-libs/ld-linux-aarch64.so.1 \
   && printf '%s' "${loaderDir}" > /runtime-libs/loader-dir \
-  && chmod 755 /runtime-libs/libatomic.so.1 /runtime-libs/libz.so.1 /runtime-libs/${loader}
+  && chmod 755 /runtime-libs/libatomic.so.1 /runtime-libs/libz.so.1 /runtime-libs/ld-linux-x86-64.so.2 /runtime-libs/ld-linux-aarch64.so.1
 
 FROM gcr.io/distroless/cc-debian12
 

--- a/packages/cli/test/cli.test.mjs
+++ b/packages/cli/test/cli.test.mjs
@@ -157,3 +157,11 @@ test('Dockerfile copies yt-dlp shared libraries required by the distroless runti
   t.ok(content.includes('COPY --from=runtime-libs /runtime-libs/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2'), 'final image copies the amd64 dynamic loader path')
   t.ok(content.includes('COPY --from=runtime-libs /runtime-libs/ld-linux-aarch64.so.1 /lib/ld-linux-aarch64.so.1'), 'final image copies the arm64 dynamic loader path')
 })
+
+test('Dockerfile stages both dynamic loader filenames for each platform build', async (t) => {
+  const dockerfilePath = join(__dirname, '..', 'Dockerfile')
+  const content = readFileSync(dockerfilePath, 'utf8')
+
+  t.ok(content.includes('test -e /runtime-libs/ld-linux-x86-64.so.2 || cp /runtime-libs/${loader} /runtime-libs/ld-linux-x86-64.so.2'), 'amd64 build still exposes the arm64 loader COPY source placeholder')
+  t.ok(content.includes('test -e /runtime-libs/ld-linux-aarch64.so.1 || cp /runtime-libs/${loader} /runtime-libs/ld-linux-aarch64.so.1'), 'arm64 build still exposes the amd64 loader COPY source placeholder')
+})


### PR DESCRIPTION
## Summary
- fix the v0.1.41 relay release build failure caused by multi-platform COPY sources
- ensure each platform's runtime-libs stage exposes both loader filenames so Dockerfile COPY instructions resolve for amd64 and arm64 builds
- add a Dockerfile regression test for the placeholder loader files

## Root cause
The Dockerfile had unconditional final-stage COPY lines for both amd64 and arm64 loader names. In a per-platform runtime-libs stage, only the current platform loader existed, so the amd64 build failed when trying to copy `/runtime-libs/ld-linux-aarch64.so.1`.

## Tests
- `git diff --check`
- `node --test packages/cli/test/cli.test.mjs packages/cli/test/service.test.mjs packages/cli/test/archive-ui.test.mjs`
- `npm test --prefix packages/cli` → 51/51 tests, 271/271 asserts
