### PR TITLE
Use Debian 13 runtime for relay bgutil binary

### DIFF
--- a/packages/cli/Dockerfile
+++ b/packages/cli/Dockerfile
@@ -13,7 +13,7 @@ RUN case "${TARGETARCH}" in \
   esac \
   && chmod 755 /peartube-relay
 
-FROM debian:12-slim AS runtime-libs
+FROM debian:13-slim AS runtime-libs
 
 ARG TARGETARCH
 ARG YT_DLP_VERSION=2026.03.17
@@ -94,7 +94,7 @@ RUN mkdir -p /runtime-libs \
   && printf '%s' "${loaderDir}" > /runtime-libs/loader-dir \
   && chmod 755 /runtime-libs/libatomic.so.1 /runtime-libs/libz.so.1 /runtime-libs/libc.so.6 /runtime-libs/ld-linux-x86-64.so.2 /runtime-libs/ld-linux-aarch64.so.1
 
-FROM gcr.io/distroless/cc-debian12
+FROM gcr.io/distroless/cc-debian13
 
 ENV PEARTUBE_MODE=public
 ENV PEARTUBE_POLICY=discovery

--- a/packages/cli/test/cli.test.mjs
+++ b/packages/cli/test/cli.test.mjs
@@ -101,7 +101,7 @@ test('Dockerfile packages the standalone relay executable in a minimal runtime i
   const content = readFileSync(dockerfilePath, 'utf8')
 
   t.ok(content.includes('FROM busybox:1.36.1 AS artifact'), 'artifact stage selects the prebuilt standalone relay binary')
-  t.ok(content.includes('FROM debian:12-slim AS runtime-libs'), 'runtime libs stage installs missing shared libraries for native addons')
+  t.ok(content.includes('FROM debian:13-slim AS runtime-libs'), 'runtime libs stage installs missing shared libraries for native addons')
   t.ok(content.includes('ARG YT_DLP_VERSION='), 'Dockerfile pins the yt-dlp release version as a build arg')
   t.ok(content.includes('ca-certificates curl libatomic1'), 'runtime libs stage installs curl and CA roots to download archive helpers')
   t.ok(content.includes('YT_DLP_ASSET=yt-dlp_linux'), 'runtime libs stage selects the Linux standalone yt-dlp binary for amd64')
@@ -112,7 +112,7 @@ test('Dockerfile packages the standalone relay executable in a minimal runtime i
   t.ok(content.includes('COPY packages/cli/dist/docker/ /dist/'), 'builder stage only packages prebuilt docker artifacts')
   t.ok(content.includes('cp /dist/linux-amd64/peartube-relay /peartube-relay'), 'artifact stage maps Docker amd64 to the prepared standalone binary')
   t.ok(content.includes('cp /dist/linux-arm64/peartube-relay /peartube-relay'), 'artifact stage maps Docker arm64 to the prepared standalone binary')
-  t.ok(content.includes('gcr.io/distroless/cc-debian12'), 'final image uses the distroless C runtime needed by the standalone relay binary')
+  t.ok(content.includes('gcr.io/distroless/cc-debian13'), 'final image uses the distroless C runtime needed by the standalone relay binary and bgutil-pot')
   t.absent(content.includes('npm run build:standalone'), 'Docker build no longer runs bare-build inside the image')
   t.ok(content.includes('COPY --from=artifact'), 'final image copies the packaged artifact from the artifact stage')
   t.ok(content.includes('COPY --from=runtime-libs /runtime-libs/libatomic.so.1 /lib/libatomic.so.1'), 'final image copies libatomic into the runtime rootfs for rocksdb-native')


### PR DESCRIPTION
## Summary
- Move the relay runtime-libs stage to debian:13-slim
- Move the final distroless image to cc-debian13
- Keeps the prebuilt bgutil-pot binary path, but gives it glibc >= 2.38 for arm64

## Why
v0.1.46 relay image failed on arm64 because the prebuilt bgutil-pot binary requires GLIBC_2.38 and debian12 provides older glibc.

## Tests
- git diff --check
- node --test packages/cli/test/cli.test.mjs
- npm test --prefix packages/cli