### PR TITLE
fix(relay): add stable catalog playback contract

### DIFF
--- a/docs/plans/2026-05-08-relay-stability-contract.md
+++ b/docs/plans/2026-05-08-relay-stability-contract.md
@@ -1,0 +1,216 @@
+# Relay Stability Contract Implementation Plan
+
+> **For Hermes:** Use this plan as the guardrail for the relay architecture pass. Do not stack one-off UI fixes unless a regression proves the contract is incomplete.
+
+**Goal:** Make the relay a deterministic bootstrap/cache-serving node again: advertise a stable catalog, retain content-core discovery, and let light clients play preview-backed videos without full channel hydration.
+
+**Architecture:** Keep the single canonical `peartube-network` Hyperswarm topic and Protomux feed channel. Add a first-class relay catalog contract on top of the existing public-feed snapshot mechanism, and restore the old v0.1.34-era behavior where known cached/seeded content expands into long-lived PublicBee/blob/thumbnail discovery joins.
+
+**Tech Stack:** Node/Bare-compatible JS, Hyperswarm, Hypercore/Corestore, Hyperbee/PublicBee, Protomux, brittle/node:test.
+
+---
+
+## Root Cause
+
+Earlier PearTube relays were boring because cached channels were expanded directly into active discovery handles for PublicBee/video/thumbnail cores. Current releases still retain some of that in CLI seeding, but the client path became layered: public feed entries → preview hydration → PublicBee reads → channel load fallback → playback. That made relay/cache availability depend on timing-sensitive channel hydration and UI preservation.
+
+The structural fix is not to revive legacy topics. It is to make relay availability explicit and local-first:
+
+1. A relay catalog entry is a stable serving contract, not a user-published channel.
+2. Known cached/seeded content must retain discovery for public metadata and blob cores on startup.
+3. Feed/list/playback APIs must prefer catalog/preview direct refs over `loadChannel()` for light-client playback.
+4. Status/tests must fail when the relay has cached videos but is not advertising/serving their cores.
+
+---
+
+## Task 1: Backend content discovery retention helper
+
+**Objective:** Restore the old simple seeding behavior as a shared backend primitive.
+
+**Files:**
+- Modify: `packages/backend/src/storage.js`
+- Test: `packages/backend/test/storage-startup-regression.test.mjs`
+
+**Implementation:**
+
+Add `retainPublicBeeContentDiscovery(ctx, publicBeeKeyHex, options = {})` near `retainSwarmDiscovery()`.
+
+Contract:
+- validate 64-hex `publicBeeKeyHex`;
+- call `loadPublicBee(ctx, publicBeeKeyHex)` so PublicBee discovery is retained by the existing loader;
+- list videos best-effort;
+- collect valid `blobsCoreKey` and `thumbnailBlobsCoreKey`;
+- open each core through `ctx.store.get(b4a.from(key, 'hex'))` and `await core.ready()`;
+- call `retainSwarmDiscovery(ctx, core.discoveryKey, { label })`;
+- do not block on swarm flush or core update;
+- return stats `{ publicBeeKey, videos, blobCores, thumbnailBlobCores, discoveryHandles, retained, errors, lastError }`.
+
+**Regression:** source-level test should assert the helper exists, calls `loadPublicBee`, iterates `blobsCoreKey` and `thumbnailBlobsCoreKey`, and uses `retainSwarmDiscovery`.
+
+---
+
+## Task 2: Make app/backend seed metadata restartable
+
+**Objective:** Persist enough seed metadata that clients can re-announce content cores after restart without waiting for channel hydration.
+
+**Files:**
+- Modify: `packages/backend/src/seeding.js`
+- Modify: `packages/backend/src/api.js`
+- Test: `packages/backend/test/playback-api.test.mjs` or `packages/backend/test/public-feed-api.test.mjs`
+
+**Implementation:**
+
+Extend `SeedingManager.addSeed(driveKey, videoPath, metadata = {})` to accept and persist optional:
+- `publicBeeKey`
+- `blobId`
+- `blobsCoreKey`
+- `thumbnailBlobId`
+- `thumbnailBlobsCoreKey`
+- `mimeType`
+- `thumbnailMimeType`
+
+Patch `api.prefetchVideo()` so when it registers a seed it passes the above fields from the resolved video metadata/publicBeeKey.
+
+**Regression:** add a test that `prefetchVideo()` calls `seedingManager.addSeed()` with `blobsCoreKey`, `blobId`, and `publicBeeKey` when video metadata contains direct refs.
+
+---
+
+## Task 3: App/backend startup expands known seeds/pins into content discovery
+
+**Objective:** Normal clients should regain the old “cached content advertises itself” behavior, not just CLI relays.
+
+**Files:**
+- Modify: `packages/backend/src/orchestrator.js`
+- Test: `packages/backend/test/orchestrator-seed-mismatch.test.mjs` or new source-level regression
+
+**Implementation:**
+
+In deferred warmup after subscriptions/pins/seeds are loaded:
+- for every persisted seed with direct `blobsCoreKey`, retain that blob core discovery immediately;
+- for every seed/pin/subscription with a `publicBeeKey`, call `retainPublicBeeContentDiscovery()` in a bounded background queue;
+- if only driveKey exists, keep existing `loadChannel()` warmup as fallback but do not make it the only content-serving path.
+
+**Regression:** assert orchestrator imports/calls `retainPublicBeeContentDiscovery` and uses direct seed `blobsCoreKey` before channel fallback.
+
+---
+
+## Task 4: First-class relay catalog entries in PublicFeedManager
+
+**Objective:** Stop conflating relay cache inventory with user-published channels.
+
+**Files:**
+- Modify: `packages/backend/src/public-feed.js`
+- Test: `packages/backend/test/public-feed-manager.test.mjs`
+
+**Implementation:**
+
+Add catalog fields to serialized/restored entries:
+- `schema: 'peartube.relayCatalog'`
+- `catalogVersion: 1`
+- `relayRole: 'publisher' | 'cache' | 'mirror'`
+- `relayServing: boolean`
+- `lastSeenAt`
+- `previewVideosHash`
+
+Add `submitRelayCatalogEntry(entry)`:
+- normalizes `driveKey`, `publicBeeKey`, preview videos, and relay fields;
+- stores entry with `source: 'relay-cache'`, `relayRole: 'cache'`, `relayServing: true`;
+- persists to a catalog key such as `public-feed-relay-catalog-v1`;
+- broadcasts over the existing Protomux feed channel;
+- does **not** add to `publishedChannels`.
+
+Update `getFeed()` visibility so relay-serving entries with valid `publicBeeKey` or playable direct preview refs remain visible at `peerCount: 0`.
+
+**Regressions:**
+- relay catalog submission does not add to `publishedChannels`;
+- `HAVE_FEED` preserves relay catalog fields;
+- restore from catalog persistence preserves preview direct refs;
+- relay-cache entries remain visible at zero live peer count.
+
+---
+
+## Task 5: Relay runtime uses catalog contract
+
+**Objective:** Relay startup should advertise cached inventory as relay-serving catalog entries before first gossip.
+
+**Files:**
+- Modify: `packages/cli/src/runtime.js`
+- Modify: `packages/cli/src/cache-manager.js` if needed
+- Modify: `packages/cli/src/seeding.js`
+- Test: `packages/cli/test/runtime.test.mjs`
+- Test: `packages/cli/test/relay-seeding.test.mjs`
+
+**Implementation:**
+
+Reorder relay startup:
+1. init cache manager;
+2. create API;
+3. install `setAvailabilityHintProvider` and `setFeedSnapshotProvider`;
+4. start public feed;
+5. restore cached channels as `submitRelayCatalogEntry()` instead of `submitChannel()`;
+6. seed each cached channel and update catalog snapshots from seeder/API metadata.
+
+Patch `emitFeedEntries()` to emit `source: 'relay-cache'`, `relayServing`, and `previewVideos` for relay catalog entries.
+
+Patch seeder to return a `catalogEntry` snapshot with preview direct refs where available.
+
+**Regressions:**
+- runtime registers providers before `publicFeed.start()`;
+- cached channels use `submitRelayCatalogEntry`, not `submitChannel`;
+- seeder returns catalogEntry with direct refs and seeding stats.
+
+---
+
+## Task 6: API uses relay catalog previews before channel hydration
+
+**Objective:** Light clients must not need full channel `loadChannel()` to list/play feed-preview-backed relay videos.
+
+**Files:**
+- Modify: `packages/backend/src/api.js`
+- Test: `packages/backend/test/public-feed-api.test.mjs`
+- Test: `packages/backend/test/playback-api.test.mjs`
+
+**Implementation:**
+
+Add helpers inside `createApi()`:
+- `getPublicFeedEntry(driveKey)`
+- `normalizeVideoId(value)`
+- `getPreviewVideoFromFeed(driveKey, videoId)`
+- `previewVideosFromFeedEntry(driveKey)`
+
+Patch:
+- `listVideos()`: if PublicBee is empty/fails and feed entry has preview direct refs, return preview videos and do not call `loadChannel()`.
+- `getVideoData()`: after direct request refs and PublicBee miss/fail, use feed preview direct refs before `loadChannel()`.
+- `getFeedSnapshotEntries()`: preserve existing preview refs if local enrichment fails.
+- `getPublicFeed()`: expose relay catalog fields.
+
+**Regressions:**
+- PublicBee empty + relay preview returns videos with `channelKey`/`publicBeeKey` and `channelLoads === 0`.
+- PublicBee failure + relay preview returns videos with `channelLoads === 0`.
+- `getVideoData()` resolves preview `blobId`/`blobsCoreKey` with `channelLoads === 0`.
+- `preparePlayback()`/`getVideoUrl()` can use that direct metadata path.
+
+---
+
+## Verification
+
+Run targeted tests first:
+
+```bash
+node --test packages/backend/test/storage-startup-regression.test.mjs
+node --test packages/backend/test/public-feed-manager.test.mjs packages/backend/test/public-feed-api.test.mjs packages/backend/test/playback-api.test.mjs
+npm test --prefix packages/cli -- --timeout=30000
+npm run lint:changed
+git diff --check
+```
+
+Then open PR, wait for CI, merge, and cut the next tag release.
+
+---
+
+## Non-goals
+
+- Do not reintroduce `peartube-public-feed-v1`.
+- Do not bake relay-specific behavior into UI card components.
+- Do not require Google/YouTube credentials or cookies for relay availability.
+- Do not make backend readiness depend on P2P/feed sync.

