### PR TITLE
fix(relay): preserve discovered peer relay hints

### DIFF
--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -553,12 +553,24 @@ export class PublicFeedManager {
    * @param {Buffer | Uint8Array | string | null} [topic]
    * @returns {boolean}
    */
+  _queueDiscoveredPeer(peer, topic) {
+    const publicKey = this._peerEntryPublicKey(peer)
+    if (!publicKey || !this.swarm) return null
+    if (topic && typeof this.swarm._handlePeer === 'function') {
+      try {
+        this.swarm._handlePeer(peer, topic)
+      } catch (err) {
+        console.log('[PublicFeed] Failed to preserve discovered peer relay hints:', err?.message || String(err))
+      }
+    }
+    return this._rememberPeerPublicKey(publicKey)
+  }
+
   handleDiscoveredPeer(peer, topic = null) {
     if (topic && !this._isNetworkTopic(topic)) return false
-    const publicKey = this._peerEntryPublicKey(peer)
-    if (!publicKey || !this.swarm || typeof this.swarm.joinPeer !== 'function') return false
+    if (!this.swarm || typeof this.swarm.joinPeer !== 'function') return false
 
-    const remembered = this._rememberPeerPublicKey(publicKey)
+    const remembered = this._queueDiscoveredPeer(peer, topic)
     if (!remembered) return false
     if (this._hasActivePeerConnection(remembered.keyHex, remembered.publicKey)) return false
 

--- a/packages/backend/test/public-feed-manager.test.mjs
+++ b/packages/backend/test/public-feed-manager.test.mjs
@@ -32,6 +32,25 @@ function createSwarm() {
     joinPeer(publicKey) {
       this.joinPeerCalls.push(publicKey)
       return {}
+    },
+    _handlePeer(peer, topic) {
+      const keyHex = b4a.toString(peer.publicKey, 'hex')
+      let peerInfo = this.peers.get(keyHex)
+      if (!peerInfo) {
+        peerInfo = {
+          publicKey: peer.publicKey,
+          topics: [],
+          _updatePriority() { return true }
+        }
+        this.peers.set(keyHex, peerInfo)
+      }
+      peerInfo.relayAddresses = peer.relayAddresses
+      if (topic) peerInfo.topics.push(topic)
+      return peerInfo
+    },
+    _enqueue(peerInfo) {
+      peerInfo.queued = true
+      this.joinPeerCalls.push(peerInfo.publicKey)
     }
   }
 }
@@ -135,6 +154,24 @@ test('PublicFeedManager directly dials discovered peers that are known but not c
     assert.equal(manager.handleDiscoveredPeer({ publicKey }), true)
     assert.equal(swarm.joinPeerCalls.length, 1)
     assert.equal(b4a.toString(swarm.joinPeerCalls[0], 'hex'), keyHex)
+  } finally {
+    manager.stop()
+  }
+})
+
+test('PublicFeedManager keeps discovered relay address hints before explicit joinPeer redial', () => {
+  const publicKey = b4a.alloc(32, 14)
+  const keyHex = b4a.toString(publicKey, 'hex')
+  const relayAddresses = [{ host: '167.86.111.230', port: 49737 }]
+  const swarm = createSwarm()
+  const manager = new PublicFeedManager(swarm, createMetaDb())
+
+  try {
+    assert.equal(manager.handleDiscoveredPeer({ publicKey, relayAddresses }, NETWORK_TOPIC), true)
+    assert.equal(swarm.joinPeerCalls.length, 1)
+    assert.equal(swarm.peers.get(keyHex).relayAddresses, relayAddresses)
+    assert.deepEqual(swarm.peers.get(keyHex).topics, [NETWORK_TOPIC])
+    assert.equal(manager.getStats().directPeerDial.peers[0].swarm.relayAddresses, 1)
   } finally {
     manager.stop()
   }

--- a/packages/cli/src/init.js
+++ b/packages/cli/src/init.js
@@ -17,8 +17,8 @@ export async function initPeer ({ storagePath, maxBytes, pinnedChannels = [] }) 
   ctx.swarm.on('connection', (conn, info) => {
     publicFeed.handleConnection(conn, info)
   })
-  ctx.swarm.on('peer', (peer) => {
-    publicFeed.handleDiscoveredPeer(peer)
+  ctx.swarm.on('peer', (peer, topic) => {
+    publicFeed.handleDiscoveredPeer(peer, topic)
   })
 
   publicFeed.setOnFeedUpdate(() => {

--- a/packages/cli/test/cli.test.mjs
+++ b/packages/cli/test/cli.test.mjs
@@ -197,7 +197,15 @@ test('relay runtime source wires client-equivalent feed availability providers',
   t.ok(content.includes('publicFeed.setFeedSnapshotProvider'), 'relay runtime should gossip compact playable feed snapshots')
   t.ok(content.includes('this.api.getFeedSnapshotEntries(entries, { limitPerChannel: 3 })'), 'relay feed snapshot provider should use the same API path as clients')
   t.ok(content.includes("ctx.swarm.on('peer'"), 'relay runtime should react to shared-topic peer discoveries')
-  t.ok(content.includes('publicFeed.handleDiscoveredPeer(peer, topic)'), 'relay runtime should explicitly dial shared-topic discovered peers')
+  t.ok(content.includes('publicFeed.handleDiscoveredPeer(peer, topic)'), 'relay runtime should explicitly dial shared-topic discovered peers with discovery topic context')
+})
+
+test('legacy relay init passes discovery topic context into public feed dialing', async (t) => {
+  const initPath = join(__dirname, '..', 'src', 'init.js')
+  const content = readFileSync(initPath, 'utf8')
+
+  t.ok(content.includes("ctx.swarm.on('peer', (peer, topic)"), 'legacy relay init should keep the Hyperswarm discovery topic')
+  t.ok(content.includes('publicFeed.handleDiscoveredPeer(peer, topic)'), 'legacy relay init should preserve relay address hints before redialing')
 })
 
 test('Dockerfile packages the yt-dlp POT provider plugin for noninteractive YouTube bot checks', async (t) => {


### PR DESCRIPTION
## Summary
- preserves Hyperswarm-discovered relay address hints before the relay explicitly redials a shared-topic peer
- keeps the discovery topic context flowing through relay init/runtime so direct peer dialing does not lose DHT relay address data
- adds regressions for relay-address preservation and legacy init topic forwarding

## Tests
- node --test packages/backend/test/public-feed-manager.test.mjs packages/backend/test/storage-startup-regression.test.mjs
- npm test --prefix packages/cli -- --timeout=30000
- npm run lint:changed
- git diff --check