### PR TITLE
fix(cli): use Invidious direct media fallback

### DIFF
--- a/packages/cli/src/archive-manager.js
+++ b/packages/cli/src/archive-manager.js
@@ -52,13 +52,17 @@ function extractYouTubeVideoId(url) {
   return null
 }
 
-function rewriteToInvidiousUrl(sourceUrl, instance) {
+function buildInvidiousFallbackUrls(sourceUrl, instance) {
   const normalizedInstance = normalizeInvidiousInstance(instance)
-  if (!normalizedInstance) return null
+  if (!normalizedInstance) return []
   const url = parseArchiveUrl(sourceUrl)
   const videoId = extractYouTubeVideoId(url)
-  if (!videoId) return null
-  return `${normalizedInstance}/watch?v=${encodeURIComponent(videoId)}`
+  if (!videoId) return []
+  const encoded = encodeURIComponent(videoId)
+  return [
+    `${normalizedInstance}/latest_version?id=${encoded}&itag=18&local=true`,
+    `${normalizedInstance}/watch?v=${encoded}`
+  ]
 }
 
 function sanitizeName(value) {
@@ -193,11 +197,11 @@ export function createYtDlpDownloader({
         return args
       }
 
-      const invidiousUrl = rewriteToInvidiousUrl(input.url, input.invidiousInstance)
+      const invidiousFallbackUrls = buildInvidiousFallbackUrls(input.url, input.invidiousInstance)
       const attempts = [
         { args: safeArgsArray(ytDlpExtraArgs), url: input.url },
         ...safeArray(ytDlpRetryExtraArgs).map((args) => ({ args: safeArgsArray(args), url: input.url })),
-        ...(invidiousUrl ? [{ args: safeArgsArray(ytDlpExtraArgs), url: invidiousUrl }] : [])
+        ...invidiousFallbackUrls.map((url) => ({ args: [], url }))
       ]
       let stdout = ''
 
@@ -220,7 +224,7 @@ export function createYtDlpDownloader({
           break
         } catch (err) {
           const message = err?.message || String(err)
-          const canRetry = /Sign in to confirm.*not a bot|LOGIN_REQUIRED|HTTP Error 403|Requested format is not available/i.test(message)
+          const canRetry = /Sign in to confirm.*not a bot|LOGIN_REQUIRED|HTTP Error (?:400|403|418|429|500)|Requested format is not available/i.test(message)
           if (!canRetry || attempt === attempts.length - 1) throw err
           fs.rmSync(targetDir, { recursive: true, force: true })
           fs.mkdirSync(targetDir, { recursive: true })

--- a/packages/cli/src/archive-ui.js
+++ b/packages/cli/src/archive-ui.js
@@ -89,7 +89,7 @@ export function renderArchiveWebHome(model = {}) {
     </section>
     <form method="post" action="/archive">
       <label>Video or channel URL<input name="url" required placeholder="https://www.youtube.com/watch?v=..."></label>
-      <label>Invidious fallback instance<input name="invidiousInstance" placeholder="Optional, e.g. https://yewtu.be"><small>Used only if the direct YouTube archive hits a bot-check/403.</small></label>
+      <label>Invidious fallback instance<input name="invidiousInstance" placeholder="Optional, e.g. https://inv.thepixora.com"><small>Used only if direct YouTube archive hits a bot-check/403. The relay tries the instance's direct media endpoint before the watch page.</small></label>
       <label>Anonymous channel name<input name="channelName" value="Anonymous Archive"></label>
       <label>Title override<input name="title" placeholder="Optional"></label>
       <label>Description override<textarea name="description" rows="4" placeholder="Optional"></textarea></label>

--- a/packages/cli/test/archive-ui.test.mjs
+++ b/packages/cli/test/archive-ui.test.mjs
@@ -353,9 +353,49 @@ test('yt-dlp downloader can retry through a UI-provided Invidious instance', asy
   await downloader.download({
     id: 'arch_inv',
     url: 'https://www.youtube.com/shorts/6ZVnOQ8DmFI',
-    invidiousInstance: 'https://yewtu.be/'
+    invidiousInstance: 'https://inv.thepixora.com/'
   })
 
   t.is(calls.length, 2, '403 failure triggers Invidious fallback when configured')
-  t.is(calls[1].args.at(-1), 'https://yewtu.be/watch?v=6ZVnOQ8DmFI')
+  t.is(calls[1].args.at(-1), 'https://inv.thepixora.com/latest_version?id=6ZVnOQ8DmFI&itag=18&local=true')
+  t.absent(calls[1].args.includes('--extractor-args'), 'direct Invidious media fallback does not reuse YouTube extractor args')
+})
+
+test('yt-dlp downloader falls back from Invidious direct media to watch page', async (t) => {
+  const calls = []
+  const existing = new Set(['/archive/tmp/arch_inv_watch/example.mp4'])
+  const downloader = createYtDlpDownloader({
+    outputDir: '/archive/tmp',
+    fs: {
+      mkdirSync() {},
+      rmSync() {},
+      existsSync(path) { return existing.has(path) }
+    },
+    path: {
+      join(...parts) { return parts.join('/').replace(/\/+/g, '/') }
+    },
+    spawnFn(binary, args) {
+      calls.push({ binary, args })
+      const callNumber = calls.length
+      return {
+        stdout: { on(event, cb) { if (event === 'data' && callNumber === 3) cb('filepath\n/archive/tmp/arch_inv_watch/example.mp4\n') } },
+        stderr: { on(event, cb) {
+          if (event !== 'data') return
+          if (callNumber === 1) cb('ERROR: [youtube] 6ZVnOQ8DmFI: Sign in to confirm you’re not a bot')
+          if (callNumber === 2) cb('ERROR: [generic] Unable to download webpage: HTTP Error 400: Bad Request')
+        } },
+        on(event, cb) { if (event === 'close') cb(callNumber === 3 ? 0 : 1) }
+      }
+    }
+  })
+
+  await downloader.download({
+    id: 'arch_inv_watch',
+    url: 'https://youtu.be/6ZVnOQ8DmFI',
+    invidiousInstance: 'inv.thepixora.com'
+  })
+
+  t.is(calls.length, 3, 'direct media failure retries the Invidious watch page')
+  t.is(calls[1].args.at(-1), 'https://inv.thepixora.com/latest_version?id=6ZVnOQ8DmFI&itag=18&local=true')
+  t.is(calls[2].args.at(-1), 'https://inv.thepixora.com/watch?v=6ZVnOQ8DmFI')
 })


### PR DESCRIPTION
## Summary
- Make the Invidious fallback try the direct `/latest_version` media endpoint before the watch page
- Do not reuse YouTube-specific extractor args on Invidious fallback attempts
- Retry more transient Invidious/public-instance HTTP failures so the fallback can proceed to the next URL
- Update the archive UI hint to point at a currently responsive instance example

## Test Plan
- `git diff --check`
- `node --test packages/cli/test/archive-ui.test.mjs`
- `npm test --prefix packages/cli`

## Notes
The prior fallback only passed an Invidious watch page to yt-dlp, which still routes through generic extraction and can fail before reaching a playable media URL. The direct media endpoint is a better first fallback for single-video archive jobs.
