### PR TITLE
fix(relay): avoid recursive swarm peer redials

### DIFF
--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -81,6 +81,8 @@ export class PublicFeedManager {
     this._directPeerLastDialedAt = new Map();
     /** @type {Map<string, string>} */
     this._directPeerLastDialError = new Map();
+    /** @type {Map<string, string>} */
+    this._directPeerLastDialErrorStack = new Map();
     /** @type {Map<string, number>} */
     this._directPeerLastQueuedAt = new Map();
     /** @type {Set<string>} */
@@ -459,6 +461,7 @@ export class PublicFeedManager {
     this._directPeerLastQueuedAt.delete(remembered.keyHex)
     this._directPeerRetryCounts.delete(remembered.keyHex)
     this._directPeerLastDialError.delete(remembered.keyHex)
+    this._directPeerLastDialErrorStack.delete(remembered.keyHex)
     this._directPeerDialStats.connected++
     this._directPeerDialStats.lastReason = 'connected'
   }
@@ -574,16 +577,24 @@ export class PublicFeedManager {
       this._directPeerDialStats.lastReason = 'max-direct-peers'
       return false
     }
-    // Discovered peers are part of the app protocol surface. There is no hard
-    // retry cap here: a peer that remains on the shared topic should keep being
-    // dialed after the pending dial window expires until Hyperswarm gives us a
-    // socket, at which point handleConnection opens the Protomux feed channel.
+    const attempts = this._directPeerRetryCounts.get(keyHex) || 0
+    if (this._maxDirectPeerRetries > 0 && attempts >= this._maxDirectPeerRetries) {
+      this._directPeerDialStats.skipped++
+      this._directPeerDialStats.lastReason = 'max-direct-peer-retries'
+      return false
+    }
+    // Once a peer is marked explicit, Hyperswarm owns transport retry/backoff.
+    // The app-level nudge is capped so relay heartbeats do not create noisy
+    // redial loops when the DHT transport is failing below the feed protocol.
     try {
-      const attempts = this._directPeerRetryCounts.get(keyHex) || 0
       const result = ensureSwarmPeerConnection(this.swarm, peer || publicKey, topic)
       if (!result.queued) {
         this._directPeerDialStats.skipped++
         this._directPeerDialStats.lastReason = result.reason || 'queue-skipped'
+        if (result.error) {
+          this._directPeerLastDialError.set(keyHex, result.errorMessage || result.error)
+          this._directPeerLastDialErrorStack.set(keyHex, result.error)
+        }
         return false
       }
       const now = this._now()
@@ -592,6 +603,7 @@ export class PublicFeedManager {
       this._directPeerLastQueuedAt.set(keyHex, now)
       this._directPeerPending.add(keyHex)
       this._directPeerLastDialError.delete(keyHex)
+      this._directPeerLastDialErrorStack.delete(keyHex)
       this._directPeerDialStats.queued++
       this._directPeerDialStats.lastReason = 'queued'
       this._directPeerDialStats.lastDialedAt = now
@@ -602,6 +614,7 @@ export class PublicFeedManager {
       this._directPeerDialStats.failed++
       this._directPeerDialStats.lastReason = 'joinPeer-error'
       this._directPeerLastDialError.set(keyHex, message)
+      if (err?.stack) this._directPeerLastDialErrorStack.set(keyHex, err.stack)
       console.log('[PublicFeed] Direct peer dial failed:', keyHex.slice(0, 16), message)
       return false
     }
@@ -656,6 +669,7 @@ export class PublicFeedManager {
         lastDialedAt: this._directPeerLastDialedAt.get(keyHex) || null,
         lastQueuedAt: this._directPeerLastQueuedAt.get(keyHex) || null,
         lastError: this._directPeerLastDialError.get(keyHex) || null,
+        lastErrorStack: this._directPeerLastDialErrorStack.get(keyHex) || null,
         pending,
         connected: this._hasActivePeerConnection(keyHex, this._discoveredPeers.get(keyHex)),
         swarm: this._swarmDialState(keyHex),
@@ -873,6 +887,7 @@ export class PublicFeedManager {
       this._discoveredPeers.clear()
       this._directPeerLastDialedAt.clear()
       this._directPeerLastDialError.clear()
+      this._directPeerLastDialErrorStack.clear()
       this._directPeerLastQueuedAt.clear()
       this._directPeerPending.clear()
       if (this._persistTimer) clearTimeout(this._persistTimer)

--- a/packages/backend/src/storage.js
+++ b/packages/backend/src/storage.js
@@ -332,6 +332,7 @@ function installSwarmPeerDiscoveryEmitter(swarm) {
   if (typeof swarm._handlePeer !== 'function' || typeof swarm.emit !== 'function') return false
 
   const handlePeer = swarm._handlePeer
+  swarm._peartubeHandlePeerWithoutEmit = handlePeer
   swarm._handlePeer = function peartubeHandlePeer(peer, topic) {
     const result = handlePeer.call(this, peer, topic)
     try {

--- a/packages/backend/src/swarm-peer-dial.js
+++ b/packages/backend/src/swarm-peer-dial.js
@@ -44,6 +44,36 @@ export function swarmConnectionLike(entry) {
   )
 }
 
+function relayAddressesFromPeer(peer) {
+  return Array.isArray(peer?.relayAddresses) && peer.relayAddresses.length > 0 ? peer.relayAddresses : null
+}
+
+function upsertPeerWithoutEmit(swarm, peer, publicKey, topic) {
+  if (!swarm || !publicKey || !peer || typeof peer !== 'object') return null
+  if (b4a.isBuffer(peer) || peer instanceof Uint8Array) return null
+
+  const relayAddresses = relayAddressesFromPeer(peer)
+  const keyHex = b4a.toString(publicKey, 'hex')
+  const existing = swarm.peers?.get?.(keyHex) || null
+  if (!relayAddresses) {
+    if (existing && topic && typeof existing._topic === 'function') existing._topic(topic)
+    return existing
+  }
+
+  if (typeof swarm._upsertPeer === 'function') {
+    const peerInfo = swarm._upsertPeer(publicKey, relayAddresses)
+    if (peerInfo && topic && typeof peerInfo._topic === 'function') peerInfo._topic(topic)
+    return peerInfo
+  }
+
+  const handlePeer = swarm._peartubeHandlePeerWithoutEmit
+  if (topic && typeof handlePeer === 'function') {
+    return handlePeer.call(swarm, { publicKey, relayAddresses }, topic) || null
+  }
+
+  return null
+}
+
 export function swarmHasConnection(swarm, keyHex, publicKey = null) {
   if (!swarm || !keyHex) return false
   const connections = swarm.connections
@@ -55,7 +85,7 @@ export function swarmHasConnection(swarm, keyHex, publicKey = null) {
   const all = swarm._allConnections
   if (all && typeof all[Symbol.iterator] === 'function') {
     for (const entry of all) {
-      if (entry && typeof entry === 'object' && (swarmConnectionLike(entry) || entry.remotePublicKey || entry.publicKey) && peerMatchesKey(entry, keyHex)) return true
+      if (entry && typeof entry === 'object' && swarmConnectionLike(entry) && peerMatchesKey(entry, keyHex)) return true
     }
   }
   const peers = swarm.peers
@@ -89,24 +119,38 @@ export function ensureSwarmPeerConnection(swarm, peer, topic = null) {
     return { queued: false, reason: 'already-connected-peer', keyHex, publicKey }
   }
 
-  if (topic && typeof swarm._handlePeer === 'function' && peer && typeof peer === 'object') {
-    swarm._handlePeer(peer, topic)
-  }
+  try {
+    const preservedPeerInfo = topic ? upsertPeerWithoutEmit(swarm, peer, publicKey, topic) : null
 
-  const peerInfo = swarm.peers?.get?.(keyHex)
-  if (peerInfo && typeof swarm._enqueue === 'function' && typeof peerInfo._updatePriority === 'function') {
-    peerInfo.explicit = true
-    swarm.explicitPeers?.add?.(peerInfo)
-    if (!swarm._allConnections?.has?.(publicKey) && peerInfo._updatePriority()) {
-      const queued = swarm._enqueue(peerInfo) !== false
-      return { queued, reason: queued ? 'queued' : 'enqueue-skipped', keyHex, publicKey }
+    const peerInfo = preservedPeerInfo || swarm.peers?.get?.(keyHex)
+    if (peerInfo?.queued) {
+      peerInfo.explicit = true
+      swarm.explicitPeers?.add?.(peerInfo)
+      return { queued: true, reason: 'queued', keyHex, publicKey }
     }
-    return { queued: false, reason: 'already-connecting', keyHex, publicKey }
-  }
+    if (peerInfo && typeof swarm._enqueue === 'function' && typeof peerInfo._updatePriority === 'function') {
+      peerInfo.explicit = true
+      swarm.explicitPeers?.add?.(peerInfo)
+      if (!swarm._allConnections?.has?.(publicKey) && peerInfo._updatePriority()) {
+        const queued = swarm._enqueue(peerInfo) !== false
+        return { queued, reason: queued ? 'queued' : 'enqueue-skipped', keyHex, publicKey }
+      }
+      return { queued: false, reason: 'already-connecting', keyHex, publicKey }
+    }
 
-  if (typeof swarm.joinPeer === 'function') {
-    swarm.joinPeer(publicKey)
-    return { queued: true, reason: 'queued', keyHex, publicKey }
+    if (typeof swarm.joinPeer === 'function') {
+      swarm.joinPeer(publicKey)
+      return { queued: true, reason: 'queued', keyHex, publicKey }
+    }
+    return { queued: false, reason: 'joinPeer-unavailable', keyHex, publicKey }
+  } catch (err) {
+    return {
+      queued: false,
+      reason: 'queue-error',
+      keyHex,
+      publicKey,
+      errorMessage: err?.message || String(err),
+      error: err?.stack || err?.message || String(err)
+    }
   }
-  return { queued: false, reason: 'joinPeer-unavailable', keyHex, publicKey }
 }

--- a/packages/backend/test/public-feed-manager.test.mjs
+++ b/packages/backend/test/public-feed-manager.test.mjs
@@ -7,6 +7,7 @@ import b4a from 'b4a'
 
 import Protomux from 'protomux'
 
+import { ensureSwarmPeerConnection } from '../src/swarm-peer-dial.js'
 import { PublicFeedManager } from '../src/public-feed.js'
 import { NETWORK_TOPIC_STRING } from '../src/types.js'
 const DRIVE_KEY = '11'.repeat(32)
@@ -35,19 +36,30 @@ function createSwarm() {
       this.fallbackJoinPeerCalls.push(publicKey)
       return {}
     },
-    _handlePeer(peer, topic) {
-      const keyHex = b4a.toString(peer.publicKey, 'hex')
+    _upsertPeer(publicKey, relayAddresses) {
+      const keyHex = b4a.toString(publicKey, 'hex')
       let peerInfo = this.peers.get(keyHex)
       if (!peerInfo) {
         peerInfo = {
-          publicKey: peer.publicKey,
+          publicKey,
+          relayAddresses,
           topics: [],
-          _updatePriority() { return true }
+          _topic(topic) {
+            if (topic && !this.topics.some((seen) => b4a.equals(seen, topic))) this.topics.push(topic)
+          },
+          _updatePriority() { return !this.queued }
         }
         this.peers.set(keyHex, peerInfo)
+        return peerInfo
       }
-      peerInfo.relayAddresses = peer.relayAddresses
-      if (topic) peerInfo.topics.push(topic)
+      if (relayAddresses) peerInfo.relayAddresses = relayAddresses
+      return peerInfo
+    },
+    _handlePeer(peer, topic) {
+      const peerInfo = this._upsertPeer(peer.publicKey, peer.relayAddresses)
+      if (!peerInfo) return peerInfo
+      if (topic) peerInfo._topic(topic)
+      if (peerInfo._updatePriority()) this._enqueue(peerInfo)
       return peerInfo
     },
     _enqueue(peerInfo) {
@@ -180,6 +192,89 @@ test('PublicFeedManager keeps discovered relay address hints before explicit joi
   }
 })
 
+test('ensureSwarmPeerConnection preserves relay hints without calling wrapped _handlePeer', () => {
+  const publicKey = b4a.alloc(32, 15)
+  const keyHex = b4a.toString(publicKey, 'hex')
+  const relayAddresses = [{ host: '150.136.237.154', port: 38619 }]
+  const swarm = createSwarm()
+  let handled = 0
+  const originalHandlePeer = swarm._handlePeer
+  swarm._handlePeer = (peer, topic) => {
+    handled++
+    return originalHandlePeer.call(swarm, peer, topic)
+  }
+
+  const rawResult = ensureSwarmPeerConnection(swarm, { publicKey, relayAddresses }, NETWORK_TOPIC)
+  assert.equal(rawResult.queued, true)
+  assert.equal(handled, 0)
+  assert.equal(swarm.peers.get(keyHex).relayAddresses, relayAddresses)
+
+  const peerInfo = swarm.peers.get(keyHex)
+  peerInfo.queued = false
+  peerInfo.attempts = 0
+  const peerInfoResult = ensureSwarmPeerConnection(swarm, peerInfo, NETWORK_TOPIC)
+  assert.equal(peerInfoResult.queued, true)
+  assert.equal(handled, 0)
+
+  const mapEntry = { key: keyHex, value: peerInfo }
+  peerInfo.queued = false
+  peerInfo.attempts = 0
+  const mapEntryResult = ensureSwarmPeerConnection(swarm, mapEntry, NETWORK_TOPIC)
+  assert.equal(mapEntryResult.queued, true)
+  assert.equal(handled, 0)
+})
+
+test('PublicFeedManager does not recurse through the storage peer emitter wrapper', () => {
+  const publicKey = b4a.alloc(32, 16)
+  const keyHex = b4a.toString(publicKey, 'hex')
+  const relayAddresses = [
+    { host: '167.86.111.230', port: 49737 },
+    { host: '150.136.237.154', port: 38619 },
+    { host: '193.123.77.4', port: 49737 },
+  ]
+  const swarm = createSwarm()
+  const listeners = new Map()
+  let emitted = 0
+  const originalHandlePeer = swarm._handlePeer
+
+  swarm.on = (event, listener) => {
+    if (!listeners.has(event)) listeners.set(event, new Set())
+    listeners.get(event).add(listener)
+    return swarm
+  }
+  swarm.emit = (event, ...args) => {
+    emitted++
+    for (const listener of listeners.get(event) || []) listener(...args)
+    return true
+  }
+  swarm._peartubeHandlePeerWithoutEmit = originalHandlePeer
+  swarm._handlePeer = function wrappedHandlePeer(peer, topic) {
+    const result = originalHandlePeer.call(this, peer, topic)
+    this.emit('peer', peer, topic)
+    return result
+  }
+
+  const manager = new PublicFeedManager(swarm, createMetaDb())
+  swarm.on('peer', (peer, topic) => {
+    manager.handleDiscoveredPeer(peer, topic)
+  })
+
+  try {
+    swarm._handlePeer({ publicKey, relayAddresses }, NETWORK_TOPIC)
+
+    const stats = manager.getStats().directPeerDial
+    assert.equal(emitted, 1)
+    assert.equal(stats.queued, 1)
+    assert.equal(stats.failed, 0)
+    assert.equal(stats.skipped, 0)
+    assert.equal(stats.peers[0].lastError, null)
+    assert.equal(swarm.peers.get(keyHex).relayAddresses, relayAddresses)
+    assert.equal(manager.getStats().directPeerDial.peers[0].swarm.relayAddresses, 3)
+  } finally {
+    manager.stop()
+  }
+})
+
 test('PublicFeedManager skips direct dials for actively connected peers across swarm shapes', () => {
   const publicKey = b4a.alloc(32, 8)
   const keyHex = b4a.toString(publicKey, 'hex')
@@ -189,7 +284,7 @@ test('PublicFeedManager skips direct dials for actively connected peers across s
     (swarm) => { swarm.peers = new Set([{ publicKey, connected: true }]) },
     (swarm) => { swarm.peers = new Set([{ publicKey, stream: {} }]) },
     (swarm) => { swarm.connections.add({ remotePublicKey: publicKey }) },
-    (swarm) => { swarm._allConnections = new Set([{ remotePublicKey: publicKey }]) },
+    (swarm) => { swarm._allConnections = new Set([{ remotePublicKey: publicKey, opened: true }]) },
     (swarm) => { swarm.peers.set(keyHex, { publicKey, connectedTime: Date.now() }) },
   ]
 
@@ -217,6 +312,21 @@ test('PublicFeedManager does not treat stale Hyperswarm _allConnections keys as 
     assert.equal(manager.handleDiscoveredPeer({ publicKey }), true)
     assert.equal(swarm.joinPeerCalls.length, 1)
     assert.equal(manager.getStats().directPeerDial.lastReason, 'queued')
+  } finally {
+    manager.stop()
+  }
+})
+
+test('PublicFeedManager does not treat pending Hyperswarm _allConnections entries as active sockets', () => {
+  const publicKey = b4a.alloc(32, 19)
+  const swarm = createSwarm()
+  swarm._allConnections = new Set([{ remotePublicKey: publicKey, opened: false }])
+  const manager = new PublicFeedManager(swarm, createMetaDb())
+
+  try {
+    assert.equal(manager.handleDiscoveredPeer({ publicKey }), true)
+    assert.equal(swarm.joinPeerCalls.length, 1)
+    assert.equal(manager.getStats().directPeerDial.peers[0].connected, false)
   } finally {
     manager.stop()
   }
@@ -256,7 +366,7 @@ test('periodic gossip re-dials remembered shared-topic peers when sockets droppe
   }
 })
 
-test('forceRedialDiscoveredPeers keeps trying known discovered peers after pending dial windows expire', () => {
+test('forceRedialDiscoveredPeers caps app-level redials after pending dial windows expire', () => {
   const publicKey = b4a.alloc(32, 11)
   const swarm = createSwarm()
   const manager = new PublicFeedManager(swarm, createMetaDb())
@@ -271,20 +381,20 @@ test('forceRedialDiscoveredPeers keeps trying known discovered peers after pendi
     now += manager._directPeerPendingTimeoutMs + 1
     assert.equal(manager._redialDiscoveredPeers(), 1)
     now += manager._directPeerPendingTimeoutMs + 1
-    assert.equal(manager._redialDiscoveredPeers(), 1)
-    assert.equal(swarm.joinPeerCalls.length, 4)
+    assert.equal(manager._redialDiscoveredPeers(), 0)
+    assert.equal(swarm.joinPeerCalls.length, 3)
 
     assert.equal(manager.forceRedialDiscoveredPeers(), 0)
-    assert.equal(swarm.joinPeerCalls.length, 4)
+    assert.equal(swarm.joinPeerCalls.length, 3)
     now += manager._directPeerPendingTimeoutMs + 1
-    assert.equal(manager.forceRedialDiscoveredPeers(), 1)
-    assert.equal(swarm.joinPeerCalls.length, 5)
+    assert.equal(manager.forceRedialDiscoveredPeers(), 0)
+    assert.equal(swarm.joinPeerCalls.length, 3)
 
     const stats = manager.getStats().directPeerDial
     assert.equal(stats.discoveredPeers, 1)
-    assert.equal(stats.queued, 5)
-    assert.equal(stats.lastReason, 'queued')
-    assert.equal(stats.peers[0].attempts, 5)
+    assert.equal(stats.queued, 3)
+    assert.equal(stats.lastReason, 'max-direct-peer-retries')
+    assert.equal(stats.peers[0].attempts, 3)
   } finally {
     manager.stop()
   }
@@ -333,9 +443,11 @@ test('direct peer dial diagnostics expose skipped joinPeer failures', () => {
     assert.equal(manager.handleDiscoveredPeer({ publicKey }), false)
     const stats = manager.getStats().directPeerDial
     assert.equal(stats.discoveredPeers, 1)
-    assert.equal(stats.failed, 1)
-    assert.equal(stats.lastReason, 'joinPeer-error')
-    assert.equal(stats.peers[0].lastError, 'dial unavailable')
+    assert.equal(stats.failed, 0)
+    assert.equal(stats.skipped, 1)
+    assert.equal(stats.lastReason, 'queue-error')
+    assert.match(stats.peers[0].lastError, /dial unavailable/)
+    assert.match(stats.peers[0].lastErrorStack, /dial unavailable/)
   } finally {
     manager.stop()
   }
@@ -347,9 +459,8 @@ test('direct peer dial diagnostics include Hyperswarm queue state', () => {
   const swarm = createSwarm()
   swarm.connecting = 1
   swarm._allConnections = new Set([{}])
-  swarm.explicitPeers = new Set([publicKey])
   swarm._queue = { length: 2 }
-  swarm.peers.set(keyHex, {
+  const peerInfo = {
     publicKey,
     attempts: 2,
     queued: true,
@@ -359,7 +470,9 @@ test('direct peer dial diagnostics include Hyperswarm queue state', () => {
     topics: [b4a.alloc(32, 2)],
     connectedTime: -1,
     disconnectedTime: 123,
-  })
+  }
+  swarm.peers.set(keyHex, peerInfo)
+  swarm.explicitPeers = new Set([peerInfo])
   const manager = new PublicFeedManager(swarm, createMetaDb())
 
   try {

--- a/packages/backend/test/storage-startup-regression.test.mjs
+++ b/packages/backend/test/storage-startup-regression.test.mjs
@@ -107,6 +107,11 @@ test('storage exposes Hyperswarm peer discovery as a peer event for feed fallbac
     /swarm\.emit\('peer', peer, topic\)/,
     'adapter should emit peer events with the discovered peer and topic'
   )
+  assert.match(
+    storageSource,
+    /_peartubeHandlePeerWithoutEmit/,
+    'adapter should retain the raw Hyperswarm handler for internal relay hint upserts'
+  )
 })
 
 test('storage captures Hyperswarm connection lifecycle diagnostics', () => {

--- a/packages/cli/src/status.js
+++ b/packages/cli/src/status.js
@@ -75,6 +75,9 @@ export function readRelayStatus(statusPath) {
 }
 
 export function formatRelayStatus(status) {
+  const firstDialError = status.runtime.directPeerDial?.peers
+    ?.find((peer) => peer?.lastError)
+    ?.lastError || null
   const lines = [
     `mode: ${status.mode}`,
     `policy: ${status.policy}`,
@@ -89,7 +92,7 @@ export function formatRelayStatus(status) {
     `feedEntries: ${status.runtime.feedEntries}`,
     `dht: bootstrapped=${status.runtime.dht.bootstrapped} firewalled=${status.runtime.dht.firewalled} online=${status.runtime.dht.online}`,
     `network: offline=${status.runtime.swarmOffline} reason=${status.runtime.swarmOfflineReason || 'none'} listenResolved=${status.runtime.swarmListenResolved} peerPoolJoined=${status.runtime.peerPoolJoined} publicFeedDiscoveryJoined=${status.runtime.publicFeedDiscoveryJoined}`,
-    `directPeerDial: discovered=${status.runtime.directPeerDial?.discoveredPeers || 0} pending=${status.runtime.directPeerDial?.pending || 0} queued=${status.runtime.directPeerDial?.queued || 0} skipped=${status.runtime.directPeerDial?.skipped || 0} failed=${status.runtime.directPeerDial?.failed || 0} connected=${status.runtime.directPeerDial?.connected || 0} lastReason=${status.runtime.directPeerDial?.lastReason || 'none'}`,
+    `directPeerDial: discovered=${status.runtime.directPeerDial?.discoveredPeers || 0} pending=${status.runtime.directPeerDial?.pending || 0} queued=${status.runtime.directPeerDial?.queued || 0} skipped=${status.runtime.directPeerDial?.skipped || 0} failed=${status.runtime.directPeerDial?.failed || 0} connected=${status.runtime.directPeerDial?.connected || 0} lastReason=${status.runtime.directPeerDial?.lastReason || 'none'} lastError=${firstDialError || 'none'}`,
     `blindPeer: enabled=${Boolean(status.runtime.blindPeer?.enabled)} key=${status.runtime.blindPeer?.publicKey || 'none'} mirroredCores=${status.runtime.blindPeer?.mirroredCores || 0} mirroredAutobases=${status.runtime.blindPeer?.mirroredAutobases || 0}`,
     `seeding: channels=${status.runtime.seeding.channels} videos=${status.runtime.seeding.videos} publicBeeCores=${status.runtime.seeding.publicBeeCores} blobCores=${status.runtime.seeding.blobCores} discoveryHandles=${status.runtime.seeding.discoveryHandles}`
   ]

--- a/packages/cli/test/relay-seeding.test.mjs
+++ b/packages/cli/test/relay-seeding.test.mjs
@@ -200,7 +200,16 @@ test('relay status surfaces DHT and seeding stats for phone connectivity diagnos
       swarmListenResolved: true,
       blindPeer: { enabled: true, publicKey: 'abcd', mirroredCores: 4, mirroredAutobases: 0, error: null },
       seeding: { channels: 2, videos: 5, publicBeeCores: 2, blobCores: 8, discoveryHandles: 10 },
-      directPeerDial: { discoveredPeers: 2, pending: 1, queued: 3, skipped: 1, failed: 0, connected: 1, lastReason: 'queued' }
+      directPeerDial: {
+        discoveredPeers: 2,
+        pending: 1,
+        queued: 3,
+        skipped: 1,
+        failed: 0,
+        connected: 1,
+        lastReason: 'queued',
+        peers: [{ key: 'peer-a', lastError: 'Maximum call stack size exceeded' }]
+      }
     }
   })
 
@@ -219,6 +228,7 @@ test('relay status surfaces DHT and seeding stats for phone connectivity diagnos
   t.ok(formatted.includes('dht: bootstrapped=true firewalled=false online=true'))
   t.ok(formatted.includes('network: offline=false reason=none listenResolved=true peerPoolJoined=true publicFeedDiscoveryJoined=true'))
   t.ok(formatted.includes('directPeerDial: discovered=2 pending=1 queued=3 skipped=1 failed=0 connected=1 lastReason=queued'))
+  t.ok(formatted.includes('lastError=Maximum call stack size exceeded'))
   t.ok(formatted.includes('blindPeer: enabled=true key=abcd mirroredCores=4 mirroredAutobases=0'))
   t.ok(formatted.includes('seeding: channels=2 videos=5 publicBeeCores=2 blobCores=8 discoveryHandles=10'))
 })


### PR DESCRIPTION
## Summary
- Fixes the relay direct-dial recursion exposed by `Maximum call stack size exceeded` in v0.1.65 heartbeats.
- Stops feeding PearTube's wrapped `swarm._handlePeer` back into `ensureSwarmPeerConnection()`; raw DHT peers are now upserted without re-emitting the `peer` event that called us.
- Caps app-level redial nudges after Hyperswarm owns an explicit peer, so failing transport attempts do not create a noisy heartbeat loop.
- Preserves relay-address hints, surfaces per-peer stack/error context in diagnostics, and keeps socket/feed protocol handling unchanged.

## First-principles read
Latest logs show:
- DHT discovery works: peer keys and `relayAddresses: 3` arrive.
- Hyperswarm owns a pending transport attempt: `connecting: 1`, `allConnections: 1`.
- No socket opens: `connections: 0`, `recentConnections: []`.
- The app-level dial record has `lastError: "Maximum call stack size exceeded"`.

That points at our wrapper path, not video feed rendering: discovery emits a peer event, PublicFeed redial calls `ensureSwarmPeerConnection()`, and that called the wrapped `_handlePeer()` again, recursively re-emitting the same peer.

## Agent cross-check
- Codex independently flagged the same failure boundary: avoid calling the wrapped `_handlePeer` from the direct dial helper and expose queue errors.
- Claude independently produced the concrete fix shape now on this branch: upsert raw DHT peers without emitting, keep relay hints, add a recursion regression, and cap app-level retry nudges.

## Verification
```bash
node --test packages/backend/test/public-feed-manager.test.mjs packages/backend/test/storage-startup-regression.test.mjs
npm test --prefix packages/cli -- --timeout=30000
npm run lint:changed
git diff --check
```

All passed locally.