--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -170,6 +170,54 @@ export function createApi({
     } catch { /* best effort */ }
   }
 
+
+  function normalizeVideoId(value) {
+    if (!value || typeof value !== 'string') return value
+    if (value.startsWith('/videos/')) {
+      const match = value.match(/\/videos\/([^./]+)/)
+      if (match?.[1]) return match[1]
+    }
+    const base = value.split('/').pop() || value
+    return base.replace(/\.[^./]+$/, '') || value
+  }
+
+  function getPublicFeedEntry(driveKey) {
+    try {
+      const feed = typeof publicFeed?.getFeed === 'function' ? publicFeed.getFeed() : []
+      if (!Array.isArray(feed)) return null
+      return feed.find((entry) => (entry?.driveKey || entry?.channelKey) === driveKey) || null
+    } catch {
+      return null
+    }
+  }
+
+  function previewVideosFromFeedEntry(driveKey, publicBeeKey = null) {
+    const entry = getPublicFeedEntry(driveKey)
+    const previews = Array.isArray(entry?.previewVideos) ? entry.previewVideos : []
+    if (previews.length === 0) return []
+    const resolvedPublicBeeKey = publicBeeKey || entry?.publicBeeKey || null
+    return previews
+      .filter((video) => video?.id || video?.path)
+      .map((video) => {
+        const id = normalizeVideoId(video.id || video.path)
+        return {
+          ...video,
+          id,
+          path: video.path || `/videos/${id}.mp4`,
+          channelKey: driveKey,
+          publicBeeKey: resolvedPublicBeeKey,
+          relayBacked: Boolean(entry?.relayServing || entry?.relayRole === 'cache' || entry?.source === 'relay-cache'),
+          mimeType: video.mimeType || 'video/mp4',
+        }
+      })
+  }
+
+  function getPreviewVideoFromFeed(driveKey, videoId, publicBeeKey = null) {
+    const targetId = normalizeVideoId(videoId)
+    const previews = previewVideosFromFeedEntry(driveKey, publicBeeKey)
+    return previews.find((video) => normalizeVideoId(video?.id || video?.path) === targetId) || null
+  }
+
   // ============================================
   // Download Intent Persistence Helpers
   // ============================================
