### PR TITLE
fix(backend): restore legacy feed topic discovery

### DIFF
--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -18,7 +18,7 @@ import Protomux from 'protomux';
 import c from 'compact-encoding';
 import crypto from 'hypercore-crypto'
 import b4a from 'b4a'
-import { NETWORK_TOPIC_STRING, PROTOCOL_NAME } from './types.js';
+import { LEGACY_FEED_TOPIC_STRING, NETWORK_TOPIC_STRING, PROTOCOL_NAME } from './types.js';
 import { logger } from './logger.js'
 import { hashFeedEntries, hashPreviewVideos } from './hash-utils.js'
 
@@ -64,6 +64,8 @@ export class PublicFeedManager {
     this.pendingAvailabilityRequests = new Map();
     /** @type {any | null} */
     this.feedDiscovery = null;
+    /** @type {any | null} */
+    this.legacyFeedDiscovery = null;
     /** @type {any | null} */
     this._gossipInterval = null;
     /** @type {number} */
@@ -382,16 +384,24 @@ export class PublicFeedManager {
       try { this.onFeedUpdate?.(); } catch {}
     }
 
-    const feedTopic = crypto.data(b4a.from(NETWORK_TOPIC_STRING, 'utf-8'))
-    try {
-      this.feedDiscovery = this.swarm.join(feedTopic, { server: true, client: true })
-      this.feedDiscovery?.flushed?.().then(() => {
-        console.log('[PublicFeed] Shared network feed discovery flushed, connections:', this.swarm.connections?.size || 0)
-      }).catch(() => {})
-      console.log('[PublicFeed] Joined shared network feed topic:', b4a.toString(feedTopic, 'hex').slice(0, 16))
-    } catch (err) {
-      console.log('[PublicFeed] Shared network feed topic join failed:', err?.message)
-      this.feedDiscovery = null
+    const joinDiscoveryTopic = (topicString, label) => {
+      const topic = crypto.data(b4a.from(topicString, 'utf-8'))
+      try {
+        const discovery = this.swarm.join(topic, { server: true, client: true })
+        discovery?.flushed?.().then(() => {
+          console.log(`[PublicFeed] ${label} discovery flushed, connections:`, this.swarm.connections?.size || 0)
+        }).catch(() => {})
+        console.log(`[PublicFeed] Joined ${label} topic:`, b4a.toString(topic, 'hex').slice(0, 16))
+        return discovery
+      } catch (err) {
+        console.log(`[PublicFeed] ${label} topic join failed:`, err?.message)
+        return null
+      }
+    }
+
+    this.feedDiscovery = joinDiscoveryTopic(NETWORK_TOPIC_STRING, 'shared network feed')
+    if (LEGACY_FEED_TOPIC_STRING && LEGACY_FEED_TOPIC_STRING !== NETWORK_TOPIC_STRING) {
+      this.legacyFeedDiscovery = joinDiscoveryTopic(LEGACY_FEED_TOPIC_STRING, 'legacy public-feed')
     }
 
     // Set up feed protocol on any existing connections.
@@ -449,10 +459,12 @@ export class PublicFeedManager {
       if (this._persistTimer) clearTimeout(this._persistTimer)
       if (this._gossipInterval) clearInterval(this._gossipInterval)
       this.feedDiscovery?.destroy?.()
+      this.legacyFeedDiscovery?.destroy?.()
     } catch {}
     this._persistTimer = null
     this._gossipInterval = null
     this.feedDiscovery = null
+    this.legacyFeedDiscovery = null
   }
 
   /**

--- a/packages/backend/src/types.js
+++ b/packages/backend/src/types.js
@@ -126,4 +126,5 @@
  */
 
 export const NETWORK_TOPIC_STRING = 'peartube-network';
+export const LEGACY_FEED_TOPIC_STRING = 'peartube-public-feed-v1';
 export const PROTOCOL_NAME = 'peartube-feed';

--- a/packages/backend/test/public-feed-manager.test.mjs
+++ b/packages/backend/test/public-feed-manager.test.mjs
@@ -7,7 +7,7 @@ import b4a from 'b4a'
 import Protomux from 'protomux'
 
 import { PublicFeedManager } from '../src/public-feed.js'
-import { NETWORK_TOPIC_STRING } from '../src/types.js'
+import { LEGACY_FEED_TOPIC_STRING, NETWORK_TOPIC_STRING } from '../src/types.js'
 const DRIVE_KEY = '11'.repeat(32)
 const PUBLIC_BEE_KEY = '22'.repeat(32)
 
@@ -55,15 +55,17 @@ function createConnection() {
   return new EventEmitter()
 }
 
-test('PublicFeedManager.start joins shared PearTube network topic for feed-peer discovery', async () => {
+test('PublicFeedManager.start joins current and legacy feed discovery topics', async () => {
   const swarm = createSwarm()
   const manager = new PublicFeedManager(swarm, createMetaDb())
 
   try {
     await manager.start()
-    assert.equal(swarm.joinCalls.length, 1)
+    assert.equal(swarm.joinCalls.length, 2)
     assert.equal(b4a.toString(swarm.joinCalls[0].topic, 'hex'), b4a.toString(crypto.data(b4a.from(NETWORK_TOPIC_STRING, 'utf-8')), 'hex'))
     assert.deepEqual(swarm.joinCalls[0].opts, { server: true, client: true })
+    assert.equal(b4a.toString(swarm.joinCalls[1].topic, 'hex'), b4a.toString(crypto.data(b4a.from(LEGACY_FEED_TOPIC_STRING, 'utf-8')), 'hex'))
+    assert.deepEqual(swarm.joinCalls[1].opts, { server: true, client: true })
   } finally {
     manager.stop()
   }


### PR DESCRIPTION
## Summary
- Restore the legacy `peartube-public-feed-v1` public-feed discovery topic alongside the current `peartube-network` topic.
- Retain and clean up both discovery handles for the PublicFeedManager lifetime.
- Update the regression test so feed startup must join both rendezvous topics.

## Why
Git history showed swarming used to rely on a dedicated public-feed topic through `v0.1.10`. `v0.1.11` removed that topic during the single-topic migration, leaving feed sync dependent on shared swarm connections. Recent fixes restored the current shared topic, but mixed builds / older clients / topic-era peers still cannot rendezvous. Joining both topics is a low-risk compatibility bridge and closer to the known-working behavior.

## Verification
- `git diff --check`
- `node --test packages/backend/test/public-feed-manager.test.mjs packages/backend/test/storage-startup-regression.test.mjs`
- `npm test --prefix packages/cli`
- `npm run lint:changed`
