### PR TITLE
fix(cli): package ffmpeg for relay archives

### DIFF
--- a/docker-compose.relay.yml
+++ b/docker-compose.relay.yml
@@ -23,6 +23,7 @@ services:
       PEARTUBE_ARCHIVE_UI_HOST: 0.0.0.0
       PEARTUBE_ARCHIVE_UI_PORT: "8174"
       PEARTUBE_ARCHIVE_TMP_PATH: /var/lib/peartube-relay/archive-tmp
+      PEARTUBE_ARCHIVE_FFMPEG_PATH: /usr/local/bin/ffmpeg
       # Optional but often required by YouTube bot checks. Mount a Netscape-format
       # cookies.txt file at this path before enabling the variable.
       # PEARTUBE_ARCHIVE_COOKIES_PATH: /var/lib/peartube-relay/youtube-cookies.txt

--- a/packages/cli/Dockerfile
+++ b/packages/cli/Dockerfile
@@ -18,9 +18,10 @@ FROM debian:12-slim AS runtime-libs
 ARG TARGETARCH
 ARG YT_DLP_VERSION=2026.03.17
 ARG DENO_VERSION=v2.5.6
+ARG FFMPEG_VERSION=release
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends ca-certificates curl libatomic1 python3 zlib1g \
+  && apt-get install -y --no-install-recommends ca-certificates curl libatomic1 python3 tar xz-utils zlib1g \
   && rm -rf /var/lib/apt/lists/*
 
 RUN case "${TARGETARCH}" in \
@@ -45,6 +46,21 @@ RUN case "${TARGETARCH}" in \
   && chmod 755 /usr/local/bin/deno \
   && /usr/local/bin/deno --version
 
+RUN case "${TARGETARCH}" in \
+    amd64) FFMPEG_ASSET=ffmpeg-${FFMPEG_VERSION}-amd64-static.tar.xz ;; \
+    arm64) FFMPEG_ASSET=ffmpeg-${FFMPEG_VERSION}-arm64-static.tar.xz ;; \
+    *) echo "Unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+  esac \
+  && curl -fsSL "https://johnvansickle.com/ffmpeg/releases/${FFMPEG_ASSET}" \
+    -o /tmp/ffmpeg.tar.xz \
+  && mkdir -p /tmp/ffmpeg \
+  && tar -xJf /tmp/ffmpeg.tar.xz -C /tmp/ffmpeg --strip-components=1 \
+  && cp /tmp/ffmpeg/ffmpeg /usr/local/bin/ffmpeg \
+  && cp /tmp/ffmpeg/ffprobe /usr/local/bin/ffprobe \
+  && rm -rf /tmp/ffmpeg /tmp/ffmpeg.tar.xz \
+  && chmod 755 /usr/local/bin/ffmpeg /usr/local/bin/ffprobe \
+  && /usr/local/bin/ffmpeg -version
+
 RUN mkdir -p /runtime-libs \
   && case "${TARGETARCH}" in \
     amd64) archTriplet=x86_64-linux-gnu; loader=ld-linux-x86-64.so.2; loaderDir=/lib64 ;; \
@@ -67,6 +83,7 @@ ENV PEARTUBE_STORAGE_PATH=/var/lib/peartube-relay
 ENV PEARTUBE_STORAGE_MAX_BYTES=107374182400
 ENV PEARTUBE_LOG_LEVEL=info
 ENV PEARTUBE_ARCHIVE_YT_DLP_PATH=/usr/local/bin/yt-dlp
+ENV PEARTUBE_ARCHIVE_FFMPEG_PATH=/usr/local/bin/ffmpeg
 ENV PEARTUBE_ARCHIVE_JS_RUNTIME=deno:/usr/local/bin/deno
 ENV PATH="/usr/local/bin:/usr/bin:${PATH}"
 
@@ -79,6 +96,8 @@ COPY --from=runtime-libs /runtime-libs/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-
 COPY --from=runtime-libs /runtime-libs/ld-linux-aarch64.so.1 /lib/ld-linux-aarch64.so.1
 COPY --from=runtime-libs /usr/local/bin/yt-dlp /usr/local/bin/yt-dlp
 COPY --from=runtime-libs /usr/local/bin/deno /usr/local/bin/deno
+COPY --from=runtime-libs /usr/local/bin/ffmpeg /usr/local/bin/ffmpeg
+COPY --from=runtime-libs /usr/local/bin/ffprobe /usr/local/bin/ffprobe
 
 VOLUME ["/var/lib/peartube-relay"]
 

--- a/packages/cli/src/archive-manager.js
+++ b/packages/cli/src/archive-manager.js
@@ -117,6 +117,8 @@ export async function enqueueArchiveJob(store, input = {}) {
 export function createYtDlpDownloader({
   bin = 'yt-dlp',
   outputDir,
+  format = 'bv*[height<=1080][ext=mp4]+ba[ext=m4a]/b[height<=1080][ext=mp4]/b',
+  ffmpegPath = null,
   cookiesPath = null,
   jsRuntime = null,
   spawnFn = spawn,
@@ -136,10 +138,11 @@ export function createYtDlpDownloader({
         '--restrict-filenames',
         '--write-info-json',
         '--print', 'after_move:filepath',
-        '-f', 'bv*+ba/b',
+        '-f', format,
         '--merge-output-format', 'mp4',
         '-o', outputTemplate
       ]
+      if (ffmpegPath) args.push('--ffmpeg-location', ffmpegPath)
       if (cookiesPath) args.push('--cookies', cookiesPath)
       if (jsRuntime) args.push('--js-runtimes', jsRuntime)
       args.push(input.url)

--- a/packages/cli/src/config.js
+++ b/packages/cli/src/config.js
@@ -3,6 +3,7 @@ import { join } from '#path'
 import process from '#process'
 import {
   DEFAULT_ARCHIVE_CONFIG,
+  DEFAULT_ARCHIVE_FFMPEG_PATH,
   DEFAULT_ARCHIVE_FORMAT,
   DEFAULT_ARCHIVE_JS_RUNTIME,
   DEFAULT_ARCHIVE_MAX_ITEMS,
@@ -233,6 +234,7 @@ function configFromEnv(env = {}) {
     env.PEARTUBE_ARCHIVE_POLL ||
     env.PEARTUBE_ARCHIVE_FORMAT ||
     env.PEARTUBE_ARCHIVE_YT_DLP_PATH ||
+    env.PEARTUBE_ARCHIVE_FFMPEG_PATH ||
     env.PEARTUBE_ARCHIVE_COOKIES_PATH ||
     env.PEARTUBE_ARCHIVE_JS_RUNTIME ||
     env.PEARTUBE_ARCHIVE_SOURCES
@@ -249,6 +251,7 @@ function configFromEnv(env = {}) {
     if (env.PEARTUBE_ARCHIVE_POLL) config.archive.poll = Number(env.PEARTUBE_ARCHIVE_POLL)
     if (env.PEARTUBE_ARCHIVE_FORMAT) config.archive.format = env.PEARTUBE_ARCHIVE_FORMAT
     if (env.PEARTUBE_ARCHIVE_YT_DLP_PATH) config.archive.ytDlpPath = env.PEARTUBE_ARCHIVE_YT_DLP_PATH
+    if (env.PEARTUBE_ARCHIVE_FFMPEG_PATH) config.archive.ffmpegPath = env.PEARTUBE_ARCHIVE_FFMPEG_PATH
     if (env.PEARTUBE_ARCHIVE_COOKIES_PATH) config.archive.cookiesPath = env.PEARTUBE_ARCHIVE_COOKIES_PATH
     if (env.PEARTUBE_ARCHIVE_JS_RUNTIME) config.archive.jsRuntime = env.PEARTUBE_ARCHIVE_JS_RUNTIME
     if (env.PEARTUBE_ARCHIVE_SOURCES) {
@@ -348,6 +351,10 @@ function resolveArchiveConfig(rawArchive, { storagePath }) {
   merged.ytDlpPath = typeof merged.ytDlpPath === 'string' && merged.ytDlpPath.trim()
     ? merged.ytDlpPath.trim()
     : DEFAULT_ARCHIVE_YT_DLP_PATH
+
+  merged.ffmpegPath = typeof merged.ffmpegPath === 'string' && merged.ffmpegPath.trim()
+    ? merged.ffmpegPath.trim()
+    : DEFAULT_ARCHIVE_FFMPEG_PATH
 
   merged.cookiesPath = typeof merged.cookiesPath === 'string' && merged.cookiesPath.trim()
     ? merged.cookiesPath.trim()

--- a/packages/cli/src/constants.js
+++ b/packages/cli/src/constants.js
@@ -34,6 +34,7 @@ export const DEFAULT_ARCHIVE_MAX_ITEMS = 50
 export const DEFAULT_ARCHIVE_MAX_RETRIES = 3
 export const DEFAULT_ARCHIVE_BUDGET_RESERVE_PERCENT = 5
 export const DEFAULT_ARCHIVE_YT_DLP_PATH = 'yt-dlp'
+export const DEFAULT_ARCHIVE_FFMPEG_PATH = ''
 export const DEFAULT_ARCHIVE_JS_RUNTIME = ''
 
 export const DEFAULT_ARCHIVE_CONFIG = {
@@ -42,6 +43,7 @@ export const DEFAULT_ARCHIVE_CONFIG = {
   format: DEFAULT_ARCHIVE_FORMAT,
   tmpPath: null,
   ytDlpPath: DEFAULT_ARCHIVE_YT_DLP_PATH,
+  ffmpegPath: DEFAULT_ARCHIVE_FFMPEG_PATH,
   cookiesPath: null,
   jsRuntime: DEFAULT_ARCHIVE_JS_RUNTIME,
   maxRetries: DEFAULT_ARCHIVE_MAX_RETRIES,

--- a/packages/cli/src/service.js
+++ b/packages/cli/src/service.js
@@ -200,6 +200,8 @@ export async function createRelayService({
           downloader: createYtDlpDownloader({
             bin: config.archive.ytDlpPath,
             outputDir: config.archive.tmpPath,
+            format: config.archive.format,
+            ffmpegPath: config.archive.ffmpegPath,
             cookiesPath: config.archive.cookiesPath,
             jsRuntime: config.archive.jsRuntime,
             spawnFn: spawnFn || undefined,
@@ -251,6 +253,8 @@ export async function createRelayService({
         downloader: createYtDlpDownloader({
           bin: config.archive?.ytDlpPath,
           outputDir: config.archive?.tmpPath || './peartube-relay/archive-tmp',
+          format: config.archive?.format,
+          ffmpegPath: config.archive?.ffmpegPath,
           cookiesPath: config.archive?.cookiesPath,
           jsRuntime: config.archive?.jsRuntime,
           spawnFn: spawnFn || undefined,

--- a/packages/cli/test/archive-ui.test.mjs
+++ b/packages/cli/test/archive-ui.test.mjs
@@ -22,6 +22,7 @@ test('archive UI commands and flags are exposed by the relay CLI', async (t) => 
   t.absent(readFileSync(join(__dirname, '..', 'src', 'archive-console.js'), 'utf8').includes('node:http'), 'archive console uses runtime HTTP shim')
   t.ok(compose.includes('8174:8174'), 'root relay compose exposes the local archive UI port')
   t.ok(compose.includes('PEARTUBE_ARCHIVE_UI_ENABLED: "true"'), 'compose enables archive UI by default')
+  t.ok(compose.includes('PEARTUBE_ARCHIVE_FFMPEG_PATH: /usr/local/bin/ffmpeg'), 'compose configures ffmpeg for yt-dlp archive merging')
   t.ok(compose.includes('PEARTUBE_ARCHIVE_COOKIES_PATH'), 'compose documents optional YouTube cookies path for bot checks')
 })
 
@@ -217,4 +218,37 @@ test('yt-dlp downloader removes deprecated no-call-home and passes cookies/js ru
   t.is(args[args.indexOf('--cookies') + 1], '/var/lib/peartube-relay/youtube-cookies.txt')
   t.ok(args.includes('--js-runtimes'), 'JS runtime option is passed when configured')
   t.is(args[args.indexOf('--js-runtimes') + 1], 'deno:/usr/local/bin/deno')
+})
+
+test('yt-dlp WebUI downloader uses ffmpeg and prefers merged mp4-compatible archives', async (t) => {
+  const calls = []
+  const existing = new Set(['/archive/tmp/arch_ffmpeg/example.mp4'])
+  const downloader = createYtDlpDownloader({
+    outputDir: '/archive/tmp',
+    ffmpegPath: '/usr/local/bin/ffmpeg',
+    fs: {
+      mkdirSync() {},
+      rmSync() {},
+      existsSync(path) { return existing.has(path) }
+    },
+    path: {
+      join(...parts) { return parts.join('/').replace(/\/+/g, '/') }
+    },
+    spawnFn(binary, args) {
+      calls.push({ binary, args })
+      return {
+        stdout: { on(event, cb) { if (event === 'data') cb('filepath\n/archive/tmp/arch_ffmpeg/example.mp4\n') } },
+        stderr: { on() {} },
+        on(event, cb) { if (event === 'close') cb(0) }
+      }
+    }
+  })
+
+  await downloader.download({ id: 'arch_ffmpeg', url: 'https://www.youtube.com/watch?v=ABbqy1VGeck' })
+
+  const args = calls[0].args
+  t.is(args[args.indexOf('-f') + 1], 'bv*[height<=1080][ext=mp4]+ba[ext=m4a]/b[height<=1080][ext=mp4]/b', 'WebUI archive prefers bounded mp4-compatible video+audio with progressive fallback')
+  t.ok(args.includes('--merge-output-format'), 'merge output stays mp4 when separate streams are selected')
+  t.ok(args.includes('--ffmpeg-location'), 'ffmpeg location is passed when configured')
+  t.is(args[args.indexOf('--ffmpeg-location') + 1], '/usr/local/bin/ffmpeg')
 })

--- a/packages/cli/test/cli.test.mjs
+++ b/packages/cli/test/cli.test.mjs
@@ -175,3 +175,14 @@ test('Dockerfile packages deno for yt-dlp YouTube JavaScript extraction', async 
   t.ok(dockerfile.includes('PEARTUBE_ARCHIVE_JS_RUNTIME=deno:/usr/local/bin/deno'), 'final image configures yt-dlp to use Deno')
   t.ok(dockerfile.includes('COPY --from=runtime-libs /usr/local/bin/deno /usr/local/bin/deno'), 'final image includes Deno executable')
 })
+
+test('Dockerfile packages ffmpeg for yt-dlp archive merging', async (t) => {
+  const dockerfile = readFileSync(join(__dirname, '..', 'Dockerfile'), 'utf8')
+
+  t.ok(dockerfile.includes('ARG FFMPEG_VERSION='), 'Dockerfile pins an ffmpeg static build version')
+  t.ok(dockerfile.includes('johnvansickle.com/ffmpeg/releases'), 'Dockerfile downloads static ffmpeg release assets')
+  t.ok(dockerfile.includes('/usr/local/bin/ffmpeg -version'), 'Dockerfile validates ffmpeg during image build')
+  t.ok(dockerfile.includes('PEARTUBE_ARCHIVE_FFMPEG_PATH=/usr/local/bin/ffmpeg'), 'final image exposes configured ffmpeg path to archive jobs')
+  t.ok(dockerfile.includes('COPY --from=runtime-libs /usr/local/bin/ffmpeg /usr/local/bin/ffmpeg'), 'final image includes ffmpeg executable')
+  t.ok(dockerfile.includes('COPY --from=runtime-libs /usr/local/bin/ffprobe /usr/local/bin/ffprobe'), 'final image includes ffprobe executable')
+})

--- a/packages/cli/test/config.test.mjs
+++ b/packages/cli/test/config.test.mjs
@@ -137,3 +137,14 @@ test('resolveRelayConfig reads archive cookies and JS runtime env vars', async (
   t.is(config.archive.cookiesPath, '/var/lib/peartube-relay/youtube-cookies.txt')
   t.is(config.archive.jsRuntime, 'deno:/usr/local/bin/deno')
 })
+
+test('resolveRelayConfig reads archive ffmpeg path env var', async (t) => {
+  const config = resolveRelayConfig({}, {
+    env: {
+      PEARTUBE_ARCHIVE_UI_ENABLED: 'true',
+      PEARTUBE_ARCHIVE_FFMPEG_PATH: '/usr/local/bin/ffmpeg'
+    }
+  })
+
+  t.is(config.archive.ffmpegPath, '/usr/local/bin/ffmpeg')
+})


### PR DESCRIPTION
## Summary
- package static `ffmpeg` and `ffprobe` into the relay image
- set `PEARTUBE_ARCHIVE_FFMPEG_PATH=/usr/local/bin/ffmpeg` in the image and relay compose
- pass `--ffmpeg-location` into WebUI/direct archive yt-dlp jobs when configured
- use the bounded mp4-compatible archive format from the relay config instead of the WebUI hardcoded `bv*+ba/b`
- add regression tests for ffmpeg image packaging, config parsing, compose docs, and yt-dlp args

## Test Plan
- `node --test packages/cli/test/archive-ui.test.mjs packages/cli/test/cli.test.mjs packages/cli/test/config.test.mjs packages/cli/test/service.test.mjs`
- `git diff --check`
- `npm test --prefix packages/cli` → 57/57 tests, 296/296 asserts

## Notes
This fixes the missing-ffmpeg merge warning. The remaining `HTTP Error 403: Forbidden` can still be YouTube-side bot/auth/signature enforcement, so keep testing with fresh mounted cookies on the next tagged relay image.
