### PR TITLE
fix(cli): support authenticated yt-dlp archive jobs

### DIFF
--- a/docker-compose.relay.yml
+++ b/docker-compose.relay.yml
@@ -23,6 +23,9 @@ services:
       PEARTUBE_ARCHIVE_UI_HOST: 0.0.0.0
       PEARTUBE_ARCHIVE_UI_PORT: "8174"
       PEARTUBE_ARCHIVE_TMP_PATH: /var/lib/peartube-relay/archive-tmp
+      # Optional but often required by YouTube bot checks. Mount a Netscape-format
+      # cookies.txt file at this path before enabling the variable.
+      # PEARTUBE_ARCHIVE_COOKIES_PATH: /var/lib/peartube-relay/youtube-cookies.txt
     volumes:
       - peartube-relay-data:/var/lib/peartube-relay
     command: ["ui", "--host", "0.0.0.0", "--port", "8174"]

--- a/packages/cli/Dockerfile
+++ b/packages/cli/Dockerfile
@@ -17,9 +17,10 @@ FROM debian:12-slim AS runtime-libs
 
 ARG TARGETARCH
 ARG YT_DLP_VERSION=2026.03.17
+ARG DENO_VERSION=v2.5.6
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends ca-certificates curl libatomic1 zlib1g \
+  && apt-get install -y --no-install-recommends ca-certificates curl libatomic1 python3 zlib1g \
   && rm -rf /var/lib/apt/lists/*
 
 RUN case "${TARGETARCH}" in \
@@ -31,6 +32,18 @@ RUN case "${TARGETARCH}" in \
     -o /usr/local/bin/yt-dlp \
   && chmod 755 /usr/local/bin/yt-dlp \
   && /usr/local/bin/yt-dlp --version
+
+RUN case "${TARGETARCH}" in \
+    amd64) DENO_ASSET=deno-x86_64-unknown-linux-gnu.zip ;; \
+    arm64) DENO_ASSET=deno-aarch64-unknown-linux-gnu.zip ;; \
+    *) echo "Unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+  esac \
+  && curl -fsSL "https://github.com/denoland/deno/releases/download/${DENO_VERSION}/${DENO_ASSET}" \
+    -o /tmp/deno.zip \
+  && python3 -m zipfile -e /tmp/deno.zip /usr/local/bin \
+  && rm -f /tmp/deno.zip \
+  && chmod 755 /usr/local/bin/deno \
+  && /usr/local/bin/deno --version
 
 RUN mkdir -p /runtime-libs \
   && case "${TARGETARCH}" in \
@@ -54,6 +67,7 @@ ENV PEARTUBE_STORAGE_PATH=/var/lib/peartube-relay
 ENV PEARTUBE_STORAGE_MAX_BYTES=107374182400
 ENV PEARTUBE_LOG_LEVEL=info
 ENV PEARTUBE_ARCHIVE_YT_DLP_PATH=/usr/local/bin/yt-dlp
+ENV PEARTUBE_ARCHIVE_JS_RUNTIME=deno:/usr/local/bin/deno
 ENV PATH="/usr/local/bin:/usr/bin:${PATH}"
 
 WORKDIR /var/lib/peartube-relay
@@ -64,6 +78,7 @@ COPY --from=runtime-libs /runtime-libs/libz.so.1 /lib/libz.so.1
 COPY --from=runtime-libs /runtime-libs/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
 COPY --from=runtime-libs /runtime-libs/ld-linux-aarch64.so.1 /lib/ld-linux-aarch64.so.1
 COPY --from=runtime-libs /usr/local/bin/yt-dlp /usr/local/bin/yt-dlp
+COPY --from=runtime-libs /usr/local/bin/deno /usr/local/bin/deno
 
 VOLUME ["/var/lib/peartube-relay"]
 

--- a/packages/cli/src/archive-manager.js
+++ b/packages/cli/src/archive-manager.js
@@ -114,7 +114,15 @@ export async function enqueueArchiveJob(store, input = {}) {
   })
 }
 
-export function createYtDlpDownloader({ bin = 'yt-dlp', outputDir, spawnFn = spawn, fs = { mkdirSync, rmSync, existsSync }, path = { join } } = {}) {
+export function createYtDlpDownloader({
+  bin = 'yt-dlp',
+  outputDir,
+  cookiesPath = null,
+  jsRuntime = null,
+  spawnFn = spawn,
+  fs = { mkdirSync, rmSync, existsSync },
+  path = { join }
+} = {}) {
   if (!outputDir) throw new Error('outputDir is required')
 
   return {
@@ -125,15 +133,16 @@ export function createYtDlpDownloader({ bin = 'yt-dlp', outputDir, spawnFn = spa
       const outputTemplate = path.join(targetDir, '%(title).200B [%(id)s].%(ext)s')
       const args = [
         '--no-playlist',
-        '--no-call-home',
         '--restrict-filenames',
         '--write-info-json',
         '--print', 'after_move:filepath',
         '-f', 'bv*+ba/b',
         '--merge-output-format', 'mp4',
-        '-o', outputTemplate,
-        input.url
+        '-o', outputTemplate
       ]
+      if (cookiesPath) args.push('--cookies', cookiesPath)
+      if (jsRuntime) args.push('--js-runtimes', jsRuntime)
+      args.push(input.url)
 
       const { stdout, stderr } = await new Promise((resolve, reject) => {
         const child = spawnFn(bin, args, { stdio: ['ignore', 'pipe', 'pipe'] })

--- a/packages/cli/src/config.js
+++ b/packages/cli/src/config.js
@@ -4,6 +4,7 @@ import process from '#process'
 import {
   DEFAULT_ARCHIVE_CONFIG,
   DEFAULT_ARCHIVE_FORMAT,
+  DEFAULT_ARCHIVE_JS_RUNTIME,
   DEFAULT_ARCHIVE_MAX_ITEMS,
   DEFAULT_ARCHIVE_MAX_RETRIES,
   DEFAULT_ARCHIVE_POLL_SECONDS,
@@ -232,6 +233,8 @@ function configFromEnv(env = {}) {
     env.PEARTUBE_ARCHIVE_POLL ||
     env.PEARTUBE_ARCHIVE_FORMAT ||
     env.PEARTUBE_ARCHIVE_YT_DLP_PATH ||
+    env.PEARTUBE_ARCHIVE_COOKIES_PATH ||
+    env.PEARTUBE_ARCHIVE_JS_RUNTIME ||
     env.PEARTUBE_ARCHIVE_SOURCES
   ) {
     config.archive = {}
@@ -246,6 +249,8 @@ function configFromEnv(env = {}) {
     if (env.PEARTUBE_ARCHIVE_POLL) config.archive.poll = Number(env.PEARTUBE_ARCHIVE_POLL)
     if (env.PEARTUBE_ARCHIVE_FORMAT) config.archive.format = env.PEARTUBE_ARCHIVE_FORMAT
     if (env.PEARTUBE_ARCHIVE_YT_DLP_PATH) config.archive.ytDlpPath = env.PEARTUBE_ARCHIVE_YT_DLP_PATH
+    if (env.PEARTUBE_ARCHIVE_COOKIES_PATH) config.archive.cookiesPath = env.PEARTUBE_ARCHIVE_COOKIES_PATH
+    if (env.PEARTUBE_ARCHIVE_JS_RUNTIME) config.archive.jsRuntime = env.PEARTUBE_ARCHIVE_JS_RUNTIME
     if (env.PEARTUBE_ARCHIVE_SOURCES) {
       config.archive.sources = splitCommaList(env.PEARTUBE_ARCHIVE_SOURCES).map((url) => ({ url }))
     }
@@ -343,6 +348,14 @@ function resolveArchiveConfig(rawArchive, { storagePath }) {
   merged.ytDlpPath = typeof merged.ytDlpPath === 'string' && merged.ytDlpPath.trim()
     ? merged.ytDlpPath.trim()
     : DEFAULT_ARCHIVE_YT_DLP_PATH
+
+  merged.cookiesPath = typeof merged.cookiesPath === 'string' && merged.cookiesPath.trim()
+    ? merged.cookiesPath.trim()
+    : null
+
+  merged.jsRuntime = typeof merged.jsRuntime === 'string' && merged.jsRuntime.trim()
+    ? merged.jsRuntime.trim()
+    : DEFAULT_ARCHIVE_JS_RUNTIME
 
   merged.maxRetries = Number(merged.maxRetries)
   if (!Number.isFinite(merged.maxRetries) || merged.maxRetries < 0) {

--- a/packages/cli/src/constants.js
+++ b/packages/cli/src/constants.js
@@ -34,6 +34,7 @@ export const DEFAULT_ARCHIVE_MAX_ITEMS = 50
 export const DEFAULT_ARCHIVE_MAX_RETRIES = 3
 export const DEFAULT_ARCHIVE_BUDGET_RESERVE_PERCENT = 5
 export const DEFAULT_ARCHIVE_YT_DLP_PATH = 'yt-dlp'
+export const DEFAULT_ARCHIVE_JS_RUNTIME = ''
 
 export const DEFAULT_ARCHIVE_CONFIG = {
   enabled: false,
@@ -41,6 +42,8 @@ export const DEFAULT_ARCHIVE_CONFIG = {
   format: DEFAULT_ARCHIVE_FORMAT,
   tmpPath: null,
   ytDlpPath: DEFAULT_ARCHIVE_YT_DLP_PATH,
+  cookiesPath: null,
+  jsRuntime: DEFAULT_ARCHIVE_JS_RUNTIME,
   maxRetries: DEFAULT_ARCHIVE_MAX_RETRIES,
   budgetReservePercent: DEFAULT_ARCHIVE_BUDGET_RESERVE_PERCENT,
   maxItems: DEFAULT_ARCHIVE_MAX_ITEMS,

--- a/packages/cli/src/service.js
+++ b/packages/cli/src/service.js
@@ -200,6 +200,8 @@ export async function createRelayService({
           downloader: createYtDlpDownloader({
             bin: config.archive.ytDlpPath,
             outputDir: config.archive.tmpPath,
+            cookiesPath: config.archive.cookiesPath,
+            jsRuntime: config.archive.jsRuntime,
             spawnFn: spawnFn || undefined,
             fs: runtimeFsModule,
             path: runtimePathModule
@@ -249,6 +251,8 @@ export async function createRelayService({
         downloader: createYtDlpDownloader({
           bin: config.archive?.ytDlpPath,
           outputDir: config.archive?.tmpPath || './peartube-relay/archive-tmp',
+          cookiesPath: config.archive?.cookiesPath,
+          jsRuntime: config.archive?.jsRuntime,
           spawnFn: spawnFn || undefined,
           fs: runtimeFsModule,
           path: runtimePathModule

--- a/packages/cli/test/archive-ui.test.mjs
+++ b/packages/cli/test/archive-ui.test.mjs
@@ -22,6 +22,7 @@ test('archive UI commands and flags are exposed by the relay CLI', async (t) => 
   t.absent(readFileSync(join(__dirname, '..', 'src', 'archive-console.js'), 'utf8').includes('node:http'), 'archive console uses runtime HTTP shim')
   t.ok(compose.includes('8174:8174'), 'root relay compose exposes the local archive UI port')
   t.ok(compose.includes('PEARTUBE_ARCHIVE_UI_ENABLED: "true"'), 'compose enables archive UI by default')
+  t.ok(compose.includes('PEARTUBE_ARCHIVE_COOKIES_PATH'), 'compose documents optional YouTube cookies path for bot checks')
 })
 
 test('archive manager stores anonymous channel/job state without raw URLs in public status', async (t) => {
@@ -181,4 +182,39 @@ test('yt-dlp downloader fails with useful context when reported output file is m
     () => downloader.download({ id: 'arch_2', url: 'https://youtu.be/abc' }),
     /yt-dlp reported output file does not exist: \/archive\/tmp\/arch_2\/missing\.mp4/
   )
+})
+
+test('yt-dlp downloader removes deprecated no-call-home and passes cookies/js runtime options', async (t) => {
+  const calls = []
+  const existing = new Set(['/archive/tmp/arch_auth/example.mp4'])
+  const downloader = createYtDlpDownloader({
+    outputDir: '/archive/tmp',
+    cookiesPath: '/var/lib/peartube-relay/youtube-cookies.txt',
+    jsRuntime: 'deno:/usr/local/bin/deno',
+    fs: {
+      mkdirSync() {},
+      rmSync() {},
+      existsSync(path) { return existing.has(path) }
+    },
+    path: {
+      join(...parts) { return parts.join('/').replace(/\/+/g, '/') }
+    },
+    spawnFn(binary, args) {
+      calls.push({ binary, args })
+      return {
+        stdout: { on(event, cb) { if (event === 'data') cb('filepath\n/archive/tmp/arch_auth/example.mp4\n') } },
+        stderr: { on() {} },
+        on(event, cb) { if (event === 'close') cb(0) }
+      }
+    }
+  })
+
+  await downloader.download({ id: 'arch_auth', url: 'https://www.youtube.com/watch?v=ABbqy1VGeck' })
+
+  const args = calls[0].args
+  t.absent(args.includes('--no-call-home'), 'deprecated yt-dlp no-call-home flag is not passed')
+  t.ok(args.includes('--cookies'), 'cookies option is passed when configured')
+  t.is(args[args.indexOf('--cookies') + 1], '/var/lib/peartube-relay/youtube-cookies.txt')
+  t.ok(args.includes('--js-runtimes'), 'JS runtime option is passed when configured')
+  t.is(args[args.indexOf('--js-runtimes') + 1], 'deno:/usr/local/bin/deno')
 })

--- a/packages/cli/test/cli.test.mjs
+++ b/packages/cli/test/cli.test.mjs
@@ -165,3 +165,13 @@ test('Dockerfile stages both dynamic loader filenames for each platform build', 
   t.ok(content.includes('test -e /runtime-libs/ld-linux-x86-64.so.2 || cp /runtime-libs/${loader} /runtime-libs/ld-linux-x86-64.so.2'), 'amd64 build still exposes the arm64 loader COPY source placeholder')
   t.ok(content.includes('test -e /runtime-libs/ld-linux-aarch64.so.1 || cp /runtime-libs/${loader} /runtime-libs/ld-linux-aarch64.so.1'), 'arm64 build still exposes the amd64 loader COPY source placeholder')
 })
+
+test('Dockerfile packages deno for yt-dlp YouTube JavaScript extraction', async (t) => {
+  const dockerfile = readFileSync(join(__dirname, '..', 'Dockerfile'), 'utf8')
+
+  t.ok(dockerfile.includes('ARG DENO_VERSION='), 'Dockerfile pins a Deno version for reproducible relay images')
+  t.ok(dockerfile.includes('github.com/denoland/deno/releases/download'), 'Dockerfile downloads Deno release assets')
+  t.ok(dockerfile.includes('/usr/local/bin/deno --version'), 'Dockerfile validates Deno during image build')
+  t.ok(dockerfile.includes('PEARTUBE_ARCHIVE_JS_RUNTIME=deno:/usr/local/bin/deno'), 'final image configures yt-dlp to use Deno')
+  t.ok(dockerfile.includes('COPY --from=runtime-libs /usr/local/bin/deno /usr/local/bin/deno'), 'final image includes Deno executable')
+})

--- a/packages/cli/test/config.test.mjs
+++ b/packages/cli/test/config.test.mjs
@@ -124,3 +124,16 @@ test('loadRelayConfig supports env-only relay configuration', async (t) => {
   t.is(config.retention.protectAllowlist, false)
   t.is(config.logging.level, 'debug')
 })
+
+test('resolveRelayConfig reads archive cookies and JS runtime env vars', async (t) => {
+  const config = resolveRelayConfig({}, {
+    env: {
+      PEARTUBE_ARCHIVE_UI_ENABLED: 'true',
+      PEARTUBE_ARCHIVE_COOKIES_PATH: '/var/lib/peartube-relay/youtube-cookies.txt',
+      PEARTUBE_ARCHIVE_JS_RUNTIME: 'deno:/usr/local/bin/deno'
+    }
+  })
+
+  t.is(config.archive.cookiesPath, '/var/lib/peartube-relay/youtube-cookies.txt')
+  t.is(config.archive.jsRuntime, 'deno:/usr/local/bin/deno')
+})


### PR DESCRIPTION
## Summary
- remove deprecated `--no-call-home` from WebUI/archive yt-dlp jobs
- add configurable YouTube cookies support via `PEARTUBE_ARCHIVE_COOKIES_PATH`
- package Deno in the relay image and pass `--js-runtimes deno:/usr/local/bin/deno` by default
- thread cookies/JS runtime config through WebUI and direct archive jobs
- document the optional cookies path in the relay compose file

## Test Plan
- `git diff --check`
- `node --test packages/cli/test/archive-ui.test.mjs packages/cli/test/config.test.mjs packages/cli/test/cli.test.mjs packages/cli/test/service.test.mjs`
- `npm test --prefix packages/cli` → 54/54 tests, 284/284 asserts

## Notes
The reported YouTube error still requires valid YouTube cookies for that video/account path. This PR makes the relay able to mount and pass a cookies.txt file; it does not bypass YouTube's bot/auth gate.
