### PR TITLE
refactor(relay): centralize swarm peer dialing

### DIFF
--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -21,6 +21,7 @@ import b4a from 'b4a'
 import { NETWORK_TOPIC_STRING, PROTOCOL_NAME } from './types.js';
 import { logger } from './logger.js'
 import { hashFeedEntries, hashPreviewVideos } from './hash-utils.js'
+import { ensureSwarmPeerConnection, peerPublicKey, swarmHasConnection } from './swarm-peer-dial.js'
 
 const log = logger('PublicFeed')
 const PUBLIC_FEED_CATALOG_VERSION = 1
@@ -448,33 +449,7 @@ export class PublicFeedManager {
   }
 
   _hasActivePeerConnection(keyHex, publicKey = null) {
-    if (!this.swarm || !keyHex) return false
-
-    const connections = this.swarm.connections
-    if (connections && typeof connections[Symbol.iterator] === 'function') {
-      for (const conn of connections) {
-        if (this._peerEntryMatchesKey(conn, keyHex)) return true
-      }
-    }
-
-    for (const entry of this._activeSwarmConnectionEntries()) {
-      if (this._peerEntryMatchesKey(entry, keyHex)) return true
-    }
-
-    const peers = this.swarm.peers
-    if (peers && typeof peers.get === 'function') {
-      let peerInfo = peers.get(keyHex)
-      if (!peerInfo && publicKey) {
-        try { peerInfo = peers.get(publicKey) } catch {}
-      }
-      if (peerInfo && this._peerEntryIsConnected({ key: keyHex, value: peerInfo })) return true
-    }
-
-    for (const entry of this._swarmPeerEntries()) {
-      if (this._peerEntryMatchesKey(entry, keyHex, { requireConnected: true })) return true
-    }
-
-    return false
+    return swarmHasConnection(this.swarm, keyHex, publicKey)
   }
 
   _markPeerConnected(publicKey) {
@@ -556,46 +531,25 @@ export class PublicFeedManager {
   _queueDiscoveredPeer(peer, topic) {
     const publicKey = this._peerEntryPublicKey(peer)
     if (!publicKey || !this.swarm) return null
-    if (topic && typeof this.swarm._handlePeer === 'function') {
-      try {
-        this.swarm._handlePeer(peer, topic)
-      } catch (err) {
-        console.log('[PublicFeed] Failed to preserve discovered peer relay hints:', err?.message || String(err))
-      }
-    }
     return this._rememberPeerPublicKey(publicKey)
-  }
-
-  _explicitlyQueuePeer(keyHex, publicKey) {
-    const peerInfo = this.swarm?.peers?.get?.(keyHex)
-    if (peerInfo && typeof this.swarm?._enqueue === 'function' && typeof peerInfo._updatePriority === 'function') {
-      peerInfo.explicit = true
-      this.swarm.explicitPeers?.add?.(peerInfo)
-      if (!this.swarm._allConnections?.has?.(publicKey) && peerInfo._updatePriority()) {
-        return this.swarm._enqueue(peerInfo) !== false
-      }
-      return false
-    }
-    this.swarm.joinPeer(publicKey)
-    return true
   }
 
   handleDiscoveredPeer(peer, topic = null) {
     if (topic && !this._isNetworkTopic(topic)) return false
-    if (!this.swarm || typeof this.swarm.joinPeer !== 'function') return false
+    if (!this.swarm) return false
 
     const remembered = this._queueDiscoveredPeer(peer, topic)
     if (!remembered) return false
     if (this._hasActivePeerConnection(remembered.keyHex, remembered.publicKey)) return false
 
-    return this._dialDiscoveredPeer(remembered.keyHex, remembered.publicKey)
+    return this._dialDiscoveredPeer(remembered.keyHex, remembered.publicKey, peer, topic)
   }
 
-  _dialDiscoveredPeer(keyHex, publicKey, attempts = this._directPeerRetryCounts.get(keyHex) || 0, { force = false } = {}) {
+  _dialDiscoveredPeer(keyHex, publicKey, peer = publicKey, topic = null) {
     this._directPeerDialStats.attempted++
-    if (!publicKey || !this.swarm || typeof this.swarm.joinPeer !== 'function') {
+    if (!publicKey || !this.swarm) {
       this._directPeerDialStats.skipped++
-      this._directPeerDialStats.lastReason = 'joinPeer-unavailable'
+      this._directPeerDialStats.lastReason = 'swarm-unavailable'
       return false
     }
     if (!keyHex || keyHex === b4a.toString(this.swarm.keyPair?.publicKey || [], 'hex')) {
@@ -625,7 +579,13 @@ export class PublicFeedManager {
     // dialed after the pending dial window expires until Hyperswarm gives us a
     // socket, at which point handleConnection opens the Protomux feed channel.
     try {
-      this._explicitlyQueuePeer(keyHex, publicKey)
+      const attempts = this._directPeerRetryCounts.get(keyHex) || 0
+      const result = ensureSwarmPeerConnection(this.swarm, peer || publicKey, topic)
+      if (!result.queued) {
+        this._directPeerDialStats.skipped++
+        this._directPeerDialStats.lastReason = result.reason || 'queue-skipped'
+        return false
+      }
       const now = this._now()
       this._directPeerRetryCounts.set(keyHex, attempts + 1)
       this._directPeerLastDialedAt.set(keyHex, now)
@@ -655,8 +615,7 @@ export class PublicFeedManager {
     let dialed = 0
     for (const [keyHex, publicKey] of this._discoveredPeers) {
       if ((this.swarm.connections?.size || 0) >= this._maxDirectPeers) break
-      const attempts = this._directPeerRetryCounts.get(keyHex) || 0
-      if (this._dialDiscoveredPeer(keyHex, publicKey, attempts, { force })) dialed++
+      if (this._dialDiscoveredPeer(keyHex, publicKey)) dialed++
     }
     return dialed
   }

--- a/packages/backend/src/swarm-peer-dial.js
+++ b/packages/backend/src/swarm-peer-dial.js
@@ -62,7 +62,11 @@ export function swarmHasConnection(swarm, keyHex, publicKey = null) {
   if (peers && typeof peers.get === 'function') {
     let peerInfo = peers.get(keyHex)
     if (!peerInfo && publicKey) {
-      try { peerInfo = peers.get(publicKey) } catch {}
+      try {
+        peerInfo = peers.get(publicKey)
+      } catch {
+        peerInfo = null
+      }
     }
     if (swarmConnectionLike(peerInfo)) return true
   }

--- a/packages/backend/src/swarm-peer-dial.js
+++ b/packages/backend/src/swarm-peer-dial.js
@@ -1,0 +1,108 @@
+import b4a from 'b4a'
+
+export function peerPublicKey(peer) {
+  if (!peer) return null
+  if (typeof peer === 'string' && /^[a-f0-9]{64}$/i.test(peer)) return b4a.from(peer, 'hex')
+  if (b4a.isBuffer(peer) || peer instanceof Uint8Array) return peer
+  const publicKey =
+    peer.publicKey ||
+    peer.remotePublicKey ||
+    peer.key ||
+    peer.value?.publicKey ||
+    peer.value?.remotePublicKey ||
+    peer.value?.key ||
+    peer.peer?.publicKey ||
+    peer.peer?.remotePublicKey ||
+    peer[1]?.publicKey ||
+    peer[1]?.remotePublicKey ||
+    peer[1]?.key
+  if (typeof publicKey === 'string' && /^[a-f0-9]{64}$/i.test(publicKey)) return b4a.from(publicKey, 'hex')
+  if (publicKey && (b4a.isBuffer(publicKey) || publicKey instanceof Uint8Array)) return publicKey
+  return null
+}
+
+export function peerKeyHex(peer) {
+  const publicKey = peerPublicKey(peer)
+  return publicKey ? b4a.toString(publicKey, 'hex') : null
+}
+
+export function peerMatchesKey(peer, keyHex) {
+  const key = peerKeyHex(peer)
+  return Boolean(key && key === keyHex)
+}
+
+export function swarmConnectionLike(entry) {
+  const value = entry?.value || entry
+  if (!value || typeof value !== 'object') return false
+  return Boolean(
+    value.stream ||
+    value.rawStream ||
+    value.opened ||
+    value.open ||
+    value.connected ||
+    value.connectedTime >= 0
+  )
+}
+
+export function swarmHasConnection(swarm, keyHex, publicKey = null) {
+  if (!swarm || !keyHex) return false
+  const connections = swarm.connections
+  if (connections && typeof connections[Symbol.iterator] === 'function') {
+    for (const conn of connections) {
+      if (peerMatchesKey(conn, keyHex)) return true
+    }
+  }
+  const all = swarm._allConnections
+  if (all && typeof all[Symbol.iterator] === 'function') {
+    for (const entry of all) {
+      if (entry && typeof entry === 'object' && (swarmConnectionLike(entry) || entry.remotePublicKey || entry.publicKey) && peerMatchesKey(entry, keyHex)) return true
+    }
+  }
+  const peers = swarm.peers
+  if (peers && typeof peers.get === 'function') {
+    let peerInfo = peers.get(keyHex)
+    if (!peerInfo && publicKey) {
+      try { peerInfo = peers.get(publicKey) } catch {}
+    }
+    if (swarmConnectionLike(peerInfo)) return true
+  }
+  if (peers && typeof peers[Symbol.iterator] === 'function') {
+    for (const peer of peers) {
+      if (swarmConnectionLike(peer) && peerMatchesKey(peer, keyHex)) return true
+    }
+  }
+  return false
+}
+
+export function ensureSwarmPeerConnection(swarm, peer, topic = null) {
+  const publicKey = peerPublicKey(peer)
+  if (!swarm || !publicKey) return { queued: false, reason: 'missing-peer' }
+  const keyHex = b4a.toString(publicKey, 'hex')
+  if (!keyHex || keyHex === b4a.toString(swarm.keyPair?.publicKey || [], 'hex')) {
+    return { queued: false, reason: 'self-or-missing-key', keyHex, publicKey }
+  }
+  if (swarmHasConnection(swarm, keyHex)) {
+    return { queued: false, reason: 'already-connected-peer', keyHex, publicKey }
+  }
+
+  if (topic && typeof swarm._handlePeer === 'function' && peer && typeof peer === 'object') {
+    swarm._handlePeer(peer, topic)
+  }
+
+  const peerInfo = swarm.peers?.get?.(keyHex)
+  if (peerInfo && typeof swarm._enqueue === 'function' && typeof peerInfo._updatePriority === 'function') {
+    peerInfo.explicit = true
+    swarm.explicitPeers?.add?.(peerInfo)
+    if (!swarm._allConnections?.has?.(publicKey) && peerInfo._updatePriority()) {
+      const queued = swarm._enqueue(peerInfo) !== false
+      return { queued, reason: queued ? 'queued' : 'enqueue-skipped', keyHex, publicKey }
+    }
+    return { queued: false, reason: 'already-connecting', keyHex, publicKey }
+  }
+
+  if (typeof swarm.joinPeer === 'function') {
+    swarm.joinPeer(publicKey)
+    return { queued: true, reason: 'queued', keyHex, publicKey }
+  }
+  return { queued: false, reason: 'joinPeer-unavailable', keyHex, publicKey }
+}


### PR DESCRIPTION
## Summary
- extract Hyperswarm peer key/connection/explicit queue handling into `swarm-peer-dial.js`
- leave `PublicFeedManager` focused on remembering candidates and opening the feed protocol once sockets exist
- preserve the relay-address-hint behavior from PR #129 while removing direct `_handlePeer` / `_enqueue` transport logic from the feed manager class

## Verification
- `node --test packages/backend/test/public-feed-manager.test.mjs packages/backend/test/storage-startup-regression.test.mjs`
- `npm test --prefix packages/cli -- --timeout=30000`
- `npm run lint:changed`
- `git diff --check`
