### PR TITLE
ci: reduce redundant workflow runs

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -3,8 +3,15 @@ name: Build Desktop
 on:
   push:
     branches: [main]
-    tags:
-      - 'v*'
+    paths:
+      - 'packages/app/**'
+      - 'packages/desktop-native/**'
+      - 'packages/backend/**'
+      - 'packages/platform/**'
+      - 'packages/spec/**'
+      - 'packages/bare-*/**'
+      - '.github/actions/**'
+      - '.github/workflows/build-desktop.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build-mobile.yml
+++ b/.github/workflows/build-mobile.yml
@@ -3,8 +3,14 @@ name: Build Mobile
 on:
   push:
     branches: [main]
-    tags:
-      - 'v*'
+    paths:
+      - 'packages/app/**'
+      - 'packages/backend/**'
+      - 'packages/platform/**'
+      - 'packages/spec/**'
+      - 'packages/bare-*/**'
+      - '.github/actions/**'
+      - '.github/workflows/build-mobile.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build-relay.yml
+++ b/.github/workflows/build-relay.yml
@@ -14,6 +14,15 @@ on:
       - '.github/workflows/build-relay.yml'
   push:
     branches: [main]
+    paths:
+      - 'packages/cli/**'
+      - 'packages/backend/**'
+      - 'packages/bare-ffmpeg/**'
+      - 'packages/spec/**'
+      - 'packages/cli/Dockerfile'
+      - '.dockerignore'
+      - '.github/actions/**'
+      - '.github/workflows/build-relay.yml'
   schedule:
     - cron: '47 6 * * *'
   workflow_dispatch:

--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -3,8 +3,26 @@ name: Fast CI
 on:
   push:
     branches: [main]
+    paths:
+      - 'packages/backend/**'
+      - 'packages/cli/**'
+      - 'packages/platform/**'
+      - 'packages/spec/**'
+      - 'packages/app/tests/**'
+      - 'scripts/**'
+      - '.github/actions/**'
+      - '.github/workflows/**'
   pull_request:
     branches: [main]
+    paths:
+      - 'packages/backend/**'
+      - 'packages/cli/**'
+      - 'packages/platform/**'
+      - 'packages/spec/**'
+      - 'packages/app/tests/**'
+      - 'scripts/**'
+      - '.github/actions/**'
+      - '.github/workflows/**'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1,9 +1,6 @@
 name: Release Desktop
 
 on:
-  push:
-    tags:
-      - 'v*'
   workflow_dispatch:
     inputs:
       tag:

--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -1,9 +1,6 @@
 name: Release iOS
 
 on:
-  push:
-    tags:
-      - 'v*'
   workflow_dispatch:
     inputs:
       tag:

--- a/packages/app/tests/ci-app-build-trigger-regression.test.mjs
+++ b/packages/app/tests/ci-app-build-trigger-regression.test.mjs
@@ -19,7 +19,7 @@ function workflowHeader(workflow) {
   return workflow.slice(0, index)
 }
 
-test('app build workflows only run on main merges, version tags, or manual dispatch', () => {
+test('app build workflows only run on relevant main-path changes or manual dispatch', () => {
   const workflows = [
     ['build-mobile', readFile('.github/workflows/build-mobile.yml')],
     ['build-desktop', readFile('.github/workflows/build-desktop.yml')],
@@ -41,17 +41,44 @@ test('app build workflows only run on main merges, version tags, or manual dispa
     assert.match(
       header,
       /push:\s*\n\s*branches:\s*\[main\]/,
-      `${name} should build after merges into main`,
+      `${name} should build after relevant merges into main`,
+    )
+    assert.doesNotMatch(
+      header,
+      /push:[\s\S]*tags:/,
+      `${name} should not run redundant app builds when release tags are cut`,
     )
     assert.match(
       header,
-      /push:[\s\S]*tags:\s*\n\s*- 'v\*'/,
-      `${name} should build when version tags are cut`,
+      /paths:\s*\n(?:\s*- '[^']+'\s*\n)+/,
+      `${name} should limit main builds with path filters`,
     )
     assert.match(
       header,
       /workflow_dispatch:/,
       `${name} should still allow manual dispatch`,
+    )
+  }
+})
+
+test('expensive desktop and iOS release workflows are manual-only', () => {
+  const workflows = [
+    ['release-desktop', readFile('.github/workflows/release-desktop.yml')],
+    ['release-ios', readFile('.github/workflows/release-ios.yml')],
+  ]
+
+  for (const [name, workflow] of workflows) {
+    const header = workflowHeader(workflow)
+
+    assert.doesNotMatch(
+      header,
+      /push:/,
+      `${name} should not run automatically on tags`,
+    )
+    assert.match(
+      header,
+      /workflow_dispatch:/,
+      `${name} should remain available for manual releases`,
     )
   }
 })

--- a/packages/app/tests/ci-workflow-split-regression.test.mjs
+++ b/packages/app/tests/ci-workflow-split-regression.test.mjs
@@ -77,6 +77,23 @@ test('tagged Android releases only build the arm64-v8a APK', () => {
   )
 })
 
+test('routine validation workflows use path filters to avoid irrelevant runs', () => {
+  const workflows = [
+    ['ci-fast', readFile('.github/workflows/ci-fast.yml')],
+    ['build-relay', readFile('.github/workflows/build-relay.yml')],
+    ['build-mobile', readFile('.github/workflows/build-mobile.yml')],
+    ['build-desktop', readFile('.github/workflows/build-desktop.yml')],
+  ]
+
+  for (const [name, workflow] of workflows) {
+    assert.match(
+      workflow,
+      /paths:\s*\n(?:\s*- '[^']+'\s*\n)+/,
+      `${name} should use trigger-level paths filters`,
+    )
+  }
+})
+
 test('GitHub Actions references use Node 24-compatible action majors', () => {
   const files = [
     ...fs.readdirSync(path.join(repoRoot, '.github/workflows')).map((name) => `.github/workflows/${name}`),


### PR DESCRIPTION
## Summary
- stop redundant app build workflows from running on every `v*` tag
- make expensive desktop/iOS release workflows manual-only
- add trigger-level path filters to routine CI/build workflows so irrelevant changes skip them
- update workflow regression tests to lock in the lower-fanout behavior

## Expected effect
A relay/backend tag release should no longer wake up desktop/iOS release workflows or redundant build-mobile/build-desktop tag builds. Routine pushes/PRs should also skip CI/build workflows when only unrelated paths change.

## Test plan
- [x] `git diff --check`
- [x] `npm run lint:changed`
- [x] `node --test packages/app/tests/ci-app-build-trigger-regression.test.mjs packages/app/tests/ci-workflow-split-regression.test.mjs packages/app/tests/ci-lockfile-install-regression.test.mjs packages/app/tests/android-apk-build-pipeline-regression.test.mjs packages/app/tests/ci-generated-schema-workflow-regression.test.mjs`
