### PR TITLE
chore: expose swarm discovery diagnostics

### DIFF
--- a/packages/app/backend/mobile-handlers.mjs
+++ b/packages/app/backend/mobile-handlers.mjs
@@ -1,3 +1,4 @@
+/* eslint-disable no-empty */
 /**
  * PearTube Mobile Handler Adapters
  *

--- a/packages/app/backend/mobile-handlers.mjs
+++ b/packages/app/backend/mobile-handlers.mjs
@@ -164,6 +164,13 @@ export function attachMobileHandlers(B, deps) {
       feedConnections: s.feedConnections || 0,
       feedEntries: s.feedEntries || 0,
       channelsLoaded: s.channelsLoaded || 0,
+      network: s.network || null,
+      swarmOffline: Boolean(s.swarmOffline),
+      swarmOfflineReason: s.swarmOfflineReason || null,
+      swarmListenResolved: Boolean(s.swarmListenResolved),
+      peerPoolJoined: Boolean(s.peerPoolJoined),
+      publicFeedDiscoveryJoined: Boolean(s.publicFeedDiscoveryJoined),
+      feedTopicHex: s.feedTopicHex || null,
     }
   }
 

--- a/packages/app/tests/native-backend-startup-regression.test.mjs
+++ b/packages/app/tests/native-backend-startup-regression.test.mjs
@@ -79,6 +79,24 @@ test('native root layout clears startup timeout and releases loading on explicit
   assert.match(catchBlock, /setLoading\(false\)/)
 })
 
+test('mobile getSwarmStatus forwards low-level network diagnostics', () => {
+  const source = readAppFile('backend/mobile-handlers.mjs')
+  const handlerBlock = source.match(/B\.getSwarmStatus = async \(\) => \{([\s\S]*?)\n\s*\}/)?.[1] ?? ''
+
+  assert.ok(handlerBlock, 'mobile getSwarmStatus handler should exist')
+  for (const field of [
+    'network',
+    'swarmOffline',
+    'swarmOfflineReason',
+    'swarmListenResolved',
+    'peerPoolJoined',
+    'publicFeedDiscoveryJoined',
+    'feedTopicHex',
+  ]) {
+    assert.match(handlerBlock, new RegExp(field), `getSwarmStatus should expose ${field}`)
+  }
+})
+
 test('backend orchestrator defers warm-up behind startup gates and does not force a boot-time feed sync request', () => {
   const source = readWorkspaceFile('backend/src/orchestrator.js')
 

--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -10,7 +10,7 @@ import crypto from 'hypercore-crypto';
 import HypercoreID from 'hypercore-id-encoding';
 import z32 from 'z32';
 import c from 'compact-encoding';
-import { getVideoUrlFromBlob, loadChannel as storageLoadChannel, loadPublicBee as storageLoadPublicBee, pairDevice as pairChannelDevice, suspendNetworking, resumeNetworking, getNetworkStats, getNetworkStatsReadable } from './storage.js';
+import { getVideoUrlFromBlob, loadChannel as storageLoadChannel, loadPublicBee as storageLoadPublicBee, pairDevice as pairChannelDevice, suspendNetworking, resumeNetworking, getNetworkStats, getNetworkStatsReadable, retainSwarmDiscovery } from './storage.js';
 import { createBlobPlaybackService } from './blob-playback-service.js';
 import { SemanticFinder } from './search/semantic-finder.js';
 import { FederatedSearch } from './search/federated-search.js';

--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -2447,12 +2447,19 @@ export function createApi({
      */
     getSwarmStatus() {
       const topicHex = b4a.toString(crypto.data(b4a.from(NETWORK_TOPIC_STRING, 'utf-8')), 'hex')
+      const networkDebug = getNetworkStats()
       return {
         swarmConnections: ctx.swarm?.connections?.size || 0,
         swarmPeers: ctx.swarm?.peers?.size || 0,
         feedConnections: publicFeed?.feedConnections?.size || 0,
         feedEntries: publicFeed?.entries?.size || 0,
         feedTopicHex: topicHex,
+        network: networkDebug,
+        swarmOffline: Boolean(ctx.swarm?._peartubeOffline),
+        swarmOfflineReason: ctx.swarm?._peartubeOfflineReason || null,
+        swarmListenResolved: Boolean(ctx.swarm?._peartubeListenResolved),
+        peerPoolJoined: Boolean(ctx.peerPoolDiscovery),
+        publicFeedDiscoveryJoined: Boolean(publicFeed?.feedDiscovery),
         swarmPublicKey: ctx.swarm?.keyPair?.publicKey
           ? b4a.toString(ctx.swarm.keyPair.publicKey, 'hex').slice(0, 32)
           : 'unknown',

--- a/packages/backend/src/storage.js
+++ b/packages/backend/src/storage.js
@@ -91,6 +91,7 @@ let globalSwarm = null;
 let globalBlobServer = null;
 let globalChannels = null;
 let globalPeerPoolDiscovery = null;
+let globalPeerPoolTopicHex = null;
 
 // Cast active flag — set by API handlers to prevent network suspension during active cast
 let globalCastActive = false
@@ -662,6 +663,7 @@ export async function initializeStorage(config) {
   // Join the PearTube network topic for peer pool building
   // More connected peers = better relay options for symmetric NAT holepunching
   const PEARTUBE_NETWORK_TOPIC = crypto.data(b4a.from(NETWORK_TOPIC_STRING, 'utf-8'));
+  globalPeerPoolTopicHex = b4a.toString(PEARTUBE_NETWORK_TOPIC, 'hex')
   if (!swarm._peartubeOffline) {
     try {
       const poolDiscovery = swarm.join(PEARTUBE_NETWORK_TOPIC, { server: true, client: true });
@@ -1861,6 +1863,11 @@ export function getNetworkStats() {
       return {
         connections: globalSwarm.connections?.size || 0,
         peers: globalSwarm.peers?.size || 0,
+        offline: Boolean(globalSwarm._peartubeOffline),
+        offlineReason: globalSwarm._peartubeOfflineReason || null,
+        listenResolved: Boolean(globalSwarm._peartubeListenResolved),
+        peerPoolJoined: Boolean(globalPeerPoolDiscovery),
+        peerPoolTopicHex: globalPeerPoolTopicHex,
         dht: {
           firewalled: globalSwarm.dht?.firewalled ?? null,
           bootstrapped: globalSwarm.dht?.bootstrapped ?? null,
@@ -1893,6 +1900,11 @@ export function getNetworkStatsReadable() {
       return [
         `Connections: ${globalSwarm.connections?.size || 0}`,
         `Peers discovered: ${globalSwarm.peers?.size || 0}`,
+        `Swarm offline: ${Boolean(globalSwarm._peartubeOffline)}`,
+        `Swarm offline reason: ${globalSwarm._peartubeOfflineReason || 'none'}`,
+        `Swarm listen resolved: ${Boolean(globalSwarm._peartubeListenResolved)}`,
+        `Peer pool joined: ${Boolean(globalPeerPoolDiscovery)}`,
+        `Peer pool topic: ${globalPeerPoolTopicHex || 'unknown'}`,
         `DHT firewalled: ${dht?.firewalled ?? 'unknown'}`,
         `DHT bootstrapped: ${dht?.bootstrapped ?? 'unknown'}`,
         `DHT online: ${dht?.online ?? 'unknown'}`

--- a/packages/cli/src/runtime.js
+++ b/packages/cli/src/runtime.js
@@ -225,6 +225,11 @@ export async function createRelayRuntime({ config, logger }) {
           firewalled: ctx.swarm?.dht?.firewalled ?? null,
           online: ctx.swarm?.dht?.online ?? null
         },
+        publicFeedDiscoveryJoined: Boolean(publicFeed.feedDiscovery),
+        peerPoolJoined: Boolean(ctx.peerPoolDiscovery),
+        swarmOffline: Boolean(ctx.swarm?._peartubeOffline),
+        swarmOfflineReason: ctx.swarm?._peartubeOfflineReason || null,
+        swarmListenResolved: Boolean(ctx.swarm?._peartubeListenResolved),
         seeding: seeder.getStats()
       }
     },

--- a/packages/cli/src/status.js
+++ b/packages/cli/src/status.js
@@ -36,6 +36,11 @@ export function buildRelayStatus({ config, catalog, runtimeStats = {} }) {
         firewalled: runtimeStats.dht?.firewalled ?? null,
         online: runtimeStats.dht?.online ?? null
       },
+      publicFeedDiscoveryJoined: Boolean(runtimeStats.publicFeedDiscoveryJoined),
+      peerPoolJoined: Boolean(runtimeStats.peerPoolJoined),
+      swarmOffline: Boolean(runtimeStats.swarmOffline),
+      swarmOfflineReason: runtimeStats.swarmOfflineReason || null,
+      swarmListenResolved: Boolean(runtimeStats.swarmListenResolved),
       seeding: {
         channels: runtimeStats.seeding?.channels || 0,
         videos: runtimeStats.seeding?.videos || 0,
@@ -80,6 +85,7 @@ export function formatRelayStatus(status) {
     `feedConnections: ${status.runtime.feedConnections}`,
     `feedEntries: ${status.runtime.feedEntries}`,
     `dht: bootstrapped=${status.runtime.dht.bootstrapped} firewalled=${status.runtime.dht.firewalled} online=${status.runtime.dht.online}`,
+    `network: offline=${status.runtime.swarmOffline} reason=${status.runtime.swarmOfflineReason || 'none'} listenResolved=${status.runtime.swarmListenResolved} peerPoolJoined=${status.runtime.peerPoolJoined} publicFeedDiscoveryJoined=${status.runtime.publicFeedDiscoveryJoined}`,
     `seeding: channels=${status.runtime.seeding.channels} videos=${status.runtime.seeding.videos} publicBeeCores=${status.runtime.seeding.publicBeeCores} blobCores=${status.runtime.seeding.blobCores} discoveryHandles=${status.runtime.seeding.discoveryHandles}`
   ]
 

--- a/packages/cli/test/relay-seeding.test.mjs
+++ b/packages/cli/test/relay-seeding.test.mjs
@@ -149,6 +149,11 @@ test('relay status surfaces DHT and seeding stats for phone connectivity diagnos
       feedConnections: 1,
       feedEntries: 3,
       dht: { bootstrapped: true, firewalled: false, online: true },
+      publicFeedDiscoveryJoined: true,
+      peerPoolJoined: true,
+      swarmOffline: false,
+      swarmOfflineReason: null,
+      swarmListenResolved: true,
       seeding: { channels: 2, videos: 5, publicBeeCores: 2, blobCores: 8, discoveryHandles: 10 }
     }
   })
@@ -166,5 +171,6 @@ test('relay status surfaces DHT and seeding stats for phone connectivity diagnos
 
   const formatted = formatRelayStatus(status)
   t.ok(formatted.includes('dht: bootstrapped=true firewalled=false online=true'))
+  t.ok(formatted.includes('network: offline=false reason=none listenResolved=true peerPoolJoined=true publicFeedDiscoveryJoined=true'))
   t.ok(formatted.includes('seeding: channels=2 videos=5 publicBeeCores=2 blobCores=8 discoveryHandles=10'))
 })


### PR DESCRIPTION
## Summary
- expose low-level swarm diagnostics through app/mobile `getSwarmStatus()` and relay status
- surface whether the runtime fell back to the offline swarm, whether `listen()` resolved, and whether peer-pool / public-feed discovery handles are actually retained
- include the computed shared feed topic hex so relay and mobile can be compared directly

## Why
After v0.1.51, three clients still show zero peers. Code inspection shows all clients are using the same shared topic string (`peartube-network`) and the expected hashed topic (`660317ae9e952274c923999437d2d5827ba1e6ef646ae1ccb4b148b65102db1d`). At this point the useful next cut is not another guessed protocol change; we need runtime evidence from the devices:

- did Hyperswarm load, or did mobile/relay silently fall back to the offline swarm?
- did `swarm.listen()` resolve?
- did the relay/mobile retain peer-pool and public-feed discovery handles?
- is DHT online/bootstrapped/firewalled?

## Verification
```bash
git diff --check
node --test packages/app/tests/native-backend-startup-regression.test.mjs packages/backend/test/storage-startup-regression.test.mjs packages/backend/test/public-feed-manager.test.mjs
npm test --prefix packages/cli
```
