### PR TITLE
refactor(app): extract vertical Discover feed controller

### DIFF
--- a/packages/app/app/(tabs)/discover.tsx
+++ b/packages/app/app/(tabs)/discover.tsx
@@ -25,7 +25,14 @@ import { useApp } from '../_layout'
 import { usePlatform } from '@/lib/PlatformProvider'
 import { colors } from '@/lib/colors'
 import { fetchThumbnailUrlWithRetry } from '@/lib/thumbnail'
-import { getFeedPreviewVideos, getVisibleSeededFeedEntries, shouldRenderFeedVideo } from '@/lib/feed-hydration'
+import {
+  clearHydratedFeedChannels,
+  getVerticalFeedPreviewVideos,
+  mapHydratedVerticalFeedVideos,
+  mergeUniqueFeedVideos,
+  warmNextPlaybackUrls,
+  withFeedTimeout,
+} from '@/lib/discover-feed-controller'
 import { getCachedVideoUrl, makeVideoUrlCacheKey, setCachedVideoUrl } from '@/lib/video-url-cache'
 import { formatTimeAgo } from '@/lib/formatters'
 import { VerticalShortsPlayer } from '@/components/discovery/VerticalShortsPlayer'
@@ -50,13 +57,6 @@ interface FeedEntry {
     thumbnailBlobsCoreKey?: string | null
     thumbnailMimeType?: string | null
   }>
