### PR TITLE
diagnose(relay): surface pre-open DHT connect state

### DIFF
--- a/docker-compose.relay.yml
+++ b/docker-compose.relay.yml
@@ -14,11 +14,13 @@ services:
     restart: unless-stopped
     ports:
       - "8174:8174"
+      - "49737:49737/udp"
     environment:
       PEARTUBE_MODE: public
       PEARTUBE_POLICY: discovery
       PEARTUBE_DISCOVERY_ENABLED: "true"
       PEARTUBE_NETWORK_ANNOUNCE: "true"
+      PEARTUBE_NETWORK_PORT: "49737"
       PEARTUBE_ARCHIVE_UI_ENABLED: "true"
       PEARTUBE_ARCHIVE_UI_HOST: 0.0.0.0
       PEARTUBE_ARCHIVE_UI_PORT: "8174"

--- a/packages/backend/src/storage.js
+++ b/packages/backend/src/storage.js
@@ -148,8 +148,53 @@ function describeRelayAddresses(relayAddresses) {
   })
 }
 
+function describeStreamError(stream) {
+  try {
+    const err = stream?.errored || stream?._error || stream?.error || null
+    if (!err) return null
+    return {
+      name: err.name || null,
+      code: err.code || null,
+      message: err.message || String(err)
+    }
+  } catch {
+    return { message: 'unreadable' }
+  }
+}
+
+function describeSocketAddress(socket) {
+  try {
+    const address = socket?.address?.()
+    if (!address) return null
+    return {
+      host: address.host || address.address || null,
+      port: Number(address.port || 0) || null,
+      family: address.family || null
+    }
+  } catch {
+    return null
+  }
+}
+
+function describeAddress(address) {
+  try {
+    if (!address) return null
+    if (typeof address === 'string') return { host: address, port: null }
+    return {
+      host: address.host || address.address || null,
+      port: Number(address.port || 0) || null,
+      family: address.family || null
+    }
+  } catch {
+    return null
+  }
+}
+
 function describeTrackedConnection(conn) {
   if (!conn || typeof conn !== 'object') return null
+  const rawStream = conn.rawStream || conn._rawStream || null
+  const socket = rawStream?.socket || rawStream?._socket || conn.socket || null
+  const remoteAddress = rawStream?.remoteAddress || rawStream?.remote || conn.remoteAddress || null
   return {
     constructor: conn.constructor?.name || null,
     destroyed: Boolean(conn.destroyed),
@@ -159,8 +204,20 @@ function describeTrackedConnection(conn) {
     readable: Boolean(conn.readable),
     writable: Boolean(conn.writable),
     connecting: Boolean(conn.connecting),
-    bytesRead: Number(conn.bytesRead || conn.rawStream?.bytesRead || 0),
-    bytesWritten: Number(conn.bytesWritten || conn.rawStream?.bytesWritten || 0)
+    error: describeStreamError(conn),
+    rawStream: rawStream ? {
+      constructor: rawStream.constructor?.name || null,
+      connected: Boolean(rawStream.connected),
+      destroyed: Boolean(rawStream.destroyed),
+      errored: describeStreamError(rawStream),
+      id: rawStream.id ? shortKeyHex(rawStream.id) : null,
+      remoteHost: rawStream.remoteHost || null,
+      remotePort: Number(rawStream.remotePort || 0) || null,
+      remoteAddress: describeAddress(remoteAddress),
+      socketLocal: describeSocketAddress(socket)
+    } : null,
+    bytesRead: Number(conn.bytesRead || rawStream?.bytesRead || 0),
+    bytesWritten: Number(conn.bytesWritten || rawStream?.bytesWritten || 0)
   }
 }
 
@@ -182,6 +239,50 @@ function describePeerInfo(peerInfo) {
     relayAddresses: relayAddresses.length,
     relayAddressHints: describeRelayAddresses(relayAddresses),
     topics: topics.length
+  }
+}
+
+function attachConnectionDiagnostics(conn, entry) {
+  if (!conn || !entry) return
+  const recordEvent = (event, detail = {}) => {
+    entry.events.push({ at: Date.now(), event, ...detail })
+    while (entry.events.length > 20) entry.events.shift()
+    entry.stream = describeTrackedConnection(conn)
+  }
+
+  try { conn.once?.('open', () => recordEvent('open')) } catch { /* diagnostics only */ }
+  try { conn.once?.('close', () => recordEvent('close', { error: describeStreamError(conn) })) } catch { /* diagnostics only */ }
+  try { conn.once?.('error', (err) => recordEvent('error', { error: describeStreamError({ errored: err }) })) } catch { /* diagnostics only */ }
+
+  const rawStream = conn.rawStream || conn._rawStream || null
+  try { rawStream?.once?.('connect', () => recordEvent('raw-connect')) } catch { /* diagnostics only */ }
+  try { rawStream?.once?.('close', () => recordEvent('raw-close', { error: describeStreamError(rawStream) })) } catch { /* diagnostics only */ }
+  try { rawStream?.once?.('error', (err) => recordEvent('raw-error', { error: describeStreamError({ errored: err }) })) } catch { /* diagnostics only */ }
+}
+
+function describeDhtState(dht) {
+  if (!dht) return null
+  let socketAddress = null
+  let localAddress = null
+  let remoteAddress = null
+  try {
+    socketAddress = dht.address?.() || null
+    if (!socketAddress && dht.io?.serverSocket?.address) socketAddress = dht.io.serverSocket.address()
+  } catch { socketAddress = null }
+  try { localAddress = dht.localAddress?.() || null } catch { localAddress = null }
+  try { remoteAddress = dht.remoteAddress?.() || null } catch { remoteAddress = null }
+  return {
+    bootstrapped: dht.bootstrapped ?? null,
+    firewalled: dht.firewalled ?? null,
+    ephemeral: dht.ephemeral ?? null,
+    online: dht.online ?? null,
+    host: dht.host || null,
+    port: Number(dht.port || 0) || null,
+    socketAddress,
+    localAddress,
+    remoteAddress,
+    serverSocket: describeSocketAddress(dht.io?.serverSocket),
+    clientSocket: describeSocketAddress(dht.io?.clientSocket)
   }
 }
 
