### PR TITLE
fix(relay): keep DHT port automatic

### DIFF
--- a/docker-compose.relay.yml
+++ b/docker-compose.relay.yml
@@ -14,13 +14,11 @@ services:
     restart: unless-stopped
     ports:
       - "8174:8174"
-      - "49737:49737/udp"
     environment:
       PEARTUBE_MODE: public
       PEARTUBE_POLICY: discovery
       PEARTUBE_DISCOVERY_ENABLED: "true"
       PEARTUBE_NETWORK_ANNOUNCE: "true"
-      PEARTUBE_NETWORK_PORT: "49737"
       PEARTUBE_ARCHIVE_UI_ENABLED: "true"
       PEARTUBE_ARCHIVE_UI_HOST: 0.0.0.0
       PEARTUBE_ARCHIVE_UI_PORT: "8174"

--- a/packages/backend/src/storage.js
+++ b/packages/backend/src/storage.js
@@ -784,8 +784,7 @@ export async function initializeStorage(config) {
     blobServerBindHost: blobServerBindHostOverride,
     primaryKey = null,
     corestoreWaitForLock = false,
-    corestoreAllowBackup = false,
-    swarmPort = null
+    corestoreAllowBackup = false
   } = config;
 
   console.log('[Storage] Initializing storage at:', storagePath);
@@ -1025,11 +1024,7 @@ export async function initializeStorage(config) {
     swarm = createOfflineSwarm(keyPair, 'module-unavailable')
   } else {
     try {
-      const swarmOptions = { keyPair }
-      if (Number.isFinite(Number(swarmPort)) && Number(swarmPort) > 0) {
-        swarmOptions.port = Number(swarmPort)
-      }
-      swarm = new Hyperswarm(swarmOptions);
+      swarm = new Hyperswarm({ keyPair });
     } catch (err) {
       console.warn('[Storage] Hyperswarm creation failed; continuing with offline P2P networking:', err?.message)
       await appendDebugLine(`[storage] hyperswarm create failed; using offline swarm ${err?.message || String(err)}`)
@@ -1037,12 +1032,11 @@ export async function initializeStorage(config) {
     }
   }
   console.log('[Storage] Swarm created, publicKey:', b4a.toString(swarm.keyPair.publicKey, 'hex').slice(0, 16));
-  if (swarmPort) console.log('[Storage] Requested Hyperswarm/DHT port:', Number(swarmPort))
   const initialDhtState = describeDhtState(swarm.dht)
   if (initialDhtState) {
     console.log('[Storage] Initial DHT bind state:', JSON.stringify(initialDhtState))
   }
-  await appendDebugLine(`[storage] hyperswarm created offline=${Boolean(swarm._peartubeOffline)} port=${swarmPort || 'auto'}`)
+  await appendDebugLine(`[storage] hyperswarm created offline=${Boolean(swarm._peartubeOffline)}`)
   globalSwarmDiagnostics = createSwarmDiagnostics(swarm)
   installSwarmConnectDiagnostics(swarm, globalSwarmDiagnostics)
   installSwarmPeerDiscoveryEmitter(swarm)

--- a/packages/backend/test/storage-startup-regression.test.mjs
+++ b/packages/backend/test/storage-startup-regression.test.mjs
@@ -131,9 +131,3 @@ test('storage captures pre-open DHT connect close diagnostics', () => {
   assert.match(storageSource, /remoteHost: rawStream\.remoteHost/)
   assert.match(storageSource, /event, \.\.\.detail/)
 })
-
-test('storage accepts an optional fixed swarm port for relay diagnostics', () => {
-  assert.match(storageSource, /swarmPort = null/)
-  assert.match(storageSource, /swarmOptions\.port = Number\(swarmPort\)/)
-  assert.match(storageSource, /Requested Hyperswarm\/DHT port/)
-})

--- a/packages/cli/src/config.js
+++ b/packages/cli/src/config.js
@@ -255,11 +255,10 @@ function configFromEnv(env = {}) {
       config.discovery.maxChannelsPerOwner = Number(env.PEARTUBE_DISCOVERY_MAX_CHANNELS_PER_OWNER)
     }
   }