-}
-
-function withTimeout<T>(promise: Promise<T>, ms: number, fallback: T): Promise<T> {
-  return Promise.race([
-    promise,
-    new Promise<T>((resolve) => setTimeout(() => resolve(fallback), ms)),
-  ])
 }
 
 function getVideoRef(video: VideoData) {
@@ -160,30 +160,14 @@ export default function VerticalDiscoveryScreen() {
   }, [blobServerPort, rpc, thumbnailCache])
 
   const seedFromFeedEntries = useCallback((entries: FeedEntry[]) => {
-    const visibleEntries = getVisibleSeededFeedEntries(entries as any)
-    const previewVideos = getFeedPreviewVideos(visibleEntries as any, {
+    const renderable = getVerticalFeedPreviewVideos(entries as any, {
       identityDriveKey: identity?.driveKey || undefined,
       channelMeta: {},
+      limit: 40,
     }) as VideoData[]
 
-    const renderable = previewVideos
-      .filter((video) => shouldRenderFeedVideo({
-        video,
-        identityDriveKey: identity?.driveKey || undefined,
-      }))
-      .slice(0, 40)
-
     if (renderable.length > 0) {
-      setVideos((prev) => {
-        const seen = new Set<string>()
-        const merged = [...prev, ...renderable].filter((video) => {
-          const key = `${video.channelKey}:${video.id}`
-          if (seen.has(key)) return false
-          seen.add(key)
-          return true
-        })
-        return merged
-      })
+      setVideos((prev) => mergeUniqueFeedVideos(prev, renderable, 80))
       void fetchThumbnailsForVideos(renderable)
     }
   }, [fetchThumbnailsForVideos, identity?.driveKey])
@@ -195,7 +179,7 @@ export default function VerticalDiscoveryScreen() {
 
     try {
       const timeoutToken = Symbol('vertical-channel-timeout')
-      const result = await withTimeout(
+      const result = await withFeedTimeout(
         rpc.listVideos({ channelKey, publicBeeKey: entry.publicBeeKey || undefined }),
         3500,
         timeoutToken as any,
@@ -203,24 +187,12 @@ export default function VerticalDiscoveryScreen() {
       if (result === timeoutToken) return
       hydratedChannelsRef.current.add(channelKey)
       const channelVideos = Array.isArray((result as any)?.videos) ? (result as any).videos : []
-      const mapped = channelVideos
-        .filter((video: any) => shouldRenderFeedVideo({
-          video: { ...video, channelKey },
-          identityDriveKey: identity?.driveKey || undefined,
-        }))
-        .map((video: any) => ({
-          ...video,
-          channelKey,
-          publicBeeKey: entry.publicBeeKey || undefined,
-          channel: { name: entry.channelName || 'Channel' },
-        }))
+      const mapped = mapHydratedVerticalFeedVideos(entry, channelVideos, {
+        identityDriveKey: identity?.driveKey || undefined,
+      }) as VideoData[]
 
       if (mapped.length > 0) {
-        setVideos((prev) => {
-          const byKey = new Map<string, VideoData>()
-          for (const video of [...prev, ...mapped]) byKey.set(`${video.channelKey}:${video.id}`, video)
-          return Array.from(byKey.values()).slice(0, 80)
-        })
+        setVideos((prev) => mergeUniqueFeedVideos(prev, mapped, 80))
         void fetchThumbnailsForVideos(mapped)
       }
     } catch (err) {
@@ -232,7 +204,7 @@ export default function VerticalDiscoveryScreen() {
     if (!rpc) return
     setFeedLoading(true)
     try {
-      const result = await withTimeout(rpc.getPublicFeed({}), 4000, { entries: [] } as any)
+      const result = await withFeedTimeout(rpc.getPublicFeed({}), 4000, { entries: [] } as any)
       const entries = Array.isArray((result as any)?.entries) ? (result as any).entries : []
       setFeedEntries(entries)
       seedFromFeedEntries(entries)
@@ -310,22 +282,20 @@ export default function VerticalDiscoveryScreen() {
   }, [activeVideo, playVideo, ready])
 
   useEffect(() => {
-    const warmPlaybackUrl = async (video: VideoData) => {
-      const { cacheKey, playbackRequest } = makePlaybackRequest(video)
-      if (cacheKey && getCachedVideoUrl(cacheKey)) return
-      const result = await rpc?.preparePlayback?.(playbackRequest)
-      if (result?.url && cacheKey) setCachedVideoUrl(cacheKey, result.url)
-    }
-
-    const nextVideos = videos.slice(activeIndex + 1, activeIndex + 5)
-    for (const video of nextVideos) {
-      void warmPlaybackUrl(video).catch(() => undefined)
-    }
+    if (!rpc) return
+    void warmNextPlaybackUrls({
+      videos,
+      activeIndex,
+      makePlaybackRequest,
+      getCachedVideoUrl,
+      setCachedVideoUrl,
+      preparePlayback: rpc.preparePlayback?.bind(rpc),
+    })
   }, [activeIndex, makePlaybackRequest, rpc, videos])
 
   const onRefresh = useCallback(async () => {
     setRefreshing(true)
-    hydratedChannelsRef.current.clear()
+    clearHydratedFeedChannels(hydratedChannelsRef)
     try {
       await rpc?.refreshFeed?.({})
       await loadFeed()

--- a/packages/app/lib/discover-feed-controller.d.ts
+++ b/packages/app/lib/discover-feed-controller.d.ts
@@ -1,0 +1,34 @@
+export function withFeedTimeout<T>(promise: Promise<T>, ms: number, fallback: T): Promise<T>
+
+export function mergeUniqueFeedVideos<T extends { channelKey?: string; driveKey?: string; id?: string; path?: string }>(
+  previousVideos?: T[],
+  incomingVideos?: T[],
+  limit?: number,
+): T[]
+
+export function getVerticalFeedPreviewVideos<T = any>(
+  entries: any[],
+  options?: {
+    identityDriveKey?: string
+    channelMeta?: Record<string, any>
+    limit?: number
+  },
+): T[]
+
+export function mapHydratedVerticalFeedVideos<T = any>(
+  entry: any,
+  videoList: T[],
+  options?: { identityDriveKey?: string },
+): T[]
+
+export function clearHydratedFeedChannels(hydratedChannelsRef: { current?: { clear?: () => void } } | null | undefined): void
+
+export function warmNextPlaybackUrls(options: {
+  videos: any[]
+  activeIndex: number
+  makePlaybackRequest: (video: any) => { cacheKey?: string | null; playbackRequest: any }
+  getCachedVideoUrl: (cacheKey: string) => string | null | undefined
+  setCachedVideoUrl: (cacheKey: string, url: string) => void
+  preparePlayback?: (request: any) => Promise<{ url?: string | null } | null | undefined>
+  windowSize?: number
+}): Promise<void>

--- a/packages/app/lib/discover-feed-controller.js
+++ b/packages/app/lib/discover-feed-controller.js
@@ -1,0 +1,81 @@
+import {
+  getFeedPreviewVideos,
+  getVisibleSeededFeedEntries,
+  shouldRenderFeedVideo,
+} from './feed-hydration.js'
+
+export function withFeedTimeout(promise, ms, fallback) {
+  return Promise.race([
+    promise,
+    new Promise((resolve) => setTimeout(() => resolve(fallback), ms)),
+  ])
+}
+
+export function mergeUniqueFeedVideos(previousVideos = [], incomingVideos = [], limit = 80) {
+  const byKey = new Map()
+
+  for (const video of [...(previousVideos || []), ...(incomingVideos || [])]) {
+    if (!video) continue
+    const channelKey = video.channelKey || video.driveKey || ''
+    const identifier = video.id || video.path || ''
+    if (!identifier) continue
+    byKey.set(`${channelKey}:${identifier}`, video)
+  }
+
+  return Array.from(byKey.values()).slice(0, limit)
+}
+
+export function getVerticalFeedPreviewVideos(entries, { identityDriveKey, channelMeta = {}, limit = 40 } = {}) {
+  const visibleEntries = getVisibleSeededFeedEntries(entries || [], Infinity)
+  const previewVideos = getFeedPreviewVideos(
+    visibleEntries,
+    channelMeta,
+    identityDriveKey,
+    limit,
+  )
+
+  return previewVideos
+    .filter((video) => shouldRenderFeedVideo({ video, identityDriveKey }))
+    .slice(0, limit)
+}
+
+export function mapHydratedVerticalFeedVideos(entry, videoList, { identityDriveKey } = {}) {
+  const channelKey = entry?.channelKey || entry?.driveKey
+  if (!channelKey || !Array.isArray(videoList)) return []
+
+  return videoList
+    .filter((video) => shouldRenderFeedVideo({
+      video: { ...video, channelKey },
+      identityDriveKey,
+    }))
+    .map((video) => ({
+      ...video,
+      channelKey,
+      publicBeeKey: entry.publicBeeKey || undefined,
+      channel: { name: entry.channelName || 'Channel' },
+    }))
+}
+
+export function clearHydratedFeedChannels(hydratedChannelsRef) {
+  hydratedChannelsRef?.current?.clear?.()
+}
+
+export async function warmNextPlaybackUrls({
+  videos,
+  activeIndex,
+  makePlaybackRequest,
+  getCachedVideoUrl,
+  setCachedVideoUrl,
+  preparePlayback,
+  windowSize = 4,
+}) {
+  const nextVideos = (videos || []).slice(activeIndex + 1, activeIndex + 1 + windowSize)
+
+  await Promise.allSettled(nextVideos.map(async (video) => {
+    const { cacheKey, playbackRequest } = makePlaybackRequest(video)
+    if (cacheKey && getCachedVideoUrl(cacheKey)) return null
+    const result = await preparePlayback?.(playbackRequest)
+    if (result?.url && cacheKey) setCachedVideoUrl(cacheKey, result.url)
+    return result?.url || null
+  }))
+}

--- a/packages/app/tests/discover-feed-controller.test.mjs
+++ b/packages/app/tests/discover-feed-controller.test.mjs
@@ -1,0 +1,127 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  clearHydratedFeedChannels,
+  getVerticalFeedPreviewVideos,
+  mapHydratedVerticalFeedVideos,
+  mergeUniqueFeedVideos,
+  warmNextPlaybackUrls,
+  withFeedTimeout,
+} from '../lib/discover-feed-controller.js'
+
+test('vertical feed controller falls back when feed RPC times out', async () => {
+  const fallback = { entries: [] }
+  const result = await withFeedTimeout(new Promise(() => {}), 5, fallback)
+
+  assert.equal(result, fallback)
+})
+
+test('vertical feed controller dedupes preview and hydrated videos by channel/video key', () => {
+  const merged = mergeUniqueFeedVideos([
+    { id: 'a', channelKey: 'one', title: 'old' },
+    { id: 'b', channelKey: 'one', title: 'keep' },
+  ], [
+    { id: 'a', channelKey: 'one', title: 'new' },
+    { id: 'c', channelKey: 'two', title: 'add' },
+  ])
+
+  assert.deepEqual(merged.map((video) => [video.channelKey, video.id, video.title]), [
+    ['one', 'a', 'new'],
+    ['one', 'b', 'keep'],
+    ['two', 'c', 'add'],
+  ])
+})
+
+test('vertical feed controller filters preview videos through renderability policy', () => {
+  const videos = getVerticalFeedPreviewVideos([
+    {
+      driveKey: 'stale-remote',
+      peerCount: 0,
+      previewVideos: [{ id: 'stale', availability: 'playable', uploadedAt: 30 }],
+    },
+    {
+      driveKey: 'live-remote',
+      peerCount: 2,
+      publicBeeKey: 'bee-live',
+      channelName: 'Live',
+      previewVideos: [
+        { id: 'playable', availability: 'playable', uploadedAt: 20 },
+        { id: 'unknown', availability: 'unknown', uploadedAt: 10 },
+      ],
+    },
+  ], { identityDriveKey: 'local', limit: 10 })
+
+  assert.deepEqual(videos.map((video) => ({
+    id: video.id,
+    channelKey: video.channelKey,
+    publicBeeKey: video.publicBeeKey,
+  })), [
+    { id: 'playable', channelKey: 'live-remote', publicBeeKey: 'bee-live' },
+  ])
+})
+
+test('vertical feed controller maps hydrated videos with channel metadata and renderability policy', () => {
+  const mapped = mapHydratedVerticalFeedVideos({
+    driveKey: 'remote',
+    publicBeeKey: 'bee-remote',
+    channelName: 'Remote Channel',
+  }, [
+    { id: 'playable', availability: 'playable' },
+    { id: 'unknown', availability: 'unknown' },
+  ], { identityDriveKey: 'local' })
+
+  assert.deepEqual(mapped, [{
+    id: 'playable',
+    availability: 'playable',
+    channelKey: 'remote',
+    publicBeeKey: 'bee-remote',
+    channel: { name: 'Remote Channel' },
+  }])
+})
+
+test('vertical feed refresh clears hydrated channel state through controller helper', () => {
+  const hydratedChannelsRef = { current: new Set(['one', 'two']) }
+
+  clearHydratedFeedChannels(hydratedChannelsRef)
+
+  assert.equal(hydratedChannelsRef.current.size, 0)
+})
+
+test('vertical feed controller prewarms next playback URLs best-effort', async () => {
+  const prepared = []
+  const cached = new Map([['one:a', 'http://cached/a']])
+
+  await warmNextPlaybackUrls({
+    videos: [
+      { id: 'current', channelKey: 'one' },
+      { id: 'a', channelKey: 'one' },
+      { id: 'b', channelKey: 'one' },
+      { id: 'c', channelKey: 'two' },
+    ],
+    activeIndex: 0,
+    makePlaybackRequest(video) {
+      return {
+        cacheKey: `${video.channelKey}:${video.id}`,
+        playbackRequest: { channelKey: video.channelKey, videoId: video.id },
+      }
+    },
+    getCachedVideoUrl(cacheKey) {
+      return cached.get(cacheKey)
+    },
+    setCachedVideoUrl(cacheKey, url) {
+      cached.set(cacheKey, url)
+    },
+    async preparePlayback(request) {
+      prepared.push(request)
+      if (request.videoId === 'c') throw new Error('network flake')
+      return { url: `http://prepared/${request.videoId}` }
+    },
+  })
+
+  assert.deepEqual(prepared, [
+    { channelKey: 'one', videoId: 'b' },
+    { channelKey: 'two', videoId: 'c' },
+  ])
+  assert.equal(cached.get('one:b'), 'http://prepared/b')
+})

--- a/packages/app/tests/vertical-discovery-regression.test.mjs
+++ b/packages/app/tests/vertical-discovery-regression.test.mjs
@@ -83,10 +83,8 @@ test('vertical discovery hydrates beyond sparse previews without permanently poi
 test('vertical discovery preloads the next few videos into the playback URL cache', () => {
   const source = readAppFile('app/(tabs)/discover.tsx')
 
-  assert.match(source, /const nextVideos = videos\.slice\(activeIndex \+ 1, activeIndex \+ 5\)/, 'shorts should warm the next few videos, not only one or two')
-  assert.match(source, /const warmPlaybackUrl = async \(video: VideoData\)/, 'preload should use a named URL warming helper')
-  assert.match(source, /const result = await rpc\?\.preparePlayback\?\.\(playbackRequest\)/, 'preload should await preparePlayback so it can keep the resolved URL')
-  assert.match(source, /if \(result\?\.url && cacheKey\) setCachedVideoUrl\(cacheKey, result\.url\)/, 'preload should populate the playback URL cache for instant swipe playback')
+  assert.match(source, /warmNextPlaybackUrls\(\{[\s\S]*videos,[\s\S]*activeIndex,[\s\S]*makePlaybackRequest/, 'shorts should warm the next few videos through the feed controller')
+  assert.match(source, /preparePlayback:\s*rpc\.preparePlayback\?\.bind\(rpc\)/, 'preload should route through backend preparePlayback')
 })
 
 


### PR DESCRIPTION
## Summary
- Extract vertical Discover feed orchestration helpers into `discover-feed-controller`
- Move preview seeding, hydrated video mapping/dedupe, timeout fallback, refresh clearing, and URL prewarm into focused controller functions
- Add controller regression coverage for timeout fallback, dedupe, refresh clearing, renderability filtering, and best-effort prewarm

## Test Plan
- `node --test packages/app/tests/discover-feed-controller.test.mjs packages/app/tests/feed-hydration.test.mjs packages/app/tests/feed-snapshot.test.mjs packages/app/tests/vertical-discovery-regression.test.mjs`
- `git diff --check`
- `npm run lint:changed` (reports no changed JS/TS files to lint; repo script limitation)
- `node_modules/.bin/tsc --noEmit -p packages/app/tsconfig.json` (blocked by existing unrelated repo/type dependency errors in UI/gluestack/video-player/core files; no new discover-feed-controller errors surfaced separately)

Closes #71
