### PR TITLE
[codex] fix public feed peer protocol dialing

### DIFF
--- a/packages/app/tests/native-backend-startup-regression.test.mjs
+++ b/packages/app/tests/native-backend-startup-regression.test.mjs
@@ -83,7 +83,7 @@ test('backend orchestrator explicitly dials peers discovered on the single share
   const source = readWorkspaceFile('backend/src/orchestrator.js')
 
   assert.match(source, /ctx\.swarm\.on\('peer'/)
-  assert.match(source, /publicFeed\.handleDiscoveredPeer\(peer\)/)
+  assert.match(source, /publicFeed\.handleDiscoveredPeer\(peer, topic\)/)
 })
 
 test('mobile getSwarmStatus forwards low-level network diagnostics', () => {

--- a/packages/backend/src/orchestrator.js
+++ b/packages/backend/src/orchestrator.js
@@ -325,9 +325,9 @@ export async function createBackendContext(config) {
       console.error('[Orchestrator] publicFeed.handleConnection failed:', err?.message);
     }
   });
-  ctx.swarm.on('peer', (peer) => {
+  ctx.swarm.on('peer', (peer, topic) => {
     try {
-      if (publicFeed.handleDiscoveredPeer(peer)) {
+      if (publicFeed.handleDiscoveredPeer(peer, topic)) {
         startupGate.noteSwarmPeer()
       }
     } catch (err) {

--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -25,6 +25,8 @@ import { hashFeedEntries, hashPreviewVideos } from './hash-utils.js'
 const log = logger('PublicFeed')
 const PUBLIC_FEED_CATALOG_VERSION = 1
 const PUBLIC_FEED_RELAY_CATALOG_KEY = 'public-feed-relay-catalog-v1'
+const NETWORK_TOPIC = crypto.data(b4a.from(NETWORK_TOPIC_STRING, 'utf-8'))
+const NETWORK_TOPIC_HEX = b4a.toString(NETWORK_TOPIC, 'hex')
 
 /**
  * @typedef {import('./types.js').PublicFeedEntry} PublicFeedEntry
@@ -365,37 +367,105 @@ export class PublicFeedManager {
     return []
   }
 
+  _topicToHex(topic) {
+    if (!topic) return null
+    if (typeof topic === 'string') return /^[a-f0-9]{64}$/i.test(topic) ? topic.toLowerCase() : null
+    if (b4a.isBuffer(topic) || topic instanceof Uint8Array) return b4a.toString(topic, 'hex')
+    return null
+  }
+
+  _isNetworkTopic(topic) {
+    const topicHex = this._topicToHex(topic)
+    return topicHex === NETWORK_TOPIC_HEX
+  }
+
+  _peerEntryHasNetworkTopic(peer) {
+    if (!peer || typeof peer !== 'object') return false
+    const nestedPeer = peer.value || peer.peer || peer[1]
+    const topics = [
+      peer.topic,
+      ...(Array.isArray(peer.topics) ? peer.topics : []),
+      nestedPeer?.topic,
+      ...(Array.isArray(nestedPeer?.topics) ? nestedPeer.topics : []),
+    ].filter(Boolean)
+    if (topics.length === 0) return false
+    return topics.some((topic) => this._isNetworkTopic(topic))
+  }
+
+  _peerEntryPublicKey(peer) {
+    if (!peer) return null
+    if (typeof peer === 'string' && /^[a-f0-9]{64}$/i.test(peer)) return b4a.from(peer, 'hex')
+    if (b4a.isBuffer(peer) || peer instanceof Uint8Array) return peer
+
+    const publicKey =
+      peer.publicKey ||
+      peer.remotePublicKey ||
+      peer.key ||
+      peer.value?.publicKey ||
+      peer.value?.remotePublicKey ||
+      peer.value?.key ||
+      peer.peer?.publicKey ||
+      peer.peer?.remotePublicKey ||
+      peer[1]?.publicKey ||
+      peer[1]?.remotePublicKey ||
+      peer[1]?.key
+
+    if (typeof publicKey === 'string' && /^[a-f0-9]{64}$/i.test(publicKey)) return b4a.from(publicKey, 'hex')
+    if (publicKey && (b4a.isBuffer(publicKey) || publicKey instanceof Uint8Array)) return publicKey
+    return null
+  }
+
   _peerEntryIsConnected(entry) {
     if (!entry || typeof entry !== 'object') return false
-    const nestedPeer = entry.value || entry.peer
-    return entry.connected === true || nestedPeer?.connected === true || Boolean(entry.stream || nestedPeer?.stream)
+    const nestedPeer = entry.value || entry.peer || entry[1]
+    return (
+      entry.connected === true ||
+      entry.opened === true ||
+      (Number.isFinite(entry.connectedTime) && entry.connectedTime >= 0) ||
+      nestedPeer?.connected === true ||
+      nestedPeer?.opened === true ||
+      (Number.isFinite(nestedPeer?.connectedTime) && nestedPeer.connectedTime >= 0) ||
+      Boolean(entry.stream || nestedPeer?.stream)
+    )
   }
 
   _peerEntryMatchesKey(entry, keyHex, { requireConnected = false } = {}) {
-    if (!entry) return false
-    if (typeof entry === 'string') return entry === keyHex
-    if (b4a.isBuffer(entry) || entry instanceof Uint8Array) {
-      return b4a.toString(entry, 'hex') === keyHex
-    }
-    const publicKey = entry.publicKey || entry.remotePublicKey || entry.key || entry.value?.publicKey || entry.value?.remotePublicKey
-    if (publicKey && (b4a.isBuffer(publicKey) || publicKey instanceof Uint8Array)) {
-      if (b4a.toString(publicKey, 'hex') !== keyHex) return false
-      return !requireConnected || this._peerEntryIsConnected(entry)
-    }
-    return false
+    const publicKey = this._peerEntryPublicKey(entry)
+    if (!publicKey) return false
+    if (b4a.toString(publicKey, 'hex') !== keyHex) return false
+    return !requireConnected || this._peerEntryIsConnected(entry)
   }
 
-  _hasKnownPeer(keyHex) {
-    const peers = this.swarm?.peers
-    if (!peers) return false
-    if (typeof peers.has === 'function' && peers.has(keyHex)) {
-      const entry = typeof peers.get === 'function' ? peers.get(keyHex) : null
-      if (entry && this._peerEntryIsConnected({ key: keyHex, value: entry })) return true
-      if (!entry && this._discoveredPeers.has(keyHex)) return true
+  _hasActivePeerConnection(keyHex, publicKey = null) {
+    if (!this.swarm || !keyHex) return false
+
+    const allConnections = this.swarm._allConnections
+    if (publicKey && allConnections && typeof allConnections.has === 'function') {
+      try {
+        if (allConnections.has(publicKey)) return true
+      } catch {}
     }
+
+    const connections = this.swarm.connections
+    if (connections && typeof connections[Symbol.iterator] === 'function') {
+      for (const conn of connections) {
+        if (this._peerEntryMatchesKey(conn, keyHex)) return true
+      }
+    }
+
+    const peers = this.swarm.peers
+    if (peers && typeof peers.get === 'function') {
+      let peerInfo = peers.get(keyHex)
+      if (!peerInfo && publicKey) {
+        try { peerInfo = peers.get(publicKey) } catch {}
+      }
+      if (peerInfo && this._peerEntryIsConnected({ key: keyHex, value: peerInfo })) return true
+    }
+
     for (const entry of this._swarmPeerEntries()) {
       if (this._peerEntryMatchesKey(entry, keyHex, { requireConnected: true })) return true
     }
+
     return false
   }
 
@@ -456,6 +526,7 @@ export class PublicFeedManager {
   _harvestSwarmPeersForDial() {
     let remembered = 0
     for (const peer of this._swarmPeerEntries()) {
+      if (!this._peerEntryHasNetworkTopic(peer)) continue
       const publicKey = this._peerEntryPublicKey(peer)
       const keyHex = publicKey ? b4a.toString(publicKey, 'hex') : null
       const wasRemembered = keyHex ? this._discoveredPeers.has(keyHex) : false
@@ -465,34 +536,23 @@ export class PublicFeedManager {
     return remembered
   }
 
-  _peerEntryPublicKey(peer) {
-    if (!peer) return null
-    if (b4a.isBuffer(peer)) return peer
-    if (peer.publicKey) return peer.publicKey
-    if (peer.remotePublicKey) return peer.remotePublicKey
-    if (peer.value?.publicKey) return peer.value.publicKey
-    if (peer.value?.remotePublicKey) return peer.value.remotePublicKey
-    if (peer[1]?.publicKey) return peer[1].publicKey
-    if (peer[1]?.remotePublicKey) return peer[1].remotePublicKey
-    if (typeof peer === 'string' && /^[a-f0-9]{64}$/i.test(peer)) return b4a.from(peer, 'hex')
-    return null
-  }
-
   /**
    * Remember a discovered peer and explicitly dial it when the shared topic has
    * found peers but Hyperswarm has not promoted them into connections yet.
    * This keeps the hard-cutover architecture on one topic while making the
    * Protomux feed channel less dependent on passive connection timing.
    * @param {any} peer
+   * @param {Buffer | Uint8Array | string | null} [topic]
    * @returns {boolean}
    */
-  handleDiscoveredPeer(peer) {
-    const publicKey = peer?.publicKey
+  handleDiscoveredPeer(peer, topic = null) {
+    if (topic && !this._isNetworkTopic(topic)) return false
+    const publicKey = this._peerEntryPublicKey(peer)
     if (!publicKey || !this.swarm || typeof this.swarm.joinPeer !== 'function') return false
 
     const remembered = this._rememberPeerPublicKey(publicKey)
     if (!remembered) return false
-    if (this._hasKnownPeer(remembered.keyHex)) return false
+    if (this._hasActivePeerConnection(remembered.keyHex, remembered.publicKey)) return false
 
     return this._dialDiscoveredPeer(remembered.keyHex, remembered.publicKey)
   }
@@ -509,7 +569,7 @@ export class PublicFeedManager {
       this._directPeerDialStats.lastReason = 'self-or-missing-key'
       return false
     }
-    if (this._hasKnownPeer(keyHex)) {
+    if (this._hasActivePeerConnection(keyHex, publicKey)) {
       this._directPeerPending.delete(keyHex)
       this._directPeerLastQueuedAt.delete(keyHex)
       this._directPeerDialStats.skipped++
@@ -571,6 +631,28 @@ export class PublicFeedManager {
     return this._redialDiscoveredPeers({ force: true })
   }
 
+  _swarmDialState(keyHex) {
+    const peers = this.swarm?.peers
+    const peerInfo = peers && typeof peers.get === 'function' ? peers.get(keyHex) : null
+    if (!peerInfo || typeof peerInfo !== 'object') return null
+
+    const relayAddresses = Array.isArray(peerInfo.relayAddresses) ? peerInfo.relayAddresses : []
+    const topics = Array.isArray(peerInfo.topics) ? peerInfo.topics : []
+    return {
+      attempts: Number(peerInfo.attempts || 0),
+      queued: Boolean(peerInfo.queued),
+      waiting: Boolean(peerInfo.waiting),
+      explicit: Boolean(peerInfo.explicit),
+      banned: Boolean(peerInfo.banned),
+      proven: Boolean(peerInfo.proven),
+      client: Boolean(peerInfo.client),
+      connectedTime: Number(peerInfo.connectedTime ?? -1),
+      disconnectedTime: Number(peerInfo.disconnectedTime || 0),
+      relayAddresses: relayAddresses.length,
+      topics: topics.length,
+    }
+  }
+
   getDirectPeerDialStats() {
     const peers = []
     for (const [keyHex] of this._discoveredPeers) {
@@ -582,7 +664,8 @@ export class PublicFeedManager {
         lastQueuedAt: this._directPeerLastQueuedAt.get(keyHex) || null,
         lastError: this._directPeerLastDialError.get(keyHex) || null,
         pending,
-        connected: this._hasKnownPeer(keyHex),
+        connected: this._hasActivePeerConnection(keyHex, this._discoveredPeers.get(keyHex)),
+        swarm: this._swarmDialState(keyHex),
       })
     }
 
@@ -594,6 +677,12 @@ export class PublicFeedManager {
         .length,
       maxDirectPeers: this._maxDirectPeers,
       maxDirectPeerRetries: this._maxDirectPeerRetries,
+      swarmPeers: this.swarm?.peers?.size || 0,
+      swarmConnections: this.swarm?.connections?.size || 0,
+      swarmAllConnections: this.swarm?._allConnections?.size || 0,
+      swarmConnecting: Number(this.swarm?.connecting || 0),
+      swarmExplicitPeers: this.swarm?.explicitPeers?.size || 0,
+      swarmQueueSize: this.swarm?._queue?.length || 0,
       peers,
     }
   }
@@ -703,13 +792,12 @@ export class PublicFeedManager {
       try { this.onFeedUpdate?.(); } catch {}
     }
 
-    const feedTopic = crypto.data(b4a.from(NETWORK_TOPIC_STRING, 'utf-8'))
     try {
-      this.feedDiscovery = this.swarm.join(feedTopic, { server: true, client: true })
+      this.feedDiscovery = this.swarm.join(NETWORK_TOPIC, { server: true, client: true })
       this.feedDiscovery?.flushed?.().then(() => {
         console.log('[PublicFeed] Shared network feed discovery flushed, connections:', this.swarm.connections?.size || 0)
       }).catch(() => {})
-      console.log('[PublicFeed] Joined shared network feed topic:', b4a.toString(feedTopic, 'hex').slice(0, 16))
+      console.log('[PublicFeed] Joined shared network feed topic:', NETWORK_TOPIC_HEX.slice(0, 16))
     } catch (err) {
       console.log('[PublicFeed] Shared network feed topic join failed:', err?.message)
       this.feedDiscovery = null
@@ -720,6 +808,10 @@ export class PublicFeedManager {
     console.log('[PublicFeed] Setting up feed protocol on', existingConns, 'existing connections');
     for (const conn of this.swarm.connections) {
       this.handleConnection(conn, {});
+    }
+    const redialedPeers = this._redialDiscoveredPeers()
+    if (redialedPeers) {
+      console.log('[PublicFeed] Redialed shared-topic peers on startup:', redialedPeers)
     }
     this._startGossipLoop()
     console.log('[PublicFeed] ===== PUBLIC FEED STARTED =====');

--- a/packages/backend/src/storage.js
+++ b/packages/backend/src/storage.js
@@ -167,6 +167,22 @@ function createOfflineSwarm(keyPair, reason = 'unavailable') {
   return swarm
 }
 
+function installSwarmPeerDiscoveryEmitter(swarm) {
+  if (!swarm || swarm._peartubePeerDiscoveryEmitterInstalled) return false
+  if (typeof swarm._handlePeer !== 'function' || typeof swarm.emit !== 'function') return false
+
+  const handlePeer = swarm._handlePeer
+  swarm._handlePeer = function peartubeHandlePeer(peer, topic) {
+    const result = handlePeer.call(this, peer, topic)
+    try {
+      swarm.emit('peer', peer, topic)
+    } catch { /* best effort */ }
+    return result
+  }
+  swarm._peartubePeerDiscoveryEmitterInstalled = true
+  return true
+}
+
 async function ensureHttpModule() {
   if (http) return http
   try {
@@ -729,6 +745,7 @@ export async function initializeStorage(config) {
   }
   console.log('[Storage] Swarm created, publicKey:', b4a.toString(swarm.keyPair.publicKey, 'hex').slice(0, 16));
   await appendDebugLine(`[storage] hyperswarm created offline=${Boolean(swarm._peartubeOffline)}`)
+  installSwarmPeerDiscoveryEmitter(swarm)
 
   // Set global references for suspend/resume and stats
   globalSwarm = swarm;

--- a/packages/backend/test/public-feed-manager.test.mjs
+++ b/packages/backend/test/public-feed-manager.test.mjs
@@ -11,6 +11,8 @@ import { PublicFeedManager } from '../src/public-feed.js'
 import { NETWORK_TOPIC_STRING } from '../src/types.js'
 const DRIVE_KEY = '11'.repeat(32)
 const PUBLIC_BEE_KEY = '22'.repeat(32)
+const NETWORK_TOPIC = crypto.data(b4a.from(NETWORK_TOPIC_STRING, 'utf-8'))
+const OTHER_TOPIC = b4a.alloc(32, 99)
 
 function createSwarm() {
   return {
@@ -100,7 +102,7 @@ test('PublicFeedManager explicitly dials peers discovered on the shared topic', 
   const publicKey = b4a.alloc(32, 7)
 
   try {
-    assert.equal(manager.handleDiscoveredPeer({ publicKey }), true)
+    assert.equal(manager.handleDiscoveredPeer({ publicKey }, NETWORK_TOPIC), true)
     assert.equal(swarm.joinPeerCalls.length, 1)
     assert.equal(b4a.toString(swarm.joinPeerCalls[0], 'hex'), b4a.toString(publicKey, 'hex'))
   } finally {
@@ -108,19 +110,52 @@ test('PublicFeedManager explicitly dials peers discovered on the shared topic', 
   }
 })
 
-test('PublicFeedManager skips direct dials for known peers across swarm peer shapes', () => {
+test('PublicFeedManager ignores peers discovered on non-app topics', () => {
+  const swarm = createSwarm()
+  const manager = new PublicFeedManager(swarm, createMetaDb())
+  const publicKey = b4a.alloc(32, 17)
+
+  try {
+    assert.equal(manager.handleDiscoveredPeer({ publicKey }, OTHER_TOPIC), false)
+    assert.equal(swarm.joinPeerCalls.length, 0)
+    assert.equal(manager.getStats().directPeerDial.discoveredPeers, 0)
+  } finally {
+    manager.stop()
+  }
+})
+
+test('PublicFeedManager directly dials discovered peers that are known but not connected', () => {
+  const publicKey = b4a.alloc(32, 13)
+  const keyHex = b4a.toString(publicKey, 'hex')
+  const swarm = createSwarm()
+  swarm.peers.set(keyHex, { publicKey })
+  const manager = new PublicFeedManager(swarm, createMetaDb())
+
+  try {
+    assert.equal(manager.handleDiscoveredPeer({ publicKey }), true)
+    assert.equal(swarm.joinPeerCalls.length, 1)
+    assert.equal(b4a.toString(swarm.joinPeerCalls[0], 'hex'), keyHex)
+  } finally {
+    manager.stop()
+  }
+})
+
+test('PublicFeedManager skips direct dials for actively connected peers across swarm shapes', () => {
   const publicKey = b4a.alloc(32, 8)
   const keyHex = b4a.toString(publicKey, 'hex')
   const cases = [
-    { entries: new Map([[keyHex, { publicKey, connected: true }]]) },
-    { entries: new Map([[publicKey, { publicKey, connected: true }]]) },
-    { entries: new Set([{ publicKey, connected: true }]) },
-    { entries: new Set([{ publicKey, stream: {} }]) },
+    (swarm) => { swarm.peers = new Map([[keyHex, { publicKey, connected: true }]]) },
+    (swarm) => { swarm.peers = new Map([[publicKey, { publicKey, connected: true }]]) },
+    (swarm) => { swarm.peers = new Set([{ publicKey, connected: true }]) },
+    (swarm) => { swarm.peers = new Set([{ publicKey, stream: {} }]) },
+    (swarm) => { swarm.connections.add({ remotePublicKey: publicKey }) },
+    (swarm) => { swarm._allConnections = { has: (key) => b4a.equals(key, publicKey) } },
+    (swarm) => { swarm.peers.set(keyHex, { publicKey, connectedTime: Date.now() }) },
   ]
 
-  for (const peers of cases) {
+  for (const setup of cases) {
     const swarm = createSwarm()
-    swarm.peers = peers.entries
+    setup(swarm)
     const manager = new PublicFeedManager(swarm, createMetaDb())
 
     try {
@@ -129,6 +164,22 @@ test('PublicFeedManager skips direct dials for known peers across swarm peer sha
     } finally {
       manager.stop()
     }
+  }
+})
+
+test('PublicFeedManager.start remembers existing discovered swarm peers for direct dialing', async () => {
+  const publicKey = b4a.alloc(32, 14)
+  const keyHex = b4a.toString(publicKey, 'hex')
+  const swarm = createSwarm()
+  swarm.peers.set(keyHex, { publicKey, topics: [NETWORK_TOPIC] })
+  const manager = new PublicFeedManager(swarm, createMetaDb())
+
+  try {
+    await manager.start()
+    assert.equal(swarm.joinPeerCalls.length, 1)
+    assert.equal(b4a.toString(swarm.joinPeerCalls[0], 'hex'), keyHex)
+  } finally {
+    manager.stop()
   }
 })
 
@@ -187,7 +238,7 @@ test('forceRedialDiscoveredPeers keeps trying known discovered peers after pendi
 test('forceRedialDiscoveredPeers harvests swarm.peers candidates when no peer event was remembered', () => {
   const publicKey = b4a.alloc(32, 13)
   const swarm = createSwarm()
-  swarm.peers.set(b4a.toString(publicKey, 'hex'), { publicKey })
+  swarm.peers.set(b4a.toString(publicKey, 'hex'), { publicKey, topics: [NETWORK_TOPIC] })
   const manager = new PublicFeedManager(swarm, createMetaDb())
 
   try {
@@ -197,6 +248,21 @@ test('forceRedialDiscoveredPeers harvests swarm.peers candidates when no peer ev
     assert.equal(stats.discoveredPeers, 1)
     assert.equal(stats.queued, 1)
     assert.equal(stats.peers[0].key, b4a.toString(publicKey, 'hex').slice(0, 16))
+  } finally {
+    manager.stop()
+  }
+})
+
+test('forceRedialDiscoveredPeers skips swarm.peers candidates from non-app topics', () => {
+  const publicKey = b4a.alloc(32, 18)
+  const swarm = createSwarm()
+  swarm.peers.set(b4a.toString(publicKey, 'hex'), { publicKey, topics: [OTHER_TOPIC] })
+  const manager = new PublicFeedManager(swarm, createMetaDb())
+
+  try {
+    assert.equal(manager.forceRedialDiscoveredPeers(), 0)
+    assert.equal(swarm.joinPeerCalls.length, 0)
+    assert.equal(manager.getStats().directPeerDial.discoveredPeers, 0)
   } finally {
     manager.stop()
   }
@@ -215,6 +281,52 @@ test('direct peer dial diagnostics expose skipped joinPeer failures', () => {
     assert.equal(stats.failed, 1)
     assert.equal(stats.lastReason, 'joinPeer-error')
     assert.equal(stats.peers[0].lastError, 'dial unavailable')
+  } finally {
+    manager.stop()
+  }
+})
+
+test('direct peer dial diagnostics include Hyperswarm queue state', () => {
+  const publicKey = b4a.alloc(32, 13)
+  const keyHex = b4a.toString(publicKey, 'hex')
+  const swarm = createSwarm()
+  swarm.connecting = 1
+  swarm._allConnections = new Set([{}])
+  swarm.explicitPeers = new Set([publicKey])
+  swarm._queue = { length: 2 }
+  swarm.peers.set(keyHex, {
+    publicKey,
+    attempts: 2,
+    queued: true,
+    waiting: true,
+    explicit: true,
+    relayAddresses: [b4a.alloc(32, 1)],
+    topics: [b4a.alloc(32, 2)],
+    connectedTime: -1,
+    disconnectedTime: 123,
+  })
+  const manager = new PublicFeedManager(swarm, createMetaDb())
+
+  try {
+    assert.equal(manager.handleDiscoveredPeer({ publicKey }), true)
+    const stats = manager.getStats().directPeerDial
+    assert.equal(stats.swarmConnecting, 1)
+    assert.equal(stats.swarmAllConnections, 1)
+    assert.equal(stats.swarmExplicitPeers, 1)
+    assert.equal(stats.swarmQueueSize, 2)
+    assert.deepEqual(stats.peers[0].swarm, {
+      attempts: 2,
+      queued: true,
+      waiting: true,
+      explicit: true,
+      banned: false,
+      proven: false,
+      client: false,
+      connectedTime: -1,
+      disconnectedTime: 123,
+      relayAddresses: 1,
+      topics: 1,
+    })
   } finally {
     manager.stop()
   }

--- a/packages/backend/test/storage-startup-regression.test.mjs
+++ b/packages/backend/test/storage-startup-regression.test.mjs
@@ -83,11 +83,28 @@ test('offline swarm fallback skips peer pool discovery instead of joining noop t
   )
 })
 
-
 test('storage exposes public bee content discovery retention for cached serving cores', () => {
   assert.match(storageSource, /export async function retainPublicBeeContentDiscovery\(ctx, publicBeeKeyHex/)
   assert.match(storageSource, /await loadPublicBee\(ctx, publicBeeKeyHex\)/)
   assert.match(storageSource, /video\?\.blobsCoreKey/)
   assert.match(storageSource, /video\?\.thumbnailBlobsCoreKey/)
   assert.match(storageSource, /retainSwarmDiscovery\(ctx, core\.discoveryKey/)
+})
+
+test('storage exposes Hyperswarm peer discovery as a peer event for feed fallback dialing', () => {
+  assert.match(
+    storageSource,
+    /function installSwarmPeerDiscoveryEmitter\(swarm\)/,
+    'storage should install a peer discovery event adapter'
+  )
+  assert.match(
+    storageSource,
+    /installSwarmPeerDiscoveryEmitter\(swarm\)/,
+    'real swarm startup should install the peer discovery event adapter'
+  )
+  assert.match(
+    storageSource,
+    /swarm\.emit\('peer', peer, topic\)/,
+    'adapter should emit peer events with the discovered peer and topic'
+  )
 })

--- a/packages/cli/src/runtime.js
+++ b/packages/cli/src/runtime.js
@@ -89,8 +89,8 @@ export async function createRelayRuntime({ config, logger }) {
   ctx.swarm.on('connection', (conn, info) => {
     publicFeed.handleConnection(conn, info)
   })
-  ctx.swarm.on('peer', (peer) => {
-    publicFeed.handleDiscoveredPeer(peer)
+  ctx.swarm.on('peer', (peer, topic) => {
+    publicFeed.handleDiscoveredPeer(peer, topic)
   })
 
   publicFeed.setOnFeedUpdate(() => {

--- a/packages/cli/src/service.js
+++ b/packages/cli/src/service.js
@@ -237,6 +237,11 @@ export async function createRelayService({
               failed: directPeerDial.failed || 0,
               connected: directPeerDial.connected || 0,
               lastReason: directPeerDial.lastReason || null,
+              swarmConnecting: directPeerDial.swarmConnecting || 0,
+              swarmAllConnections: directPeerDial.swarmAllConnections || 0,
+              swarmExplicitPeers: directPeerDial.swarmExplicitPeers || 0,
+              swarmQueueSize: directPeerDial.swarmQueueSize || 0,
+              dialPeers: Array.isArray(directPeerDial.peers) ? directPeerDial.peers : [],
               redialed
             })
           }

--- a/packages/cli/test/cli.test.mjs
+++ b/packages/cli/test/cli.test.mjs
@@ -197,7 +197,7 @@ test('relay runtime source wires client-equivalent feed availability providers',
   t.ok(content.includes('publicFeed.setFeedSnapshotProvider'), 'relay runtime should gossip compact playable feed snapshots')
   t.ok(content.includes('this.api.getFeedSnapshotEntries(entries, { limitPerChannel: 3 })'), 'relay feed snapshot provider should use the same API path as clients')
   t.ok(content.includes("ctx.swarm.on('peer'"), 'relay runtime should react to shared-topic peer discoveries')
-  t.ok(content.includes('publicFeed.handleDiscoveredPeer(peer)'), 'relay runtime should explicitly dial shared-topic discovered peers')
+  t.ok(content.includes('publicFeed.handleDiscoveredPeer(peer, topic)'), 'relay runtime should explicitly dial shared-topic discovered peers')
 })
 
 test('Dockerfile packages the yt-dlp POT provider plugin for noninteractive YouTube bot checks', async (t) => {

--- a/packages/cli/test/service.test.mjs
+++ b/packages/cli/test/service.test.mjs
@@ -299,6 +299,86 @@ test('createRelayService installs and clears a heartbeat interval', async (t) =>
   }
 })
 
+test('relay heartbeat logs Hyperswarm dial diagnostics when peers have no sockets', async (t) => {
+  const dir = makeTempDir('peartube-relay-service-dial-diagnostics-')
+  const runtime = createFakeRuntime()
+  runtime.getNetworkStats = () => ({
+    peers: 2,
+    connections: 0,
+    directPeerDial: {
+      discoveredPeers: 2,
+      queued: 4,
+      skipped: 1,
+      failed: 0,
+      lastReason: 'queued',
+      swarmConnecting: 1,
+      swarmAllConnections: 1,
+      swarmExplicitPeers: 2,
+      swarmQueueSize: 1,
+      peers: [{ key: 'peer-a', swarm: { attempts: 2, relayAddresses: 1 } }]
+    }
+  })
+  runtime.publicFeed = {
+    forceRedialDiscoveredPeers() {
+      return 2
+    }
+  }
+  const logger = createFakeLogger()
+  let scheduled = null
+
+  function setIntervalFn(fn, ms) {
+    scheduled = { fn, ms, timer: {} }
+    return scheduled.timer
+  }
+
+  try {
+    const service = await createRelayService({
+      config: {
+        mode: 'public',
+        policy: 'discovery',
+        storage: { path: dir, maxBytes: 10_000 },
+        paths: {
+          catalog: join(dir, 'relay-catalog.json'),
+          status: join(dir, 'relay-status.json')
+        },
+        admission: {
+          channels: [],
+          owners: []
+        },
+        discovery: {
+          enabled: true,
+          maxChannels: 5,
+          maxChannelsPerOwner: 2
+        }
+      },
+      logger,
+      runtimeFactory: async () => runtime,
+      mirrorChannel: async () => ({ bytesDownloaded: 0, videosFound: 0, videosDownloaded: 0 }),
+      writeStatusFile: async () => {},
+      setIntervalFn
+    })
+
+    await service.start()
+    await scheduled.fn()
+
+    const warning = logger.entries.find((entry) => (
+      entry.component === 'status' &&
+      entry.level === 'warn' &&
+      entry.msg === 'Relay discovered peers without sockets; forced direct redial'
+    ))
+    t.ok(warning)
+    t.is(warning.data.swarmConnecting, 1)
+    t.is(warning.data.swarmAllConnections, 1)
+    t.is(warning.data.swarmExplicitPeers, 2)
+    t.is(warning.data.swarmQueueSize, 1)
+    t.alike(warning.data.dialPeers, [{ key: 'peer-a', swarm: { attempts: 2, relayAddresses: 1 } }])
+
+    await service.close()
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('archive job uses configured yt-dlp binary when started from the WebUI relay service', async (t) => {
   const dir = makeTempDir('peartube-relay-service-archive-bin-')
   const runtime = createFakeRuntime()


### PR DESCRIPTION
## Summary

- Promote peers discovered on the PearTube Hyperswarm topic into direct peer dials so they can establish the app protocol transport.
- Pass the discovery topic through the backend and relay runtime, and only treat the PearTube network topic as app-protocol discovery.
- Ensure every Hyperswarm connection opens the public feed Protomux channel and add relay diagnostics for discovered peers that never reach sockets.

## Root Cause

The relay could discover peer IDs on the shared topic, but the public feed protocol only runs after a real Hyperswarm connection exists. Some discovered peers were not being promoted reliably into direct connection attempts, and topic-less harvesting could mix app-topic discovery with content-core discovery.

## Validation

- `node --test packages/backend/test/public-feed-manager.test.mjs`
- `node --test packages/backend/test/storage-startup-regression.test.mjs`
- `node --test packages/app/tests/native-backend-startup-regression.test.mjs`
- `packages/cli/node_modules/.bin/brittle packages/cli/test/cli.test.mjs packages/cli/test/service.test.mjs`
- `git diff --check`
- `node --check` on touched runtime/source files

Note: the local working tree still has unrelated unstaged/untracked files that are intentionally not part of this PR.