@@ -215,7 +316,8 @@ function createSwarmDiagnostics(swarm) {
         connections: swarm?.connections?.size || 0,
         allConnections: swarm?._allConnections?.size || 0,
         connecting: Number(swarm?.connecting || 0),
-        queueSize: swarm?._queue?.length || 0
+        queueSize: swarm?._queue?.length || 0,
+        dht: describeDhtState(swarm?.dht)
       })
     },
     recordConnection(conn, info) {
@@ -226,26 +328,29 @@ function createSwarmDiagnostics(swarm) {
         type: info?.type || null,
         topics: Array.isArray(info?.topics) ? info.topics.length : null,
         stream: describeTrackedConnection(conn),
+        events: [],
         closedAt: null,
         error: null
       }
       record(recentConnections, entry)
-      try {
-        conn?.once?.('close', () => {
-          entry.closedAt = Date.now()
-          entry.stream = describeTrackedConnection(conn)
-        })
-      } catch {
-        // Diagnostics must never break swarm connection handling.
+      attachConnectionDiagnostics(conn, entry)
+    },
+    recordClientConnect(conn, peerInfo) {
+      const entry = {
+        key: shortKeyHex(peerInfo?.publicKey || conn?.remotePublicKey),
+        openedAt: Date.now(),
+        initiator: true,
+        type: 'client-attempt',
+        topics: Array.isArray(peerInfo?.topics) ? peerInfo.topics.length : null,
+        stream: describeTrackedConnection(conn),
+        relayAddresses: Array.isArray(peerInfo?.relayAddresses) ? peerInfo.relayAddresses.length : 0,
+        relayAddressHints: describeRelayAddresses(peerInfo?.relayAddresses),
+        events: [],
+        closedAt: null,
+        error: null
       }
-      try {
-        conn?.once?.('error', (err) => {
-          entry.error = err?.message || String(err)
-          entry.stream = describeTrackedConnection(conn)
-        })
-      } catch {
-        // Diagnostics must never break swarm connection handling.
-      }
+      record(recentConnections, entry)
+      attachConnectionDiagnostics(conn, entry)
     },
     snapshot() {
       const peerStates = []
@@ -325,6 +430,28 @@ function createOfflineSwarm(keyPair, reason = 'unavailable') {
     }
   }
   return swarm
+}
+
+function installSwarmConnectDiagnostics(swarm, diagnostics) {
+  if (!swarm || swarm._peartubeConnectDiagnosticsInstalled) return false
+  if (typeof swarm._connect !== 'function') return false
+
+  const connect = swarm._connect
+  swarm._connect = function peartubeDiagnosedConnect(peerInfo, queued) {
+    const before = this._allConnections?.size || 0
+    const result = connect.call(this, peerInfo, queued)
+    try {
+      const after = this._allConnections?.size || 0
+      if (after > before && this._allConnections && typeof this._allConnections.values === 'function') {
+        let latest = null
+        for (const conn of this._allConnections.values()) latest = conn
+        diagnostics?.recordClientConnect?.(latest, peerInfo)
+      }
+    } catch { /* diagnostics only */ }
+    return result
+  }
+  swarm._peartubeConnectDiagnosticsInstalled = true
+  return true
 }
 
 function installSwarmPeerDiscoveryEmitter(swarm) {
@@ -657,7 +784,8 @@ export async function initializeStorage(config) {
     blobServerBindHost: blobServerBindHostOverride,
     primaryKey = null,
     corestoreWaitForLock = false,
-    corestoreAllowBackup = false
+    corestoreAllowBackup = false,
+    swarmPort = null
   } = config;
 
   console.log('[Storage] Initializing storage at:', storagePath);
@@ -897,7 +1025,11 @@ export async function initializeStorage(config) {
     swarm = createOfflineSwarm(keyPair, 'module-unavailable')
   } else {
     try {
-      swarm = new Hyperswarm({ keyPair });
+      const swarmOptions = { keyPair }
+      if (Number.isFinite(Number(swarmPort)) && Number(swarmPort) > 0) {
+        swarmOptions.port = Number(swarmPort)
+      }
+      swarm = new Hyperswarm(swarmOptions);
     } catch (err) {
       console.warn('[Storage] Hyperswarm creation failed; continuing with offline P2P networking:', err?.message)
       await appendDebugLine(`[storage] hyperswarm create failed; using offline swarm ${err?.message || String(err)}`)
@@ -905,8 +1037,14 @@ export async function initializeStorage(config) {
     }
   }
   console.log('[Storage] Swarm created, publicKey:', b4a.toString(swarm.keyPair.publicKey, 'hex').slice(0, 16));
-  await appendDebugLine(`[storage] hyperswarm created offline=${Boolean(swarm._peartubeOffline)}`)
+  if (swarmPort) console.log('[Storage] Requested Hyperswarm/DHT port:', Number(swarmPort))
+  const initialDhtState = describeDhtState(swarm.dht)
+  if (initialDhtState) {
+    console.log('[Storage] Initial DHT bind state:', JSON.stringify(initialDhtState))
+  }
+  await appendDebugLine(`[storage] hyperswarm created offline=${Boolean(swarm._peartubeOffline)} port=${swarmPort || 'auto'}`)
   globalSwarmDiagnostics = createSwarmDiagnostics(swarm)
+  installSwarmConnectDiagnostics(swarm, globalSwarmDiagnostics)
   installSwarmPeerDiscoveryEmitter(swarm)
 
   // Set global references for suspend/resume and stats
@@ -975,9 +1113,10 @@ export async function initializeStorage(config) {
   const logDhtState = () => {
     const dht = swarm.dht
     if (dht) {
-      console.log('[Storage] DHT state: bootstrapped=', dht.bootstrapped, 'firewalled=', dht.firewalled, 'ephemeral=', dht.ephemeral, 'online=', dht.online)
+      const state = describeDhtState(dht)
+      console.log('[Storage] DHT state: bootstrapped=', dht.bootstrapped, 'firewalled=', dht.firewalled, 'ephemeral=', dht.ephemeral, 'online=', dht.online, 'address=', state?.socketAddress, 'remoteAddress=', state?.remoteAddress)
       void appendDebugLine(
-        `[storage] dht state bootstrapped=${dht.bootstrapped} firewalled=${dht.firewalled} ephemeral=${dht.ephemeral} online=${dht.online}`
+        `[storage] dht state bootstrapped=${dht.bootstrapped} firewalled=${dht.firewalled} ephemeral=${dht.ephemeral} online=${dht.online} address=${JSON.stringify(state?.socketAddress || null)} remoteAddress=${JSON.stringify(state?.remoteAddress || null)}`
       )
     }
   }

--- a/packages/backend/test/storage-startup-regression.test.mjs
+++ b/packages/backend/test/storage-startup-regression.test.mjs
@@ -121,3 +121,19 @@ test('storage captures Hyperswarm connection lifecycle diagnostics', () => {
   assert.match(storageSource, /globalSwarmDiagnostics\?\.recordConnection\?\.\(conn, info\)/)
   assert.match(storageSource, /hyperswarm: diagnostics/)
 })
+
+test('storage captures pre-open DHT connect close diagnostics', () => {
+  assert.match(storageSource, /function installSwarmConnectDiagnostics\(swarm, diagnostics\)/)
+  assert.match(storageSource, /installSwarmConnectDiagnostics\(swarm, globalSwarmDiagnostics\)/)
+  assert.match(storageSource, /recordClientConnect\(conn, peerInfo\)/)
+  assert.match(storageSource, /type: 'client-attempt'/)
+  assert.match(storageSource, /rawStream: rawStream \? \{/)
+  assert.match(storageSource, /remoteHost: rawStream\.remoteHost/)
+  assert.match(storageSource, /event, \.\.\.detail/)
+})
+
+test('storage accepts an optional fixed swarm port for relay diagnostics', () => {
+  assert.match(storageSource, /swarmPort = null/)
+  assert.match(storageSource, /swarmOptions\.port = Number\(swarmPort\)/)
+  assert.match(storageSource, /Requested Hyperswarm\/DHT port/)
+})

--- a/packages/cli/src/config.js
+++ b/packages/cli/src/config.js
@@ -255,10 +255,11 @@ function configFromEnv(env = {}) {
       config.discovery.maxChannelsPerOwner = Number(env.PEARTUBE_DISCOVERY_MAX_CHANNELS_PER_OWNER)
     }
   }
-  if (env.PEARTUBE_NETWORK_ANNOUNCE || env.PEARTUBE_NETWORK_BOOTSTRAP || env.PEARTUBE_RELAY_BLIND_PEER_ENABLED || env.PEARTUBE_RELAY_BLIND_PEER_TRUSTED_CLIENTS) {
+  if (env.PEARTUBE_NETWORK_ANNOUNCE || env.PEARTUBE_NETWORK_BOOTSTRAP || env.PEARTUBE_NETWORK_PORT || env.PEARTUBE_RELAY_BLIND_PEER_ENABLED || env.PEARTUBE_RELAY_BLIND_PEER_TRUSTED_CLIENTS) {
     config.network = {}
     if (env.PEARTUBE_NETWORK_ANNOUNCE) config.network.announce = parseBoolean(env.PEARTUBE_NETWORK_ANNOUNCE)
     if (env.PEARTUBE_NETWORK_BOOTSTRAP) config.network.bootstrap = env.PEARTUBE_NETWORK_BOOTSTRAP
+    if (env.PEARTUBE_NETWORK_PORT) config.network.port = Number(env.PEARTUBE_NETWORK_PORT)
     if (env.PEARTUBE_RELAY_BLIND_PEER_ENABLED) config.network.blindPeer = parseBoolean(env.PEARTUBE_RELAY_BLIND_PEER_ENABLED)
     if (env.PEARTUBE_RELAY_BLIND_PEER_TRUSTED_CLIENTS) config.network.trustedBlindPeerClients = splitCommaList(env.PEARTUBE_RELAY_BLIND_PEER_TRUSTED_CLIENTS)
   }

--- a/packages/cli/src/constants.js
+++ b/packages/cli/src/constants.js
@@ -82,6 +82,7 @@ export const DEFAULT_RELAY_CONFIG = {
   network: {
     announce: true,
     bootstrap: 'default',
+    port: 0,
     blindPeer: true,
     trustedBlindPeerClients: []
   },

--- a/packages/cli/src/runtime.js
+++ b/packages/cli/src/runtime.js
@@ -36,6 +36,7 @@ export async function createRelayRuntime({ config, logger }) {
     storagePath: storageRoot,
     primaryKey,
     wrapTimeout: true,
+    swarmPort: config?.network?.port || null,
     // Docker/bind-mounted relay volumes can trip device-file inode/mtime validation
     // across clean container restarts even with the same persisted primary key.
     // The relay is a single-writer service, so disable device-file enforcement here.

--- a/packages/cli/test/config.test.mjs
+++ b/packages/cli/test/config.test.mjs
@@ -102,6 +102,7 @@ test('loadRelayConfig supports env-only relay configuration', async (t) => {
       PEARTUBE_DISCOVERY_MAX_CHANNELS_PER_OWNER: '3',
       PEARTUBE_NETWORK_ANNOUNCE: 'false',
       PEARTUBE_NETWORK_BOOTSTRAP: 'local',
+      PEARTUBE_NETWORK_PORT: '49737',
       PEARTUBE_RELAY_BLIND_PEER_ENABLED: 'false',
       PEARTUBE_RELAY_BLIND_PEER_TRUSTED_CLIENTS: 'aa,bb',
       PEARTUBE_RETENTION_PROTECT_PRIVATE: 'false',
@@ -122,6 +123,7 @@ test('loadRelayConfig supports env-only relay configuration', async (t) => {
   t.is(config.discovery.maxChannelsPerOwner, 3)
   t.is(config.network.announce, false)
   t.is(config.network.bootstrap, 'local')
+  t.is(config.network.port, 49737)
   t.is(config.network.blindPeer, false)
   t.alike(config.network.trustedBlindPeerClients, ['aa', 'bb'])
   t.is(config.retention.protectPrivate, false)


### PR DESCRIPTION
## Summary

This moves the relay debugging boundary below the Hyperswarm `connection` event. The v0.1.66 logs show the recursive redial is gone, relay hints are preserved, and Hyperswarm attempts connects, but every attempt dies before an opened socket:

- DHT discovery works: peers discovered with `relayAddresses: 3`
- explicit peer queueing works
- `connections: 0`, `recentConnections: []`
- `dht.firewalled: true`, `dht.ephemeral: true`

So this PR does two things:

1. Captures pre-open DHT connect lifecycle diagnostics by wrapping `swarm._connect` and recording client-attempt streams before Hyperswarm emits `connection`.
2. Gives the relay a fixed UDP Hyperswarm/DHT port path via `PEARTUBE_NETWORK_PORT`, and exposes `49737/udp` in the relay compose file.

## Why

The relay is currently visible in the DHT but firewalled/ephemeral. If Docker/VPS UDP is the blocker, the current diagnostics never show the close/error reason because no Hyperswarm `connection` event fires. This makes the next relay status/logs show raw stream close/error events, local/remote addresses, and DHT bind/remote address state.

## Verification

```bash
node --test packages/backend/test/storage-startup-regression.test.mjs
npm test --prefix packages/cli -- --timeout=30000
npm run lint:changed
git diff --check
```
