### PR TITLE
fix(cli): reject bogus Invidious archive outputs

### DIFF
--- a/packages/cli/src/archive-manager.js
+++ b/packages/cli/src/archive-manager.js
@@ -65,6 +65,21 @@ function buildInvidiousFallbackUrls(sourceUrl, instance) {
   ]
 }
 
+function parseReportedFilePath(stdout) {
+  const lines = String(stdout || '').trim().split(/\r?\n/).map((line) => line.trim()).filter(Boolean)
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    const line = lines[i]
+    if (line === 'filepath') continue
+    if (line.startsWith('filepath ')) return line.slice('filepath '.length).trim()
+    return line
+  }
+  return null
+}
+
+function isSupportedArchiveVideoPath(filePath) {
+  return /\.(mp4|m4v|mov|webm|mkv)$/i.test(String(filePath || '').split('?')[0])
+}
+
 function sanitizeName(value) {
   const name = String(value || '').trim()
   return name || 'Anonymous Archive'
@@ -199,11 +214,12 @@ export function createYtDlpDownloader({
 
       const invidiousFallbackUrls = buildInvidiousFallbackUrls(input.url, input.invidiousInstance)
       const attempts = [
-        { args: safeArgsArray(ytDlpExtraArgs), url: input.url },
-        ...safeArray(ytDlpRetryExtraArgs).map((args) => ({ args: safeArgsArray(args), url: input.url })),
-        ...invidiousFallbackUrls.map((url) => ({ args: [], url }))
+        { args: safeArgsArray(ytDlpExtraArgs), url: input.url, allowUnknownExtension: false },
+        ...safeArray(ytDlpRetryExtraArgs).map((args) => ({ args: safeArgsArray(args), url: input.url, allowUnknownExtension: false })),
+        ...invidiousFallbackUrls.map((url) => ({ args: [], url, allowUnknownExtension: false }))
       ]
       let stdout = ''
+      let filePath = null
 
       for (let attempt = 0; attempt < attempts.length; attempt += 1) {
         const args = buildArgs(attempts[attempt].args, attempts[attempt].url)
@@ -221,28 +237,21 @@ export function createYtDlpDownloader({
             })
           })
           stdout = result.stdout
+          filePath = parseReportedFilePath(stdout)
+          if (!filePath) throw new Error('yt-dlp did not report an output file')
+          if (!attempts[attempt].allowUnknownExtension && !isSupportedArchiveVideoPath(filePath)) {
+            throw new Error(`yt-dlp reported unsupported archive output file: ${filePath}`)
+          }
           break
         } catch (err) {
           const message = err?.message || String(err)
-          const canRetry = /Sign in to confirm.*not a bot|LOGIN_REQUIRED|HTTP Error (?:400|403|418|429|500)|Requested format is not available/i.test(message)
+          const canRetry = /Sign in to confirm.*not a bot|LOGIN_REQUIRED|HTTP Error (?:400|403|418|429|500)|Requested format is not available|unsupported archive output file/i.test(message)
           if (!canRetry || attempt === attempts.length - 1) throw err
           fs.rmSync(targetDir, { recursive: true, force: true })
           fs.mkdirSync(targetDir, { recursive: true })
         }
       }
 
-      const lines = stdout.trim().split(/\r?\n/).map((line) => line.trim()).filter(Boolean)
-      let filePath = null
-      for (let i = lines.length - 1; i >= 0; i -= 1) {
-        const line = lines[i]
-        if (line === 'filepath') continue
-        if (line.startsWith('filepath ')) {
-          filePath = line.slice('filepath '.length).trim()
-          break
-        }
-        filePath = line
-        break
-      }
       if (!filePath) throw new Error('yt-dlp did not report an output file')
       if (typeof fs.existsSync === 'function' && !fs.existsSync(filePath)) {
         throw new Error(`yt-dlp reported output file does not exist: ${filePath}`)

--- a/packages/cli/test/archive-ui.test.mjs
+++ b/packages/cli/test/archive-ui.test.mjs
@@ -399,3 +399,45 @@ test('yt-dlp downloader falls back from Invidious direct media to watch page', a
   t.is(calls[1].args.at(-1), 'https://inv.thepixora.com/latest_version?id=6ZVnOQ8DmFI&itag=18&local=true')
   t.is(calls[2].args.at(-1), 'https://inv.thepixora.com/watch?v=6ZVnOQ8DmFI')
 })
+
+test('yt-dlp downloader rejects bogus direct Invidious output and continues fallback attempts', async (t) => {
+  const calls = []
+  const existing = new Set(['/archive/tmp/arch_inv_bogus/example.mp4'])
+  const downloader = createYtDlpDownloader({
+    outputDir: '/archive/tmp',
+    fs: {
+      mkdirSync() {},
+      rmSync() {},
+      existsSync(path) { return existing.has(path) }
+    },
+    path: {
+      join(...parts) { return parts.join('/').replace(/\/+/g, '/') }
+    },
+    spawnFn(binary, args) {
+      calls.push({ binary, args })
+      const callNumber = calls.length
+      return {
+        stdout: { on(event, cb) {
+          if (event !== 'data') return
+          if (callNumber === 2) cb('filepath\n/archive/tmp/arch_inv_bogus/latest_version [latest_version？id=6ZVnOQ8DmFI&itag=18&local=true].unknown_video\n')
+          if (callNumber === 3) cb('filepath\n/archive/tmp/arch_inv_bogus/example.mp4\n')
+        } },
+        stderr: { on(event, cb) {
+          if (event === 'data' && callNumber === 1) cb('ERROR: [youtube] 6ZVnOQ8DmFI: HTTP Error 403: Forbidden')
+        } },
+        on(event, cb) { if (event === 'close') cb(callNumber === 1 ? 1 : 0) }
+      }
+    }
+  })
+
+  const result = await downloader.download({
+    id: 'arch_inv_bogus',
+    url: 'https://www.youtube.com/watch?v=6ZVnOQ8DmFI',
+    invidiousInstance: 'https://invidious.projectsegfau.lt/'
+  })
+
+  t.is(result.filePath, '/archive/tmp/arch_inv_bogus/example.mp4')
+  t.is(calls.length, 3, 'bogus .unknown_video direct media result retries the watch page')
+  t.is(calls[1].args.at(-1), 'https://invidious.projectsegfau.lt/latest_version?id=6ZVnOQ8DmFI&itag=18&local=true')
+  t.is(calls[2].args.at(-1), 'https://invidious.projectsegfau.lt/watch?v=6ZVnOQ8DmFI')
+})


### PR DESCRIPTION
## Summary
- Reject unsupported archive output extensions from yt-dlp fallback attempts, including bogus `.unknown_video` files returned by dead/shutdown Invidious instances
- Continue to the next fallback URL instead of importing garbage when a public Invidious endpoint returns a false-positive "successful" download
- Add regression coverage for the shutdown-instance behavior observed during live probing

## Test Plan
- `git diff --check`
- `node --test packages/cli/test/archive-ui.test.mjs`
- `npm test --prefix packages/cli`

## Notes
This is the follow-up that was accidentally pushed after PR #104 had already merged. It is now based on current `origin/main` as a separate PR.
