### PR TITLE
fix(relay): requeue discovered peers without erasing hints

### DIFF
--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -566,6 +566,20 @@ export class PublicFeedManager {
     return this._rememberPeerPublicKey(publicKey)
   }
 
+  _explicitlyQueuePeer(keyHex, publicKey) {
+    const peerInfo = this.swarm?.peers?.get?.(keyHex)
+    if (peerInfo && typeof this.swarm?._enqueue === 'function' && typeof peerInfo._updatePriority === 'function') {
+      peerInfo.explicit = true
+      this.swarm.explicitPeers?.add?.(peerInfo)
+      if (!this.swarm._allConnections?.has?.(publicKey) && peerInfo._updatePriority()) {
+        return this.swarm._enqueue(peerInfo) !== false
+      }
+      return false
+    }
+    this.swarm.joinPeer(publicKey)
+    return true
+  }
+
   handleDiscoveredPeer(peer, topic = null) {
     if (topic && !this._isNetworkTopic(topic)) return false
     if (!this.swarm || typeof this.swarm.joinPeer !== 'function') return false
@@ -611,7 +625,7 @@ export class PublicFeedManager {
     // dialed after the pending dial window expires until Hyperswarm gives us a
     // socket, at which point handleConnection opens the Protomux feed channel.
     try {
-      this.swarm.joinPeer(publicKey)
+      this._explicitlyQueuePeer(keyHex, publicKey)
       const now = this._now()
       this._directPeerRetryCounts.set(keyHex, attempts + 1)
       this._directPeerLastDialedAt.set(keyHex, now)

--- a/packages/backend/test/public-feed-manager.test.mjs
+++ b/packages/backend/test/public-feed-manager.test.mjs
@@ -21,6 +21,7 @@ function createSwarm() {
     peers: new Map(),
     joinCalls: [],
     joinPeerCalls: [],
+    fallbackJoinPeerCalls: [],
     join(topic, opts) {
       this.joinCalls.push({ topic, opts })
       return {
@@ -31,6 +32,7 @@ function createSwarm() {
     },
     joinPeer(publicKey) {
       this.joinPeerCalls.push(publicKey)
+      this.fallbackJoinPeerCalls.push(publicKey)
       return {}
     },
     _handlePeer(peer, topic) {
@@ -51,6 +53,7 @@ function createSwarm() {
     _enqueue(peerInfo) {
       peerInfo.queued = true
       this.joinPeerCalls.push(peerInfo.publicKey)
+      return true
     }
   }
 }


### PR DESCRIPTION
## Summary
- Avoid calling `swarm.joinPeer(publicKey)` after Hyperswarm has already created a discovered peer entry with relay-address hints
- Queue the existing Hyperswarm peer entry directly via `_enqueue(peerInfo)` so `relayAddresses` survive explicit redial
- Keep a fallback to `joinPeer()` for fake/older swarm shapes where no internal peer entry is available

## Why
The v0.1.63 logs still show DHT discovery receiving relay hints, but the explicit redial peer state has `relayAddresses: 0`:

```text
recentPeers[].relayAddresses: 3
peerStates[].relayAddresses: 0
```

Hyperswarm's `joinPeer(publicKey)` path upserts the existing peer with `relayAddresses = null`, which erases the DHT-discovered hints we preserved in PR #128. This patch marks the existing peer explicit and requeues it without re-upserting through `joinPeer()`.

## Test Plan
- `node --test packages/backend/test/public-feed-manager.test.mjs packages/backend/test/storage-startup-regression.test.mjs`
- `npm test --prefix packages/cli -- --timeout=30000`
- `npm run lint:changed`
- `git diff --check`
