### PR TITLE
fix(feed): allow relay previews with direct blobs

### DIFF
--- a/packages/app/app/(tabs)/discover.tsx
+++ b/packages/app/app/(tabs)/discover.tsx
@@ -164,10 +164,12 @@ export default function VerticalDiscoveryScreen() {
 
   const seedFromFeedEntries = useCallback((entries: FeedEntry[]) => {
     const visibleEntries = getVisibleSeededFeedEntries(entries as any)
-    const previewVideos = getFeedPreviewVideos(visibleEntries as any, {
-      identityDriveKey: identity?.driveKey || undefined,
-      channelMeta: {},
-    }) as VideoData[]
+    const previewVideos = getFeedPreviewVideos(
+      visibleEntries as any,
+      {},
+      identity?.driveKey || undefined,
+      40,
+    ) as VideoData[]
 
     const renderable = previewVideos
       .filter((video) => shouldRenderFeedVideo({

--- a/packages/app/lib/feed-hydration.js
+++ b/packages/app/lib/feed-hydration.js
@@ -51,12 +51,18 @@ export function getFeedVideoLoadEntries(feedEntries, limit = 15) {
   return getVisibleSeededFeedEntries(feedEntries, limit)
 }
 
+function hasDirectBlobRef(video) {
+  return typeof video?.blobId === 'string' && video.blobId.length > 0 &&
+    typeof video?.blobsCoreKey === 'string' && /^[a-f0-9]{64}$/i.test(video.blobsCoreKey)
+}
+
 function canUseFeedPreviewVideos(entry, identityDriveKey) {
   const channelKey = entry?.channelKey || entry?.driveKey || null
   if (!channelKey) return false
   if (identityDriveKey && channelKey === identityDriveKey) return true
   if (entry?.source === 'local') return true
-  return (entry?.peerCount ?? 0) > 0
+  if ((entry?.peerCount ?? 0) > 0) return true
+  return Boolean(entry?.publicBeeKey && Array.isArray(entry?.previewVideos) && entry.previewVideos.some(hasDirectBlobRef))
 }
 
 export function getFeedPreviewVideos(feedEntries, channelMeta, identityDriveKey, limit = 15) {

--- a/packages/app/tests/feed-hydration.test.mjs
+++ b/packages/app/tests/feed-hydration.test.mjs
@@ -144,7 +144,38 @@ test('getFeedPreviewVideos only uses local or live-peer manifest previews', () =
       publicBeeKey: 'bee-live',
       channelName: 'Live channel',
     },
-  ])
+  ], 'stale cached remote preview without blob refs is ignored before a live peer proves availability')
+})
+
+test('getFeedPreviewVideos keeps relay manifest previews with direct blob refs even when peer count temporarily drops', () => {
+  const previews = getFeedPreviewVideos([
+    {
+      driveKey: 'relay-archive',
+      peerCount: 0,
+      publicBeeKey: 'bee-relay',
+      channelName: 'Relay archive',
+      previewVideos: [{
+        id: 'archived-video',
+        title: 'Archived video',
+        uploadedAt: 40,
+        availability: 'playable',
+        blobId: '0:8:0:1024',
+        blobsCoreKey: 'aa'.repeat(32),
+      }],
+    },
+  ], {}, 'local', 5)
+
+  assert.deepEqual(previews.map((video) => ({
+    id: video.id,
+    channelKey: video.channelKey,
+    publicBeeKey: video.publicBeeKey,
+    channelName: video.channel?.name,
+  })), [{
+    id: 'archived-video',
+    channelKey: 'relay-archive',
+    publicBeeKey: 'bee-relay',
+    channelName: 'Relay archive',
+  }])
 })
 
 test('shouldKeepFeedVideoForVisibleEntries keeps restored snapshot cards until their channels are refreshed', () => {

--- a/packages/app/tests/vertical-discovery-regression.test.mjs
+++ b/packages/app/tests/vertical-discovery-regression.test.mjs
@@ -97,6 +97,13 @@ test('vertical discovery subscribes to backend feed-update events instead of onl
   assert.match(source, /if \(typeof unsubscribe === 'function'\) unsubscribe\(\)/, 'Discover should unsubscribe from feed events on unmount')
 })
 
+test('vertical discovery calls getFeedPreviewVideos with the shared feed-preview signature', () => {
+  const source = readAppFile('app/(tabs)/discover.tsx')
+
+  assert.match(source, /getFeedPreviewVideos\(\s*visibleEntries as any,\s*\{\},\s*identity\?\.driveKey \|\| undefined,\s*40,\s*\)/, 'Shorts route should pass channelMeta, identityDriveKey, and limit separately')
+  assert.doesNotMatch(source, /getFeedPreviewVideos\(visibleEntries as any, \{\s*identityDriveKey:/, 'Shorts route should not pass an options object into the shared helper')
+})
+
 
 test('vertical discovery lets the shorts player hide card chrome', () => {
   const source = readAppFile('app/(tabs)/discover.tsx')


### PR DESCRIPTION
## Summary
- Reapply PR #118's relay/archive preview filtering on top of current `origin/main`
- Keep relay manifest previews visible when they include direct `blobId` + `blobsCoreKey` refs even if `peerCount` temporarily drops to 0
- Fix the Shorts/vertical route to call the shared feed-preview helper with the correct positional signature

## Test Plan
- `git diff --check`
- `node --test packages/app/tests/vertical-discovery-regression.test.mjs packages/app/tests/feed-hydration.test.mjs`
- `npm run lint:changed`

Supersedes #118, whose branch had conflicts from the already-merged #117 work.
