### PR TITLE
fix(backend): explicitly dial shared-topic peers

### DIFF
--- a/packages/app/tests/native-backend-startup-regression.test.mjs
+++ b/packages/app/tests/native-backend-startup-regression.test.mjs
@@ -79,6 +79,13 @@ test('native root layout clears startup timeout and releases loading on explicit
   assert.match(catchBlock, /setLoading\(false\)/)
 })
 
+test('backend orchestrator explicitly dials peers discovered on the single shared topic', () => {
+  const source = readWorkspaceFile('backend/src/orchestrator.js')
+
+  assert.match(source, /ctx\.swarm\.on\('peer'/)
+  assert.match(source, /publicFeed\.handleDiscoveredPeer\(peer\)/)
+})
+
 test('mobile getSwarmStatus forwards low-level network diagnostics', () => {
   const source = readAppFile('backend/mobile-handlers.mjs')
   const handlerBlock = source.match(/B\.getSwarmStatus = async \(\) => \{([\s\S]*?)\n\s*\}/)?.[1] ?? ''

--- a/packages/backend/src/orchestrator.js
+++ b/packages/backend/src/orchestrator.js
@@ -52,7 +52,9 @@ async function appendDebugLine(line) {
     const fs = fsModule?.default ?? fsModule
     if (typeof fs?.appendFileSync !== 'function') return
     fs.appendFileSync(filePath, `${new Date().toISOString()} ${line}\n`)
-  } catch {}
+  } catch (err) {
+    void err
+  }
 }
 
 // Shutdown flag to prevent deferred init from running during cleanup
@@ -184,7 +186,11 @@ export async function createBackendContext(config) {
                 _path.join(opts.storagePath, 'primary', 'LOCK')
               ]
               for (const lockFile of lockFiles) {
-                try { _fs.unlinkSync(lockFile) } catch {}
+                try {
+                  _fs.unlinkSync(lockFile)
+                } catch (err) {
+                  void err
+                }
               }
               const result = await initializeStorage(opts)
               console.log('[Orchestrator] Stale lock recovery succeeded')

--- a/packages/backend/src/orchestrator.js
+++ b/packages/backend/src/orchestrator.js
@@ -319,6 +319,15 @@ export async function createBackendContext(config) {
       console.error('[Orchestrator] publicFeed.handleConnection failed:', err?.message);
     }
   });
+  ctx.swarm.on('peer', (peer) => {
+    try {
+      if (publicFeed.handleDiscoveredPeer(peer)) {
+        startupGate.noteSwarmPeer()
+      }
+    } catch (err) {
+      console.error('[Orchestrator] publicFeed.handleDiscoveredPeer failed:', err?.message)
+    }
+  })
   ipcLog('[orchestrator] seedingManager.init starting')
   await appendDebugLine('[orchestrator] seedingManager.init starting')
 

