### PR TITLE
fix(relay): force redial discovered peers

### DIFF
--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -72,6 +72,19 @@ export class PublicFeedManager {
     this._directPeerRetryCounts = new Map();
     /** @type {Map<string, any>} */
     this._discoveredPeers = new Map();
+    /** @type {Map<string, number>} */
+    this._directPeerLastDialedAt = new Map();
+    /** @type {Map<string, string>} */
+    this._directPeerLastDialError = new Map();
+    /** @type {{attempted: number, queued: number, skipped: number, failed: number, lastReason: string | null, lastDialedAt: number | null}} */
+    this._directPeerDialStats = {
+      attempted: 0,
+      queued: 0,
+      skipped: 0,
+      failed: 0,
+      lastReason: null,
+      lastDialedAt: null,
+    };
     /** @type {number} */
     this._maxDirectPeerRetries = 3;
     /** @type {number} */
@@ -394,19 +407,50 @@ export class PublicFeedManager {
   }
 
   _dialDiscoveredPeer(keyHex, publicKey, attempts = this._directPeerRetryCounts.get(keyHex) || 0, { force = false } = {}) {
-    if (!publicKey || !this.swarm || typeof this.swarm.joinPeer !== 'function') return false
-    if (!keyHex || keyHex === b4a.toString(this.swarm.keyPair?.publicKey || [], 'hex')) return false
-    if (this._hasKnownPeer(keyHex)) return false
-    if ((this.swarm.connections?.size || 0) >= this._maxDirectPeers) return false
-    if (!force && attempts >= this._maxDirectPeerRetries) return false
+    this._directPeerDialStats.attempted++
+    if (!publicKey || !this.swarm || typeof this.swarm.joinPeer !== 'function') {
+      this._directPeerDialStats.skipped++
+      this._directPeerDialStats.lastReason = 'joinPeer-unavailable'
+      return false
+    }
+    if (!keyHex || keyHex === b4a.toString(this.swarm.keyPair?.publicKey || [], 'hex')) {
+      this._directPeerDialStats.skipped++
+      this._directPeerDialStats.lastReason = 'self-or-missing-key'
+      return false
+    }
+    if (this._hasKnownPeer(keyHex)) {
+      this._directPeerDialStats.skipped++
+      this._directPeerDialStats.lastReason = 'already-known-peer'
+      return false
+    }
+    if ((this.swarm.connections?.size || 0) >= this._maxDirectPeers) {
+      this._directPeerDialStats.skipped++
+      this._directPeerDialStats.lastReason = 'max-direct-peers'
+      return false
+    }
+    if (!force && attempts >= this._maxDirectPeerRetries) {
+      this._directPeerDialStats.skipped++
+      this._directPeerDialStats.lastReason = 'max-retries'
+      return false
+    }
 
     try {
       this.swarm.joinPeer(publicKey)
+      const now = this._now()
       this._directPeerRetryCounts.set(keyHex, attempts + 1)
+      this._directPeerLastDialedAt.set(keyHex, now)
+      this._directPeerLastDialError.delete(keyHex)
+      this._directPeerDialStats.queued++
+      this._directPeerDialStats.lastReason = 'queued'
+      this._directPeerDialStats.lastDialedAt = now
       console.log('[PublicFeed] Direct peer dial queued from shared topic:', keyHex.slice(0, 16), 'attempt=', attempts + 1)
       return true
     } catch (err) {
-      console.log('[PublicFeed] Direct peer dial failed:', keyHex.slice(0, 16), err?.message)
+      const message = err?.message || String(err)
+      this._directPeerDialStats.failed++
+      this._directPeerDialStats.lastReason = 'joinPeer-error'
+      this._directPeerLastDialError.set(keyHex, message)
+      console.log('[PublicFeed] Direct peer dial failed:', keyHex.slice(0, 16), message)
       return false
     }
   }
@@ -420,6 +464,31 @@ export class PublicFeedManager {
       if (this._dialDiscoveredPeer(keyHex, publicKey, attempts, { force })) dialed++
     }
     return dialed
+  }
+
+  forceRedialDiscoveredPeers() {
+    return this._redialDiscoveredPeers({ force: true })
+  }
+
+  getDirectPeerDialStats() {
+    const peers = []
+    for (const [keyHex] of this._discoveredPeers) {
+      peers.push({
+        key: keyHex.slice(0, 16),
+        attempts: this._directPeerRetryCounts.get(keyHex) || 0,
+        lastDialedAt: this._directPeerLastDialedAt.get(keyHex) || null,
+        lastError: this._directPeerLastDialError.get(keyHex) || null,
+        connected: this._hasKnownPeer(keyHex),
+      })
+    }
+
+    return {
+      ...this._directPeerDialStats,
+      discoveredPeers: this._discoveredPeers.size,
+      maxDirectPeers: this._maxDirectPeers,
+      maxDirectPeerRetries: this._maxDirectPeerRetries,
+      peers,
+    }
   }
 
   /**
@@ -1244,7 +1313,9 @@ export class PublicFeedManager {
     return {
       totalEntries: this.entries.size,
       hiddenCount: this.hiddenKeys.size,
-      peerCount: this.peerChannels.size
+      peerCount: this.peerChannels.size,
+      feedConnections: this.feedConnections.size,
+      directPeerDial: this.getDirectPeerDialStats(),
     };
   }
 }

--- a/packages/backend/test/public-feed-manager.test.mjs
+++ b/packages/backend/test/public-feed-manager.test.mjs
@@ -147,6 +147,49 @@ test('periodic gossip re-dials remembered shared-topic peers when sockets droppe
   }
 })
 
+test('forceRedialDiscoveredPeers keeps trying known discovered peers after normal retry cap', () => {
+  const publicKey = b4a.alloc(32, 11)
+  const swarm = createSwarm()
+  const manager = new PublicFeedManager(swarm, createMetaDb())
+
+  try {
+    assert.equal(manager.handleDiscoveredPeer({ publicKey }), true)
+    assert.equal(manager._redialDiscoveredPeers(), 1)
+    assert.equal(manager._redialDiscoveredPeers(), 1)
+    assert.equal(manager._redialDiscoveredPeers(), 0)
+    assert.equal(swarm.joinPeerCalls.length, 3)
+
+    assert.equal(manager.forceRedialDiscoveredPeers(), 1)
+    assert.equal(swarm.joinPeerCalls.length, 4)
+
+    const stats = manager.getStats().directPeerDial
+    assert.equal(stats.discoveredPeers, 1)
+    assert.equal(stats.queued, 4)
+    assert.equal(stats.lastReason, 'queued')
+    assert.equal(stats.peers[0].attempts, 4)
+  } finally {
+    manager.stop()
+  }
+})
+
+test('direct peer dial diagnostics expose skipped joinPeer failures', () => {
+  const publicKey = b4a.alloc(32, 12)
+  const swarm = createSwarm()
+  swarm.joinPeer = () => { throw new Error('dial unavailable') }
+  const manager = new PublicFeedManager(swarm, createMetaDb())
+
+  try {
+    assert.equal(manager.handleDiscoveredPeer({ publicKey }), false)
+    const stats = manager.getStats().directPeerDial
+    assert.equal(stats.discoveredPeers, 1)
+    assert.equal(stats.failed, 1)
+    assert.equal(stats.lastReason, 'joinPeer-error')
+    assert.equal(stats.peers[0].lastError, 'dial unavailable')
+  } finally {
+    manager.stop()
+  }
+})
+
 test('PublicFeedManager.start joins shared PearTube network topic for feed-peer discovery', async () => {
   const swarm = createSwarm()
   const manager = new PublicFeedManager(swarm, createMetaDb())

--- a/packages/cli/src/runtime.js
+++ b/packages/cli/src/runtime.js
@@ -241,6 +241,7 @@ export async function createRelayRuntime({ config, logger }) {
         publicFeedDiscoveryJoined: Boolean(publicFeed.feedDiscovery),
         blindPeer: blindPeer.getStats?.() || null,
         peerPoolJoined: Boolean(ctx.peerPoolDiscovery),
+        directPeerDial: feedStats.directPeerDial || null,
         swarmOffline: Boolean(ctx.swarm?._peartubeOffline),
         swarmOfflineReason: ctx.swarm?._peartubeOfflineReason || null,
         swarmListenResolved: Boolean(ctx.swarm?._peartubeListenResolved),

--- a/packages/cli/src/service.js
+++ b/packages/cli/src/service.js
@@ -224,13 +224,32 @@ export async function createRelayService({
       heartbeatTimer = setIntervalFn(async () => {
         try {
           const heartbeatStatus = await persistStatus()
+          const directPeerDial = heartbeatStatus.runtime.directPeerDial || {}
+          if ((heartbeatStatus.runtime.peers || 0) > 0 && (heartbeatStatus.runtime.connections || 0) === 0) {
+            const redialed = runtime.publicFeed?.forceRedialDiscoveredPeers?.() || 0
+            logger.status.warn('Relay discovered peers without sockets; forced direct redial', {
+              peers: heartbeatStatus.runtime.peers,
+              connections: heartbeatStatus.runtime.connections,
+              discoveredPeers: directPeerDial.discoveredPeers || 0,
+              queued: directPeerDial.queued || 0,
+              skipped: directPeerDial.skipped || 0,
+              failed: directPeerDial.failed || 0,
+              lastReason: directPeerDial.lastReason || null,
+              redialed
+            })
+          }
           logger.status.info('Relay heartbeat', {
             peers: heartbeatStatus.runtime.peers,
             connections: heartbeatStatus.runtime.connections,
             feedPeers: heartbeatStatus.runtime.feedPeers,
             feedConnections: heartbeatStatus.runtime.feedConnections,
             feedEntries: heartbeatStatus.runtime.feedEntries,
-            mirroredChannels: heartbeatStatus.summary.totalChannels
+            mirroredChannels: heartbeatStatus.summary.totalChannels,
+            discoveredPeers: directPeerDial.discoveredPeers || 0,
+            dialQueued: directPeerDial.queued || 0,
+            dialSkipped: directPeerDial.skipped || 0,
+            dialFailed: directPeerDial.failed || 0,
+            dialLastReason: directPeerDial.lastReason || null
           })
         } catch (err) {
           logger.status.error('Relay heartbeat failed', {

--- a/packages/cli/src/status.js
+++ b/packages/cli/src/status.js
@@ -39,6 +39,7 @@ export function buildRelayStatus({ config, catalog, runtimeStats = {} }) {
       publicFeedDiscoveryJoined: Boolean(runtimeStats.publicFeedDiscoveryJoined),
       blindPeer: runtimeStats.blindPeer || runtimeStats.seeding?.blindPeer || null,
       peerPoolJoined: Boolean(runtimeStats.peerPoolJoined),
+      directPeerDial: runtimeStats.directPeerDial || null,
       swarmOffline: Boolean(runtimeStats.swarmOffline),
       swarmOfflineReason: runtimeStats.swarmOfflineReason || null,
       swarmListenResolved: Boolean(runtimeStats.swarmListenResolved),
@@ -87,6 +88,7 @@ export function formatRelayStatus(status) {
     `feedEntries: ${status.runtime.feedEntries}`,
     `dht: bootstrapped=${status.runtime.dht.bootstrapped} firewalled=${status.runtime.dht.firewalled} online=${status.runtime.dht.online}`,
     `network: offline=${status.runtime.swarmOffline} reason=${status.runtime.swarmOfflineReason || 'none'} listenResolved=${status.runtime.swarmListenResolved} peerPoolJoined=${status.runtime.peerPoolJoined} publicFeedDiscoveryJoined=${status.runtime.publicFeedDiscoveryJoined}`,
+    `directPeerDial: discovered=${status.runtime.directPeerDial?.discoveredPeers || 0} queued=${status.runtime.directPeerDial?.queued || 0} skipped=${status.runtime.directPeerDial?.skipped || 0} failed=${status.runtime.directPeerDial?.failed || 0} lastReason=${status.runtime.directPeerDial?.lastReason || 'none'}`,
     `blindPeer: enabled=${Boolean(status.runtime.blindPeer?.enabled)} key=${status.runtime.blindPeer?.publicKey || 'none'} mirroredCores=${status.runtime.blindPeer?.mirroredCores || 0} mirroredAutobases=${status.runtime.blindPeer?.mirroredAutobases || 0}`,
     `seeding: channels=${status.runtime.seeding.channels} videos=${status.runtime.seeding.videos} publicBeeCores=${status.runtime.seeding.publicBeeCores} blobCores=${status.runtime.seeding.blobCores} discoveryHandles=${status.runtime.seeding.discoveryHandles}`
   ]

--- a/packages/cli/test/relay-seeding.test.mjs
+++ b/packages/cli/test/relay-seeding.test.mjs
@@ -199,7 +199,8 @@ test('relay status surfaces DHT and seeding stats for phone connectivity diagnos
       swarmOfflineReason: null,
       swarmListenResolved: true,
       blindPeer: { enabled: true, publicKey: 'abcd', mirroredCores: 4, mirroredAutobases: 0, error: null },
-      seeding: { channels: 2, videos: 5, publicBeeCores: 2, blobCores: 8, discoveryHandles: 10 }
+      seeding: { channels: 2, videos: 5, publicBeeCores: 2, blobCores: 8, discoveryHandles: 10 },
+      directPeerDial: { discoveredPeers: 2, queued: 3, skipped: 1, failed: 0, lastReason: 'queued' }
     }
   })
 
@@ -217,6 +218,7 @@ test('relay status surfaces DHT and seeding stats for phone connectivity diagnos
   const formatted = formatRelayStatus(status)
   t.ok(formatted.includes('dht: bootstrapped=true firewalled=false online=true'))
   t.ok(formatted.includes('network: offline=false reason=none listenResolved=true peerPoolJoined=true publicFeedDiscoveryJoined=true'))
+  t.ok(formatted.includes('directPeerDial: discovered=2 queued=3 skipped=1 failed=0 lastReason=queued'))
   t.ok(formatted.includes('blindPeer: enabled=true key=abcd mirroredCores=4 mirroredAutobases=0'))
   t.ok(formatted.includes('seeding: channels=2 videos=5 publicBeeCores=2 blobCores=8 discoveryHandles=10'))
 })


### PR DESCRIPTION
## Summary
- Add direct-peer dial diagnostics to `PublicFeedManager` and relay status output
- Force a relay heartbeat redial when discovery sees peers but Hyperswarm has zero sockets
- Expose discovered peer count, queued/skipped/failed dial counts, last dial reason, and per-peer attempt state

## Why
`v0.1.55` relay logs showed `peers=2 connections=0 feedConnections=0`: the relay saw discovered peers but did not convert them into sockets/feed channels. Since the relay is meant to bootstrap light clients and cache-serve content, it needs active recovery when peer discovery stalls before socket creation.

## Tests
- `node --test packages/backend/test/public-feed-manager.test.mjs`
- `npm test --prefix packages/cli -- --timeout=30000`
- `npm run lint:changed`
- `git diff --check`
