### PR TITLE
Add noninteractive YouTube POT support for relay archives

### DIFF
--- a/docker-compose.relay.yml
+++ b/docker-compose.relay.yml
@@ -24,6 +24,7 @@ services:
       PEARTUBE_ARCHIVE_UI_PORT: "8174"
       PEARTUBE_ARCHIVE_TMP_PATH: /var/lib/peartube-relay/archive-tmp
       PEARTUBE_ARCHIVE_FFMPEG_PATH: /usr/local/bin/ffmpeg
+      PEARTUBE_ARCHIVE_YT_DLP_EXTRA_ARGS: "--plugin-dirs /usr/local/share/yt-dlp-plugins --extractor-args youtube:player_client=mweb;youtubepot-bgutilcli:cli_path=/usr/local/bin/bgutil-pot"
       # Optional but often required by YouTube bot checks. Mount a Netscape-format
       # cookies.txt file at this path before enabling the variable.
       # PEARTUBE_ARCHIVE_COOKIES_PATH: /var/lib/peartube-relay/youtube-cookies.txt

--- a/packages/cli/Dockerfile
+++ b/packages/cli/Dockerfile
@@ -19,6 +19,7 @@ ARG TARGETARCH
 ARG YT_DLP_VERSION=2026.03.17
 ARG DENO_VERSION=v2.5.6
 ARG FFMPEG_VERSION=release
+ARG BGUTIL_POT_PROVIDER_VERSION=v0.8.1
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates curl libatomic1 python3 tar xz-utils zlib1g \
@@ -33,6 +34,23 @@ RUN case "${TARGETARCH}" in \
     -o /usr/local/bin/yt-dlp \
   && chmod 755 /usr/local/bin/yt-dlp \
   && /usr/local/bin/yt-dlp --version
+
+RUN case "${TARGETARCH}" in \
+    amd64) BGUTIL_POT_ASSET=bgutil-pot-linux-x86_64 ;; \
+    arm64) BGUTIL_POT_ASSET=bgutil-pot-linux-aarch64 ;; \
+    *) echo "Unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+  esac \
+  && curl -fsSL "https://github.com/jim60105/bgutil-ytdlp-pot-provider-rs/releases/download/${BGUTIL_POT_PROVIDER_VERSION}/${BGUTIL_POT_ASSET}" \
+    -o /usr/local/bin/bgutil-pot \
+  && chmod 755 /usr/local/bin/bgutil-pot \
+  && /usr/local/bin/bgutil-pot --version
+
+RUN mkdir -p /usr/local/share/yt-dlp-plugins \
+  && curl -fsSL "https://github.com/jim60105/bgutil-ytdlp-pot-provider-rs/releases/download/${BGUTIL_POT_PROVIDER_VERSION}/bgutil-ytdlp-pot-provider-rs.zip" \
+    -o /tmp/bgutil-ytdlp-pot-provider-rs.zip \
+  && python3 -m zipfile -e /tmp/bgutil-ytdlp-pot-provider-rs.zip /usr/local/share/yt-dlp-plugins \
+  && rm -f /tmp/bgutil-ytdlp-pot-provider-rs.zip \
+  && /usr/local/bin/yt-dlp --plugin-dirs /usr/local/share/yt-dlp-plugins --extractor-args "youtube:player_client=mweb;youtubepot-bgutilcli:cli_path=/usr/local/bin/bgutil-pot" --version
 
 RUN case "${TARGETARCH}" in \
     amd64) DENO_ASSET=deno-x86_64-unknown-linux-gnu.zip ;; \
@@ -69,11 +87,12 @@ RUN mkdir -p /runtime-libs \
   esac \
   && cp /usr/lib/${archTriplet}/libatomic.so.1 /runtime-libs/libatomic.so.1 \
   && cp /lib/${archTriplet}/libz.so.1 /runtime-libs/libz.so.1 \
