### PR TITLE
fix(feed): preserve preview cards on partial hydration

### DIFF
--- a/packages/app/app/(tabs)/index.tsx
+++ b/packages/app/app/(tabs)/index.tsx
@@ -411,6 +411,7 @@ export default function HomeScreen() {
         previousVideos: prev,
         incomingVideos: incoming,
         refreshedChannelKeys,
+        feedEntries,
         identityDriveKey: identity?.driveKey || undefined,
         limit: 50,
       }))

--- a/packages/app/lib/feed-hydration.js
+++ b/packages/app/lib/feed-hydration.js
@@ -138,23 +138,50 @@ export function isConfirmedFeedHydrationResult({ entry, resolved, videos = [] })
   if (Array.isArray(videos) && videos.length > 0) return true
   const previewVideos = Array.isArray(entry?.previewVideos) ? entry.previewVideos : []
   const manifestUpdatedAt = Number(entry?.manifestUpdatedAt || 0) || 0
+
+  // An empty `listVideos()` result is only authoritative if the feed snapshot
+  // itself says the channel manifest is empty. If the public feed still carries
+  // preview videos, the channel/PublicBee load was partial or stale and must not
+  // delete already-renderable preview cards. Desktop startup commonly hits this:
+  // previews render first, then overloaded GET_CHANNEL_META/listVideos calls time
+  // out or return empty for the same channel.
   return manifestUpdatedAt > 0 && previewVideos.length === 0
+}
+
+function isPreviewBackedByFeedEntry(video, feedEntryByChannel) {
+  const channelKey = video?.channelKey || video?.driveKey || null
+  if (!channelKey) return false
+  const entry = feedEntryByChannel?.get(channelKey)
+  const previewVideos = Array.isArray(entry?.previewVideos) ? entry.previewVideos : []
+  const identifier = video?.id || video?.path || ''
+  if (!identifier || previewVideos.length === 0) return false
+
+  return previewVideos.some((preview) => {
+    const previewIdentifier = preview?.id || preview?.path || ''
+    return previewIdentifier === identifier
+  })
 }
 
 export function mergeHydratedFeedVideos({
   previousVideos = /** @type {any[]} */ ([]),
   incomingVideos = /** @type {any[]} */ ([]),
   refreshedChannelKeys = /** @type {string[]} */ ([]),
+  feedEntries = /** @type {any[]} */ ([]),
   identityDriveKey = undefined,
   limit = 50,
 }) {
   const refreshed = new Set((refreshedChannelKeys || []).filter(Boolean))
+  const feedEntryByChannel = new Map()
+  for (const entry of feedEntries || []) {
+    const channelKey = entry?.channelKey || entry?.driveKey || null
+    if (channelKey && !feedEntryByChannel.has(channelKey)) feedEntryByChannel.set(channelKey, entry)
+  }
   const byKey = new Map()
 
   for (const video of previousVideos || []) {
     if (!video) continue
     const channelKey = video?.channelKey || video?.driveKey || null
-    if (channelKey && refreshed.has(channelKey)) continue
+    if (channelKey && refreshed.has(channelKey) && !isPreviewBackedByFeedEntry(video, feedEntryByChannel)) continue
     const identifier = video?.id || video?.path || ''
     if (!identifier) continue
     const key = `${channelKey || ''}:${identifier}`

--- a/packages/app/tests/feed-hydration.test.mjs
+++ b/packages/app/tests/feed-hydration.test.mjs
@@ -226,12 +226,40 @@ test('mergeHydratedFeedVideos replaces stale channel cards when a refreshed chan
     ],
     incomingVideos: [],
     refreshedChannelKeys: ['remote-a'],
+    feedEntries: [
+      { driveKey: 'remote-a', manifestUpdatedAt: 123, previewVideos: [] },
+    ],
     identityDriveKey: 'local',
     limit: 50,
   })
 
   assert.deepEqual(merged.map((video) => ({ id: video.id, channelKey: video.channelKey })), [
     { id: 'keep-remote', channelKey: 'remote-b' },
+  ])
+})
+
+test('mergeHydratedFeedVideos preserves preview-backed cards when channel hydration returns an empty partial result', () => {
+  const merged = mergeHydratedFeedVideos({
+    previousVideos: [
+      { id: 'preview-a', channelKey: 'remote-a', uploadedAt: 30, availability: 'playable', __feedSource: 'preview' },
+      { id: 'keep-remote', channelKey: 'remote-b', uploadedAt: 20, availability: 'playable' },
+    ],
+    incomingVideos: [],
+    refreshedChannelKeys: ['remote-a'],
+    feedEntries: [
+      {
+        driveKey: 'remote-a',
+        manifestUpdatedAt: 123,
+        previewVideos: [{ id: 'preview-a', availability: 'playable' }],
+      },
+    ],
+    identityDriveKey: 'local',
+    limit: 50,
+  })
+
+  assert.deepEqual(merged.map((video) => ({ id: video.id, channelKey: video.channelKey, source: video.__feedSource || 'hydrated' })), [
+    { id: 'preview-a', channelKey: 'remote-a', source: 'preview' },
+    { id: 'keep-remote', channelKey: 'remote-b', source: 'hydrated' },
   ])
 })
 
@@ -247,6 +275,12 @@ test('isConfirmedFeedHydrationResult only treats empty results as authoritative 
     resolved: true,
     videos: [],
   }), true)
+
+  assert.equal(isConfirmedFeedHydrationResult({
+    entry: { manifestUpdatedAt: 123, previewVideos: [{ id: 'preview-a' }] },
+    resolved: true,
+    videos: [],
+  }), false)
 
   assert.equal(isConfirmedFeedHydrationResult({
     entry: { manifestUpdatedAt: 123, previewVideos: [{ id: 'preview-a' }] },


### PR DESCRIPTION
## Summary
- Preserve preview-backed Discover cards when channel hydration/listVideos returns an empty partial result
- Treat empty hydration as authoritative only when the feed manifest itself has no preview videos
- Pass current feed entries into hydrated merge so previews still advertised by public feed are not deleted during desktop startup timeout storms

## Why
Desktop logs show previews rendering from PublicBee snapshots, then repeated `GET_CHANNEL_META` / `loadChannel wait timeout` / empty `LIST_VIDEOS` results. The UI was allowed to treat those partial empty hydrations as refreshed channels, so visible preview cards could be removed even though the public feed still advertised playable preview videos.

## Test Plan
- `node --test packages/app/tests/feed-hydration.test.mjs`
- `node --test packages/app/tests/feed-hydration.test.mjs packages/app/tests/native-backend-startup-regression.test.mjs`
- `npm run lint:changed`
- `git diff --check`