@@ -706,6 +754,14 @@ export function createApi({
             const videos = await publicBee.listVideos()
             console.log('[API] LIST_VIDEOS: PublicBee returned', videos?.length, 'videos')
             if ((videos?.length || 0) === 0) {
+              const previewVideos = previewVideosFromFeedEntry(driveKey, publicBeeKey)
+              if (previewVideos.length > 0) {
+                console.log('[API] LIST_VIDEOS: PublicBee empty, using relay/feed preview direct refs')
+                const previewWithAvailability = await attachVideoAvailability(previewVideos)
+                listVideosCache.set(driveKey, { ts: Date.now(), value: previewWithAvailability })
+                backgroundIndexVideos(previewWithAvailability, driveKey)
+                return cloneArrayOfObjects(previewWithAvailability)
+              }
               console.log('[API] LIST_VIDEOS: PublicBee returned no videos, trying channel fallback')
               const channel = await loadChannel(ctx, driveKey)
               const fallbackVideos = await channel.listVideos()
@@ -725,6 +781,14 @@ export function createApi({
             backgroundIndexVideos(withAvailability, driveKey)
             return cloneArrayOfObjects(withAvailability)
           } catch (err) {
+            const previewVideos = previewVideosFromFeedEntry(driveKey, publicBeeKey)
+            if (previewVideos.length > 0) {
+              console.log('[API] LIST_VIDEOS: PublicBee failed, using relay/feed preview direct refs:', err.message)
+              const previewWithAvailability = await attachVideoAvailability(previewVideos)
+              listVideosCache.set(driveKey, { ts: Date.now(), value: previewWithAvailability })
+              backgroundIndexVideos(previewWithAvailability, driveKey)
+              return cloneArrayOfObjects(previewWithAvailability)
+            }
             console.log('[API] LIST_VIDEOS: PublicBee fast path failed:', err.message, '- trying channel directly')
             // If PublicBee fails, try loading the channel directly (for paired devices or when PublicBee isn't synced)
             try {
@@ -972,7 +1036,20 @@ export function createApi({
           const v = await publicBee.getVideo(id)
           console.log('[API] GET_VIDEO_DATA PublicBee result:', v?.id, 'blobId:', v?.blobId, 'blobsCoreKey:', v?.blobsCoreKey?.slice(0, 16))
           if (v) return { ...v, channelKey: driveKey }
-          // Fall through to other methods if not found
+          // Fall through to feed previews/channel methods if not found
+        }
+
+        const previewVideo = getPreviewVideoFromFeed(driveKey, id, publicBeeKey)
+        if (previewVideo?.blobId && previewVideo?.blobsCoreKey) {
+          console.log('[API] GET_VIDEO_DATA: using relay/feed preview direct refs')
+          return {
+            ...previewVideo,
+            id,
+            path: previewVideo.path || `/videos/${id}.mp4`,
+            channelKey: driveKey,
+            publicBeeKey: previewVideo.publicBeeKey || publicBeeKey || null,
+            mimeType: previewVideo.mimeType || mimeType || 'video/mp4',
+          }
         }
 
       const channel = await loadChannel(ctx, driveKey)
@@ -1418,10 +1495,14 @@ export function createApi({
             channelKey: entry?.channelKey || entry?.driveKey || '',
             source: entry?.source || 'peer',
             publicBeeKey: entry?.publicBeeKey || null,
+            relayRole: entry?.relayRole || null,
+            relayServing: Boolean(entry?.relayServing),
+            catalogVersion: entry?.catalogVersion || null,
+            previewVideosHash: entry?.previewVideosHash || null,
             channelName: entry?.channelName || null,
             videoCount: entry?.videoCount || 0,
             peerCount: entry?.peerCount || 0,
-            lastSeen: entry?.lastSeen || entry?.addedAt || 0,
+            lastSeen: entry?.lastSeen || entry?.lastSeenAt || entry?.addedAt || 0,
             manifestUpdatedAt: entry?.manifestUpdatedAt || 0,
             previewVideos: Array.isArray(entry?.previewVideos) ? entry.previewVideos : [],
           }
@@ -1891,7 +1972,14 @@ export function createApi({
                 if (seedingManager) {
                   seedingManager.addSeed(driveKey, videoPath, 'watched', {
                     blockLength: totalBlocks,
-                    byteLength: totalBytes
+                    byteLength: totalBytes,
+                    publicBeeKey: publicBeeKey || v?.publicBeeKey || null,
+                    blobId: blobMeta.blobId,
+                    blobsCoreKey: blobMeta.blobsCoreKey,
+                    thumbnailBlobId: v?.thumbnailBlobId || null,
+                    thumbnailBlobsCoreKey: v?.thumbnailBlobsCoreKey || null,
+                    mimeType: v?.mimeType || existingIntent?.mimeType || null,
+                    thumbnailMimeType: v?.thumbnailMimeType || null
                   }).catch(err => console.log('[API] Failed to register seed:', err?.message))
                 }
               }).catch(err => {
@@ -1982,7 +2070,14 @@ export function createApi({
             if (seedingManager) {
               seedingManager.addSeed(driveKey, videoPath, 'watched', {
                 blockLength: totalBlocks,
-                byteLength: totalBytes
+                byteLength: totalBytes,
+                publicBeeKey: publicBeeKey || v?.publicBeeKey || null,
+                blobId: blobMeta.blobId,
+                blobsCoreKey: blobMeta.blobsCoreKey,
+                thumbnailBlobId: v?.thumbnailBlobId || null,
+                thumbnailBlobsCoreKey: v?.thumbnailBlobsCoreKey || null,
+                mimeType: v?.mimeType || existingIntent?.mimeType || null,
+                thumbnailMimeType: v?.thumbnailMimeType || null
               }).catch(() => {})
             }
           }

--- a/packages/backend/src/orchestrator.js
+++ b/packages/backend/src/orchestrator.js
@@ -9,7 +9,7 @@
  *   const { ctx, api, identityManager, uploadManager, publicFeed, seedingManager, videoStats } = backend;
  */
 
-import { initializeStorage, loadChannel } from './storage.js';
+import { initializeStorage, loadChannel, retainPublicBeeContentDiscovery, retainSwarmDiscovery } from './storage.js';
 import { PublicFeedManager } from './public-feed.js';
 import { VideoStatsTracker } from './video-stats.js';
 import { SeedingManager } from './seeding.js';
@@ -462,7 +462,25 @@ export async function createBackendContext(config) {
         const subs = (await ctx.metaDb.get('subscriptions').catch(() => null))?.value || []
         const subscriptionKeys = subs.map((s) => s.driveKey).filter(Boolean)
         const pinnedKeys = seedingManager.getPinnedChannels?.() || []
-        const seedKeys = seedingManager.getActiveSeeds?.().map((s) => s.driveKey).filter(Boolean) || []
+        const seeds = seedingManager.getActiveSeeds?.() || []
+        const seedKeys = seeds.map((s) => s.driveKey).filter(Boolean) || []
+
+        // Restore old relay-like serving behavior for normal clients: persisted
+        // watched/seeded entries retain their blob-core discovery immediately,
+        // without waiting for full channel hydration.
+        for (const seed of seeds) {
+          if (seed?.blobsCoreKey && ctx.store) {
+            try {
+              const core = ctx.store.get(Buffer.from(seed.blobsCoreKey, 'hex'))
+              await core?.ready?.()
+              if (core?.discoveryKey) retainSwarmDiscovery(ctx, core.discoveryKey, { label: `seed:${seed.blobsCoreKey.slice(0, 16)}` })
+            } catch {}
+          }
+          if (seed?.publicBeeKey) {
+            retainPublicBeeContentDiscovery(ctx, seed.publicBeeKey, { label: `seed:${seed.driveKey?.slice?.(0, 16) || 'channel'}` }).catch(() => {})
+          }
+        }
+
         await warmChannels(ctx, [...subscriptionKeys, ...pinnedKeys, ...seedKeys], 'subscriptions/pins/seeds')
         // Skip prefetch - it was causing errors and slowing things down
       } catch (e) {

--- a/packages/backend/src/orchestrator.js
+++ b/packages/backend/src/orchestrator.js
@@ -474,7 +474,9 @@ export async function createBackendContext(config) {
               const core = ctx.store.get(Buffer.from(seed.blobsCoreKey, 'hex'))
               await core?.ready?.()
               if (core?.discoveryKey) retainSwarmDiscovery(ctx, core.discoveryKey, { label: `seed:${seed.blobsCoreKey.slice(0, 16)}` })
-            } catch {}
+            } catch {
+              // Discovery retention is best-effort during startup warmup.
+            }
           }
           if (seed?.publicBeeKey) {
             retainPublicBeeContentDiscovery(ctx, seed.publicBeeKey, { label: `seed:${seed.driveKey?.slice?.(0, 16) || 'channel'}` }).catch(() => {})

--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -23,6 +23,8 @@ import { logger } from './logger.js'
 import { hashFeedEntries, hashPreviewVideos } from './hash-utils.js'
 
 const log = logger('PublicFeed')
+const PUBLIC_FEED_CATALOG_VERSION = 1
+const PUBLIC_FEED_RELAY_CATALOG_KEY = 'public-feed-relay-catalog-v1'
 
 /**
  * @typedef {import('./types.js').PublicFeedEntry} PublicFeedEntry
@@ -180,8 +182,13 @@ export class PublicFeedManager {
 
   _serializeEntry(entry) {
     const serialized = {
+      schema: 'peartube.relayCatalog',
+      catalogVersion: entry.catalogVersion || PUBLIC_FEED_CATALOG_VERSION,
       driveKey: entry.driveKey,
       publicBeeKey: entry.publicBeeKey || null,
+      relayRole: entry.relayRole || (entry.source === 'relay-cache' ? 'cache' : 'publisher'),
+      relayServing: Boolean(entry.relayServing || entry.source === 'relay-cache' || entry.source === 'local'),
+      lastSeenAt: entry.lastSeenAt || entry.addedAt || Date.now(),
       version: Number(entry.version || 0) || 0,
     }
     if (entry.channelName) serialized.channelName = entry.channelName
@@ -206,6 +213,22 @@ export class PublicFeedManager {
     }
     if (typeof snapshot.channelName === 'string' && snapshot.channelName && snapshot.channelName !== entry.channelName) {
       entry.channelName = snapshot.channelName
+      changed = true
+    }
+    if (typeof snapshot.relayRole === 'string' && snapshot.relayRole && snapshot.relayRole !== entry.relayRole) {
+      entry.relayRole = snapshot.relayRole
+      changed = true
+    }
+    if (typeof snapshot.catalogVersion !== 'undefined' && snapshot.catalogVersion !== entry.catalogVersion) {
+      entry.catalogVersion = Number(snapshot.catalogVersion || PUBLIC_FEED_CATALOG_VERSION) || PUBLIC_FEED_CATALOG_VERSION
+      changed = true
+    }
+    if (typeof snapshot.relayServing !== 'undefined' && Boolean(snapshot.relayServing) !== Boolean(entry.relayServing)) {
+      entry.relayServing = Boolean(snapshot.relayServing)
+      changed = true
+    }
+    if (Number(snapshot.lastSeenAt || 0) > Number(entry.lastSeenAt || 0)) {
+      entry.lastSeenAt = Number(snapshot.lastSeenAt)
       changed = true
     }
     if (Number.isFinite(snapshot.videoCount) && Number(snapshot.videoCount) !== Number(entry.videoCount || 0)) {
@@ -617,6 +640,26 @@ export class PublicFeedManager {
       }
     }
 
+    // Restore first-class relay catalog entries after legacy feed entries so richer
+    // relay-serving metadata wins on restart.
+    if (this.metaDb) {
+      try {
+        const catalog = await this.metaDb.get(PUBLIC_FEED_RELAY_CATALOG_KEY).catch(() => null)
+        const entries = Array.isArray(catalog?.value?.entries) ? catalog.value.entries : []
+        let restoredCatalog = 0
+        for (const entry of entries) {
+          if (entry?.driveKey && this.addEntry(entry.driveKey, entry.source || 'relay-cache', entry.publicBeeKey, entry)) {
+            restoredCatalog++
+          } else if (entry?.driveKey && this._applyEntrySnapshot(entry.driveKey, entry)) {
+            restoredCatalog++
+          }
+        }
+        if (restoredCatalog > 0) console.log('[PublicFeed] Restored', restoredCatalog, 'relay catalog entries')
+      } catch (err) {
+        console.log('[PublicFeed] Relay catalog restore skipped:', err?.message)
+      }
+    }
+
     // If we loaded any entries from disk, notify listeners so UIs don't stay empty until the first peer message arrives.
     if (this.entries.size > 0) {
       console.log('[PublicFeed] Notifying listeners of', this.entries.size, 'restored entries');
@@ -741,6 +784,12 @@ export class PublicFeedManager {
         .map(e => ({
           driveKey: e.driveKey,
           publicBeeKey: e.publicBeeKey || null,
+          source: e.source || 'peer',
+          schema: e.schema || 'peartube.relayCatalog',
+          catalogVersion: Number(e.catalogVersion || PUBLIC_FEED_CATALOG_VERSION) || PUBLIC_FEED_CATALOG_VERSION,
+          relayRole: e.relayRole || null,
+          relayServing: Boolean(e.relayServing),
+          lastSeenAt: e.lastSeenAt || e.addedAt || Date.now(),
           channelName: e.channelName || null,
           videoCount: Number(e.videoCount || 0) || 0,
           manifestUpdatedAt: Number(e.manifestUpdatedAt || 0) || 0,
@@ -752,6 +801,22 @@ export class PublicFeedManager {
       const keys = entries.map(e => e.driveKey)
       await this.metaDb.put('discovered-channels', keys)
       await this.metaDb.put('public-feed-cache', keys)
+      const relayCatalogEntries = entries
+        .filter(e => e.relayServing || e.source === 'relay-cache' || e.relayRole === 'cache')
+        .map(e => ({
+          ...e,
+          schema: 'peartube.relayCatalog',
+          catalogVersion: PUBLIC_FEED_CATALOG_VERSION,
+          relayRole: e.relayRole || 'cache',
+          relayServing: Boolean(e.relayServing || e.source === 'relay-cache' || e.relayRole === 'cache'),
+          lastSeenAt: e.lastSeenAt || Date.now(),
+        }))
+      await this.metaDb.put(PUBLIC_FEED_RELAY_CATALOG_KEY, {
+        schema: 'peartube.relayCatalog',
+        version: PUBLIC_FEED_CATALOG_VERSION,
+        entries: relayCatalogEntries,
+        updatedAt: Date.now(),
+      })
     } catch (err) {
       console.log('[PublicFeed] Discovered-channel cache persist skipped:', err?.message)
     }
@@ -1052,7 +1117,8 @@ export class PublicFeedManager {
       console.log('[PublicFeed] SUBMIT_CHANNEL received:', msg.key?.slice(0, 16), 'publicBee:', msg.publicBeeKey?.slice(0, 16) || 'none');
       const isValidKey = (k) => typeof k === 'string' && /^[a-f0-9]{64}$/i.test(k)
       if (!isValidKey(msg.publicBeeKey)) return
-      if (this.addEntry(msg.key, 'peer', msg.publicBeeKey, msg)) {
+      const entrySource = msg.source === 'relay-cache' ? 'relay-cache' : 'peer'
+      if (this.addEntry(msg.key, entrySource, msg.publicBeeKey, msg)) {
         this.onFeedUpdate?.();
         this._schedulePersistDiscovered()
         // Re-gossip to other peers (exclude sender, include publicBeeKey)
@@ -1155,6 +1221,11 @@ export class PublicFeedManager {
       addedAt: Date.now(),
       source,
       peerCount: source === 'local' ? 1 : 0,
+      schema: snapshot?.schema || 'peartube.relayCatalog',
+      catalogVersion: Number(snapshot?.catalogVersion || PUBLIC_FEED_CATALOG_VERSION) || PUBLIC_FEED_CATALOG_VERSION,
+      relayRole: snapshot?.relayRole || (source === 'relay-cache' ? 'cache' : source === 'local' ? 'publisher' : null),
+      relayServing: Boolean(snapshot?.relayServing || source === 'relay-cache' || source === 'local'),
+      lastSeenAt: Number(snapshot?.lastSeenAt || Date.now()) || Date.now(),
       channelName: snapshot?.channelName || null,
       videoCount: Number(snapshot?.videoCount || 0) || 0,
       manifestUpdatedAt: Number(snapshot?.manifestUpdatedAt || 0) || 0,
@@ -1232,6 +1303,39 @@ export class PublicFeedManager {
   }
 
   /**
+   * Submit relay-owned/cache-serving catalog inventory without marking it as a
+   * user-published channel.
+   * @param {Object} entry
+   */
+  async submitRelayCatalogEntry(entry = {}) {
+    const driveKey = entry.driveKey || entry.channelKey
+    const publicBeeKey = entry.publicBeeKey || null
+    if (!driveKey || !publicBeeKey) return false
+
+    const snapshot = {
+      ...entry,
+      schema: 'peartube.relayCatalog',
+      catalogVersion: PUBLIC_FEED_CATALOG_VERSION,
+      source: 'relay-cache',
+      relayRole: entry.relayRole || 'cache',
+      relayServing: true,
+      lastSeenAt: Date.now(),
+      previewVideos: this._sanitizePreviewVideos(entry.previewVideos),
+    }
+
+    const added = this.addEntry(driveKey, 'relay-cache', publicBeeKey, snapshot)
+    const updated = !added && this._applyEntrySnapshot(driveKey, snapshot)
+    if (added || updated) {
+      console.log('[PublicFeed] Submitted relay catalog entry:', driveKey.slice(0, 16), 'videos=', snapshot.previewVideos.length)
+      this.onFeedUpdate?.()
+    }
+    this.broadcastSubmitChannel(driveKey, null, publicBeeKey, snapshot)
+    this._schedulePersistDiscovered()
+    await this._persistDiscoveredNow().catch(() => {})
+    return true
+  }
+
+  /**
    * Unpublish a channel from the public feed
    * @param {string} driveKey
    */
@@ -1270,6 +1374,12 @@ export class PublicFeedManager {
       type: 'SUBMIT_CHANNEL',
       key: driveKey,
       publicBeeKey: publicBeeKey || null,
+      schema: snapshot?.schema || 'peartube.relayCatalog',
+      catalogVersion: Number(snapshot?.catalogVersion || PUBLIC_FEED_CATALOG_VERSION) || PUBLIC_FEED_CATALOG_VERSION,
+      source: snapshot?.source || null,
+      relayRole: snapshot?.relayRole || null,
+      relayServing: Boolean(snapshot?.relayServing),
+      lastSeenAt: snapshot?.lastSeenAt || Date.now(),
       channelName: snapshot?.channelName || null,
       videoCount: Number(snapshot?.videoCount || 0) || 0,
       manifestUpdatedAt: Number(snapshot?.manifestUpdatedAt || 0) || 0,
@@ -1330,6 +1440,7 @@ export class PublicFeedManager {
    * @returns {PublicFeedEntry[]}
    */
   getFeed() {
+    const isValidKey = (k) => typeof k === 'string' && /^[a-f0-9]{64}$/i.test(k)
     return Array.from(this.entries.values())
       .filter(e => !this.hiddenKeys.has(e.driveKey))
       .map((entry) => ({
@@ -1343,6 +1454,9 @@ export class PublicFeedManager {
         if (entry.source === 'local') return true
         // Peer-discovered channels with live peers are visible.
         if ((entry.peerCount || 0) > 0) return true
+        // Relay catalog entries are explicit cache-serving inventory and must
+        // remain visible even when no live feed socket is currently open.
+        if (entry.relayServing && (isValidKey(entry.publicBeeKey) || this._sanitizePreviewVideos(entry.previewVideos).some(v => v.blobId && v.blobsCoreKey))) return true
         // IMPORTANT: keep cached peer-discovered channels visible if they carry
         // a valid publicBeeKey. This is what allows the app to hydrate/feed-load
         // instantly on restart instead of coming up empty until a live gossip peer

--- a/packages/backend/src/seeding.js
+++ b/packages/backend/src/seeding.js
@@ -67,7 +67,7 @@ export class SeedingManager {
    * @param {string} driveKey
    * @param {string} videoPath
    * @param {'watched'|'pinned'|'subscribed'} reason
-   * @param {{blockLength?: number, byteLength?: number}} [blobInfo]
+   * @param {{blockLength?: number, byteLength?: number, publicBeeKey?: string | null, blobId?: string | null, blobsCoreKey?: string | null, thumbnailBlobId?: string | null, thumbnailBlobsCoreKey?: string | null, mimeType?: string | null, thumbnailMimeType?: string | null}} [blobInfo]
    * @returns {Promise<boolean>}
    */
   async addSeed(driveKey, videoPath, reason, blobInfo) {
@@ -91,7 +91,14 @@ export class SeedingManager {
       reason,
       addedAt: Date.now(),
       blocks: blobInfo?.blockLength || 0,
-      bytes: blobInfo?.byteLength || 0
+      bytes: blobInfo?.byteLength || 0,
+      publicBeeKey: blobInfo?.publicBeeKey || null,
+      blobId: blobInfo?.blobId || null,
+      blobsCoreKey: blobInfo?.blobsCoreKey || null,
+      thumbnailBlobId: blobInfo?.thumbnailBlobId || null,
+      thumbnailBlobsCoreKey: blobInfo?.thumbnailBlobsCoreKey || null,
+      mimeType: blobInfo?.mimeType || null,
+      thumbnailMimeType: blobInfo?.thumbnailMimeType || null
     };
 
     this.activeSeeds.set(key, seedInfo);
@@ -169,7 +176,14 @@ export class SeedingManager {
         videoPath: s.videoPath,
         reason: s.reason,
         bytes: s.bytes,
-        addedAt: s.addedAt
+        addedAt: s.addedAt,
+        publicBeeKey: s.publicBeeKey || null,
+        blobId: s.blobId || null,
+        blobsCoreKey: s.blobsCoreKey || null,
+        thumbnailBlobId: s.thumbnailBlobId || null,
+        thumbnailBlobsCoreKey: s.thumbnailBlobsCoreKey || null,
+        mimeType: s.mimeType || null,
+        thumbnailMimeType: s.thumbnailMimeType || null
       }))
     };
   }

--- a/packages/backend/src/storage.js
+++ b/packages/backend/src/storage.js
@@ -371,6 +371,89 @@ export function retainSwarmDiscovery(ctx, discoveryKey, options = {}) {
   return handle
 }
 
+
+function isValidCoreKeyHex(value) {
+  return typeof value === 'string' && /^[a-f0-9]{64}$/i.test(value)
+}
+
+/**
+ * Retain discovery for a PublicBee and the video/thumbnail blob cores it advertises.
+ * This restores the old relay-style cache behavior for any runtime: once we know a
+ * publicBeeKey, cached content is announced as content cores without waiting for a
+ * full channel Autobase load.
+ *
+ * @param {import('./types.js').StorageContext} ctx
+ * @param {string} publicBeeKeyHex
+ * @param {{ label?: string, maxVideos?: number }} [options]
+ * @returns {Promise<{publicBeeKey: string, videos: number, blobCores: number, thumbnailBlobCores: number, discoveryHandles: number, retained: number, errors: number, lastError: string | null}>}
+ */
+export async function retainPublicBeeContentDiscovery(ctx, publicBeeKeyHex, options = {}) {
+  const stats = {
+    publicBeeKey: publicBeeKeyHex,
+    videos: 0,
+    blobCores: 0,
+    thumbnailBlobCores: 0,
+    discoveryHandles: getSwarmDiscoveryHandles(ctx).size,
+    retained: 0,
+    errors: 0,
+    lastError: null,
+  }
+
+  if (!isValidCoreKeyHex(publicBeeKeyHex)) {
+    stats.errors += 1
+    stats.lastError = 'invalid-publicBeeKey'
+    return stats
+  }
+
+  let publicBee = null
+  try {
+    publicBee = await loadPublicBee(ctx, publicBeeKeyHex)
+  } catch (err) {
+    stats.errors += 1
+    stats.lastError = err?.message || String(err)
+    return stats
+  }
+
+  let videos = []
+  try {
+    videos = await publicBee?.listVideos?.().catch(() => [])
+  } catch (err) {
+    stats.errors += 1
+    stats.lastError = err?.message || String(err)
+    videos = []
+  }
+
+  const maxVideos = Number.isFinite(options.maxVideos) && options.maxVideos > 0
+    ? Math.floor(options.maxVideos)
+    : 200
+  const coreKeys = new Map()
+  for (const video of (Array.isArray(videos) ? videos.slice(0, maxVideos) : [])) {
+    stats.videos += 1
+    if (isValidCoreKeyHex(video?.blobsCoreKey)) coreKeys.set(video.blobsCoreKey.toLowerCase(), 'blob')
+    if (isValidCoreKeyHex(video?.thumbnailBlobsCoreKey)) coreKeys.set(video.thumbnailBlobsCoreKey.toLowerCase(), 'thumbnail')
+  }
+
+  for (const [coreKeyHex, kind] of coreKeys) {
+    try {
+      const core = ctx.store?.get?.(b4a.from(coreKeyHex, 'hex'))
+      await core?.ready?.()
+      if (core?.discoveryKey && retainSwarmDiscovery(ctx, core.discoveryKey, {
+        label: `${options.label || 'publicBee'}:${kind}:${coreKeyHex.slice(0, 16)}`
+      })) {
+        stats.retained += 1
+        if (kind === 'thumbnail') stats.thumbnailBlobCores += 1
+        else stats.blobCores += 1
+      }
+    } catch (err) {
+      stats.errors += 1
+      stats.lastError = err?.message || String(err)
+    }
+  }
+
+  stats.discoveryHandles = getSwarmDiscoveryHandles(ctx).size
+  return stats
+}
+
 /**
  * Initialize core storage components.
  *

--- a/packages/backend/test/public-feed-api.test.mjs
+++ b/packages/backend/test/public-feed-api.test.mjs
@@ -46,6 +46,10 @@ test('getPublicFeed returns peer entries even when publicBeeKey is absent', (t) 
     channelKey: '11'.repeat(32),
     source: 'peer',
     publicBeeKey: null,
+    relayRole: null,
+    relayServing: false,
+    catalogVersion: null,
+    previewVideosHash: null,
     channelName: null,
     videoCount: 0,
     peerCount: 0,
@@ -699,4 +703,133 @@ test('submitToFeed fails closed when the channel cannot provide a publicBeeKey',
   t.is(result.success, false)
   t.is(submitted, false)
   t.ok(/publicBeeKey/i.test(result.error || ''))
+})
+
+
+test('listVideos uses relay catalog preview refs without channel load when PublicBee is empty', async (t) => {
+  let publicBeeLoads = 0
+  let channelLoads = 0
+  const driveKey = 'ab'.repeat(32)
+  const publicBeeKey = 'bc'.repeat(32)
+
+  const api = createApi({
+    ctx: {
+      store: {
+        get() {
+          return {
+            async ready() {},
+            async has() { return true },
+          }
+        },
+      },
+      metaDb: { async get() { return null }, async put() {} },
+    },
+    publicFeed: {
+      getFeed() {
+        return [{
+          driveKey,
+          publicBeeKey,
+          source: 'relay-cache',
+          relayRole: 'cache',
+          relayServing: true,
+          previewVideos: [{
+            id: 'relay-video',
+            title: 'Relay Video',
+            blobId: '0:8:0:1024',
+            blobsCoreKey: 'cd'.repeat(32),
+            mimeType: 'video/mp4',
+            availability: 'playable',
+          }],
+        }]
+      },
+      async requestAvailabilityHints() { return [] },
+    },
+    loadPublicBee: async () => {
+      publicBeeLoads += 1
+      return { async listVideos() { return [] } }
+    },
+    loadChannel: async () => {
+      channelLoads += 1
+      throw new Error('loadChannel should not be called')
+    },
+  })
+
+  const videos = await api.listVideos(driveKey, publicBeeKey)
+  t.is(publicBeeLoads, 1)
+  t.is(channelLoads, 0)
+  t.is(videos.length, 1)
+  t.is(videos[0].id, 'relay-video')
+  t.is(videos[0].channelKey, driveKey)
+  t.is(videos[0].publicBeeKey, publicBeeKey)
+  t.is(videos[0].relayBacked, true)
+})
+
+test('getVideoData resolves relay catalog preview refs without channel load', async (t) => {
+  let channelLoads = 0
+  const driveKey = 'de'.repeat(32)
+  const publicBeeKey = 'ef'.repeat(32)
+
+  const api = createApi({
+    ctx: { metaDb: { async get() { return null }, async put() {} } },
+    publicFeed: {
+      getFeed() {
+        return [{
+          driveKey,
+          publicBeeKey,
+          source: 'relay-cache',
+          relayRole: 'cache',
+          relayServing: true,
+          previewVideos: [{
+            id: 'preview-only',
+            title: 'Preview Only',
+            blobId: '0:4:0:512',
+            blobsCoreKey: 'fa'.repeat(32),
+            mimeType: 'video/mp4',
+            availability: 'playable',
+          }],
+        }]
+      },
+    },
+    loadPublicBee: async () => ({ async getVideo() { return null } }),
+    loadChannel: async () => {
+      channelLoads += 1
+      throw new Error('loadChannel should not be called')
+    },
+  })
+
+  const video = await api.getVideoData(driveKey, 'preview-only', publicBeeKey)
+  t.is(channelLoads, 0)
+  t.is(video.id, 'preview-only')
+  t.is(video.blobId, '0:4:0:512')
+  t.is(video.blobsCoreKey, 'fa'.repeat(32))
+  t.is(video.relayBacked, true)
+})
+
+test('getPublicFeed exposes relay catalog fields', (t) => {
+  const api = createApi({
+    ctx: {},
+    publicFeed: {
+      getFeed() {
+        return [{
+          driveKey: '12'.repeat(32),
+          publicBeeKey: '34'.repeat(32),
+          addedAt: 9,
+          source: 'relay-cache',
+          relayRole: 'cache',
+          relayServing: true,
+          catalogVersion: 1,
+          previewVideosHash: 'hash-value',
+          previewVideos: [],
+        }]
+      },
+      getStats() { return { totalEntries: 1, hiddenCount: 0, peerCount: 0 } },
+    },
+  })
+
+  const result = api.getPublicFeed()
+  t.is(result.entries[0].source, 'relay-cache')
+  t.is(result.entries[0].relayRole, 'cache')
+  t.is(result.entries[0].relayServing, true)
+  t.is(result.entries[0].catalogVersion, 1)
+  t.is(result.entries[0].previewVideosHash, 'hash-value')
 })

--- a/packages/backend/test/public-feed-manager.test.mjs
+++ b/packages/backend/test/public-feed-manager.test.mjs
@@ -763,3 +763,34 @@ test('requestAvailabilityHints merges playable responses from feed peers (includ
     manager.stop()
   }
 })
+
+
+test('relay catalog entries stay visible and do not become published channels', async (t) => {
+  const feed = new PublicFeedManager({
+    connections: new Set(),
+    peers: new Set(),
+    join() { return { flushed: async () => {} } },
+  }, {
+    async get() { return null },
+    async put() {},
+  })
+
+  await feed.submitRelayCatalogEntry({
+    driveKey: 'aa'.repeat(32),
+    publicBeeKey: 'bb'.repeat(32),
+    previewVideos: [{
+      id: 'relay-video',
+      blobId: '0:4:0:512',
+      blobsCoreKey: 'cc'.repeat(32),
+      availability: 'playable',
+    }],
+  })
+
+  assert.equal(feed.isChannelPublished('aa'.repeat(32)), false)
+  const entries = feed.getFeed()
+  assert.equal(entries.length, 1)
+  assert.equal(entries[0].source, 'relay-cache')
+  assert.equal(entries[0].relayRole, 'cache')
+  assert.equal(entries[0].relayServing, true)
+  assert.equal(entries[0].peerCount, 0)
+})

--- a/packages/backend/test/storage-startup-regression.test.mjs
+++ b/packages/backend/test/storage-startup-regression.test.mjs
@@ -81,3 +81,12 @@ test('offline swarm fallback skips peer pool discovery instead of joining noop t
     'offline swarm should skip peer pool discovery'
   )
 })
+
+
+test('storage exposes public bee content discovery retention for cached serving cores', () => {
+  assert.match(storageSource, /export async function retainPublicBeeContentDiscovery\(ctx, publicBeeKeyHex/)
+  assert.match(storageSource, /await loadPublicBee\(ctx, publicBeeKeyHex\)/)
+  assert.match(storageSource, /video\?\.blobsCoreKey/)
+  assert.match(storageSource, /video\?\.thumbnailBlobsCoreKey/)
+  assert.match(storageSource, /retainSwarmDiscovery\(ctx, core\.discoveryKey/)
+})

--- a/packages/backend/test/storage-startup-regression.test.mjs
+++ b/packages/backend/test/storage-startup-regression.test.mjs
@@ -26,8 +26,9 @@ test('blob server watchdog lazily loads HTTP only when cast probing is needed', 
 })
 
 test('blob server startup does not await listen before storage init can finish', () => {
-  const blobServerBody =
-    storageSource.match(/try \{\n    const desiredPort = blobServerPortOverride \|\| 0;([\s\S]*?)\n  \} catch \(err\) \{/ )?.[1] ?? ''
+  const blobServerBody = storageSource.match(
+    /const desiredPort = blobServerPortOverride \|\| 0;([\s\S]*?)catch \(err\) \{/
+  )?.[1] ?? ''
 
   assert.ok(blobServerBody, 'blob server startup block should exist')
   assert.doesNotMatch(blobServerBody, /await blobServer\.listen\(\)/)

--- a/packages/cli/src/runtime.js
+++ b/packages/cli/src/runtime.js
@@ -74,12 +74,14 @@ export async function createRelayRuntime({ config, logger }) {
   function emitFeedEntries() {
     if (typeof candidateHandler !== 'function') return
 
-    for (const entry of publicFeed.entries.values()) {
-      if (!entry?.driveKey) continue
+    for (const entry of publicFeed.getFeed?.() || publicFeed.entries.values()) {
+      if (!entry?.driveKey || !entry?.publicBeeKey) continue
       candidateHandler({
         channelKey: entry.driveKey,
         publicBeeKey: entry.publicBeeKey || null,
-        source: 'discovered'
+        source: entry.relayRole === 'cache' || entry.source === 'relay-cache' ? 'relay-cache' : 'discovered',
+        relayServing: Boolean(entry.relayServing),
+        previewVideos: Array.isArray(entry.previewVideos) ? entry.previewVideos : []
       })
     }
   }
@@ -145,14 +147,23 @@ export async function createRelayRuntime({ config, logger }) {
         publicFeed.setFeedSnapshotProvider((entries) => this.api.getFeedSnapshotEntries(entries, { limitPerChannel: 3 }))
       }
 
-      // Restore mirrored/cached channels as actively served feed entries so the
-      // relay behaves like a real serving peer even when original publishers are offline.
+      // Restore mirrored/cached channels as relay catalog entries, not as
+      // user-published channels. This keeps the relay contract explicit: it is
+      // serving/cache infrastructure for these publicBee/blob cores.
       for (const channel of cacheManager.getChannels()) {
         if (!channel?.driveKey || !channel?.publicBeeKey) continue
         try {
-          await loadPublicBee(ctx, channel.publicBeeKey)
-          await publicFeed.submitChannel(channel.driveKey, channel.publicBeeKey)
-          await seeder.seedChannel(channel)
+          const seedStats = await seeder.seedChannel(channel)
+          await publicFeed.submitRelayCatalogEntry({
+            ...(seedStats?.catalogEntry || {}),
+            driveKey: channel.driveKey,
+            publicBeeKey: channel.publicBeeKey,
+            channelName: seedStats?.catalogEntry?.channelName || channel.channelName || null,
+            videoCount: seedStats?.videos || channel.videoCount || 0,
+            previewVideos: seedStats?.catalogEntry?.previewVideos || channel.previewVideos || [],
+            relayRole: 'cache',
+            relayServing: true,
+          })
         } catch (err) {
           logger.runtime?.debug('Failed to restore cached mirrored channel', {
             channelKey: channel.driveKey,
@@ -245,7 +256,13 @@ export async function createRelayRuntime({ config, logger }) {
         swarmOffline: Boolean(ctx.swarm?._peartubeOffline),
         swarmOfflineReason: ctx.swarm?._peartubeOfflineReason || null,
         swarmListenResolved: Boolean(ctx.swarm?._peartubeListenResolved),
-        seeding: seeder.getStats()
+        seeding: seeder.getStats(),
+        relayCatalogEntries: Array.from(publicFeed.entries?.values?.() || []).filter(e => e?.relayRole === 'cache' || e?.source === 'relay-cache').length,
+        relayServingEntries: Array.from(publicFeed.entries?.values?.() || []).filter(e => e?.relayServing).length,
+        relayPlayablePreviewVideos: Array.from(publicFeed.entries?.values?.() || []).reduce((total, e) => {
+          const videos = Array.isArray(e?.previewVideos) ? e.previewVideos : []
+          return total + videos.filter(v => v?.availability === 'playable' && v?.blobId && v?.blobsCoreKey).length
+        }, 0)
       }
     },
     async close() {

--- a/packages/cli/src/seeding.js
+++ b/packages/cli/src/seeding.js
@@ -93,12 +93,30 @@ export function createRelaySeeder({ ctx, loadPublicBee, logger = {}, blindPeer =
       }
 
       const videos = await bee?.listVideos?.().catch(() => [])
+      const meta = await bee?.getMetadata?.().catch(() => null)
       const blobCoreKeys = new Set()
+      const previewVideos = []
       if (Array.isArray(videos)) {
         stats.videos = videos.length
         for (const video of videos) {
           addCoreKey(blobCoreKeys, video?.blobsCoreKey)
           addCoreKey(blobCoreKeys, video?.thumbnailBlobsCoreKey)
+          if (previewVideos.length < 3 && video?.id && video?.blobId && video?.blobsCoreKey) {
+            previewVideos.push({
+              id: String(video.id),
+              title: video?.title ? String(video.title) : 'Untitled',
+              uploadedAt: Number(video?.uploadedAt || 0) || 0,
+              duration: Number(video?.duration || 0) || 0,
+              thumbnail: video?.thumbnail || null,
+              blobId: String(video.blobId),
+              blobsCoreKey: String(video.blobsCoreKey),
+              mimeType: video?.mimeType || 'video/mp4',
+              availability: 'playable',
+              thumbnailBlobId: video?.thumbnailBlobId || null,
+              thumbnailBlobsCoreKey: video?.thumbnailBlobsCoreKey || null,
+              thumbnailMimeType: video?.thumbnailMimeType || null
+            })
+          }
         }
       }
 
@@ -129,6 +147,19 @@ export function createRelaySeeder({ ctx, loadPublicBee, logger = {}, blindPeer =
         blobCores: stats.blobCores,
         discoveryHandles: handles.size
       })
+      stats.catalogEntry = {
+        schema: 'peartube.relayCatalog',
+        catalogVersion: 1,
+        driveKey,
+        publicBeeKey,
+        source: 'relay-cache',
+        relayRole: 'cache',
+        relayServing: true,
+        channelName: meta?.name || channel?.channelName || null,
+        videoCount: stats.videos,
+        manifestUpdatedAt: Number(meta?.updatedAt || meta?.createdAt || 0) || Date.now(),
+        previewVideos
+      }
       return stats
     } catch (err) {
       stats.lastError = err?.message || String(err)


### PR DESCRIPTION
## Summary
- Adds a first-class relay catalog contract so relay/cache entries are persisted and gossiped as cache-serving inventory, separate from user-published channels.
- Keeps relay catalog cards visible even when no live feed socket is open, as long as they have a valid PublicBee key or direct blob refs.
- Lets `listVideos` and `getVideoData` resolve relay catalog preview refs without falling through to full channel `loadChannel()` timeouts.
- Retains PublicBee discovery handles for relay/cache cores and has the relay seed path submit explicit relay catalog entries.
- Adds an implementation plan under `docs/plans/2026-05-08-relay-stability-contract.md` to keep future work aligned around the relay-as-bootstrap/cache contract.

## Test Plan
- `node --test packages/backend/test/storage-startup-regression.test.mjs packages/backend/test/public-feed-api.test.mjs packages/backend/test/public-feed-manager.test.mjs packages/backend/test/playback-api.test.mjs`
- `npm test --prefix packages/cli -- --timeout=30000`
- `npm run lint:changed`
- `git diff --check`