+  && cp /lib/${archTriplet}/libc.so.6 /runtime-libs/libc.so.6 \
   && cp /lib/${archTriplet}/${loader} /runtime-libs/${loader} \
   && test -e /runtime-libs/ld-linux-x86-64.so.2 || cp /runtime-libs/${loader} /runtime-libs/ld-linux-x86-64.so.2 \
   && test -e /runtime-libs/ld-linux-aarch64.so.1 || cp /runtime-libs/${loader} /runtime-libs/ld-linux-aarch64.so.1 \
   && printf '%s' "${loaderDir}" > /runtime-libs/loader-dir \
-  && chmod 755 /runtime-libs/libatomic.so.1 /runtime-libs/libz.so.1 /runtime-libs/ld-linux-x86-64.so.2 /runtime-libs/ld-linux-aarch64.so.1
+  && chmod 755 /runtime-libs/libatomic.so.1 /runtime-libs/libz.so.1 /runtime-libs/libc.so.6 /runtime-libs/ld-linux-x86-64.so.2 /runtime-libs/ld-linux-aarch64.so.1
 
 FROM gcr.io/distroless/cc-debian12
 
@@ -85,6 +104,7 @@ ENV PEARTUBE_LOG_LEVEL=info
 ENV PEARTUBE_ARCHIVE_YT_DLP_PATH=/usr/local/bin/yt-dlp
 ENV PEARTUBE_ARCHIVE_FFMPEG_PATH=/usr/local/bin/ffmpeg
 ENV PEARTUBE_ARCHIVE_JS_RUNTIME=deno:/usr/local/bin/deno
+ENV PEARTUBE_ARCHIVE_YT_DLP_EXTRA_ARGS="--plugin-dirs /usr/local/share/yt-dlp-plugins --extractor-args youtube:player_client=mweb;youtubepot-bgutilcli:cli_path=/usr/local/bin/bgutil-pot"
 ENV PATH="/usr/local/bin:/usr/bin:${PATH}"
 
 WORKDIR /var/lib/peartube-relay
@@ -92,9 +112,12 @@ WORKDIR /var/lib/peartube-relay
 COPY --from=artifact /peartube-relay /peartube-relay
 COPY --from=runtime-libs /runtime-libs/libatomic.so.1 /lib/libatomic.so.1
 COPY --from=runtime-libs /runtime-libs/libz.so.1 /lib/libz.so.1
+COPY --from=runtime-libs /runtime-libs/libc.so.6 /lib/libc.so.6
 COPY --from=runtime-libs /runtime-libs/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
 COPY --from=runtime-libs /runtime-libs/ld-linux-aarch64.so.1 /lib/ld-linux-aarch64.so.1
 COPY --from=runtime-libs /usr/local/bin/yt-dlp /usr/local/bin/yt-dlp
+COPY --from=runtime-libs /usr/local/bin/bgutil-pot /usr/local/bin/bgutil-pot
+COPY --from=runtime-libs /usr/local/share/yt-dlp-plugins /usr/local/share/yt-dlp-plugins
 COPY --from=runtime-libs /usr/local/bin/deno /usr/local/bin/deno
 COPY --from=runtime-libs /usr/local/bin/ffmpeg /usr/local/bin/ffmpeg
 COPY --from=runtime-libs /usr/local/bin/ffprobe /usr/local/bin/ffprobe

