### PR TITLE
fix(cli): align relay feed gossip with clients

### DIFF
--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-empty */
 /**
  * PublicFeedManager - P2P channel discovery over Hyperswarm
  *
@@ -808,7 +809,7 @@ export class PublicFeedManager {
       }
     }
     else if (msg.type === 'AVAILABILITY_HINT_REQUEST' && msg.requestId && Array.isArray(msg.requests)) {
-      ;(async () => {
+      (async () => {
         try {
           const hints = this.availabilityHintProvider
             ? await this.availabilityHintProvider(msg.requests, conn)

--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -59,6 +59,10 @@ export class PublicFeedManager {
     this._nextAvailabilityRequestId = 1;
     /** @type {Map<string, { resolve: Function, timeout: any }>} */
     this.pendingAvailabilityRequests = new Map();
+    /** @type {any | null} */
+    this._gossipInterval = null;
+    /** @type {number} */
+    this._gossipIntervalMs = 30000;
     /** @type {(() => void) | null} */
     this.onFeedUpdate = null;
     /** @type {((conn: any) => void) | null} */
@@ -379,7 +383,33 @@ export class PublicFeedManager {
     for (const conn of this.swarm.connections) {
       this.handleConnection(conn, {});
     }
+    this._startGossipLoop()
     console.log('[PublicFeed] ===== PUBLIC FEED STARTED =====');
+  }
+
+  _startGossipLoop() {
+    if (this._gossipInterval) return
+    try {
+      this._gossipInterval = setInterval(() => {
+        if (!this.started || this.peerChannels.size === 0) return
+        let announced = 0
+        for (const conn of this.peerChannels.keys()) {
+          try {
+            this.sendHaveFeed(conn)
+            announced++
+          } catch (err) {
+            console.log('[PublicFeed] periodic HAVE_FEED failed:', err?.message)
+          }
+        }
+        const requested = this.requestFeedsFromPeers()
+        if (announced || requested) {
+          console.log('[PublicFeed] Periodic feed gossip announced=', announced, 'requested=', requested)
+        }
+      }, this._gossipIntervalMs)
+      if (typeof this._gossipInterval?.unref === 'function') this._gossipInterval.unref()
+    } catch (err) {
+      console.log('[PublicFeed] Periodic feed gossip setup failed:', err?.message)
+    }
   }
 
   /**
@@ -400,8 +430,10 @@ export class PublicFeedManager {
       }
       this.pendingAvailabilityRequests.clear()
       if (this._persistTimer) clearTimeout(this._persistTimer)
+      if (this._gossipInterval) clearInterval(this._gossipInterval)
     } catch {}
     this._persistTimer = null
+    this._gossipInterval = null
   }
 
   /**

--- a/packages/backend/test/public-feed-manager.test.mjs
+++ b/packages/backend/test/public-feed-manager.test.mjs
@@ -128,14 +128,10 @@ test('feed channel open sends HAVE_FEED immediately', () => {
     manager.handleConnection(conn, {})
 
     assert.equal(sent.length, 2)
-    assert.deepEqual(sent[0], {
-      type: 'HAVE_FEED',
-      keys: [DRIVE_KEY],
-      entries: [{
-        driveKey: DRIVE_KEY,
-        publicBeeKey: PUBLIC_BEE_KEY
-      }]
-    })
+    assert.equal(sent[0].type, 'HAVE_FEED')
+    assert.deepEqual(sent[0].keys, [DRIVE_KEY])
+    assert.equal(sent[0].entries[0].driveKey, DRIVE_KEY)
+    assert.equal(sent[0].entries[0].publicBeeKey, PUBLIC_BEE_KEY)
     assert.deepEqual(sent[1], { type: 'NEED_FEED' })
   } finally {
     Protomux.from = originalFrom
@@ -190,10 +186,8 @@ test('feed channel open includes serving manifest snapshots when available', asy
 
     assert.equal(sent.length, 3)
     assert.equal(sent[0].type, 'HAVE_FEED')
-    assert.deepEqual(sent[0].entries[0], {
-      driveKey: DRIVE_KEY,
-      publicBeeKey: PUBLIC_BEE_KEY,
-    })
+    assert.equal(sent[0].entries[0].driveKey, DRIVE_KEY)
+    assert.equal(sent[0].entries[0].publicBeeKey, PUBLIC_BEE_KEY)
     assert.deepEqual(sent[1], { type: 'NEED_FEED' })
     assert.equal(sent[2].type, 'HAVE_FEED')
     assert.equal(sent[2].entries[0].channelName, 'Manifest Channel')
@@ -345,6 +339,41 @@ test('requestFeedsFromPeers sends NEED_FEED so peers reply with their feed', () 
     const count = manager.requestFeedsFromPeers()
     assert.equal(count, 1)
     assert.deepEqual(sent[sent.length - 1], { type: 'NEED_FEED' })
+  } finally {
+    Protomux.from = originalFrom
+    manager.stop()
+  }
+})
+
+test('periodic feed gossip resends HAVE_FEED and NEED_FEED on existing client connections', async () => {
+  const swarm = createSwarm()
+  const manager = new PublicFeedManager(swarm, createMetaDb())
+  const conn = createConnection()
+  const sent = []
+
+  manager._gossipIntervalMs = 10
+  manager.addEntry(DRIVE_KEY, 'local', PUBLIC_BEE_KEY)
+
+  const originalFrom = Protomux.from
+  Protomux.from = () => ({
+    pair() {},
+    createChannel(opts) {
+      return {
+        messages: [{ send(msg) { sent.push(msg) } }],
+        open() { opts.onopen() },
+      }
+    }
+  })
+
+  try {
+    await manager.start()
+    manager.handleConnection(conn, {})
+    sent.length = 0
+
+    await new Promise((resolve) => setTimeout(resolve, 35))
+
+    assert.ok(sent.some((msg) => msg.type === 'HAVE_FEED'), 'gossip loop should re-announce local feed entries')
+    assert.ok(sent.some((msg) => msg.type === 'NEED_FEED'), 'gossip loop should request peer feed refresh')
   } finally {
     Protomux.from = originalFrom
     manager.stop()

--- a/packages/cli/src/runtime.js
+++ b/packages/cli/src/runtime.js
@@ -122,6 +122,16 @@ export async function createRelayRuntime({ config, logger }) {
       this.uploadManager = createUploadManager({ ctx })
       this.api = createApi({ ctx, publicFeed, seedingManager: null, videoStats: null })
 
+      // Use the same feed snapshot and availability-hint plumbing as the normal
+      // PearTube backend. Without these providers the relay can gossip channel
+      // keys, but phones do not learn that the relay has playable local bytes.
+      if (typeof this.api.getAvailabilityHints === 'function') {
+        publicFeed.setAvailabilityHintProvider((requests, conn) => this.api.getAvailabilityHints(requests, conn))
+      }
+      if (typeof this.api.getFeedSnapshotEntries === 'function') {
+        publicFeed.setFeedSnapshotProvider((entries) => this.api.getFeedSnapshotEntries(entries, { limitPerChannel: 3 }))
+      }
+
       // Restore mirrored/cached channels as actively served feed entries so the
       // relay behaves like a real serving peer even when original publishers are offline.
       for (const channel of cacheManager.getChannels()) {

--- a/packages/cli/test/cli.test.mjs
+++ b/packages/cli/test/cli.test.mjs
@@ -188,6 +188,16 @@ test('Dockerfile packages ffmpeg for yt-dlp archive merging', async (t) => {
   t.ok(dockerfile.includes('COPY --from=runtime-libs /usr/local/bin/ffprobe /usr/local/bin/ffprobe'), 'final image includes ffprobe executable')
 })
 
+test('relay runtime source wires client-equivalent feed availability providers', async (t) => {
+  const runtimePath = join(__dirname, '..', 'src', 'runtime.js')
+  const content = readFileSync(runtimePath, 'utf8')
+
+  t.ok(content.includes('publicFeed.setAvailabilityHintProvider'), 'relay runtime should answer availability hint requests over the feed protocol')
+  t.ok(content.includes('this.api.getAvailabilityHints(requests, conn)'), 'relay availability provider should use the same API path as clients')
+  t.ok(content.includes('publicFeed.setFeedSnapshotProvider'), 'relay runtime should gossip compact playable feed snapshots')
+  t.ok(content.includes('this.api.getFeedSnapshotEntries(entries, { limitPerChannel: 3 })'), 'relay feed snapshot provider should use the same API path as clients')
+})
+
 test('Dockerfile packages the yt-dlp POT provider plugin for noninteractive YouTube bot checks', async (t) => {
   const dockerfile = readFileSync(join(__dirname, '..', 'Dockerfile'), 'utf8')
 


### PR DESCRIPTION
## Summary
- Wire the relay runtime's public feed to the same availability-hint and compact feed-snapshot providers used by normal PearTube clients
- Add periodic feed gossip so existing feed connections keep receiving HAVE_FEED and NEED_FEED instead of relying only on channel-open timing
- Add regressions for relay runtime provider wiring and periodic feed gossip

## Why
The relay was seeding bytes and gossiping channel keys, but it was not fully behaving like the normal client backend on the public-feed protocol. Phones need feed snapshots and availability hints to learn that the relay has playable local bytes.

## Test Plan
- `git diff --check`
- `node --test packages/backend/test/public-feed-manager.test.mjs`
- `npm test --prefix packages/cli`
