### PR TITLE
fix(relay): add PearTube blind peer availability

### DIFF
--- a/packages/app/app/(tabs)/settings.tsx
+++ b/packages/app/app/(tabs)/settings.tsx
@@ -791,7 +791,7 @@ export default function SettingsScreen() {
           </View>
 
           <Text className="text-caption text-pear-text-muted">
-            Cached content from other channels. Higher limits help the network by seeding more content to other peers. Your own videos are stored separately and don't count toward this limit.
+            Cached content from other channels. Higher limits help the network by seeding more content to other peers. Your own videos are stored separately and do not count toward this limit.
           </Text>
         </View>
 

--- a/packages/app/app/(tabs)/settings.tsx
+++ b/packages/app/app/(tabs)/settings.tsx
@@ -318,7 +318,8 @@ export default function SettingsScreen() {
               text: 'Publish',
               onPress: async () => {
                 try {
-                  await rpc.submitToFeed({})
+                  const result = await rpc.submitToFeed({})
+                  if (!result?.success) throw new Error(result?.error || 'Failed to publish channel')
                   Alert.alert('Published!', 'Your channel is now visible on the public feed.')
                 } catch (err) {
                   console.error('Failed to publish to feed:', err)
@@ -346,7 +347,8 @@ export default function SettingsScreen() {
       if (confirmed) {
         try {
           console.log('[Settings] Publishing to feed, driveKey:', identity.driveKey)
-          await rpc.submitToFeed()
+          const result = await rpc.submitToFeed()
+          if (!result?.success) throw new Error(result?.error || 'Failed to publish channel')
           setIsPublished(true)
           window.alert('Published! Your channel is now visible on the public feed.')
         } catch (err) {
@@ -364,7 +366,8 @@ export default function SettingsScreen() {
             text: 'Publish',
             onPress: async () => {
               try {
-                await rpc.submitToFeed()
+                const result = await rpc.submitToFeed()
+                if (!result?.success) throw new Error(result?.error || 'Failed to publish channel')
                 setIsPublished(true)
                 Alert.alert('Published!', 'Your channel is now visible on the public feed.')
               } catch (err) {

--- a/packages/app/backend/mobile-handlers.mjs
+++ b/packages/app/backend/mobile-handlers.mjs
@@ -147,7 +147,11 @@ export function attachMobileHandlers(B, deps) {
     }
   }
   B.refreshFeed = async () => { await api.refreshFeed(); return { success: true } }
-  B.submitToFeed = async () => { const a = identityManager.getActiveIdentity(); if (a?.driveKey) await api.submitToFeed(a.driveKey); return { success: true } }
+  B.submitToFeed = async () => {
+    const a = identityManager.getActiveIdentity();
+    if (!a?.driveKey) return { success: false, error: 'No active channel to publish' }
+    return api.submitToFeed(a.driveKey)
+  }
   B.unpublishFromFeed = async () => { const a = identityManager.getActiveIdentity(); if (a?.driveKey) await api.unpublishFromFeed(a.driveKey); return { success: true } }
   B.isChannelPublished = async () => { const a = identityManager.getActiveIdentity(); return a?.driveKey ? api.isChannelPublished(a.driveKey) : { published: false } }
   B.hideChannel = async (r) => { await api.hideChannel(r.channelKey); return { success: true } }

--- a/packages/app/backend/mobile-handlers.test.mjs
+++ b/packages/app/backend/mobile-handlers.test.mjs
@@ -234,6 +234,53 @@ test('getPublicFeed preserves serving manifest fields from the backend api', asy
   })
 })
 
+test('submitToFeed returns backend failures instead of masking missing publicBeeKey', async () => {
+  const backend = {}
+  const deps = createDeps({
+    identityManager: {
+      getActiveIdentity() {
+        return { driveKey: 'channel-key' }
+      },
+    },
+    api: {
+      async submitToFeed(driveKey) {
+        assert.equal(driveKey, 'channel-key')
+        return { success: false, error: 'Unable to publish channel: missing publicBeeKey' }
+      },
+    },
+  })
+
+  attachMobileHandlers(backend, deps)
+
+  assert.deepEqual(await backend.submitToFeed({}), {
+    success: false,
+    error: 'Unable to publish channel: missing publicBeeKey',
+  })
+})
+
+test('submitToFeed fails clearly when no active channel exists', async () => {
+  const backend = {}
+  const deps = createDeps({
+    identityManager: {
+      getActiveIdentity() {
+        return null
+      },
+    },
+    api: {
+      async submitToFeed() {
+        throw new Error('should not call submitToFeed without active channel')
+      },
+    },
+  })
+
+  attachMobileHandlers(backend, deps)
+
+  assert.deepEqual(await backend.submitToFeed({}), {
+    success: false,
+    error: 'No active channel to publish',
+  })
+})
+
 test('transcodeStop and transcodeStatus await async transcoder adapters', async () => {
   const backend = {}
   const events = []

--- a/packages/app/workers/desktop/index.ts
+++ b/packages/app/workers/desktop/index.ts
@@ -531,7 +531,11 @@ B.getPublicFeed = async () => {
   }
 }
 B.refreshFeed = async () => { api.refreshFeed(); return { success: true } }
-B.submitToFeed = async () => { const a = identityManager.getActiveIdentity(); if (a?.driveKey) await api.submitToFeed(a.driveKey); return { success: true } }
+B.submitToFeed = async () => {
+  const a = identityManager.getActiveIdentity();
+  if (!a?.driveKey) return { success: false, error: 'No active channel to publish' }
+  return api.submitToFeed(a.driveKey)
+}
 B.unpublishFromFeed = async () => { const a = identityManager.getActiveIdentity(); if (a?.driveKey) await api.unpublishFromFeed(a.driveKey); return { success: true } }
 B.isChannelPublished = async () => { const a = identityManager.getActiveIdentity(); return a?.driveKey ? api.isChannelPublished(a.driveKey) : { published: false } }
 B.hideChannel = async (r: any) => { api.hideChannel(r.channelKey); return { success: true } }

--- a/packages/app/workers/desktop/index.ts
+++ b/packages/app/workers/desktop/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-imports, @typescript-eslint/ban-ts-comment, no-empty, no-extra-semi, @typescript-eslint/no-require-imports, @typescript-eslint/no-unused-expressions, prefer-const */
 /**
  * PearTube Desktop Worker — Thin HRPC Handler Shim
  * Initializes via createBackend() from @peartube/backend, which registers

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -13,6 +13,7 @@
     "./channel": "./src/channel/index.js",
     "./swarm": "./src/swarm.js",
     "./public-feed": "./src/public-feed.js",
+    "./relay-blind-peer": "./src/relay-blind-peer.js",
     "./video-stats": "./src/video-stats.js",
     "./seeding": "./src/seeding.js",
     "./api": "./src/api.js",

--- a/packages/backend/src/mobile-handlers.js
+++ b/packages/backend/src/mobile-handlers.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-empty */
 /**
  * PearTube shared app handler adapters.
  *

--- a/packages/backend/src/mobile-handlers.js
+++ b/packages/backend/src/mobile-handlers.js
@@ -139,7 +139,11 @@ export function attachMobileHandlers(B, deps) {
     }
   }
   B.refreshFeed = async () => { await api.refreshFeed(); return { success: true } }
-  B.submitToFeed = async () => { const a = identityManager.getActiveIdentity(); if (a?.driveKey) await api.submitToFeed(a.driveKey); return { success: true } }
+  B.submitToFeed = async () => {
+    const a = identityManager.getActiveIdentity();
+    if (!a?.driveKey) return { success: false, error: 'No active channel to publish' }
+    return api.submitToFeed(a.driveKey)
+  }
   B.unpublishFromFeed = async () => { const a = identityManager.getActiveIdentity(); if (a?.driveKey) await api.unpublishFromFeed(a.driveKey); return { success: true } }
   B.isChannelPublished = async () => { const a = identityManager.getActiveIdentity(); return a?.driveKey ? api.isChannelPublished(a.driveKey) : { published: false } }
   B.hideChannel = async (r) => { await api.hideChannel(r.channelKey); return { success: true } }

--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -307,6 +307,37 @@ export class PublicFeedManager {
     return Array.from(merged.values())
   }
 
+  _swarmPeerEntries() {
+    const peers = this.swarm?.peers
+    if (!peers) return []
+    if (typeof peers.values === 'function') return Array.from(peers.values())
+    if (typeof peers[Symbol.iterator] === 'function') return Array.from(peers)
+    return []
+  }
+
+  _peerEntryMatchesKey(entry, keyHex) {
+    if (!entry) return false
+    if (typeof entry === 'string') return entry === keyHex
+    if (b4a.isBuffer(entry) || entry instanceof Uint8Array) {
+      return b4a.toString(entry, 'hex') === keyHex
+    }
+    const publicKey = entry.publicKey || entry.remotePublicKey || entry.key
+    if (publicKey && (b4a.isBuffer(publicKey) || publicKey instanceof Uint8Array)) {
+      return b4a.toString(publicKey, 'hex') === keyHex
+    }
+    return false
+  }
+
+  _hasKnownPeer(keyHex) {
+    const peers = this.swarm?.peers
+    if (!peers) return false
+    if (typeof peers.has === 'function' && peers.has(keyHex)) return true
+    for (const entry of this._swarmPeerEntries()) {
+      if (this._peerEntryMatchesKey(entry, keyHex)) return true
+    }
+    return false
+  }
+
   /**
    * Remember a discovered peer and explicitly dial it when the shared topic has
    * found peers but Hyperswarm has not promoted them into connections yet.
@@ -322,25 +353,21 @@ export class PublicFeedManager {
     const keyHex = b4a.toString(publicKey, 'hex')
     if (!keyHex || keyHex === b4a.toString(this.swarm.keyPair?.publicKey || [], 'hex')) return false
     this._discoveredPeers.set(keyHex, publicKey)
-    if (this.swarm.peers?.has?.(keyHex)) return false
-    if ((this.swarm.connections?.size || 0) >= this._maxDirectPeers) return false
+    if (this._hasKnownPeer(keyHex)) return false
 
-    const attempts = this._directPeerRetryCounts.get(keyHex) || 0
-    if (attempts >= this._maxDirectPeerRetries) return false
-
-    return this._dialDiscoveredPeer(keyHex, publicKey, attempts)
+    return this._dialDiscoveredPeer(keyHex, publicKey)
   }
 
-  _dialDiscoveredPeer(keyHex, publicKey, attempts = this._directPeerRetryCounts.get(keyHex) || 0) {
+  _dialDiscoveredPeer(keyHex, publicKey, attempts = this._directPeerRetryCounts.get(keyHex) || 0, { force = false } = {}) {
     if (!publicKey || !this.swarm || typeof this.swarm.joinPeer !== 'function') return false
     if (!keyHex || keyHex === b4a.toString(this.swarm.keyPair?.publicKey || [], 'hex')) return false
-    if (this.swarm.peers?.has?.(keyHex)) return false
+    if (this._hasKnownPeer(keyHex)) return false
     if ((this.swarm.connections?.size || 0) >= this._maxDirectPeers) return false
-    if (attempts >= this._maxDirectPeerRetries) return false
+    if (!force && attempts >= this._maxDirectPeerRetries) return false
 
-    this._directPeerRetryCounts.set(keyHex, attempts + 1)
     try {
       this.swarm.joinPeer(publicKey)
+      this._directPeerRetryCounts.set(keyHex, attempts + 1)
       console.log('[PublicFeed] Direct peer dial queued from shared topic:', keyHex.slice(0, 16), 'attempt=', attempts + 1)
       return true
     } catch (err) {
@@ -349,12 +376,13 @@ export class PublicFeedManager {
     }
   }
 
-  _redialDiscoveredPeers() {
-    if (!this._discoveredPeers.size || (this.swarm?.connections?.size || 0) >= this._maxDirectPeers) return 0
+  _redialDiscoveredPeers({ force = false } = {}) {
+    if (!this._discoveredPeers.size || !this.swarm || typeof this.swarm.joinPeer !== 'function') return 0
     let dialed = 0
     for (const [keyHex, publicKey] of this._discoveredPeers) {
-      if ((this.swarm?.connections?.size || 0) >= this._maxDirectPeers) break
-      if (this._dialDiscoveredPeer(keyHex, publicKey)) dialed++
+      if ((this.swarm.connections?.size || 0) >= this._maxDirectPeers) break
+      const attempts = this._directPeerRetryCounts.get(keyHex) || 0
+      if (this._dialDiscoveredPeer(keyHex, publicKey, attempts, { force })) dialed++
     }
     return dialed
   }

--- a/packages/backend/src/relay-blind-peer.js
+++ b/packages/backend/src/relay-blind-peer.js
@@ -30,6 +30,7 @@ function createNoopRelayBlindPeer({ key, error = null } = {}) {
   }
 }
 
+/* eslint-disable no-empty */
 /**
  * Create the PearTube relay's blind-peer surface. This makes the relay usable
  * as a native Holepunch blind peer while keeping PearTube's public-feed and

--- a/packages/backend/src/relay-blind-peer.js
+++ b/packages/backend/src/relay-blind-peer.js
@@ -1,0 +1,123 @@
+import b4a from 'b4a'
+
+function isHexKey(value) {
+  return typeof value === 'string' && /^[a-f0-9]{64}$/i.test(value)
+}
+
+function toHexKey(value) {
+  if (!value) return null
+  if (typeof value === 'string') return isHexKey(value) ? value.toLowerCase() : null
+  if (b4a.isBuffer(value) || value instanceof Uint8Array) return b4a.toString(value, 'hex')
+  return null
+}
+
+function normalizeBlindPeerKeys(keys) {
+  if (!Array.isArray(keys)) return []
+  return Array.from(new Set(keys.map(toHexKey).filter(Boolean)))
+}
+
+function createNoopRelayBlindPeer({ key, error = null } = {}) {
+  return {
+    enabled: false,
+    publicKey: key || null,
+    error,
+    addCore() { return false },
+    addAutobase() { return false },
+    getStats() {
+      return { enabled: false, publicKey: key || null, mirroredCores: 0, mirroredAutobases: 0, error }
+    },
+    async close() {}
+  }
+}
+
+/**
+ * Create the PearTube relay's blind-peer surface. This makes the relay usable
+ * as a native Holepunch blind peer while keeping PearTube's public-feed and
+ * availability protocol on the canonical peartube-network topic.
+ */
+export async function createRelayBlindPeer({
+  ctx,
+  storagePath,
+  enabled = true,
+  trustedPeerKeys = [],
+  logger = {},
+  BlindPeerCtor = null,
+} = {}) {
+  if (!enabled || !ctx?.store || ctx?.swarm?._peartubeOffline) {
+    return createNoopRelayBlindPeer({ error: ctx?.swarm?._peartubeOfflineReason || null })
+  }
+
+  let BlindPeer = BlindPeerCtor
+  if (!BlindPeer) {
+    try {
+      const mod = await import('blind-peer')
+      BlindPeer = mod.default || mod
+    } catch (err) {
+      logger.warn?.('[relay-blind-peer] blind-peer unavailable', { error: err?.message || String(err) })
+      return createNoopRelayBlindPeer({ error: err?.message || String(err) })
+    }
+  }
+
+  try {
+    const blindPeer = new BlindPeer(`${storagePath}/blind-peer`, {
+      store: ctx.store,
+      swarm: ctx.swarm,
+      wakeup: ctx.wakeup || undefined,
+      trustedPubKeys: normalizeBlindPeerKeys(trustedPeerKeys),
+      // PearTube already has explicit retention/cache policy. Do not let the
+      // generic blind-peer GC clear mirrored video cores underneath the relay.
+      enableGc: false,
+    })
+    await blindPeer.ready?.()
+    await blindPeer.listen?.()
+
+    const publicKey = toHexKey(blindPeer.publicKey || ctx.swarm?.keyPair?.publicKey)
+    logger.info?.('[relay-blind-peer] listening', { publicKey })
+
+    const trackedCores = new Set()
+    const trackedAutobases = new Set()
+
+    return {
+      enabled: true,
+      publicKey,
+      instance: blindPeer,
+      addCore(core, opts = {}) {
+        if (!core) return false
+        const keyHex = toHexKey(core.key)
+        if (keyHex) trackedCores.add(keyHex)
+        try {
+          // This path is for relay-owned or already-accepted PearTube content.
+          // announce=true means the relay advertises bytes on the core's normal
+          // discovery topic while public-feed metadata still travels over
+          // peartube-network/Protomux.
+          blindPeer._announceCore?.(core.key).catch?.(() => {})
+        } catch {}
+        try { core.download?.({ start: 0, end: -1 }) } catch {}
+        return true
+      },
+      addAutobase(base, opts = {}) {
+        if (!base) return false
+        const keyHex = toHexKey(base?.key || base?.local?.key || base?.wakeupCapability?.key)
+        if (keyHex) trackedAutobases.add(keyHex)
+        if (base.local) this.addCore(base.local, opts)
+        if (base.core) this.addCore(base.core, opts)
+        return true
+      },
+      getStats() {
+        return {
+          enabled: true,
+          publicKey,
+          mirroredCores: trackedCores.size,
+          mirroredAutobases: trackedAutobases.size,
+          error: null
+        }
+      },
+      async close() {
+        await blindPeer.close?.()
+      }
+    }
+  } catch (err) {
+    logger.warn?.('[relay-blind-peer] failed to start', { error: err?.message || String(err) })
+    return createNoopRelayBlindPeer({ error: err?.message || String(err) })
+  }
+}

--- a/packages/backend/test/public-feed-manager.test.mjs
+++ b/packages/backend/test/public-feed-manager.test.mjs
@@ -76,6 +76,45 @@ test('PublicFeedManager explicitly dials peers discovered on the shared topic', 
   }
 })
 
+test('PublicFeedManager skips direct dials for known peers across swarm peer shapes', () => {
+  const publicKey = b4a.alloc(32, 8)
+  const keyHex = b4a.toString(publicKey, 'hex')
+  const cases = [
+    new Map([[keyHex, { publicKey }]]),
+    new Map([[publicKey, { publicKey }]]),
+    new Set([{ publicKey }]),
+    new Set([publicKey]),
+  ]
+
+  for (const peers of cases) {
+    const swarm = createSwarm()
+    swarm.peers = peers
+    const manager = new PublicFeedManager(swarm, createMetaDb())
+
+    try {
+      assert.equal(manager.handleDiscoveredPeer({ publicKey }), false)
+      assert.equal(swarm.joinPeerCalls.length, 0)
+    } finally {
+      manager.stop()
+    }
+  }
+})
+
+test('periodic gossip re-dials remembered shared-topic peers when sockets dropped', () => {
+  const publicKey = b4a.alloc(32, 10)
+  const swarm = createSwarm()
+  const manager = new PublicFeedManager(swarm, createMetaDb())
+
+  try {
+    assert.equal(manager.handleDiscoveredPeer({ publicKey }), true)
+    assert.equal(swarm.joinPeerCalls.length, 1)
+    assert.equal(manager._redialDiscoveredPeers(), 1)
+    assert.equal(swarm.joinPeerCalls.length, 2)
+  } finally {
+    manager.stop()
+  }
+})
+
 test('PublicFeedManager.start joins shared PearTube network topic for feed-peer discovery', async () => {
   const swarm = createSwarm()
   const manager = new PublicFeedManager(swarm, createMetaDb())

--- a/packages/backend/test/relay-blind-peer.test.mjs
+++ b/packages/backend/test/relay-blind-peer.test.mjs
@@ -1,0 +1,84 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import b4a from 'b4a'
+
+import { createRelayBlindPeer } from '../src/relay-blind-peer.js'
+
+function createCtx() {
+  return {
+    store: {},
+    wakeup: {},
+    swarm: {
+      keyPair: { publicKey: b4a.alloc(32, 9) },
+      _peartubeOffline: false,
+    }
+  }
+}
+
+test('createRelayBlindPeer starts a native blind peer on the relay swarm/store', async (t) => {
+  const calls = []
+  class FakeBlindPeer {
+    constructor(path, opts) {
+      calls.push({ path, opts })
+      this.publicKey = b4a.alloc(32, 7)
+      this.readyCalls = 0
+      this.listenCalls = 0
+      this.closeCalls = 0
+    }
+    async ready() { this.readyCalls++ }
+    async listen() { this.listenCalls++ }
+    async close() { this.closeCalls++ }
+    _announceCore() { return Promise.resolve() }
+  }
+  const ctx = createCtx()
+  const relay = await createRelayBlindPeer({
+    ctx,
+    storagePath: '/tmp/relay',
+    trustedPeerKeys: ['aa'.repeat(32)],
+    BlindPeerCtor: FakeBlindPeer,
+    logger: { info() {}, warn() {} },
+  })
+
+  assert.equal(relay.enabled, true)
+  assert.equal(relay.publicKey, '07'.repeat(32))
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0].path, '/tmp/relay/blind-peer')
+  assert.equal(calls[0].opts.store, ctx.store)
+  assert.equal(calls[0].opts.swarm, ctx.swarm)
+  assert.equal(calls[0].opts.wakeup, ctx.wakeup)
+  assert.deepEqual(calls[0].opts.trustedPubKeys, ['aa'.repeat(32)])
+  assert.equal(calls[0].opts.enableGc, false)
+})
+
+test('relay blind peer is disabled when P2P swarm is offline', async (t) => {
+  const ctx = createCtx()
+  ctx.swarm._peartubeOffline = true
+  ctx.swarm._peartubeOfflineReason = 'module-unavailable'
+
+  const relay = await createRelayBlindPeer({ ctx, storagePath: '/tmp/relay' })
+
+  assert.equal(relay.enabled, false)
+  assert.equal(relay.getStats().error, 'module-unavailable')
+})
+
+test('relay blind peer tracks announced mirrored cores', async (t) => {
+  const announced = []
+  class FakeBlindPeer {
+    constructor() { this.publicKey = b4a.alloc(32, 3) }
+    async ready() {}
+    async listen() {}
+    _announceCore(key) { announced.push(b4a.toString(key, 'hex')); return Promise.resolve() }
+  }
+  const ctx = createCtx()
+  const relay = await createRelayBlindPeer({ ctx, storagePath: '/tmp/relay', BlindPeerCtor: FakeBlindPeer })
+  const core = {
+    key: b4a.alloc(32, 4),
+    downloadCalls: [],
+    download(range) { this.downloadCalls.push(range) }
+  }
+
+  assert.equal(relay.addCore(core, { announce: true }), true)
+  assert.deepEqual(announced, ['04'.repeat(32)])
+  assert.deepEqual(core.downloadCalls, [{ start: 0, end: -1 }])
+  assert.equal(relay.getStats().mirroredCores, 1)
+})

--- a/packages/cli/src/config.js
+++ b/packages/cli/src/config.js
@@ -255,10 +255,12 @@ function configFromEnv(env = {}) {
       config.discovery.maxChannelsPerOwner = Number(env.PEARTUBE_DISCOVERY_MAX_CHANNELS_PER_OWNER)
     }
   }
-  if (env.PEARTUBE_NETWORK_ANNOUNCE || env.PEARTUBE_NETWORK_BOOTSTRAP) {
+  if (env.PEARTUBE_NETWORK_ANNOUNCE || env.PEARTUBE_NETWORK_BOOTSTRAP || env.PEARTUBE_RELAY_BLIND_PEER_ENABLED || env.PEARTUBE_RELAY_BLIND_PEER_TRUSTED_CLIENTS) {
     config.network = {}
     if (env.PEARTUBE_NETWORK_ANNOUNCE) config.network.announce = parseBoolean(env.PEARTUBE_NETWORK_ANNOUNCE)
     if (env.PEARTUBE_NETWORK_BOOTSTRAP) config.network.bootstrap = env.PEARTUBE_NETWORK_BOOTSTRAP
+    if (env.PEARTUBE_RELAY_BLIND_PEER_ENABLED) config.network.blindPeer = parseBoolean(env.PEARTUBE_RELAY_BLIND_PEER_ENABLED)
+    if (env.PEARTUBE_RELAY_BLIND_PEER_TRUSTED_CLIENTS) config.network.trustedBlindPeerClients = splitCommaList(env.PEARTUBE_RELAY_BLIND_PEER_TRUSTED_CLIENTS)
   }
   if (env.PEARTUBE_RETENTION_PROTECT_PRIVATE || env.PEARTUBE_RETENTION_PROTECT_ALLOWLIST) {
     config.retention = {}

--- a/packages/cli/src/constants.js
+++ b/packages/cli/src/constants.js
@@ -81,7 +81,9 @@ export const DEFAULT_RELAY_CONFIG = {
   },
   network: {
     announce: true,
-    bootstrap: 'default'
+    bootstrap: 'default',
+    blindPeer: true,
+    trustedBlindPeerClients: []
   },
   archive: DEFAULT_ARCHIVE_CONFIG,
   logging: {

--- a/packages/cli/src/runtime.js
+++ b/packages/cli/src/runtime.js
@@ -4,12 +4,14 @@ export async function createRelayRuntime({ config, logger }) {
     { PublicFeedManager },
     { CacheManager },
     { createRelaySeeder },
+    { createRelayBlindPeer },
     { readPrimaryKeyFile, writePrimaryKeyFile }
   ] = await Promise.all([
     import('@peartube/backend/storage'),
     import('@peartube/backend/public-feed'),
     import('./cache-manager.js'),
     import('./seeding.js'),
+    import('@peartube/backend/relay-blind-peer'),
     import('../../backend/src/identity-key-file.js')
   ])
 
@@ -54,9 +56,17 @@ export async function createRelayRuntime({ config, logger }) {
 
   const publicFeed = new PublicFeedManager(ctx.swarm, ctx.metaDb)
   const cacheManager = new CacheManager(ctx.store, ctx.metaDb, config?.storage?.maxBytes || 0)
+  const blindPeer = await createRelayBlindPeer({
+    ctx,
+    storagePath: storageRoot,
+    enabled: config?.network?.blindPeer !== false,
+    trustedPeerKeys: config?.network?.trustedBlindPeerClients || [],
+    logger: logger.runtime || logger.relay || logger
+  })
   const seeder = createRelaySeeder({
     ctx,
     loadPublicBee,
+    blindPeer,
     logger: logger.runtime || logger.relay || logger
   })
   let candidateHandler = null
@@ -229,6 +239,7 @@ export async function createRelayRuntime({ config, logger }) {
           online: ctx.swarm?.dht?.online ?? null
         },
         publicFeedDiscoveryJoined: Boolean(publicFeed.feedDiscovery),
+        blindPeer: blindPeer.getStats?.() || null,
         peerPoolJoined: Boolean(ctx.peerPoolDiscovery),
         swarmOffline: Boolean(ctx.swarm?._peartubeOffline),
         swarmOfflineReason: ctx.swarm?._peartubeOfflineReason || null,
@@ -239,6 +250,7 @@ export async function createRelayRuntime({ config, logger }) {
     async close() {
       try { publicFeed.stop() } catch (err) { logger.runtime?.debug('Public feed close failed', { error: err?.message || String(err) }) }
       try { await seeder.close() } catch (err) { logger.runtime?.debug('Relay seeder close failed', { error: err?.message || String(err) }) }
+      try { await blindPeer.close?.() } catch (err) { logger.runtime?.debug('Relay blind peer close failed', { error: err?.message || String(err) }) }
       try { await ctx.swarm.destroy() } catch (err) { logger.runtime?.debug('Swarm close failed', { error: err?.message || String(err) }) }
       try { ctx.blobServer?.close?.() } catch (err) { logger.runtime?.debug('Blob server close failed', { error: err?.message || String(err) }) }
       try { await ctx.store.close() } catch (err) { logger.runtime?.debug('Store close failed', { error: err?.message || String(err) }) }

--- a/packages/cli/src/seeding.js
+++ b/packages/cli/src/seeding.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-empty */
 import b4a from 'b4a'
 
 function isValidHexKey(value) {

--- a/packages/cli/src/seeding.js
+++ b/packages/cli/src/seeding.js
@@ -11,6 +11,7 @@ function emptyStats() {
     publicBeeCores: 0,
     blobCores: 0,
     discoveryHandles: 0,
+    blindPeer: null,
     lastSeededAt: null,
     lastError: null
   }
@@ -26,7 +27,7 @@ function addCoreKey(set, value) {
   return true
 }
 
-export function createRelaySeeder({ ctx, loadPublicBee, logger = {} }) {
+export function createRelaySeeder({ ctx, loadPublicBee, logger = {}, blindPeer = null }) {
   if (!ctx) throw new Error('ctx is required')
   if (typeof loadPublicBee !== 'function') throw new Error('loadPublicBee is required')
 
@@ -86,6 +87,7 @@ export function createRelaySeeder({ ctx, loadPublicBee, logger = {} }) {
       const bee = await loadPublicBee(ctx, publicBeeKey)
       if (bee?.core?.discoveryKey) {
         retainDiscovery(bee.core.discoveryKey, `publicBee:${String(publicBeeKey).slice(0, 16)}`)
+        try { blindPeer?.addCore?.(bee.core, { announce: true, referrer: b4a.from(publicBeeKey, 'hex') }) } catch {}
         stats.publicBeeCores = 1
       }
 
@@ -103,6 +105,7 @@ export function createRelaySeeder({ ctx, loadPublicBee, logger = {} }) {
         const core = await resolveBlobCore(keyHex)
         if (core?.discoveryKey) {
           retainDiscovery(core.discoveryKey, `blob:${keyHex.slice(0, 16)}`)
+          try { blindPeer?.addCore?.(core, { announce: true, referrer: b4a.from(publicBeeKey, 'hex') }) } catch {}
           stats.blobCores += 1
         }
       }
@@ -158,6 +161,8 @@ export function createRelaySeeder({ ctx, loadPublicBee, logger = {} }) {
     const stats = emptyStats()
     stats.channels = seededChannels.size
     stats.discoveryHandles = handles.size
+    const blindPeerStats = blindPeer?.getStats?.() || null
+    if (blindPeerStats) stats.blindPeer = blindPeerStats
     for (const channel of seededChannels.values()) {
       stats.videos += Number(channel.videos || 0)
       stats.publicBeeCores += Number(channel.publicBeeCores || 0)

--- a/packages/cli/src/status.js
+++ b/packages/cli/src/status.js
@@ -37,6 +37,7 @@ export function buildRelayStatus({ config, catalog, runtimeStats = {} }) {
         online: runtimeStats.dht?.online ?? null
       },
       publicFeedDiscoveryJoined: Boolean(runtimeStats.publicFeedDiscoveryJoined),
+      blindPeer: runtimeStats.blindPeer || runtimeStats.seeding?.blindPeer || null,
       peerPoolJoined: Boolean(runtimeStats.peerPoolJoined),
       swarmOffline: Boolean(runtimeStats.swarmOffline),
       swarmOfflineReason: runtimeStats.swarmOfflineReason || null,
@@ -86,6 +87,7 @@ export function formatRelayStatus(status) {
     `feedEntries: ${status.runtime.feedEntries}`,
     `dht: bootstrapped=${status.runtime.dht.bootstrapped} firewalled=${status.runtime.dht.firewalled} online=${status.runtime.dht.online}`,
     `network: offline=${status.runtime.swarmOffline} reason=${status.runtime.swarmOfflineReason || 'none'} listenResolved=${status.runtime.swarmListenResolved} peerPoolJoined=${status.runtime.peerPoolJoined} publicFeedDiscoveryJoined=${status.runtime.publicFeedDiscoveryJoined}`,
+    `blindPeer: enabled=${Boolean(status.runtime.blindPeer?.enabled)} key=${status.runtime.blindPeer?.publicKey || 'none'} mirroredCores=${status.runtime.blindPeer?.mirroredCores || 0} mirroredAutobases=${status.runtime.blindPeer?.mirroredAutobases || 0}`,
     `seeding: channels=${status.runtime.seeding.channels} videos=${status.runtime.seeding.videos} publicBeeCores=${status.runtime.seeding.publicBeeCores} blobCores=${status.runtime.seeding.blobCores} discoveryHandles=${status.runtime.seeding.discoveryHandles}`
   ]
 

--- a/packages/cli/test/config.test.mjs
+++ b/packages/cli/test/config.test.mjs
@@ -102,6 +102,8 @@ test('loadRelayConfig supports env-only relay configuration', async (t) => {
       PEARTUBE_DISCOVERY_MAX_CHANNELS_PER_OWNER: '3',
       PEARTUBE_NETWORK_ANNOUNCE: 'false',
       PEARTUBE_NETWORK_BOOTSTRAP: 'local',
+      PEARTUBE_RELAY_BLIND_PEER_ENABLED: 'false',
+      PEARTUBE_RELAY_BLIND_PEER_TRUSTED_CLIENTS: 'aa,bb',
       PEARTUBE_RETENTION_PROTECT_PRIVATE: 'false',
       PEARTUBE_RETENTION_PROTECT_ALLOWLIST: 'false',
       PEARTUBE_LOG_LEVEL: 'debug'
@@ -120,6 +122,8 @@ test('loadRelayConfig supports env-only relay configuration', async (t) => {
   t.is(config.discovery.maxChannelsPerOwner, 3)
   t.is(config.network.announce, false)
   t.is(config.network.bootstrap, 'local')
+  t.is(config.network.blindPeer, false)
+  t.alike(config.network.trustedBlindPeerClients, ['aa', 'bb'])
   t.is(config.retention.protectPrivate, false)
   t.is(config.retention.protectAllowlist, false)
   t.is(config.logging.level, 'debug')

--- a/packages/cli/test/relay-seeding.test.mjs
+++ b/packages/cli/test/relay-seeding.test.mjs
@@ -131,6 +131,50 @@ test('relay seeder refreshes all cached channels and deduplicates retained joins
   t.is(swarm.joins.length, 2)
 })
 
+test('relay seeder registers mirrored cores with relay blind peer', async (t) => {
+  const publicBeeCore = createCore('66')
+  const videoCore = createCore('77')
+  const thumbnailCore = createCore('88')
+  const swarm = createSwarm()
+  const blindPeerCalls = []
+  const ctx = {
+    swarm,
+    store: {
+      get(key) {
+        const keyHex = Buffer.isBuffer(key) ? key.toString('hex') : String(key)
+        if (keyHex.startsWith('77')) return videoCore
+        if (keyHex.startsWith('88')) return thumbnailCore
+        throw new Error(`unexpected core key ${keyHex}`)
+      }
+    }
+  }
+  const seeder = createRelaySeeder({
+    ctx,
+    loadPublicBee: async () => ({
+      core: publicBeeCore,
+      async listVideos() {
+        return [{
+          id: 'video-1',
+          blobsCoreKey: '77'.padEnd(64, '0'),
+          thumbnailBlobsCoreKey: '88'.padEnd(64, '0'),
+        }]
+      }
+    }),
+    blindPeer: {
+      addCore(core, opts) { blindPeerCalls.push({ core, opts }) },
+      getStats() { return { enabled: true, publicKey: 'relay-key', mirroredCores: blindPeerCalls.length, mirroredAutobases: 0, error: null } }
+    },
+    logger: { info() {}, warn() {}, debug() {} }
+  })
+
+  await seeder.seedChannel({ driveKey: 'aa'.padEnd(64, '0'), publicBeeKey: 'bb'.padEnd(64, '0') })
+
+  t.is(blindPeerCalls.length, 3)
+  t.alike(blindPeerCalls.map((call) => call.core), [publicBeeCore, videoCore, thumbnailCore])
+  t.ok(blindPeerCalls.every((call) => call.opts?.announce === true))
+  t.is(seeder.getStats().blindPeer.mirroredCores, 3)
+})
+
 test('relay status surfaces DHT and seeding stats for phone connectivity diagnostics', async (t) => {
   const status = buildRelayStatus({
     config: {
@@ -154,6 +198,7 @@ test('relay status surfaces DHT and seeding stats for phone connectivity diagnos
       swarmOffline: false,
       swarmOfflineReason: null,
       swarmListenResolved: true,
+      blindPeer: { enabled: true, publicKey: 'abcd', mirroredCores: 4, mirroredAutobases: 0, error: null },
       seeding: { channels: 2, videos: 5, publicBeeCores: 2, blobCores: 8, discoveryHandles: 10 }
     }
   })
@@ -172,5 +217,6 @@ test('relay status surfaces DHT and seeding stats for phone connectivity diagnos
   const formatted = formatRelayStatus(status)
   t.ok(formatted.includes('dht: bootstrapped=true firewalled=false online=true'))
   t.ok(formatted.includes('network: offline=false reason=none listenResolved=true peerPoolJoined=true publicFeedDiscoveryJoined=true'))
+  t.ok(formatted.includes('blindPeer: enabled=true key=abcd mirroredCores=4 mirroredAutobases=0'))
   t.ok(formatted.includes('seeding: channels=2 videos=5 publicBeeCores=2 blobCores=8 discoveryHandles=10'))
 })


### PR DESCRIPTION
## Summary
- Start a PearTube-specific relay blind-peer surface for mirrored public/feed/blob cores.
- Register relay-seeded publicBee/blob cores with the blind peer and expose blind-peer diagnostics in relay status.
- Re-dial remembered shared-topic peers during feed gossip so dropped sockets do not permanently strand feed discovery.
- Surface `submitToFeed` backend failures instead of letting app/desktop UI mark channels as published when public-feed submission failed.

## Architecture
- Keeps the hard cutover to one canonical Hyperswarm topic: `peartube-network`.
- Uses Protomux/client-equivalent channels on top; no legacy `peartube-public-feed-v1` compatibility bridge.
- Relay acts as a PearTube-specific availability/blind-peer layer, not as a special archive-only box.

## Test Plan
- `node --test packages/backend/test/public-feed-manager.test.mjs packages/backend/test/relay-blind-peer.test.mjs packages/app/backend/mobile-handlers.test.mjs`
- `npm test --prefix packages/cli -- --timeout=30000`
- `node --test packages/app/tests/vertical-discovery-regression.test.mjs`
- `git diff --check`
- `npm run lint:changed`

## Notes
- Local `npm run lint:changed` exited 0 but reported `[lint:changed] No changed JS/TS files to lint`; CI should still validate the clean environment.
