### PR TITLE
refactor(backend): centralize blob playback URL resolution

### DIFF
--- a/packages/app/tests/playback-url-instant-regression.test.mjs
+++ b/packages/app/tests/playback-url-instant-regression.test.mjs
@@ -3,45 +3,43 @@ import { readFile } from 'node:fs/promises'
 import { test } from 'node:test'
 
 const apiPath = new URL('../../backend/src/api.js', import.meta.url)
-const storagePath = new URL('../../backend/src/storage.js', import.meta.url)
+const servicePath = new URL('../../backend/src/blob-playback-service.js', import.meta.url)
 
 async function source(url) {
   return readFile(url, 'utf8')
 }
 
-test('preparePlayback/getVideoUrl uses instant blob URLs when blob keys are already known', async () => {
+test('preparePlayback/getVideoUrl delegates known blob refs to the instant playback service', async () => {
   const src = await source(apiPath)
 
   const directBlobKeyStart = src.indexOf('if (blobId && blobsCoreKey)')
   assert.notEqual(directBlobKeyStart, -1, 'expected direct blobId/blobsCoreKey fast path')
   const directBlobKeyBlock = src.slice(directBlobKeyStart, src.indexOf('const meta = await this.getVideoData', directBlobKeyStart))
-  assert.match(directBlobKeyBlock, /instant:\s*true/, 'direct blobId/blobsCoreKey playback must not wait on peer discovery before returning a URL')
+  assert.match(directBlobKeyBlock, /blobPlayback\.resolveDirectBlobUrl\(\{[\s\S]*blobsCoreKey,[\s\S]*blobId,/, 'direct blobId/blobsCoreKey playback must delegate to the instant playback service')
 
-  const publicBeeKeyStart = src.indexOf('if (meta.blobsCoreKey)')
-  assert.notEqual(publicBeeKeyStart, -1, 'expected publicBee blobsCoreKey fast path')
-  const publicBeeKeyBlock = src.slice(publicBeeKeyStart, src.indexOf('// Fallback: load channel', publicBeeKeyStart))
-  assert.match(publicBeeKeyBlock, /instant:\s*true/, 'publicBee blobsCoreKey playback must not wait on peer discovery before returning a URL')
+  const metaStart = src.indexOf('return blobPlayback.resolveFromMetadata(meta')
+  assert.notEqual(metaStart, -1, 'expected metadata playback fallback to use playback service')
 })
 
-test('fallback channel blob-entry playback also returns an instant blob URL', async () => {
-  const src = await source(apiPath)
-  const fallbackStart = src.indexOf('// Fallback: load channel to get blob entry')
-  assert.notEqual(fallbackStart, -1, 'expected fallback blob-entry path')
-  const fallbackBlock = src.slice(fallbackStart, src.indexOf('},\n\n    /**\n     * Prepare normal watch playback', fallbackStart))
+test('fallback channel blob-entry playback is centralized in the playback service', async () => {
+  const src = await source(servicePath)
+  const fallbackStart = src.indexOf('async resolveFromMetadata')
+  assert.notEqual(fallbackStart, -1, 'expected metadata resolver')
+  const fallbackBlock = src.slice(fallbackStart, src.indexOf('async preparePlayback', fallbackStart))
 
   assert.match(fallbackBlock, /const blobEntry = await channel\.getBlobEntry\(meta\)/, 'expected fallback to resolve blob entry from channel metadata')
-  assert.match(fallbackBlock, /getVideoUrlFromBlob\(ctx, blobsKeyHex, blobEntry\.blobId, \{[\s\S]*instant:\s*true/, 'fallback blob-entry path should not wait on core update once it has blob coordinates')
+  assert.match(fallbackBlock, /return this\.resolveDirectBlobUrl\(\{[\s\S]*blobsCoreKey,[\s\S]*blobId,/, 'fallback blob-entry path should use the centralized instant URL generator')
 })
 
 test('instant blob URL path generates the blob-server link before background core readiness/update', async () => {
-  const src = await source(storagePath)
-  const start = src.indexOf('function getVideoUrlInstant')
-  assert.notEqual(start, -1, 'expected getVideoUrlInstant helper')
-  const block = src.slice(start, src.indexOf('export async function getVideoUrlFromBlob', start))
+  const src = await source(servicePath)
+  const start = src.indexOf('resolveDirectBlobUrl')
+  assert.notEqual(start, -1, 'expected resolveDirectBlobUrl helper')
+  const block = src.slice(start, src.indexOf('return { url }', start))
 
   const linkIndex = block.indexOf('ctx.blobServer.getLink')
-  const readyIndex = block.indexOf('blobsCore.ready().then')
+  const warmIndex = block.indexOf('this.warmDirectBlobRef')
   assert.notEqual(linkIndex, -1, 'instant path must generate a blob URL')
-  assert.notEqual(readyIndex, -1, 'instant path should still kick off background sync')
-  assert.ok(linkIndex < readyIndex, 'instant path must return URL generation before background core ready/update work')
+  assert.notEqual(warmIndex, -1, 'instant path should still kick off background sync')
+  assert.ok(linkIndex < warmIndex, 'instant path must generate the URL before background core ready/update work')
 })

--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -10,7 +10,8 @@ import crypto from 'hypercore-crypto';
 import HypercoreID from 'hypercore-id-encoding';
 import z32 from 'z32';
 import c from 'compact-encoding';
-import { getVideoUrlFromBlob, loadChannel as storageLoadChannel, loadPublicBee as storageLoadPublicBee, pairDevice as pairChannelDevice, retainSwarmDiscovery, suspendNetworking, resumeNetworking, getNetworkStats, getNetworkStatsReadable } from './storage.js';
+import { getVideoUrlFromBlob, loadChannel as storageLoadChannel, loadPublicBee as storageLoadPublicBee, pairDevice as pairChannelDevice, suspendNetworking, resumeNetworking, getNetworkStats, getNetworkStatsReadable } from './storage.js';
+import { createBlobPlaybackService } from './blob-playback-service.js';
 import { SemanticFinder } from './search/semantic-finder.js';
 import { FederatedSearch } from './search/federated-search.js';
 import { Recommender } from './recommendations/recommender.js';
@@ -43,6 +44,8 @@ export function createApi({
   loadChannel = storageLoadChannel,
   loadPublicBee = storageLoadPublicBee,
 }) {
+  const blobPlayback = createBlobPlaybackService(ctx)
+
   async function isMultiWriterChannelKey(channelKey) {
     try {
       const res = await ctx.metaDb.get(`mw-channel:${channelKey}`)
@@ -806,94 +809,26 @@ export function createApi({
     async getVideoUrl(driveKey, videoPath, publicBeeKey, blobId, blobsCoreKey, mimeType) {
       console.log('[API] getVideoUrl:', driveKey?.slice(0, 16), videoPath);
 
-      // INSTANT PATH: If we already have blobId and blobsCoreKey, skip metadata fetch entirely
+      // INSTANT PATH: If we already have blobId and blobsCoreKey, skip metadata fetch entirely.
       if (blobId && blobsCoreKey) {
         console.log('[API] getVideoUrl: INSTANT - using direct blobId/blobsCoreKey');
-
-        // Join swarm in background (don't wait)
-        if (ctx.swarm) {
-          try {
-            const keyBuf = b4a.from(blobsCoreKey, 'hex')
-            const discoveryKey = crypto.discoveryKey(keyBuf)
-            retainSwarmDiscovery(ctx, discoveryKey, {
-              label: `blobs:${String(blobsCoreKey).slice(0, 16)}`
-            })
-          } catch { /* best effort */ }
-        }
-
-        // Return URL instantly
-        return getVideoUrlFromBlob(ctx, blobsCoreKey, blobId, {
+        return blobPlayback.resolveDirectBlobUrl({
+          blobsCoreKey,
+          blobId,
           mimeType: mimeType || 'video/mp4',
-          instant: true
         })
       }
 
       const meta = await this.getVideoData(driveKey, videoPath, publicBeeKey)
       console.log('[API] getVideoUrl meta:', meta?.id, 'blobId:', meta?.blobId, 'blobsCoreKey:', meta?.blobsCoreKey?.slice(0, 16))
-      if (!meta) {
-        console.log('[API] getVideoUrl: no metadata found');
-        throw new Error('Video metadata not found')
+
+      let channel = null
+      if (meta?.blobId && !meta?.blobsCoreKey) {
+        console.log('[API] getVideoUrl: loading channel for blob entry (slow path)')
+        channel = await loadChannel(ctx, driveKey)
       }
 
-      if (!meta.blobId) {
-        console.log('[API] getVideoUrl: missing blobId');
-        throw new Error('Video is missing blobId (not synced yet)')
-      }
-
-      // Fast path: if we have blobsCoreKey from PublicBee, use it directly
-      // Use instant mode for zero-wait URL generation - blob server fetches on-demand
-      if (meta.blobsCoreKey) {
-        console.log('[API] getVideoUrl: INSTANT mode - generating URL immediately');
-        const blobsKeyHex = meta.blobsCoreKey;
-
-        // Join swarm in background (don't wait)
-        if (ctx.swarm) {
-          try {
-            const keyBuf = b4a.from(blobsKeyHex, 'hex')
-            const discoveryKey = crypto.discoveryKey(keyBuf)
-            retainSwarmDiscovery(ctx, discoveryKey, {
-              label: `blobs:${String(blobsKeyHex).slice(0, 16)}`
-            })
-          } catch { /* best effort */ }
-        }
-
-        // Return URL instantly - blob server handles fetching
-        return getVideoUrlFromBlob(ctx, blobsKeyHex, meta.blobId, {
-          mimeType: meta.mimeType,
-          instant: true
-        })
-      }
-
-      // Fallback: load channel to get blob entry (slower)
-      console.log('[API] getVideoUrl: loading channel for blob entry (slow path)');
-      const channel = await loadChannel(ctx, driveKey)
-      if (!channel) {
-        console.log('[API] getVideoUrl: failed to load channel');
-        throw new Error('Failed to load channel')
-      }
-
-      const blobEntry = await channel.getBlobEntry(meta)
-      if (!blobEntry?.blobsKey) {
-        console.log('[API] getVideoUrl: failed to get blob entry');
-        throw new Error('Video blob not accessible (not synced yet)')
-      }
-
-      const blobsKeyHex = b4a.toString(blobEntry.blobsKey, 'hex')
-
-      // Join swarm for blobs core to ensure we can download from peers
-      if (ctx.swarm && blobEntry.blobsKey) {
-        try {
-          const discoveryKey = crypto.discoveryKey(blobEntry.blobsKey)
-          retainSwarmDiscovery(ctx, discoveryKey, {
-            label: `blobs:${blobsKeyHex.slice(0, 16)}`
-          })
-        } catch { /* best effort */ }
-      }
-      console.log('[API] getVideoUrl: blobsKey:', blobsKeyHex.slice(0, 16), 'blobId:', meta.blobId);
-      return getVideoUrlFromBlob(ctx, blobsKeyHex, blobEntry.blobId, {
-        mimeType: meta.mimeType,
-        instant: true
-      })
+      return blobPlayback.resolveFromMetadata(meta, { channel })
     },
 
     /**
@@ -910,35 +845,17 @@ export function createApi({
     async preparePlayback(driveKey, videoPath, publicBeeKey, blobId, blobsCoreKey, mimeType) {
       console.log('[API] preparePlayback:', driveKey?.slice(0, 16), videoPath)
 
-      let warmupStarted = true
-
-      try {
-        Promise.resolve(this.prefetchVideo(driveKey, videoPath, publicBeeKey)).catch((err) => {
-          warmupStarted = false
-          console.log('[API] preparePlayback warmup failed:', err?.message || err)
-        })
-      } catch (err) {
-        warmupStarted = false
-        console.log('[API] preparePlayback warmup failed:', err?.message || err)
-      }
-
-      const result = await this.getVideoUrl(
+      return blobPlayback.preparePlayback({
         driveKey,
         videoPath,
         publicBeeKey,
         blobId,
         blobsCoreKey,
-        mimeType
-      )
-
-      // Allow immediate async warmup failures to settle without waiting for the warmup itself.
-      await Promise.resolve()
-
-      return {
-        url: result.url,
-        stats: this.getVideoStats(driveKey, videoPath),
-        warmupStarted,
-      }
+        mimeType,
+        warmup: (...args) => this.prefetchVideo(...args),
+        resolveUrl: (...args) => this.getVideoUrl(...args),
+        getStats: (...args) => this.getVideoStats(...args),
+      })
     },
 
     /**

--- a/packages/backend/src/blob-playback-service.js
+++ b/packages/backend/src/blob-playback-service.js
@@ -1,0 +1,122 @@
+import b4a from 'b4a'
+
+import { normalizeBlobRefInput, parseBlobRef } from './blob-ref.js'
+import { retainSwarmDiscovery } from './storage.js'
+
+export class BlobPlaybackService {
+  constructor({ ctx }) {
+    this.ctx = ctx
+  }
+
+  resolveDirectBlobUrl({ blobsCoreKey, blobId, mimeType = 'video/mp4' }) {
+    const ctx = this.ctx
+    const ref = parseBlobRef({ blobsCoreKey, blobId, mimeType })
+    if (!ref) {
+      if (!blobsCoreKey || String(blobsCoreKey).length !== 64) {
+        throw new Error('Invalid blobsCoreKeyHex')
+      }
+      throw new Error('Invalid blob ID format')
+    }
+
+    if (!ctx.blobServer) {
+      throw new Error('BlobServer not initialized')
+    }
+
+    const keyBuffer = b4a.from(ref.blobsCoreKey, 'hex')
+    const url = ctx.blobServer.getLink(keyBuffer, {
+      blob: ref.blob,
+      type: ref.mimeType || mimeType || 'video/mp4',
+      host: ctx.blobServerHost || '127.0.0.1',
+      port: ctx.blobServer?.port || ctx.blobServerPort,
+    })
+
+    this.warmDirectBlobRef(ref.blobsCoreKey, keyBuffer)
+
+    return { url }
+  }
+
+  warmDirectBlobRef(blobsCoreKey, keyBuffer = b4a.from(blobsCoreKey, 'hex')) {
+    const ctx = this.ctx
+    if (!ctx.store) return
+
+    try {
+      const blobsCore = ctx.store.get(keyBuffer)
+      blobsCore.ready().then(() => {
+        if (ctx.swarm && blobsCore.discoveryKey) {
+          try {
+            retainSwarmDiscovery(ctx, blobsCore.discoveryKey, {
+              label: `blobs:${String(blobsCoreKey).slice(0, 16)}`,
+            })
+          } catch { /* best effort */ }
+        }
+        blobsCore.update().catch(() => {})
+      }).catch(() => {})
+    } catch { /* best effort */ }
+  }
+
+  async resolveFromMetadata(meta, { channel } = {}) {
+    if (!meta) {
+      throw new Error('Video metadata not found')
+    }
+    if (!meta.blobId) {
+      throw new Error('Video is missing blobId (not synced yet)')
+    }
+
+    const directRef = parseBlobRef(meta)
+    if (directRef) {
+      return this.resolveDirectBlobUrl(directRef)
+    }
+
+    if (!channel || typeof channel.getBlobEntry !== 'function') {
+      throw new Error('Failed to load channel')
+    }
+
+    const blobEntry = await channel.getBlobEntry(meta)
+    if (!blobEntry?.blobsKey) {
+      throw new Error('Video blob not accessible (not synced yet)')
+    }
+
+    const blobsCoreKey = b4a.toString(blobEntry.blobsKey, 'hex')
+    const blobId = normalizeBlobRefInput(blobEntry.blobId) || normalizeBlobRefInput(meta.blobId)
+    return this.resolveDirectBlobUrl({
+      blobsCoreKey,
+      blobId,
+      mimeType: meta.mimeType || 'video/mp4',
+    })
+  }
+
+  async preparePlayback({
+    driveKey,
+    videoPath,
+    publicBeeKey,
+    blobId,
+    blobsCoreKey,
+    mimeType,
+    resolveUrl,
+    warmup,
+    getStats,
+  }) {
+    let warmupStarted = true
+
+    try {
+      await Promise.resolve(warmup?.(driveKey, videoPath, publicBeeKey))
+    } catch (err) {
+      warmupStarted = false
+      console.log('[BlobPlaybackService] preparePlayback warmup failed:', err?.message || err)
+    }
+
+    const result = resolveUrl
+      ? await resolveUrl(driveKey, videoPath, publicBeeKey, blobId, blobsCoreKey, mimeType)
+      : this.resolveDirectBlobUrl({ blobsCoreKey, blobId, mimeType })
+
+    return {
+      url: result.url,
+      stats: typeof getStats === 'function' ? getStats(driveKey, videoPath) : undefined,
+      warmupStarted,
+    }
+  }
+}
+
+export function createBlobPlaybackService(ctx) {
+  return new BlobPlaybackService({ ctx })
+}

--- a/packages/backend/test/playback-service.test.mjs
+++ b/packages/backend/test/playback-service.test.mjs
@@ -1,0 +1,119 @@
+import test from 'brittle'
+
+import { BlobPlaybackService } from '../src/blob-playback-service.js'
+
+const VALID_KEY = 'a'.repeat(64)
+const VALID_BLOB = '1:2:3:4'
+
+function createCtx() {
+  const calls = []
+  const core = {
+    discoveryKey: Buffer.from('discovery-key'),
+    async ready() {
+      calls.push(['ready'])
+    },
+    async update() {
+      calls.push(['update'])
+    },
+  }
+  return {
+    calls,
+    ctx: {
+      blobServerHost: '127.0.0.1',
+      blobServerPort: 1234,
+      blobServer: {
+        port: 4321,
+        getLink(key, options) {
+          calls.push(['getLink', key.toString('hex'), options])
+          return `http://${options.host}:${options.port}/blob.mp4?token=secret`
+        },
+      },
+      store: {
+        get(key) {
+          calls.push(['store.get', key.toString('hex')])
+          return core
+        },
+      },
+      swarm: {},
+    },
+  }
+}
+
+test('direct blob refs return a URL before background warmup settles', async (t) => {
+  const { ctx, calls } = createCtx()
+  const service = new BlobPlaybackService({ ctx })
+
+  const result = service.resolveDirectBlobUrl({
+    blobsCoreKey: VALID_KEY,
+    blobId: VALID_BLOB,
+    mimeType: 'video/mp4',
+  })
+
+  t.alike(result, { url: 'http://127.0.0.1:4321/blob.mp4?token=secret' })
+  t.is(calls[0][0], 'getLink')
+  t.is(calls[1][0], 'store.get')
+
+  await Promise.resolve()
+  await Promise.resolve()
+  t.ok(calls.some((call) => call[0] === 'ready'))
+})
+
+test('metadata fallback resolves direct refs when metadata includes blobsCoreKey', async (t) => {
+  const { ctx, calls } = createCtx()
+  const service = new BlobPlaybackService({ ctx })
+
+  const result = await service.resolveFromMetadata({
+    id: 'videos/demo.mp4',
+    blobId: VALID_BLOB,
+    blobsCoreKey: VALID_KEY.toUpperCase(),
+    mimeType: 'video/webm',
+  })
+
+  t.is(result.url, 'http://127.0.0.1:4321/blob.mp4?token=secret')
+  t.alike(calls[0][2].blob, { blockOffset: 1, blockLength: 2, byteOffset: 3, byteLength: 4 })
+  t.is(calls[0][2].type, 'video/webm')
+})
+
+test('channel metadata fallback uses getBlobEntry without blocking on prefetch warmup', async (t) => {
+  const { ctx } = createCtx()
+  const service = new BlobPlaybackService({ ctx })
+  const seen = []
+  const channel = {
+    async getBlobEntry(meta) {
+      seen.push(meta.id)
+      return {
+        blobsKey: Buffer.from(VALID_KEY, 'hex'),
+        blobId: VALID_BLOB,
+      }
+    },
+  }
+
+  const result = await service.resolveFromMetadata({ id: 'legacy-video', blobId: VALID_BLOB }, { channel })
+
+  t.is(result.url, 'http://127.0.0.1:4321/blob.mp4?token=secret')
+  t.alike(seen, ['legacy-video'])
+})
+
+test('preparePlayback starts warmup best-effort and still returns URL when warmup rejects', async (t) => {
+  const { ctx } = createCtx()
+  const service = new BlobPlaybackService({ ctx })
+  const result = await service.preparePlayback({
+    driveKey: 'channel-key',
+    videoPath: 'videos/demo.mp4',
+    publicBeeKey: 'public-bee-key',
+    blobId: VALID_BLOB,
+    blobsCoreKey: VALID_KEY,
+    mimeType: 'video/mp4',
+    getStats: () => ({ progress: 0 }),
+    warmup: async () => {
+      throw new Error('warmup failed')
+    },
+  })
+
+  t.alike(result, {
+    url: 'http://127.0.0.1:4321/blob.mp4?token=secret',
+    stats: { progress: 0 },
+    warmupStarted: false,
+  })
+}
+)


### PR DESCRIPTION
## Summary
- add a focused backend `BlobPlaybackService` for direct blob URL generation, metadata fallback, and best-effort warmup
- route `getVideoUrl` and `preparePlayback` through the service while preserving instant known-blob URL behavior
- update playback URL regressions and add service-level coverage for direct refs, metadata fallback, channel blob-entry fallback, and warmup failures

## Test Plan
- `node --test packages/app/tests/playback-url-instant-regression.test.mjs packages/app/tests/vertical-discovery-regression.test.mjs`
- `node packages/backend/test/playback-api.test.mjs`
- `node packages/backend/test/playback-service.test.mjs`
- `git diff --check`

Closes #70
