### PR TITLE
ci: build only arm64 Android release APK

### DIFF
--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        abi: [arm64-v8a, armeabi-v7a, x86_64]
+        abi: [arm64-v8a]
 
     steps:
       - name: Checkout

--- a/packages/app/tests/ci-workflow-split-regression.test.mjs
+++ b/packages/app/tests/ci-workflow-split-regression.test.mjs
@@ -62,6 +62,21 @@ test('build workflows stay separate from publish workflows', () => {
   )
 })
 
+test('tagged Android releases only build the arm64-v8a APK', () => {
+  const releaseAndroid = readFile('.github/workflows/release-android.yml')
+
+  assert.match(
+    releaseAndroid,
+    /abi:\s*\[arm64-v8a\]/,
+    'release-android should only build the arm64-v8a APK for tagged releases',
+  )
+  assert.doesNotMatch(
+    releaseAndroid,
+    /abi:\s*\[[^\]]*(armeabi-v7a|x86|x86_64)/,
+    'release-android should skip armv7 and emulator APK builds for tagged releases',
+  )
+})
+
 test('GitHub Actions references use Node 24-compatible action majors', () => {
   const files = [
     ...fs.readdirSync(path.join(repoRoot, '.github/workflows')).map((name) => `.github/workflows/${name}`),


### PR DESCRIPTION
## Summary
- limit tagged Android release builds to the arm64-v8a APK
- add a regression assertion so release-android does not reintroduce armv7/x86 release APKs

## Test Plan
- `node --test packages/app/tests/ci-workflow-split-regression.test.mjs`
- `git diff --check`
