### PR TITLE
fix(backend): join public feed discovery topic

### DIFF
--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -16,7 +16,9 @@
 
 import Protomux from 'protomux';
 import c from 'compact-encoding';
-import { PROTOCOL_NAME } from './types.js';
+import crypto from 'hypercore-crypto'
+import b4a from 'b4a'
+import { NETWORK_TOPIC_STRING, PROTOCOL_NAME } from './types.js';
 import { logger } from './logger.js'
 import { hashFeedEntries, hashPreviewVideos } from './hash-utils.js'
 
@@ -60,6 +62,8 @@ export class PublicFeedManager {
     this._nextAvailabilityRequestId = 1;
     /** @type {Map<string, { resolve: Function, timeout: any }>} */
     this.pendingAvailabilityRequests = new Map();
+    /** @type {any | null} */
+    this.feedDiscovery = null;
     /** @type {any | null} */
     this._gossipInterval = null;
     /** @type {number} */
@@ -378,6 +382,18 @@ export class PublicFeedManager {
       try { this.onFeedUpdate?.(); } catch {}
     }
 
+    const feedTopic = crypto.data(b4a.from(NETWORK_TOPIC_STRING, 'utf-8'))
+    try {
+      this.feedDiscovery = this.swarm.join(feedTopic, { server: true, client: true })
+      this.feedDiscovery?.flushed?.().then(() => {
+        console.log('[PublicFeed] Shared network feed discovery flushed, connections:', this.swarm.connections?.size || 0)
+      }).catch(() => {})
+      console.log('[PublicFeed] Joined shared network feed topic:', b4a.toString(feedTopic, 'hex').slice(0, 16))
+    } catch (err) {
+      console.log('[PublicFeed] Shared network feed topic join failed:', err?.message)
+      this.feedDiscovery = null
+    }
+
     // Set up feed protocol on any existing connections.
     const existingConns = this.swarm.connections?.size || 0;
     console.log('[PublicFeed] Setting up feed protocol on', existingConns, 'existing connections');
@@ -432,9 +448,11 @@ export class PublicFeedManager {
       this.pendingAvailabilityRequests.clear()
       if (this._persistTimer) clearTimeout(this._persistTimer)
       if (this._gossipInterval) clearInterval(this._gossipInterval)
+      this.feedDiscovery?.destroy?.()
     } catch {}
     this._persistTimer = null
     this._gossipInterval = null
+    this.feedDiscovery = null
   }
 
   /**

--- a/packages/backend/test/public-feed-manager.test.mjs
+++ b/packages/backend/test/public-feed-manager.test.mjs
@@ -1,11 +1,13 @@
 import assert from 'node:assert/strict'
 import { EventEmitter } from 'node:events'
 import test from 'node:test'
+import crypto from 'hypercore-crypto'
+import b4a from 'b4a'
 
 import Protomux from 'protomux'
 
 import { PublicFeedManager } from '../src/public-feed.js'
-
+import { NETWORK_TOPIC_STRING } from '../src/types.js'
 const DRIVE_KEY = '11'.repeat(32)
 const PUBLIC_BEE_KEY = '22'.repeat(32)
 
@@ -53,13 +55,15 @@ function createConnection() {
   return new EventEmitter()
 }
 
-test('PublicFeedManager.start restores cache without joining a feed topic', async () => {
+test('PublicFeedManager.start joins shared PearTube network topic for feed-peer discovery', async () => {
   const swarm = createSwarm()
   const manager = new PublicFeedManager(swarm, createMetaDb())
 
   try {
     await manager.start()
-    assert.equal(swarm.joinCalls.length, 0)
+    assert.equal(swarm.joinCalls.length, 1)
+    assert.equal(b4a.toString(swarm.joinCalls[0].topic, 'hex'), b4a.toString(crypto.data(b4a.from(NETWORK_TOPIC_STRING, 'utf-8')), 'hex'))
+    assert.deepEqual(swarm.joinCalls[0].opts, { server: true, client: true })
   } finally {
     manager.stop()
   }


### PR DESCRIPTION
## Summary
- joins the shared PearTube network topic from `PublicFeedManager.start()` so clients/relays can actually discover feed peers
- retains and destroys the discovery handle on stop
- updates the public-feed regression test from "must not join" to "must join the shared topic as server+client"

## Why
The relay and mobile app both had feed protocol plumbing, but `PublicFeedManager.start()` restored cached entries without joining a shared feed discovery topic. With no common topic join, two fresh devices can both show zero peers forever, so the phone never sees the archived relay feed entry.

## Verification
```bash
git diff --check
node --test packages/backend/test/public-feed-manager.test.mjs
npm test --prefix packages/cli
```