--- a/packages/cli/src/archive-manager.js
+++ b/packages/cli/src/archive-manager.js
@@ -121,6 +121,7 @@ export function createYtDlpDownloader({
   ffmpegPath = null,
   cookiesPath = null,
   jsRuntime = null,
+  ytDlpExtraArgs = [],
   spawnFn = spawn,
   fs = { mkdirSync, rmSync, existsSync },
   path = { join }
@@ -145,6 +146,7 @@ export function createYtDlpDownloader({
       if (ffmpegPath) args.push('--ffmpeg-location', ffmpegPath)
       if (cookiesPath) args.push('--cookies', cookiesPath)
       if (jsRuntime) args.push('--js-runtimes', jsRuntime)
+      if (Array.isArray(ytDlpExtraArgs) && ytDlpExtraArgs.length) args.push(...ytDlpExtraArgs)
       args.push(input.url)
 
       const { stdout, stderr } = await new Promise((resolve, reject) => {

--- a/packages/cli/src/config.js
+++ b/packages/cli/src/config.js
@@ -9,6 +9,7 @@ import {
   DEFAULT_ARCHIVE_MAX_ITEMS,
   DEFAULT_ARCHIVE_MAX_RETRIES,
   DEFAULT_ARCHIVE_POLL_SECONDS,
+  DEFAULT_ARCHIVE_YT_DLP_EXTRA_ARGS,
   DEFAULT_ARCHIVE_YT_DLP_PATH,
   DEFAULT_RELAY_CONFIG,
   RELAY_CATALOG_FILENAME,
@@ -59,6 +60,51 @@ function splitCommaList(value) {
     .split(',')
     .map((entry) => entry.trim())
     .filter(Boolean)
+}
+
+function splitShellArgs(value) {
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => splitShellArgs(entry))
+  }
+  if (typeof value !== 'string') return []
+
+  const args = []
+  let current = ''
+  let quote = null
+  let escaped = false
+
+  for (const char of value.trim()) {
+    if (escaped) {
+      current += char
+      escaped = false
+      continue
+    }
+    if (char === '\\') {
+      escaped = true
+      continue
+    }
+    if (quote) {
+      if (char === quote) quote = null
+      else current += char
+      continue
+    }
+    if (char === '"' || char === "'") {
+      quote = char
+      continue
+    }
+    if (/\s/.test(char)) {
+      if (current) {
+        args.push(current)
+        current = ''
+      }
+      continue
+    }
+    current += char
+  }
+
+  if (escaped) current += '\\'
+  if (current) args.push(current)
+  return args
 }
 
 function parseBoolean(value) {
@@ -237,6 +283,7 @@ function configFromEnv(env = {}) {
     env.PEARTUBE_ARCHIVE_FFMPEG_PATH ||
     env.PEARTUBE_ARCHIVE_COOKIES_PATH ||
     env.PEARTUBE_ARCHIVE_JS_RUNTIME ||
+    env.PEARTUBE_ARCHIVE_YT_DLP_EXTRA_ARGS ||
     env.PEARTUBE_ARCHIVE_SOURCES
   ) {
     config.archive = {}
@@ -254,6 +301,7 @@ function configFromEnv(env = {}) {
     if (env.PEARTUBE_ARCHIVE_FFMPEG_PATH) config.archive.ffmpegPath = env.PEARTUBE_ARCHIVE_FFMPEG_PATH
     if (env.PEARTUBE_ARCHIVE_COOKIES_PATH) config.archive.cookiesPath = env.PEARTUBE_ARCHIVE_COOKIES_PATH
     if (env.PEARTUBE_ARCHIVE_JS_RUNTIME) config.archive.jsRuntime = env.PEARTUBE_ARCHIVE_JS_RUNTIME
+    if (env.PEARTUBE_ARCHIVE_YT_DLP_EXTRA_ARGS) config.archive.ytDlpExtraArgs = splitShellArgs(env.PEARTUBE_ARCHIVE_YT_DLP_EXTRA_ARGS)
     if (env.PEARTUBE_ARCHIVE_SOURCES) {
       config.archive.sources = splitCommaList(env.PEARTUBE_ARCHIVE_SOURCES).map((url) => ({ url }))
     }
@@ -363,6 +411,11 @@ function resolveArchiveConfig(rawArchive, { storagePath }) {
   merged.jsRuntime = typeof merged.jsRuntime === 'string' && merged.jsRuntime.trim()
     ? merged.jsRuntime.trim()
     : DEFAULT_ARCHIVE_JS_RUNTIME
+
+  merged.ytDlpExtraArgs = Array.isArray(merged.ytDlpExtraArgs)
+    ? merged.ytDlpExtraArgs.map((arg) => String(arg).trim()).filter(Boolean)
+    : splitShellArgs(String(merged.ytDlpExtraArgs || ''))
+  if (!merged.ytDlpExtraArgs.length) merged.ytDlpExtraArgs = [...DEFAULT_ARCHIVE_YT_DLP_EXTRA_ARGS]
 
   merged.maxRetries = Number(merged.maxRetries)
   if (!Number.isFinite(merged.maxRetries) || merged.maxRetries < 0) {

--- a/packages/cli/src/constants.js
+++ b/packages/cli/src/constants.js
@@ -36,6 +36,7 @@ export const DEFAULT_ARCHIVE_BUDGET_RESERVE_PERCENT = 5
 export const DEFAULT_ARCHIVE_YT_DLP_PATH = 'yt-dlp'
 export const DEFAULT_ARCHIVE_FFMPEG_PATH = ''
 export const DEFAULT_ARCHIVE_JS_RUNTIME = ''
+export const DEFAULT_ARCHIVE_YT_DLP_EXTRA_ARGS = []
 
 export const DEFAULT_ARCHIVE_CONFIG = {
   enabled: false,
@@ -46,6 +47,7 @@ export const DEFAULT_ARCHIVE_CONFIG = {
   ffmpegPath: DEFAULT_ARCHIVE_FFMPEG_PATH,
   cookiesPath: null,
   jsRuntime: DEFAULT_ARCHIVE_JS_RUNTIME,
+  ytDlpExtraArgs: DEFAULT_ARCHIVE_YT_DLP_EXTRA_ARGS,
   maxRetries: DEFAULT_ARCHIVE_MAX_RETRIES,
   budgetReservePercent: DEFAULT_ARCHIVE_BUDGET_RESERVE_PERCENT,
   maxItems: DEFAULT_ARCHIVE_MAX_ITEMS,

--- a/packages/cli/src/service.js
+++ b/packages/cli/src/service.js
@@ -204,6 +204,7 @@ export async function createRelayService({
             ffmpegPath: config.archive.ffmpegPath,
             cookiesPath: config.archive.cookiesPath,
             jsRuntime: config.archive.jsRuntime,
+            ytDlpExtraArgs: config.archive.ytDlpExtraArgs,
             spawnFn: spawnFn || undefined,
             fs: runtimeFsModule,
             path: runtimePathModule
@@ -257,6 +258,7 @@ export async function createRelayService({
           ffmpegPath: config.archive?.ffmpegPath,
           cookiesPath: config.archive?.cookiesPath,
           jsRuntime: config.archive?.jsRuntime,
+          ytDlpExtraArgs: config.archive?.ytDlpExtraArgs,
           spawnFn: spawnFn || undefined,
           fs: runtimeFsModule,
           path: runtimePathModule

--- a/packages/cli/test/archive-ui.test.mjs
+++ b/packages/cli/test/archive-ui.test.mjs
@@ -23,6 +23,7 @@ test('archive UI commands and flags are exposed by the relay CLI', async (t) => 
   t.ok(compose.includes('8174:8174'), 'root relay compose exposes the local archive UI port')
   t.ok(compose.includes('PEARTUBE_ARCHIVE_UI_ENABLED: "true"'), 'compose enables archive UI by default')
   t.ok(compose.includes('PEARTUBE_ARCHIVE_FFMPEG_PATH: /usr/local/bin/ffmpeg'), 'compose configures ffmpeg for yt-dlp archive merging')
+  t.ok(compose.includes('PEARTUBE_ARCHIVE_YT_DLP_EXTRA_ARGS: "--plugin-dirs /usr/local/share/yt-dlp-plugins --extractor-args youtube:player_client=mweb;youtubepot-bgutilcli:cli_path=/usr/local/bin/bgutil-pot"'), 'compose configures the packaged POT plugin directory and CLI provider for archive retries')
   t.ok(compose.includes('PEARTUBE_ARCHIVE_COOKIES_PATH'), 'compose documents optional YouTube cookies path for bot checks')
 })
 
@@ -251,4 +252,38 @@ test('yt-dlp WebUI downloader uses ffmpeg and prefers merged mp4-compatible arch
   t.ok(args.includes('--merge-output-format'), 'merge output stays mp4 when separate streams are selected')
   t.ok(args.includes('--ffmpeg-location'), 'ffmpeg location is passed when configured')
   t.is(args[args.indexOf('--ffmpeg-location') + 1], '/usr/local/bin/ffmpeg')
+})
+
+test('yt-dlp downloader appends configured extra args before the URL', async (t) => {
+  const calls = []
+  const existing = new Set(['/archive/tmp/arch_extra/example.mp4'])
+  const downloader = createYtDlpDownloader({
+    outputDir: '/archive/tmp',
+    ytDlpExtraArgs: ['--extractor-args', 'youtube:player_client=mweb', '--force-ipv4'],
+    fs: {
+      mkdirSync() {},
+      rmSync() {},
+      existsSync(path) { return existing.has(path) }
+    },
+    path: {
+      join(...parts) { return parts.join('/').replace(/\/+/g, '/') }
+    },
+    spawnFn(binary, args) {
+      calls.push({ binary, args })
+      return {
+        stdout: { on(event, cb) { if (event === 'data') cb('filepath\n/archive/tmp/arch_extra/example.mp4\n') } },
+        stderr: { on() {} },
+        on(event, cb) { if (event === 'close') cb(0) }
+      }
+    }
+  })
+
+  await downloader.download({ id: 'arch_extra', url: 'https://www.youtube.com/watch?v=ABbqy1VGeck' })
+
+  const args = calls[0].args
+  const urlIndex = args.indexOf('https://www.youtube.com/watch?v=ABbqy1VGeck')
+  t.ok(urlIndex > 0, 'source URL remains the final positional argument')
+  t.is(args[urlIndex - 3], '--extractor-args')
+  t.is(args[urlIndex - 2], 'youtube:player_client=mweb')
+  t.is(args[urlIndex - 1], '--force-ipv4')
 })

--- a/packages/cli/test/cli.test.mjs
+++ b/packages/cli/test/cli.test.mjs
@@ -154,6 +154,7 @@ test('Dockerfile copies yt-dlp shared libraries required by the distroless runti
   t.ok(content.includes('cp /lib/${archTriplet}/libz.so.1 /runtime-libs/libz.so.1'), 'runtime libs stage stages libz for the final image')
   t.ok(content.includes('cp /lib/${archTriplet}/${loader} /runtime-libs/${loader}'), 'runtime libs stage stages the architecture dynamic loader')
   t.ok(content.includes('COPY --from=runtime-libs /runtime-libs/libz.so.1 /lib/libz.so.1'), 'final image copies libz into the distroless runtime')
+  t.ok(content.includes('COPY --from=runtime-libs /runtime-libs/libc.so.6 /lib/libc.so.6'), 'final image copies libc into the distroless runtime for Python-based yt-dlp plugins')
   t.ok(content.includes('COPY --from=runtime-libs /runtime-libs/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2'), 'final image copies the amd64 dynamic loader path')
   t.ok(content.includes('COPY --from=runtime-libs /runtime-libs/ld-linux-aarch64.so.1 /lib/ld-linux-aarch64.so.1'), 'final image copies the arm64 dynamic loader path')
 })
@@ -185,4 +186,18 @@ test('Dockerfile packages ffmpeg for yt-dlp archive merging', async (t) => {
   t.ok(dockerfile.includes('PEARTUBE_ARCHIVE_FFMPEG_PATH=/usr/local/bin/ffmpeg'), 'final image exposes configured ffmpeg path to archive jobs')
   t.ok(dockerfile.includes('COPY --from=runtime-libs /usr/local/bin/ffmpeg /usr/local/bin/ffmpeg'), 'final image includes ffmpeg executable')
   t.ok(dockerfile.includes('COPY --from=runtime-libs /usr/local/bin/ffprobe /usr/local/bin/ffprobe'), 'final image includes ffprobe executable')
+})
+
+test('Dockerfile packages the yt-dlp POT provider plugin for noninteractive YouTube bot checks', async (t) => {
+  const dockerfile = readFileSync(join(__dirname, '..', 'Dockerfile'), 'utf8')
+
+  t.ok(dockerfile.includes('ARG BGUTIL_POT_PROVIDER_VERSION='), 'Dockerfile pins the bgutil POT provider release')
+  t.ok(dockerfile.includes('BGUTIL_POT_ASSET=bgutil-pot-linux-x86_64'), 'Dockerfile selects the bgutil POT CLI binary for amd64')
+  t.ok(dockerfile.includes('BGUTIL_POT_ASSET=bgutil-pot-linux-aarch64'), 'Dockerfile selects the bgutil POT CLI binary for arm64')
+  t.ok(dockerfile.includes('/usr/local/bin/bgutil-pot --version'), 'Dockerfile validates the bgutil POT CLI binary during image build')
+  t.ok(dockerfile.includes('bgutil-ytdlp-pot-provider-rs.zip'), 'Dockerfile downloads the yt-dlp POT provider plugin archive')
+  t.ok(dockerfile.includes('/usr/local/bin/yt-dlp --plugin-dirs /usr/local/share/yt-dlp-plugins --extractor-args "youtube:player_client=mweb;youtubepot-bgutilcli:cli_path=/usr/local/bin/bgutil-pot"'), 'Dockerfile validates yt-dlp can load the packaged plugin directory')
+  t.ok(dockerfile.includes('ENV PEARTUBE_ARCHIVE_YT_DLP_EXTRA_ARGS="--plugin-dirs /usr/local/share/yt-dlp-plugins --extractor-args youtube:player_client=mweb;youtubepot-bgutilcli:cli_path=/usr/local/bin/bgutil-pot"'), 'final image defaults YouTube archive jobs to the packaged plugin directory and CLI POT provider')
+  t.ok(dockerfile.includes('COPY --from=runtime-libs /usr/local/bin/bgutil-pot /usr/local/bin/bgutil-pot'), 'final image includes the bgutil POT CLI binary')
+  t.ok(dockerfile.includes('COPY --from=runtime-libs /usr/local/share/yt-dlp-plugins /usr/local/share/yt-dlp-plugins'), 'final image includes yt-dlp plugins')
 })

--- a/packages/cli/test/config.test.mjs
+++ b/packages/cli/test/config.test.mjs
@@ -148,3 +148,14 @@ test('resolveRelayConfig reads archive ffmpeg path env var', async (t) => {
 
   t.is(config.archive.ffmpegPath, '/usr/local/bin/ffmpeg')
 })
+
+test('resolveRelayConfig reads archive yt-dlp extra args env var', async (t) => {
+  const config = resolveRelayConfig({}, {
+    env: {
+      PEARTUBE_ARCHIVE_UI_ENABLED: 'true',
+      PEARTUBE_ARCHIVE_YT_DLP_EXTRA_ARGS: '--plugin-dirs /usr/local/share/yt-dlp-plugins --extractor-args youtube:player_client=mweb;youtubepot-bgutilcli:cli_path=/usr/local/bin/bgutil-pot --force-ipv4'
+    }
+  })
+
+  t.alike(config.archive.ytDlpExtraArgs, ['--plugin-dirs', '/usr/local/share/yt-dlp-plugins', '--extractor-args', 'youtube:player_client=mweb;youtubepot-bgutilcli:cli_path=/usr/local/bin/bgutil-pot', '--force-ipv4'])
+})


### PR DESCRIPTION
## Summary
- Package the bgutil yt-dlp POT provider plugin and bgutil-pot CLI in relay Docker images
- Default relay archive yt-dlp runs to load the packaged plugin directory and use the YouTube mweb client with the CLI POT provider
- Add PEARTUBE_ARCHIVE_YT_DLP_EXTRA_ARGS config/env plumbing so we can tune yt-dlp extractor args without another code change

## Notes
- This is the non-login path: no YouTube account credentials, no browser profile, no Camoufox login flow.
- POT support may reduce bot-check/403 failures on flagged hosts, but YouTube can still reject some requests based on IP/session/video/client behavior.
- Cookies remain optional and can still be mounted via PEARTUBE_ARCHIVE_COOKIES_PATH if needed.

## Tests
- git diff --check
- node --test packages/cli/test/archive-ui.test.mjs packages/cli/test/config.test.mjs packages/cli/test/cli.test.mjs packages/cli/test/service.test.mjs
- npm test --prefix packages/cli

## Verification caveat
- Local Docker build could not be run in this environment because docker is not installed. The Dockerfile now validates bgutil-pot and yt-dlp plugin loading during CI/image build.