-  if (env.PEARTUBE_NETWORK_ANNOUNCE || env.PEARTUBE_NETWORK_BOOTSTRAP || env.PEARTUBE_NETWORK_PORT || env.PEARTUBE_RELAY_BLIND_PEER_ENABLED || env.PEARTUBE_RELAY_BLIND_PEER_TRUSTED_CLIENTS) {
+  if (env.PEARTUBE_NETWORK_ANNOUNCE || env.PEARTUBE_NETWORK_BOOTSTRAP || env.PEARTUBE_RELAY_BLIND_PEER_ENABLED || env.PEARTUBE_RELAY_BLIND_PEER_TRUSTED_CLIENTS) {
     config.network = {}
     if (env.PEARTUBE_NETWORK_ANNOUNCE) config.network.announce = parseBoolean(env.PEARTUBE_NETWORK_ANNOUNCE)
     if (env.PEARTUBE_NETWORK_BOOTSTRAP) config.network.bootstrap = env.PEARTUBE_NETWORK_BOOTSTRAP
-    if (env.PEARTUBE_NETWORK_PORT) config.network.port = Number(env.PEARTUBE_NETWORK_PORT)
     if (env.PEARTUBE_RELAY_BLIND_PEER_ENABLED) config.network.blindPeer = parseBoolean(env.PEARTUBE_RELAY_BLIND_PEER_ENABLED)
     if (env.PEARTUBE_RELAY_BLIND_PEER_TRUSTED_CLIENTS) config.network.trustedBlindPeerClients = splitCommaList(env.PEARTUBE_RELAY_BLIND_PEER_TRUSTED_CLIENTS)
   }

--- a/packages/cli/src/constants.js
+++ b/packages/cli/src/constants.js
@@ -82,7 +82,6 @@ export const DEFAULT_RELAY_CONFIG = {
   network: {
     announce: true,
     bootstrap: 'default',
-    port: 0,
     blindPeer: true,
     trustedBlindPeerClients: []
   },

--- a/packages/cli/src/runtime.js
+++ b/packages/cli/src/runtime.js
@@ -36,7 +36,6 @@ export async function createRelayRuntime({ config, logger }) {
     storagePath: storageRoot,
     primaryKey,
     wrapTimeout: true,
-    swarmPort: config?.network?.port || null,
     // Docker/bind-mounted relay volumes can trip device-file inode/mtime validation
     // across clean container restarts even with the same persisted primary key.
     // The relay is a single-writer service, so disable device-file enforcement here.

--- a/packages/cli/test/config.test.mjs
+++ b/packages/cli/test/config.test.mjs
@@ -102,7 +102,6 @@ test('loadRelayConfig supports env-only relay configuration', async (t) => {
       PEARTUBE_DISCOVERY_MAX_CHANNELS_PER_OWNER: '3',
       PEARTUBE_NETWORK_ANNOUNCE: 'false',
       PEARTUBE_NETWORK_BOOTSTRAP: 'local',
-      PEARTUBE_NETWORK_PORT: '49737',
       PEARTUBE_RELAY_BLIND_PEER_ENABLED: 'false',
       PEARTUBE_RELAY_BLIND_PEER_TRUSTED_CLIENTS: 'aa,bb',
       PEARTUBE_RETENTION_PROTECT_PRIVATE: 'false',
@@ -123,7 +122,6 @@ test('loadRelayConfig supports env-only relay configuration', async (t) => {
   t.is(config.discovery.maxChannelsPerOwner, 3)
   t.is(config.network.announce, false)
   t.is(config.network.bootstrap, 'local')
-  t.is(config.network.port, 49737)
   t.is(config.network.blindPeer, false)
   t.alike(config.network.trustedBlindPeerClients, ['aa', 'bb'])
   t.is(config.retention.protectPrivate, false)


### PR DESCRIPTION
## Summary

Corrects the v0.1.67 relay diagnostic release by removing the fixed/manual Hyperswarm UDP port path.

The pre-open DHT connect diagnostics are still useful and remain in place, but relay networking should stay automatic. The relay compose file should not publish a static DHT port, and runtime/config should not expose `PEARTUBE_NETWORK_PORT` as a normal relay knob.

## Changes

- Remove `49737/udp` from `docker-compose.relay.yml`
- Remove `PEARTUBE_NETWORK_PORT` from relay compose/config/env parsing
- Remove `swarmPort` runtime plumbing into `initializeStorage()`
- Keep the pre-open Hyperswarm `_connect` diagnostics from PR #132
- Keep DHT bind-state/status diagnostics

## Verification

```bash
node --test packages/backend/test/storage-startup-regression.test.mjs
npm test --prefix packages/cli -- --timeout=30000
npm run lint:changed
git diff --check
```
