### PR TITLE
fix(feed): allow relay previews with direct blobs

### DIFF
--- a/packages/app/app/(tabs)/discover.tsx
+++ b/packages/app/app/(tabs)/discover.tsx
@@ -164,10 +164,12 @@ export default function VerticalDiscoveryScreen() {
 
   const seedFromFeedEntries = useCallback((entries: FeedEntry[]) => {
     const visibleEntries = getVisibleSeededFeedEntries(entries as any)
-    const previewVideos = getFeedPreviewVideos(visibleEntries as any, {
-      identityDriveKey: identity?.driveKey || undefined,
-      channelMeta: {},
-    }) as VideoData[]
+    const previewVideos = getFeedPreviewVideos(
+      visibleEntries as any,
+      {},
+      identity?.driveKey || undefined,
+      40,
+    ) as VideoData[]
 
     const renderable = previewVideos
       .filter((video) => shouldRenderFeedVideo({

--- a/packages/app/app/(tabs)/discover.tsx
+++ b/packages/app/app/(tabs)/discover.tsx
@@ -90,7 +90,7 @@ export default function VerticalDiscoveryScreen() {
   const insets = useSafeAreaInsets()
   const { height: screenHeight, width: screenWidth } = useWindowDimensions()
   const { isDesktop } = usePlatform()
-  const { ready, identity, rpc, blobServerPort, backendError, startupStatus } = useApp()
+  const { ready, identity, rpc, blobServerPort, backendError, startupStatus, platformEvents } = useApp()
   const {
     currentVideo,
     playerMode,
@@ -256,6 +256,16 @@ export default function VerticalDiscoveryScreen() {
     if (!ready || !rpc) return
     loadFeed()
   }, [loadFeed, ready, rpc])
+
+  useEffect(() => {
+    if (!ready || !rpc) return
+    const unsubscribe = (platformEvents as any)?.onFeedUpdate?.(() => {
+      void loadFeed()
+    })
+    return () => {
+      if (typeof unsubscribe === 'function') unsubscribe()
+    }
+  }, [loadFeed, platformEvents, ready, rpc])
 
   const stopShortsPlayback = useCallback(() => {
     void shortsPlayerRef.current?.stop?.()

--- a/packages/app/lib/feed-hydration.js
+++ b/packages/app/lib/feed-hydration.js
@@ -51,12 +51,18 @@ export function getFeedVideoLoadEntries(feedEntries, limit = 15) {
   return getVisibleSeededFeedEntries(feedEntries, limit)
 }
 
+function hasDirectBlobRef(video) {
+  return typeof video?.blobId === 'string' && video.blobId.length > 0 &&
+    typeof video?.blobsCoreKey === 'string' && /^[a-f0-9]{64}$/i.test(video.blobsCoreKey)
+}
+
 function canUseFeedPreviewVideos(entry, identityDriveKey) {
   const channelKey = entry?.channelKey || entry?.driveKey || null
   if (!channelKey) return false
   if (identityDriveKey && channelKey === identityDriveKey) return true
   if (entry?.source === 'local') return true
-  return (entry?.peerCount ?? 0) > 0
+  if ((entry?.peerCount ?? 0) > 0) return true
+  return Boolean(entry?.publicBeeKey && Array.isArray(entry?.previewVideos) && entry.previewVideos.some(hasDirectBlobRef))
 }
 
 export function getFeedPreviewVideos(feedEntries, channelMeta, identityDriveKey, limit = 15) {

--- a/packages/app/tests/feed-hydration.test.mjs
+++ b/packages/app/tests/feed-hydration.test.mjs
@@ -144,7 +144,38 @@ test('getFeedPreviewVideos only uses local or live-peer manifest previews', () =
       publicBeeKey: 'bee-live',
       channelName: 'Live channel',
     },
-  ])
+  ], 'stale cached remote preview without blob refs is ignored before a live peer proves availability')
+})
+
+test('getFeedPreviewVideos keeps relay manifest previews with direct blob refs even when peer count temporarily drops', () => {
+  const previews = getFeedPreviewVideos([
+    {
+      driveKey: 'relay-archive',
+      peerCount: 0,
+      publicBeeKey: 'bee-relay',
+      channelName: 'Relay archive',
+      previewVideos: [{
+        id: 'archived-video',
+        title: 'Archived video',
+        uploadedAt: 40,
+        availability: 'playable',
+        blobId: '0:8:0:1024',
+        blobsCoreKey: 'aa'.repeat(32),
+      }],
+    },
+  ], {}, 'local', 5)
+
+  assert.deepEqual(previews.map((video) => ({
+    id: video.id,
+    channelKey: video.channelKey,
+    publicBeeKey: video.publicBeeKey,
+    channelName: video.channel?.name,
+  })), [{
+    id: 'archived-video',
+    channelKey: 'relay-archive',
+    publicBeeKey: 'bee-relay',
+    channelName: 'Relay archive',
+  }])
 })
 
 test('shouldKeepFeedVideoForVisibleEntries keeps restored snapshot cards until their channels are refreshed', () => {

--- a/packages/app/tests/native-backend-startup-regression.test.mjs
+++ b/packages/app/tests/native-backend-startup-regression.test.mjs
@@ -104,6 +104,29 @@ test('mobile getSwarmStatus forwards low-level network diagnostics', () => {
   }
 })
 
+test('desktop worker forwards feed update events and full swarm diagnostics', () => {
+  const source = readAppFile('workers/desktop/index.ts')
+
+  assert.match(source, /onFeedUpdate:\s*\(\) => \{[\s\S]*?eventFeedUpdate\?\.\(\{ channelKey: 'feed', action: 'update' \}\)/)
+
+  const swarmStatusBlock = source.match(/B\.getSwarmStatus = async \(\) => \{([\s\S]*?)\n\}/)?.[1] ?? ''
+  assert.ok(swarmStatusBlock, 'desktop getSwarmStatus handler should exist')
+  assert.match(swarmStatusBlock, /api\.getSwarmStatus\(\)/)
+  for (const field of [
+    'network',
+    'swarmOffline',
+    'swarmOfflineReason',
+    'swarmListenResolved',
+    'peerPoolJoined',
+    'publicFeedDiscoveryJoined',
+    'feedTopicHex',
+    'feedConnections',
+    'feedEntries',
+  ]) {
+    assert.match(swarmStatusBlock, new RegExp(field), `desktop getSwarmStatus should expose ${field}`)
+  }
+})
+
 test('backend orchestrator defers warm-up behind startup gates and does not force a boot-time feed sync request', () => {
   const source = readWorkspaceFile('backend/src/orchestrator.js')
 

--- a/packages/app/tests/vertical-discovery-regression.test.mjs
+++ b/packages/app/tests/vertical-discovery-regression.test.mjs
@@ -97,6 +97,13 @@ test('vertical discovery subscribes to backend feed-update events instead of onl
   assert.match(source, /if \(typeof unsubscribe === 'function'\) unsubscribe\(\)/, 'Discover should unsubscribe from feed events on unmount')
 })
 
+test('vertical discovery calls getFeedPreviewVideos with the shared feed-preview signature', () => {
+  const source = readAppFile('app/(tabs)/discover.tsx')
+
+  assert.match(source, /getFeedPreviewVideos\(\s*visibleEntries as any,\s*\{\},\s*identity\?\.driveKey \|\| undefined,\s*40,\s*\)/, 'Shorts route should pass channelMeta, identityDriveKey, and limit separately')
+  assert.doesNotMatch(source, /getFeedPreviewVideos\(visibleEntries as any, \{\s*identityDriveKey:/, 'Shorts route should not pass an options object into the shared helper')
+})
+
 
 test('vertical discovery lets the shorts player hide card chrome', () => {
   const source = readAppFile('app/(tabs)/discover.tsx')

--- a/packages/app/tests/vertical-discovery-regression.test.mjs
+++ b/packages/app/tests/vertical-discovery-regression.test.mjs
@@ -89,6 +89,14 @@ test('vertical discovery preloads the next few videos into the playback URL cach
   assert.match(source, /if \(result\?\.url && cacheKey\) setCachedVideoUrl\(cacheKey, result\.url\)/, 'preload should populate the playback URL cache for instant swipe playback')
 })
 
+test('vertical discovery subscribes to backend feed-update events instead of only loading once', () => {
+  const source = readAppFile('app/(tabs)/discover.tsx')
+
+  assert.match(source, /platformEvents \} = useApp\(\)/, 'Discover should receive platform event hooks from app context')
+  assert.match(source, /platformEvents as any\)\?\.onFeedUpdate\?\.\(\(\) => \{[\s\S]*?void loadFeed\(\)/, 'Discover should reload the vertical feed when backend gossip announces feed updates')
+  assert.match(source, /if \(typeof unsubscribe === 'function'\) unsubscribe\(\)/, 'Discover should unsubscribe from feed events on unmount')
+})
+
 
 test('vertical discovery lets the shorts player hide card chrome', () => {
   const source = readAppFile('app/(tabs)/discover.tsx')

--- a/packages/app/workers/desktop/index.ts
+++ b/packages/app/workers/desktop/index.ts
@@ -423,6 +423,9 @@ const { rpc: _rpc, backend, destroy } = await createBackend({
   platform: 'desktop',
   onReady: (data: any) => { console.log('[Worker] Backend ready, blob port:', data?.blobServerPort) },
   onError: (err: any) => { console.error('[Worker] Backend error:', err?.message || err) },
+  onFeedUpdate: () => {
+    try { _rpc?.eventFeedUpdate?.({ channelKey: 'feed', action: 'update' }) } catch {}
+  },
   onVideoStats: (driveKey: string, videoPath: string, stats: any) => {
     try {
       _rpc?.eventVideoStats?.({ stats: { videoId: videoPath, channelKey: driveKey, status: stats?.status || 'unknown', progress: stats?.progress || 0, totalBlocks: stats?.totalBlocks || 0, downloadedBlocks: stats?.downloadedBlocks || 0, totalBytes: stats?.totalBytes || 0, downloadedBytes: stats?.downloadedBytes || 0, peerCount: stats?.peerCount || 0, speedMBps: stats?.speedMBps || '0', uploadSpeedMBps: stats?.uploadSpeedMBps || '0', elapsed: stats?.elapsed || 0, isComplete: Boolean(stats?.isComplete) } })
@@ -581,7 +584,25 @@ B.getVideoThumbnail = async (r: any) => {
 B.setVideoThumbnail = async (r: any) => { const a = identityManager.getActiveIdentity(); if (!a?.driveKey) return { success: false }; const ch = await identityManager.getActiveChannel?.(); if (!ch?.blobs) return { success: false }; const blob = await ch.putBlob(Buffer.from(r.imageData, 'base64')); await ch.updateVideo(r.videoId, { thumbnailBlobId: blob.id, thumbnailBlobsCoreKey: ch.blobsKeyHex }); return { success: true, thumbnailBlobId: blob.id } }
 B.setVideoThumbnailFromFile = async (r: any) => { const a = identityManager.getActiveIdentity(); if (!a?.driveKey) return { success: false }; const ch = await identityManager.getActiveChannel?.(); if (!ch?.blobs) return { success: false }; const blob = await ch.putBlob(fs.readFileSync(r.filePath)); await ch.updateVideo(r.videoId, { thumbnailBlobId: blob.id, thumbnailBlobsCoreKey: ch.blobsKeyHex }); return { success: true, thumbnailBlobId: blob.id } }
 B.getStatus = async () => ({ status: { ready: true, hasIdentity: identityManager.getIdentities().length > 0, blobServerPort: getBlobPort() } })
-B.getSwarmStatus = async () => ({ connected: ctx.swarm.connections.size > 0, peerCount: ctx.swarm.connections.size })
+B.getSwarmStatus = async () => {
+  const s = api.getSwarmStatus()
+  return {
+    connected: (s.swarmConnections || 0) > 0,
+    peerCount: s.swarmConnections || 0,
+    swarmConnections: s.swarmConnections || 0,
+    swarmPeers: s.swarmPeers || 0,
+    feedConnections: s.feedConnections || 0,
+    feedEntries: s.feedEntries || 0,
+    channelsLoaded: s.channelsLoaded || 0,
+    network: s.network || null,
+    swarmOffline: Boolean(s.swarmOffline),
+    swarmOfflineReason: s.swarmOfflineReason || null,
+    swarmListenResolved: Boolean(s.swarmListenResolved),
+    peerPoolJoined: Boolean(s.peerPoolJoined),
+    publicFeedDiscoveryJoined: Boolean(s.publicFeedDiscoveryJoined),
+    feedTopicHex: s.feedTopicHex || null,
+  }
+}
 B.getBlobServerPort = async () => ({ port: getBlobPort() })
 B.createDeviceInvite = async (r: any) => { const res = await api.createDeviceInvite(r.channelKey); return { inviteCode: res.inviteCode } }
 B.pairDevice = async (r: any) => { const res = await api.pairDevice(r.inviteCode, r.deviceName || ''); try { const ex = identityManager.getIdentities?.() || []; if (ex.length === 0 && res?.channelKey) await identityManager.addPairedChannelIdentity?.(res.channelKey, 'Paired Channel') } catch {} return { success: Boolean(res.success), channelKey: res.channelKey } }

--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -50,8 +50,14 @@ export class PublicFeedManager {
     this.peerFeedKeys = new Map();
     /** @type {Map<string, number>} driveKey → live announcing peer count */
     this.entryPeerCounts = new Map();
-    /** @type {Set<any>} Active feed connections */
+    /** @type {Set<any>} Active/open feed connections */
     this.feedConnections = new Set();
+    /** @type {Map<any, string>} conn → short diagnostic id */
+    this._connectionIds = new Map();
+    /** @type {Map<any, number>} conn → first seen timestamp */
+    this._connectionStartedAt = new Map();
+    /** @type {number} */
+    this._nextConnectionId = 1;
     /** @type {Set<any>} Connections already wired for the feed protocol */
     this.wiredConnections = new Set();
     /** @type {((requests: any[], conn?: any) => Promise<any[]>) | null} */
@@ -338,6 +344,35 @@ export class PublicFeedManager {
     return false
   }
 
+  _connectionLabel(conn, info = null) {
+    if (!conn) return 'conn:unknown'
+    let label = this._connectionIds.get(conn)
+    if (!label) {
+      const remoteKey = info?.publicKey || conn.remotePublicKey || conn.publicKey
+      const remote = remoteKey && (b4a.isBuffer(remoteKey) || remoteKey instanceof Uint8Array)
+        ? b4a.toString(remoteKey, 'hex').slice(0, 16)
+        : 'unknown'
+      label = `conn:${this._nextConnectionId++}:${remote}`
+      this._connectionIds.set(conn, label)
+      this._connectionStartedAt.set(conn, Date.now())
+    }
+    return label
+  }
+
+  _connectionAgeMs(conn) {
+    const startedAt = this._connectionStartedAt.get(conn)
+    return startedAt ? Date.now() - startedAt : 0
+  }
+
+  _forgetConnection(conn) {
+    this._clearPeerFeedKeys(conn)
+    this.wiredConnections.delete(conn)
+    this.peerChannels.delete(conn)
+    this.feedConnections.delete(conn)
+    this._connectionIds.delete(conn)
+    this._connectionStartedAt.delete(conn)
+  }
+
   /**
    * Remember a discovered peer and explicitly dial it when the shared topic has
    * found peers but Hyperswarm has not promoted them into connections yet.
@@ -494,20 +529,28 @@ export class PublicFeedManager {
     console.log('[PublicFeed] ===== PUBLIC FEED STARTED =====');
   }
 
+  _openFeedConnections() {
+    return Array.from(this.feedConnections)
+      .filter((conn) => this.peerChannels.has(conn))
+  }
+
   _startGossipLoop() {
     if (this._gossipInterval) return
     try {
       this._gossipInterval = setInterval(() => {
         if (!this.started) return
         const redialed = this._redialDiscoveredPeers()
-        if (this.peerChannels.size === 0) {
-          if (redialed) {
+        const openConns = this._openFeedConnections()
+        if (openConns.length === 0) {
+          if (this.peerChannels.size > 0) {
+            console.log('[PublicFeed] Periodic feed gossip skipped unopened channels=', this.peerChannels.size, 'redialed=', redialed)
+          } else if (redialed) {
             console.log('[PublicFeed] Periodic feed gossip announced= 0 requested= 0 redialed=', redialed)
           }
           return
         }
         let announced = 0
-        for (const conn of this.peerChannels.keys()) {
+        for (const conn of openConns) {
           try {
             this.sendHaveFeed(conn)
             announced++
@@ -537,6 +580,8 @@ export class PublicFeedManager {
     this.peerFeedKeys.clear();
     this.entryPeerCounts.clear();
     this.feedConnections.clear();
+    this._connectionIds.clear();
+    this._connectionStartedAt.clear();
     try {
       for (const pending of this.pendingAvailabilityRequests.values()) {
         try { clearTimeout(pending.timeout) } catch {}
@@ -608,7 +653,8 @@ export class PublicFeedManager {
       return;
     }
 
-    console.log('[PublicFeed] handleConnection: setting up feed protocol on new connection');
+    const label = this._connectionLabel(conn, info)
+    console.log('[PublicFeed] handleConnection:', label, 'setting up feed protocol on new connection');
     this.wiredConnections.add(conn);
 
     let mux;
@@ -628,24 +674,19 @@ export class PublicFeedManager {
   }
 
   setupFeedProtocol(conn, mux) {
-    console.log('[PublicFeed] setupFeedProtocol: creating feed channel from our side');
+    const label = this._connectionLabel(conn)
+    console.log('[PublicFeed] setupFeedProtocol:', label, 'creating feed channel from our side');
     this.createFeedChannel(mux, conn);
 
     // Clean up on connection close
     conn.on('close', () => {
-      console.log('[PublicFeed] Connection closed');
-      this._clearPeerFeedKeys(conn);
-      this.wiredConnections.delete(conn);
-      this.peerChannels.delete(conn);
-      this.feedConnections.delete(conn);
+      console.log('[PublicFeed] Connection closed:', label, 'ageMs=', this._connectionAgeMs(conn));
+      this._forgetConnection(conn);
     });
 
     conn.on('error', (err) => {
-      console.error('[PublicFeed] Connection error:', err.message);
-      this._clearPeerFeedKeys(conn);
-      this.wiredConnections.delete(conn);
-      this.peerChannels.delete(conn);
-      this.feedConnections.delete(conn);
+      console.error('[PublicFeed] Connection error:', label, err.message, 'ageMs=', this._connectionAgeMs(conn));
+      this._forgetConnection(conn);
     });
   }
 
@@ -661,7 +702,8 @@ export class PublicFeedManager {
       return;
     }
 
-    console.log('[PublicFeed] createFeedChannel: creating channel with protocol:', PROTOCOL_NAME);
+    const label = this._connectionLabel(conn)
+    console.log('[PublicFeed] createFeedChannel:', label, 'creating channel with protocol:', PROTOCOL_NAME);
 
     // Create channel with messages defined in options
     let channel;
@@ -680,7 +722,7 @@ export class PublicFeedManager {
       }
       }],
       onopen: () => {
-        console.log('[PublicFeed] Feed channel opened! Total feed connections:', this.feedConnections.size + 1);
+        console.log('[PublicFeed] Feed channel opened:', label, 'Total feed connections:', this.feedConnections.size + 1, 'ageMs=', this._connectionAgeMs(conn));
         this.feedConnections.add(conn);
         try {
           this.onFeedConnectionOpen?.(conn);
@@ -701,7 +743,7 @@ export class PublicFeedManager {
         }
       },
       onclose: () => {
-        console.log('[PublicFeed] Feed channel closed');
+        console.log('[PublicFeed] Feed channel closed:', label, 'ageMs=', this._connectionAgeMs(conn));
         this._clearPeerFeedKeys(conn);
         this.peerChannels.delete(conn);
         this.feedConnections.delete(conn);
@@ -717,7 +759,7 @@ export class PublicFeedManager {
       return;
     }
 
-    console.log('[PublicFeed] createFeedChannel: channel created, storing and opening');
+    console.log('[PublicFeed] createFeedChannel:', label, 'channel created, storing and opening');
 
     // Store the channel
     this.peerChannels.set(conn, channel);
@@ -725,7 +767,7 @@ export class PublicFeedManager {
     // Open the channel
     try {
       channel.open();
-      console.log('[PublicFeed] createFeedChannel: channel.open() called');
+      console.log('[PublicFeed] createFeedChannel:', label, 'channel.open() called');
     } catch (err) {
       console.log('[PublicFeed] channel.open failed (non-fatal):', err?.message);
       this.peerChannels.delete(conn);
@@ -1140,7 +1182,9 @@ export class PublicFeedManager {
   requestFeedsFromPeers() {
     console.log('[PublicFeed] ===== REQUESTING FEEDS FROM PEERS =====');
     let sent = 0;
-    for (const [conn, channel] of this.peerChannels) {
+    for (const conn of this._openFeedConnections()) {
+      const channel = this.peerChannels.get(conn)
+      if (!channel) continue
       try {
         // Request the peer's current feed snapshot. Re-sending our own HAVE_FEED
         // here does not make the peer reply; NEED_FEED does.

--- a/packages/backend/test/public-feed-manager.test.mjs
+++ b/packages/backend/test/public-feed-manager.test.mjs
@@ -163,6 +163,49 @@ test('handleConnection pairs and opens one feed channel per connection', () => {
   }
 })
 
+test('periodic gossip does not send on feed channels before they open', () => {
+  const swarm = createSwarm()
+  const manager = new PublicFeedManager(swarm, createMetaDb())
+  const conn = createConnection()
+  const sent = []
+
+  manager.addEntry(DRIVE_KEY, 'local', PUBLIC_BEE_KEY)
+
+  const originalFrom = Protomux.from
+  Protomux.from = () => ({
+    pair() {},
+    createChannel() {
+      return {
+        messages: [{
+          send(msg) {
+            sent.push(msg)
+          }
+        }],
+        open() {}
+      }
+    }
+  })
+
+  try {
+    manager.handleConnection(conn, {})
+
+    assert.equal(manager.peerChannels.size, 1)
+    assert.equal(manager.feedConnections.size, 0)
+    assert.equal(manager.requestFeedsFromPeers(), 0)
+    manager.sendHaveFeed(conn)
+    assert.equal(sent.length, 1, 'direct send still works for diagnostics/manual open paths')
+    sent.length = 0
+
+    const openConns = manager._openFeedConnections()
+    assert.deepEqual(openConns, [])
+    for (const openConn of openConns) manager.sendHaveFeed(openConn)
+    assert.equal(sent.length, 0)
+  } finally {
+    Protomux.from = originalFrom
+    manager.stop()
+  }
+})
+
 test('feed channel open sends HAVE_FEED immediately', () => {
   const swarm = createSwarm()
   const manager = new PublicFeedManager(swarm, createMetaDb())
@@ -390,10 +433,10 @@ test('requestFeedsFromPeers sends NEED_FEED so peers reply with their feed', () 
   const originalFrom = Protomux.from
   Protomux.from = () => ({
     pair() {},
-    createChannel() {
+    createChannel(opts) {
       return {
         messages: [{ send(msg) { sent.push(msg) } }],
-        open() {},
+        open() { opts.onopen() },
       }
     }
   })

--- a/packages/backend/test/public-feed-manager.test.mjs
+++ b/packages/backend/test/public-feed-manager.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import { Duplex } from 'node:stream'
 import { EventEmitter } from 'node:events'
 import test from 'node:test'
 import crypto from 'hypercore-crypto'
@@ -60,6 +61,37 @@ function createPersistedMetaDb(seed = {}) {
 
 function createConnection() {
   return new EventEmitter()
+}
+
+class MemoryDuplex extends Duplex {
+  constructor() {
+    super()
+    this.other = null
+    this.userData = null
+    this.remotePublicKey = null
+  }
+
+  _read() {}
+
+  _write(chunk, _encoding, callback) {
+    this.other?.push(chunk)
+    callback()
+  }
+
+  _final(callback) {
+    this.other?.push(null)
+    callback()
+  }
+}
+
+function createMemoryConnectionPair() {
+  const a = new MemoryDuplex()
+  const b = new MemoryDuplex()
+  a.other = b
+  b.other = a
+  a.remotePublicKey = b4a.alloc(32, 2)
+  b.remotePublicKey = b4a.alloc(32, 1)
+  return [a, b]
 }
 
 test('PublicFeedManager explicitly dials peers discovered on the shared topic', () => {
@@ -160,6 +192,39 @@ test('handleConnection pairs and opens one feed channel per connection', () => {
   } finally {
     Protomux.from = originalFrom
     manager.stop()
+  }
+})
+
+test('real Protomux feed channel exchanges local feed entries between two managers', async () => {
+  const managerA = new PublicFeedManager(createSwarm(), createMetaDb())
+  const managerB = new PublicFeedManager(createSwarm(), createMetaDb())
+  const [connA, connB] = createMemoryConnectionPair()
+  let updatesB = 0
+
+  managerB.setOnFeedUpdate(() => { updatesB++ })
+  managerA.addEntry(DRIVE_KEY, 'local', PUBLIC_BEE_KEY)
+
+  try {
+    managerA.handleConnection(connA, { publicKey: connA.remotePublicKey })
+    managerB.handleConnection(connB, { publicKey: connB.remotePublicKey })
+
+    const deadline = Date.now() + 2000
+    let received = null
+    while (Date.now() < deadline) {
+      received = managerB.getFeed().find((entry) => entry.driveKey === DRIVE_KEY)
+      if (received?.publicBeeKey === PUBLIC_BEE_KEY) break
+      await new Promise((resolve) => setTimeout(resolve, 20))
+    }
+
+    assert.ok(received, 'peer B should receive peer A feed entry over real Protomux messages')
+    assert.equal(received.publicBeeKey, PUBLIC_BEE_KEY)
+    assert.equal(received.source, 'peer')
+    assert.equal(updatesB > 0, true)
+  } finally {
+    managerA.stop()
+    managerB.stop()
+    connA.destroy()
+    connB.destroy()
   }
 })
 

--- a/packages/cli/src/archive/publisher.js
+++ b/packages/cli/src/archive/publisher.js
@@ -24,11 +24,66 @@ function defaultChannelDescription(source) {
   return `Auto-archived from ${source.url} by a PearTube relay.${buildSourceMarker(source)}`
 }
 
+async function resolvePublicBeeKey(channel) {
+  let publicBeeKey = channel?.publicBeeKey
+    ? (b4a.isBuffer(channel.publicBeeKey) ? b4a.toString(channel.publicBeeKey, 'hex') : String(channel.publicBeeKey))
+    : null
+
+  if (!publicBeeKey && typeof channel?.getPublicBeeKey === 'function') {
+    const resolved = await channel.getPublicBeeKey().catch(() => null)
+    if (resolved) publicBeeKey = b4a.isBuffer(resolved) ? b4a.toString(resolved, 'hex') : String(resolved)
+  }
+
+  if (!publicBeeKey) {
+    const meta = await channel?.getMetadata?.().catch(() => null)
+    if (meta?.publicBeeKey) publicBeeKey = String(meta.publicBeeKey)
+  }
+
+  return typeof publicBeeKey === 'string' && publicBeeKey.length > 0 ? publicBeeKey : null
+}
+
+async function announceArchiveChannel(runtime, channelEntry, logger, sourceId) {
+  const { channel, channelKey } = channelEntry || {}
+  if (!channel || !channelKey) return
+
+  const publicBeeKey = await resolvePublicBeeKey(channel)
+  channelEntry.publicBeeKey = publicBeeKey
+
+  if (!publicBeeKey) return
+
+  try {
+    await runtime.publicFeed?.submitChannel?.(channelKey, publicBeeKey)
+  } catch (err) {
+    logger?.archive?.debug?.('Public-feed submit failed', {
+      sourceId,
+      error: err?.message || String(err)
+    })
+  }
+  try {
+    await runtime.cacheManager?.pinChannel?.(channelKey, publicBeeKey)
+  } catch (err) {
+    logger?.archive?.debug?.('Pin channel failed', {
+      sourceId,
+      error: err?.message || String(err)
+    })
+  }
+  try {
+    await runtime.seeder?.seedChannel?.({ driveKey: channelKey, publicBeeKey })
+  } catch (err) {
+    logger?.archive?.debug?.('Seed channel failed', {
+      sourceId,
+      error: err?.message || String(err)
+    })
+  }
+}
+
 /**
  * Loads the per-source PearTube channel for this relay (creating it on first use).
  * The channel keypair is deterministic from the relay's persistent corestore primaryKey
  * and the source identifier, so restarting the relay reopens the same channel.
  */
+export { resolvePublicBeeKey, announceArchiveChannel }
+
 export function createArchivePublisher({ ctx, uploadManager, runtime, fs, logger, state = null }) {
   if (!ctx) throw new Error('ctx is required')
   if (!uploadManager) throw new Error('uploadManager is required')
@@ -70,13 +125,7 @@ export function createArchivePublisher({ ctx, uploadManager, runtime, fs, logger
         await channel.ensureLocalBlobDrive({ deviceName: 'archive' }).catch(() => {})
       }
 
-      publicBeeKey = channel.publicBeeKey
-        ? (b4a.isBuffer(channel.publicBeeKey) ? b4a.toString(channel.publicBeeKey, 'hex') : String(channel.publicBeeKey))
-        : null
-      if (!publicBeeKey) {
-        const refreshed = await channel.getMetadata().catch(() => null)
-        publicBeeKey = refreshed?.publicBeeKey || null
-      }
+      publicBeeKey = await resolvePublicBeeKey(channel)
     } catch (err) {
       logger?.archive?.warn?.('Channel metadata setup failed', {
         sourceId: source.sourceId,
@@ -84,32 +133,9 @@ export function createArchivePublisher({ ctx, uploadManager, runtime, fs, logger
       })
     }
 
-    if (publicBeeKey) {
-      try {
-        await runtime.publicFeed?.submitChannel?.(channelKey, publicBeeKey)
-      } catch (err) {
-        logger?.archive?.debug?.('Public-feed submit failed', {
-          sourceId: source.sourceId,
-          error: err?.message || String(err)
-        })
-      }
-      try {
-        await runtime.cacheManager?.pinChannel?.(channelKey, publicBeeKey)
-      } catch (err) {
-        logger?.archive?.debug?.('Pin channel failed', {
-          sourceId: source.sourceId,
-          error: err?.message || String(err)
-        })
-      }
-      try {
-        await runtime.seeder?.seedChannel?.({ driveKey: channelKey, publicBeeKey })
-      } catch (err) {
-        logger?.archive?.debug?.('Seed channel failed', {
-          sourceId: source.sourceId,
-          error: err?.message || String(err)
-        })
-      }
-    }
+    const entry = { channel, channelKey, publicBeeKey }
+
+    await announceArchiveChannel(runtime, entry, logger, source.sourceId)
 
     if (state && typeof state.putSource === 'function') {
       try {
@@ -120,7 +146,7 @@ export function createArchivePublisher({ ctx, uploadManager, runtime, fs, logger
           type: source.type,
           label: source.label || null,
           channelKey,
-          publicBeeKey: publicBeeKey || existing?.publicBeeKey || null
+          publicBeeKey: entry.publicBeeKey || existing?.publicBeeKey || null
         })
       } catch (err) {
         logger?.archive?.debug?.('Persist source channel keys failed', {
@@ -130,7 +156,6 @@ export function createArchivePublisher({ ctx, uploadManager, runtime, fs, logger
       }
     }
 
-    const entry = { channel, channelKey, publicBeeKey }
     channelCache.set(source.sourceId, entry)
     return entry
   }
@@ -175,6 +200,8 @@ export function createArchivePublisher({ ctx, uploadManager, runtime, fs, logger
         })
       }
     }
+
+    await announceArchiveChannel(runtime, channelEntry, logger, source.sourceId)
 
     return {
       videoId: result.videoId,

--- a/packages/cli/test/archive.test.mjs
+++ b/packages/cli/test/archive.test.mjs
@@ -4,6 +4,7 @@ import { resolveRelayConfig } from '../src/config.js'
 import { buildSourceId, buildWriterKeyName, classifySourceUrl } from '../src/archive/source-id.js'
 import { ARCHIVE_STATUS, createArchiveState } from '../src/archive/state.js'
 import { createArchiver } from '../src/archive/index.js'
+import { announceArchiveChannel } from '../src/archive/publisher.js'
 
 function makeFakeMetaDb() {
   const map = new Map()
@@ -63,6 +64,55 @@ function makeFakeRuntime({ metaDb, totalBytes = 0 } = {}) {
     seeder: { seedChannel: async () => {} }
   }
 }
+
+test('archive publisher announces and seeds after public bee content changes', async (t) => {
+  const logger = makeFakeLogger()
+  const calls = []
+  let videoCount = 0
+  const channelEntry = {
+    channelKey: 'aa'.repeat(32),
+    publicBeeKey: null,
+    channel: {
+      async getPublicBeeKey() {
+        return 'bb'.repeat(32)
+      },
+      async getMetadata() {
+        return { publicBeeKey: 'bb'.repeat(32) }
+      }
+    }
+  }
+  const runtime = {
+    publicFeed: {
+      async submitChannel(driveKey, publicBeeKey) {
+        calls.push(['submit', driveKey, publicBeeKey, videoCount])
+      }
+    },
+    cacheManager: {
+      async pinChannel(driveKey, publicBeeKey) {
+        calls.push(['pin', driveKey, publicBeeKey, videoCount])
+      }
+    },
+    seeder: {
+      async seedChannel(channel) {
+        calls.push(['seed', channel.driveKey, channel.publicBeeKey, videoCount])
+      }
+    }
+  }
+
+  await announceArchiveChannel(runtime, channelEntry, logger, 'youtube:source')
+  videoCount = 1
+  await announceArchiveChannel(runtime, channelEntry, logger, 'youtube:source')
+
+  t.is(channelEntry.publicBeeKey, 'bb'.repeat(32))
+  t.alike(calls, [
+    ['submit', 'aa'.repeat(32), 'bb'.repeat(32), 0],
+    ['pin', 'aa'.repeat(32), 'bb'.repeat(32), 0],
+    ['seed', 'aa'.repeat(32), 'bb'.repeat(32), 0],
+    ['submit', 'aa'.repeat(32), 'bb'.repeat(32), 1],
+    ['pin', 'aa'.repeat(32), 'bb'.repeat(32), 1],
+    ['seed', 'aa'.repeat(32), 'bb'.repeat(32), 1],
+  ])
+})
 
 test('classifySourceUrl recognises YouTube channels, handles, and playlists', (t) => {
   t.alike(classifySourceUrl('https://www.youtube.com/@somechannel'), {


### PR DESCRIPTION
## Summary
- allow cached relay/archive feed manifest previews to render when they include direct blob refs, even if peerCount has temporarily dropped to 0
- keep the stale-preview guard for cached remote previews without blob refs
- add feed hydration regression for relay archived video previews

## Verification
- node --test packages/app/tests/feed-hydration.test.mjs packages/app/tests/vertical-discovery-regression.test.mjs
- npm run lint:changed
- git diff --check

Follow-up to #117 after it merged while this fix was being pushed.