### PR TITLE
fix(relay): keep dialing stale hyperswarm peers

### DIFF
--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -429,6 +429,17 @@ export class PublicFeedManager {
     )
   }
 
+  _activeSwarmConnectionEntries() {
+    const allConnections = this.swarm?._allConnections
+    if (!allConnections || typeof allConnections[Symbol.iterator] !== 'function') return []
+    return Array.from(allConnections).filter((entry) => (
+      entry &&
+      typeof entry === 'object' &&
+      !b4a.isBuffer(entry) &&
+      !(entry instanceof Uint8Array)
+    ))
+  }
+
   _peerEntryMatchesKey(entry, keyHex, { requireConnected = false } = {}) {
     const publicKey = this._peerEntryPublicKey(entry)
     if (!publicKey) return false
@@ -439,18 +450,15 @@ export class PublicFeedManager {
   _hasActivePeerConnection(keyHex, publicKey = null) {
     if (!this.swarm || !keyHex) return false
 
-    const allConnections = this.swarm._allConnections
-    if (publicKey && allConnections && typeof allConnections.has === 'function') {
-      try {
-        if (allConnections.has(publicKey)) return true
-      } catch {}
-    }
-
     const connections = this.swarm.connections
     if (connections && typeof connections[Symbol.iterator] === 'function') {
       for (const conn of connections) {
         if (this._peerEntryMatchesKey(conn, keyHex)) return true
       }
+    }
+
+    for (const entry of this._activeSwarmConnectionEntries()) {
+      if (this._peerEntryMatchesKey(entry, keyHex)) return true
     }
 
     const peers = this.swarm.peers

--- a/packages/backend/test/public-feed-manager.test.mjs
+++ b/packages/backend/test/public-feed-manager.test.mjs
@@ -149,7 +149,7 @@ test('PublicFeedManager skips direct dials for actively connected peers across s
     (swarm) => { swarm.peers = new Set([{ publicKey, connected: true }]) },
     (swarm) => { swarm.peers = new Set([{ publicKey, stream: {} }]) },
     (swarm) => { swarm.connections.add({ remotePublicKey: publicKey }) },
-    (swarm) => { swarm._allConnections = { has: (key) => b4a.equals(key, publicKey) } },
+    (swarm) => { swarm._allConnections = new Set([{ remotePublicKey: publicKey }]) },
     (swarm) => { swarm.peers.set(keyHex, { publicKey, connectedTime: Date.now() }) },
   ]
 
@@ -164,6 +164,21 @@ test('PublicFeedManager skips direct dials for actively connected peers across s
     } finally {
       manager.stop()
     }
+  }
+})
+
+test('PublicFeedManager does not treat stale Hyperswarm _allConnections keys as active sockets', () => {
+  const publicKey = b4a.alloc(32, 9)
+  const swarm = createSwarm()
+  swarm._allConnections = new Set([publicKey])
+  const manager = new PublicFeedManager(swarm, createMetaDb())
+
+  try {
+    assert.equal(manager.handleDiscoveredPeer({ publicKey }), true)
+    assert.equal(swarm.joinPeerCalls.length, 1)
+    assert.equal(manager.getStats().directPeerDial.lastReason, 'queued')
+  } finally {
+    manager.stop()
   }
 })
 


### PR DESCRIPTION
## Summary
- fixes relay direct-dial state so stale Hyperswarm `_allConnections` peer keys are not treated as usable sockets
- keeps dialing discovered shared-topic peers until an actual connection/feed channel opens
- adds a regression matching the relay log pattern: peers discovered, `_allConnections` nonzero, but `connections=0` / `feedConnections=0`

## Root cause
Relay logs show `connections=0` and `feedConnections=0`, but `lastReason=already-connected-peer` with `_allConnections`/`swarmAllConnections` populated. The feed manager was treating `_allConnections.has(publicKey)` as proof of an active socket. In this Hyperswarm state, `_allConnections` can contain stale peer keys / internal peer state while `connectedTime=-1` and no stream exists, so redial was skipped forever.

## Test Plan
- `node --test packages/backend/test/public-feed-manager.test.mjs`
- `node --test packages/backend/test/public-feed-manager.test.mjs packages/app/tests/feed-hydration.test.mjs packages/app/tests/vertical-discovery-regression.test.mjs`
- `npm test --prefix packages/cli -- --timeout=30000`
- `npm run lint:changed`
- `git diff --check`
