### PR TITLE
Build bgutil POT provider in relay image

### DIFF
--- a/packages/cli/Dockerfile
+++ b/packages/cli/Dockerfile
@@ -23,7 +23,7 @@ ARG BGUTIL_POT_PROVIDER_VERSION=0.8.1
 ARG RUST_VERSION=1.91.1
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends ca-certificates curl libatomic1 python3 tar xz-utils zlib1g \
+  && apt-get install -y --no-install-recommends ca-certificates curl gcc libatomic1 libc6-dev python3 tar xz-utils zlib1g \
   && rm -rf /var/lib/apt/lists/*
 
 RUN case "${TARGETARCH}" in \

--- a/packages/cli/Dockerfile
+++ b/packages/cli/Dockerfile
@@ -20,7 +20,7 @@ ARG YT_DLP_VERSION=2026.03.17
 ARG DENO_VERSION=v2.5.6
 ARG FFMPEG_VERSION=release
 ARG BGUTIL_POT_PROVIDER_VERSION=0.8.1
-ARG RUST_VERSION=1.85.1
+ARG RUST_VERSION=1.91.1
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates curl libatomic1 python3 tar xz-utils zlib1g \

--- a/packages/cli/Dockerfile
+++ b/packages/cli/Dockerfile
@@ -23,7 +23,7 @@ ARG BGUTIL_POT_PROVIDER_VERSION=0.8.1
 ARG RUST_VERSION=1.91.1
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends ca-certificates curl gcc libatomic1 libc6-dev python3 tar xz-utils zlib1g \
+  && apt-get install -y --no-install-recommends ca-certificates curl gcc libatomic1 libc6-dev libssl-dev pkg-config python3 tar xz-utils zlib1g \
   && rm -rf /var/lib/apt/lists/*
 
 RUN case "${TARGETARCH}" in \

--- a/packages/cli/Dockerfile
+++ b/packages/cli/Dockerfile
@@ -20,9 +20,10 @@ ARG YT_DLP_VERSION=2026.03.17
 ARG DENO_VERSION=v2.5.6
 ARG FFMPEG_VERSION=release
 ARG BGUTIL_POT_PROVIDER_VERSION=0.8.1
+ARG RUST_VERSION=1.85.1
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends ca-certificates cargo curl libatomic1 python3 tar xz-utils zlib1g \
+  && apt-get install -y --no-install-recommends ca-certificates curl libatomic1 python3 tar xz-utils zlib1g \
   && rm -rf /var/lib/apt/lists/*
 
 RUN case "${TARGETARCH}" in \
@@ -34,6 +35,19 @@ RUN case "${TARGETARCH}" in \
     -o /usr/local/bin/yt-dlp \
   && chmod 755 /usr/local/bin/yt-dlp \
   && /usr/local/bin/yt-dlp --version
+
+RUN case "${TARGETARCH}" in \
+    amd64) RUSTUP_ARCH=x86_64-unknown-linux-gnu ;; \
+    arm64) RUSTUP_ARCH=aarch64-unknown-linux-gnu ;; \
+    *) echo "Unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+  esac \
+  && curl -fsSL "https://static.rust-lang.org/rustup/archive/1.28.2/${RUSTUP_ARCH}/rustup-init" \
+    -o /tmp/rustup-init \
+  && chmod 755 /tmp/rustup-init \
+  && /tmp/rustup-init -y --no-modify-path --profile minimal --default-toolchain "${RUST_VERSION}" \
+  && rm -f /tmp/rustup-init
+
+ENV PATH="/root/.cargo/bin:/usr/local/bin:/usr/bin:${PATH}"
 
 RUN cargo install bgutil-ytdlp-pot-provider --version "${BGUTIL_POT_PROVIDER_VERSION}" --locked \
   && cp /usr/local/cargo/bin/bgutil-pot /usr/local/bin/bgutil-pot \

--- a/packages/cli/Dockerfile
+++ b/packages/cli/Dockerfile
@@ -50,7 +50,7 @@ RUN case "${TARGETARCH}" in \
 ENV PATH="/root/.cargo/bin:/usr/local/bin:/usr/bin:${PATH}"
 
 RUN cargo install bgutil-ytdlp-pot-provider --version "${BGUTIL_POT_PROVIDER_VERSION}" --locked \
-  && cp /usr/local/cargo/bin/bgutil-pot /usr/local/bin/bgutil-pot \
+  && cp /root/.cargo/bin/bgutil-pot /usr/local/bin/bgutil-pot \
   && chmod 755 /usr/local/bin/bgutil-pot \
   && /usr/local/bin/bgutil-pot --version
 

--- a/packages/cli/Dockerfile
+++ b/packages/cli/Dockerfile
@@ -19,10 +19,10 @@ ARG TARGETARCH
 ARG YT_DLP_VERSION=2026.03.17
 ARG DENO_VERSION=v2.5.6
 ARG FFMPEG_VERSION=release
-ARG BGUTIL_POT_PROVIDER_VERSION=v0.8.1
+ARG BGUTIL_POT_PROVIDER_VERSION=0.8.1
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends ca-certificates curl libatomic1 python3 tar xz-utils zlib1g \
+  && apt-get install -y --no-install-recommends ca-certificates cargo curl libatomic1 python3 tar xz-utils zlib1g \
   && rm -rf /var/lib/apt/lists/*
 
 RUN case "${TARGETARCH}" in \
@@ -35,18 +35,13 @@ RUN case "${TARGETARCH}" in \
   && chmod 755 /usr/local/bin/yt-dlp \
   && /usr/local/bin/yt-dlp --version
 
-RUN case "${TARGETARCH}" in \
-    amd64) BGUTIL_POT_ASSET=bgutil-pot-linux-x86_64 ;; \
-    arm64) BGUTIL_POT_ASSET=bgutil-pot-linux-aarch64 ;; \
-    *) echo "Unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
-  esac \
-  && curl -fsSL "https://github.com/jim60105/bgutil-ytdlp-pot-provider-rs/releases/download/${BGUTIL_POT_PROVIDER_VERSION}/${BGUTIL_POT_ASSET}" \
-    -o /usr/local/bin/bgutil-pot \
+RUN cargo install bgutil-ytdlp-pot-provider --version "${BGUTIL_POT_PROVIDER_VERSION}" --locked \
+  && cp /usr/local/cargo/bin/bgutil-pot /usr/local/bin/bgutil-pot \
   && chmod 755 /usr/local/bin/bgutil-pot \
   && /usr/local/bin/bgutil-pot --version
 
 RUN mkdir -p /usr/local/share/yt-dlp-plugins \
-  && curl -fsSL "https://github.com/jim60105/bgutil-ytdlp-pot-provider-rs/releases/download/${BGUTIL_POT_PROVIDER_VERSION}/bgutil-ytdlp-pot-provider-rs.zip" \
+  && curl -fsSL "https://github.com/jim60105/bgutil-ytdlp-pot-provider-rs/releases/download/v${BGUTIL_POT_PROVIDER_VERSION}/bgutil-ytdlp-pot-provider-rs.zip" \
     -o /tmp/bgutil-ytdlp-pot-provider-rs.zip \
   && python3 -m zipfile -e /tmp/bgutil-ytdlp-pot-provider-rs.zip /usr/local/share/yt-dlp-plugins \
   && rm -f /tmp/bgutil-ytdlp-pot-provider-rs.zip \

--- a/packages/cli/test/cli.test.mjs
+++ b/packages/cli/test/cli.test.mjs
@@ -103,7 +103,7 @@ test('Dockerfile packages the standalone relay executable in a minimal runtime i
   t.ok(content.includes('FROM busybox:1.36.1 AS artifact'), 'artifact stage selects the prebuilt standalone relay binary')
   t.ok(content.includes('FROM debian:12-slim AS runtime-libs'), 'runtime libs stage installs missing shared libraries for native addons')
   t.ok(content.includes('ARG YT_DLP_VERSION='), 'Dockerfile pins the yt-dlp release version as a build arg')
-  t.ok(content.includes('ca-certificates cargo curl libatomic1'), 'runtime libs stage installs cargo, curl, and CA roots to build/download archive helpers')
+  t.ok(content.includes('ca-certificates curl libatomic1'), 'runtime libs stage installs curl and CA roots to download archive helpers')
   t.ok(content.includes('YT_DLP_ASSET=yt-dlp_linux'), 'runtime libs stage selects the Linux standalone yt-dlp binary for amd64')
   t.ok(content.includes('YT_DLP_ASSET=yt-dlp_linux_aarch64'), 'runtime libs stage selects the Linux standalone yt-dlp binary for arm64')
   t.ok(content.includes('https://github.com/yt-dlp/yt-dlp/releases/download/${YT_DLP_VERSION}/${YT_DLP_ASSET}'), 'runtime libs stage downloads the pinned standalone yt-dlp release asset')
@@ -192,6 +192,8 @@ test('Dockerfile packages the yt-dlp POT provider plugin for noninteractive YouT
   const dockerfile = readFileSync(join(__dirname, '..', 'Dockerfile'), 'utf8')
 
   t.ok(dockerfile.includes('ARG BGUTIL_POT_PROVIDER_VERSION='), 'Dockerfile pins the bgutil POT provider release')
+  t.ok(dockerfile.includes('ARG RUST_VERSION='), 'Dockerfile pins a Rust toolchain that supports edition 2024')
+  t.ok(dockerfile.includes('static.rust-lang.org/rustup/archive'), 'Dockerfile installs Rust with rustup instead of Debian cargo')
   t.ok(dockerfile.includes('cargo install bgutil-ytdlp-pot-provider --version "${BGUTIL_POT_PROVIDER_VERSION}" --locked'), 'Dockerfile builds the bgutil POT CLI against the relay image glibc')
   t.ok(dockerfile.includes('/usr/local/bin/bgutil-pot --version'), 'Dockerfile validates the bgutil POT CLI binary during image build')
   t.ok(dockerfile.includes('bgutil-ytdlp-pot-provider-rs.zip'), 'Dockerfile downloads the yt-dlp POT provider plugin archive')

--- a/packages/cli/test/cli.test.mjs
+++ b/packages/cli/test/cli.test.mjs
@@ -103,7 +103,7 @@ test('Dockerfile packages the standalone relay executable in a minimal runtime i
   t.ok(content.includes('FROM busybox:1.36.1 AS artifact'), 'artifact stage selects the prebuilt standalone relay binary')
   t.ok(content.includes('FROM debian:12-slim AS runtime-libs'), 'runtime libs stage installs missing shared libraries for native addons')
   t.ok(content.includes('ARG YT_DLP_VERSION='), 'Dockerfile pins the yt-dlp release version as a build arg')
-  t.ok(content.includes('ca-certificates curl libatomic1'), 'runtime libs stage installs curl and CA roots to download yt-dlp')
+  t.ok(content.includes('ca-certificates cargo curl libatomic1'), 'runtime libs stage installs cargo, curl, and CA roots to build/download archive helpers')
   t.ok(content.includes('YT_DLP_ASSET=yt-dlp_linux'), 'runtime libs stage selects the Linux standalone yt-dlp binary for amd64')
   t.ok(content.includes('YT_DLP_ASSET=yt-dlp_linux_aarch64'), 'runtime libs stage selects the Linux standalone yt-dlp binary for arm64')
   t.ok(content.includes('https://github.com/yt-dlp/yt-dlp/releases/download/${YT_DLP_VERSION}/${YT_DLP_ASSET}'), 'runtime libs stage downloads the pinned standalone yt-dlp release asset')
@@ -192,8 +192,7 @@ test('Dockerfile packages the yt-dlp POT provider plugin for noninteractive YouT
   const dockerfile = readFileSync(join(__dirname, '..', 'Dockerfile'), 'utf8')
 
   t.ok(dockerfile.includes('ARG BGUTIL_POT_PROVIDER_VERSION='), 'Dockerfile pins the bgutil POT provider release')
-  t.ok(dockerfile.includes('BGUTIL_POT_ASSET=bgutil-pot-linux-x86_64'), 'Dockerfile selects the bgutil POT CLI binary for amd64')
-  t.ok(dockerfile.includes('BGUTIL_POT_ASSET=bgutil-pot-linux-aarch64'), 'Dockerfile selects the bgutil POT CLI binary for arm64')
+  t.ok(dockerfile.includes('cargo install bgutil-ytdlp-pot-provider --version "${BGUTIL_POT_PROVIDER_VERSION}" --locked'), 'Dockerfile builds the bgutil POT CLI against the relay image glibc')
   t.ok(dockerfile.includes('/usr/local/bin/bgutil-pot --version'), 'Dockerfile validates the bgutil POT CLI binary during image build')
   t.ok(dockerfile.includes('bgutil-ytdlp-pot-provider-rs.zip'), 'Dockerfile downloads the yt-dlp POT provider plugin archive')
   t.ok(dockerfile.includes('/usr/local/bin/yt-dlp --plugin-dirs /usr/local/share/yt-dlp-plugins --extractor-args "youtube:player_client=mweb;youtubepot-bgutilcli:cli_path=/usr/local/bin/bgutil-pot"'), 'Dockerfile validates yt-dlp can load the packaged plugin directory')

--- a/packages/cli/test/cli.test.mjs
+++ b/packages/cli/test/cli.test.mjs
@@ -103,7 +103,7 @@ test('Dockerfile packages the standalone relay executable in a minimal runtime i
   t.ok(content.includes('FROM busybox:1.36.1 AS artifact'), 'artifact stage selects the prebuilt standalone relay binary')
   t.ok(content.includes('FROM debian:12-slim AS runtime-libs'), 'runtime libs stage installs missing shared libraries for native addons')
   t.ok(content.includes('ARG YT_DLP_VERSION='), 'Dockerfile pins the yt-dlp release version as a build arg')
-  t.ok(content.includes('ca-certificates curl libatomic1'), 'runtime libs stage installs curl and CA roots to download archive helpers')
+  t.ok(content.includes('ca-certificates curl gcc libatomic1 libc6-dev'), 'runtime libs stage installs curl, CA roots, and C toolchain needed to build archive helpers')
   t.ok(content.includes('YT_DLP_ASSET=yt-dlp_linux'), 'runtime libs stage selects the Linux standalone yt-dlp binary for amd64')
   t.ok(content.includes('YT_DLP_ASSET=yt-dlp_linux_aarch64'), 'runtime libs stage selects the Linux standalone yt-dlp binary for arm64')
   t.ok(content.includes('https://github.com/yt-dlp/yt-dlp/releases/download/${YT_DLP_VERSION}/${YT_DLP_ASSET}'), 'runtime libs stage downloads the pinned standalone yt-dlp release asset')

--- a/packages/cli/test/cli.test.mjs
+++ b/packages/cli/test/cli.test.mjs
@@ -195,6 +195,7 @@ test('Dockerfile packages the yt-dlp POT provider plugin for noninteractive YouT
   t.ok(dockerfile.includes('ARG RUST_VERSION='), 'Dockerfile pins a Rust toolchain that supports edition 2024')
   t.ok(dockerfile.includes('static.rust-lang.org/rustup/archive'), 'Dockerfile installs Rust with rustup instead of Debian cargo')
   t.ok(dockerfile.includes('cargo install bgutil-ytdlp-pot-provider --version "${BGUTIL_POT_PROVIDER_VERSION}" --locked'), 'Dockerfile builds the bgutil POT CLI against the relay image glibc')
+  t.ok(dockerfile.includes('cp /root/.cargo/bin/bgutil-pot /usr/local/bin/bgutil-pot'), 'Dockerfile copies rustup-installed bgutil POT CLI into the runtime path')
   t.ok(dockerfile.includes('/usr/local/bin/bgutil-pot --version'), 'Dockerfile validates the bgutil POT CLI binary during image build')
   t.ok(dockerfile.includes('bgutil-ytdlp-pot-provider-rs.zip'), 'Dockerfile downloads the yt-dlp POT provider plugin archive')
   t.ok(dockerfile.includes('/usr/local/bin/yt-dlp --plugin-dirs /usr/local/share/yt-dlp-plugins --extractor-args "youtube:player_client=mweb;youtubepot-bgutilcli:cli_path=/usr/local/bin/bgutil-pot"'), 'Dockerfile validates yt-dlp can load the packaged plugin directory')

--- a/packages/cli/test/cli.test.mjs
+++ b/packages/cli/test/cli.test.mjs
@@ -103,7 +103,7 @@ test('Dockerfile packages the standalone relay executable in a minimal runtime i
   t.ok(content.includes('FROM busybox:1.36.1 AS artifact'), 'artifact stage selects the prebuilt standalone relay binary')
   t.ok(content.includes('FROM debian:12-slim AS runtime-libs'), 'runtime libs stage installs missing shared libraries for native addons')
   t.ok(content.includes('ARG YT_DLP_VERSION='), 'Dockerfile pins the yt-dlp release version as a build arg')
-  t.ok(content.includes('ca-certificates curl gcc libatomic1 libc6-dev'), 'runtime libs stage installs curl, CA roots, and C toolchain needed to build archive helpers')
+  t.ok(content.includes('ca-certificates curl gcc libatomic1 libc6-dev libssl-dev pkg-config'), 'runtime libs stage installs curl, CA roots, C toolchain, and OpenSSL headers needed to build archive helpers')
   t.ok(content.includes('YT_DLP_ASSET=yt-dlp_linux'), 'runtime libs stage selects the Linux standalone yt-dlp binary for amd64')
   t.ok(content.includes('YT_DLP_ASSET=yt-dlp_linux_aarch64'), 'runtime libs stage selects the Linux standalone yt-dlp binary for arm64')
   t.ok(content.includes('https://github.com/yt-dlp/yt-dlp/releases/download/${YT_DLP_VERSION}/${YT_DLP_ASSET}'), 'runtime libs stage downloads the pinned standalone yt-dlp release asset')


### PR DESCRIPTION
## Summary
- Fix v0.1.45 relay release failure caused by the prebuilt bgutil-pot arm64 binary requiring GLIBC_2.38 on Debian 12
- Build bgutil-ytdlp-pot-provider from crates.io inside the Debian 12 runtime-libs stage so the binary links against the image glibc
- Keep the yt-dlp plugin archive download pinned to the same provider version

## Tests
- git diff --check
- node --test packages/cli/test/cli.test.mjs packages/cli/test/archive-ui.test.mjs packages/cli/test/config.test.mjs
- npm test --prefix packages/cli

## Release failure diagnosed
v0.1.45 release-relay failed in publish-relay on linux/arm64:

/usr/local/bin/bgutil-pot: /lib/aarch64-linux-gnu/libc.so.6: version GLIBC_2.38 not found

This PR removes reliance on that incompatible prebuilt binary.