--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -62,6 +62,14 @@ export class PublicFeedManager {
     this._nextAvailabilityRequestId = 1;
     /** @type {Map<string, { resolve: Function, timeout: any }>} */
     this.pendingAvailabilityRequests = new Map();
+    /** @type {Map<string, number>} */
+    this._directPeerRetryCounts = new Map();
+    /** @type {number} */
+    this._maxDirectPeerRetries = 3;
+    /** @type {number} */
+    this._maxDirectPeers = 16;
+    /** @type {() => number} */
+    this._now = () => Date.now();
     /** @type {any | null} */
     this.feedDiscovery = null;
     /** @type {any | null} */
@@ -298,6 +306,37 @@ export class PublicFeedManager {
   }
 
   /**
+   * Remember a discovered peer and explicitly dial it when the shared topic has
+   * found peers but Hyperswarm has not promoted them into connections yet.
+   * This keeps the hard-cutover architecture on one topic while making the
+   * Protomux feed channel less dependent on passive connection timing.
+   * @param {any} peer
+   * @returns {boolean}
+   */
+  handleDiscoveredPeer(peer) {
+    const publicKey = peer?.publicKey
+    if (!publicKey || !this.swarm || typeof this.swarm.joinPeer !== 'function') return false
+
+    const keyHex = b4a.toString(publicKey, 'hex')
+    if (!keyHex || keyHex === b4a.toString(this.swarm.keyPair?.publicKey || [], 'hex')) return false
+    if (this.swarm.peers?.has?.(keyHex)) return false
+    if ((this.swarm.connections?.size || 0) >= this._maxDirectPeers) return false
+
+    const attempts = this._directPeerRetryCounts.get(keyHex) || 0
+    if (attempts >= this._maxDirectPeerRetries) return false
+
+    this._directPeerRetryCounts.set(keyHex, attempts + 1)
+    try {
+      this.swarm.joinPeer(publicKey)
+      console.log('[PublicFeed] Direct peer dial queued from shared topic:', keyHex.slice(0, 16), 'attempt=', attempts + 1)
+      return true
+    } catch (err) {
+      console.log('[PublicFeed] Direct peer dial failed:', keyHex.slice(0, 16), err?.message)
+      return false
+    }
+  }
+
+  /**
    * Start the public feed manager - restore cache and wire current connections
    */
   async start() {
@@ -446,6 +485,7 @@ export class PublicFeedManager {
         try { pending.resolve([]) } catch {}
       }
       this.pendingAvailabilityRequests.clear()
+      this._directPeerRetryCounts.clear()
       if (this._persistTimer) clearTimeout(this._persistTimer)
       if (this._gossipInterval) clearInterval(this._gossipInterval)
       this.feedDiscovery?.destroy?.()

--- a/packages/backend/test/public-feed-manager.test.mjs
+++ b/packages/backend/test/public-feed-manager.test.mjs
@@ -13,8 +13,11 @@ const PUBLIC_BEE_KEY = '22'.repeat(32)
 
 function createSwarm() {
   return {
+    keyPair: { publicKey: b4a.alloc(32, 0) },
     connections: new Set(),
+    peers: new Map(),
     joinCalls: [],
+    joinPeerCalls: [],
     join(topic, opts) {
       this.joinCalls.push({ topic, opts })
       return {
@@ -22,6 +25,10 @@ function createSwarm() {
           return Promise.resolve()
         }
       }
+    },
+    joinPeer(publicKey) {
+      this.joinPeerCalls.push(publicKey)
+      return {}
     }
   }
 }
@@ -54,6 +61,20 @@ function createPersistedMetaDb(seed = {}) {
 function createConnection() {
   return new EventEmitter()
 }
+
+test('PublicFeedManager explicitly dials peers discovered on the shared topic', () => {
+  const swarm = createSwarm()
+  const manager = new PublicFeedManager(swarm, createMetaDb())
+  const publicKey = b4a.alloc(32, 7)
+
+  try {
+    assert.equal(manager.handleDiscoveredPeer({ publicKey }), true)
+    assert.equal(swarm.joinPeerCalls.length, 1)
+    assert.equal(b4a.toString(swarm.joinPeerCalls[0], 'hex'), b4a.toString(publicKey, 'hex'))
+  } finally {
+    manager.stop()
+  }
+})
 
 test('PublicFeedManager.start joins shared PearTube network topic for feed-peer discovery', async () => {
   const swarm = createSwarm()

--- a/packages/cli/src/init.js
+++ b/packages/cli/src/init.js
@@ -17,6 +17,9 @@ export async function initPeer ({ storagePath, maxBytes, pinnedChannels = [] }) 
   ctx.swarm.on('connection', (conn, info) => {
     publicFeed.handleConnection(conn, info)
   })
+  ctx.swarm.on('peer', (peer) => {
+    publicFeed.handleDiscoveredPeer(peer)
+  })
 
   publicFeed.setOnFeedUpdate(() => {
     for (const entry of publicFeed.entries.values()) {

--- a/packages/cli/src/runtime.js
+++ b/packages/cli/src/runtime.js
@@ -77,6 +77,9 @@ export async function createRelayRuntime({ config, logger }) {
   ctx.swarm.on('connection', (conn, info) => {
     publicFeed.handleConnection(conn, info)
   })
+  ctx.swarm.on('peer', (peer) => {
+    publicFeed.handleDiscoveredPeer(peer)
+  })
 
   publicFeed.setOnFeedUpdate(() => {
     try {

--- a/packages/cli/test/cli.test.mjs
+++ b/packages/cli/test/cli.test.mjs
@@ -196,6 +196,8 @@ test('relay runtime source wires client-equivalent feed availability providers',
   t.ok(content.includes('this.api.getAvailabilityHints(requests, conn)'), 'relay availability provider should use the same API path as clients')
   t.ok(content.includes('publicFeed.setFeedSnapshotProvider'), 'relay runtime should gossip compact playable feed snapshots')
   t.ok(content.includes('this.api.getFeedSnapshotEntries(entries, { limitPerChannel: 3 })'), 'relay feed snapshot provider should use the same API path as clients')
+  t.ok(content.includes("ctx.swarm.on('peer'"), 'relay runtime should react to shared-topic peer discoveries')
+  t.ok(content.includes('publicFeed.handleDiscoveredPeer(peer)'), 'relay runtime should explicitly dial shared-topic discovered peers')
 })
 
 test('Dockerfile packages the yt-dlp POT provider plugin for noninteractive YouTube bot checks', async (t) => {


### PR DESCRIPTION
## Summary
- keep the hard-cutover single-topic architecture on `peartube-network`
- wire Hyperswarm `peer` discovery events into the public-feed layer for app, CLI init, and relay runtime
- explicitly queue bounded `swarm.joinPeer(publicKey)` dials for discovered shared-topic peers so Protomux feed/availability channels get real sockets instead of waiting on passive connection timing
- add regressions for backend/mobile/relay wiring and the direct-dial behavior

## Root cause
After the single-topic cutover, PearTube joined `peartube-network` and logged low-level peer discovery, but nothing consumed those discovered peer identities to force an actual connection path for the public-feed Protomux channel. The previous fixes made the topic join and feed gossip correct, but the runtime could still sit with discovered peers and zero usable feed connections.

This does not reintroduce the legacy `peartube-public-feed-v1` topic. It stays on one canonical topic and uses direct peer dials from discoveries on that topic.

## Test plan
- [x] `git diff --check`
- [x] `npm run lint:changed`
- [x] `node --test packages/backend/test/public-feed-manager.test.mjs packages/app/tests/native-backend-startup-regression.test.mjs packages/backend/test/startup-gates.test.mjs`
- [x] `npm test --prefix packages/cli`
