### PR TITLE
diagnose(relay): surface no-peer DHT bootstrap state

### DIFF
--- a/packages/cli/src/runtime.js
+++ b/packages/cli/src/runtime.js
@@ -248,7 +248,8 @@ export async function createRelayRuntime({ config, logger }) {
         dht: {
           bootstrapped: ctx.swarm?.dht?.bootstrapped ?? null,
           firewalled: ctx.swarm?.dht?.firewalled ?? null,
-          online: ctx.swarm?.dht?.online ?? null
+          online: ctx.swarm?.dht?.online ?? null,
+          ephemeral: ctx.swarm?.dht?.ephemeral ?? null
         },
         publicFeedDiscoveryJoined: Boolean(publicFeed.feedDiscovery),
         blindPeer: blindPeer.getStats?.() || null,

--- a/packages/cli/src/service.js
+++ b/packages/cli/src/service.js
@@ -246,6 +246,23 @@ export async function createRelayService({
               redialed
             })
           }
+          const dht = heartbeatStatus.runtime.dht || {}
+          if ((heartbeatStatus.runtime.peers || 0) === 0 && dht.bootstrapped === false) {
+            logger.status.warn('Relay DHT has no discovered peers and is not bootstrapped', {
+              peers: heartbeatStatus.runtime.peers || 0,
+              connections: heartbeatStatus.runtime.connections || 0,
+              bootstrapped: dht.bootstrapped,
+              firewalled: dht.firewalled ?? null,
+              online: dht.online ?? null,
+              ephemeral: dht.ephemeral ?? null,
+              publicFeedDiscoveryJoined: Boolean(heartbeatStatus.runtime.publicFeedDiscoveryJoined),
+              peerPoolJoined: Boolean(heartbeatStatus.runtime.peerPoolJoined),
+              swarmListenResolved: Boolean(heartbeatStatus.runtime.swarmListenResolved),
+              swarmOffline: Boolean(heartbeatStatus.runtime.swarmOffline),
+              swarmOfflineReason: heartbeatStatus.runtime.swarmOfflineReason || null,
+              hyperswarm: heartbeatStatus.runtime.hyperswarm || null
+            })
+          }
           logger.status.info('Relay heartbeat', {
             peers: heartbeatStatus.runtime.peers,
             connections: heartbeatStatus.runtime.connections,

--- a/packages/cli/test/service.test.mjs
+++ b/packages/cli/test/service.test.mjs
@@ -33,7 +33,16 @@ function createFakeRuntime() {
       }
     },
     getNetworkStats() {
-      return { peers: 3, connections: 2 }
+      return {
+        peers: 3,
+        connections: 2,
+        dht: {
+          bootstrapped: true,
+          firewalled: false,
+          online: true,
+          ephemeral: null
+        }
+      }
     },
     async close() {},
     ctx: {
@@ -379,6 +388,102 @@ test('relay heartbeat logs Hyperswarm dial diagnostics when peers have no socket
     t.alike(warning.data.hyperswarm, {
       recentPeers: [{ key: 'peer-a', relayAddresses: 0 }],
       allConnections: [{ key: 'peer-a', opened: false, destroyed: false }]
+    })
+
+    await service.close()
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('relay heartbeat logs DHT bootstrap diagnostics when no peers are discovered', async (t) => {
+  const dir = makeTempDir('peartube-relay-service-dht-bootstrap-')
+  const runtime = createFakeRuntime()
+  runtime.getNetworkStats = () => ({
+    peers: 0,
+    connections: 0,
+    dht: {
+      bootstrapped: false,
+      firewalled: true,
+      online: true,
+      ephemeral: true
+    },
+    publicFeedDiscoveryJoined: true,
+    peerPoolJoined: true,
+    swarmListenResolved: true,
+    swarmOffline: false,
+    hyperswarm: {
+      recentPeers: [],
+      recentUpdates: [],
+      recentConnections: [],
+      peerStates: [],
+      allConnections: []
+    },
+    directPeerDial: {
+      discoveredPeers: 0,
+      queued: 0,
+      skipped: 0,
+      failed: 0
+    }
+  })
+  const logger = createFakeLogger()
+  let scheduled = null
+
+  function setIntervalFn(fn, ms) {
+    scheduled = { fn, ms, timer: {} }
+    return scheduled.timer
+  }
+
+  try {
+    const service = await createRelayService({
+      config: {
+        mode: 'public',
+        policy: 'discovery',
+        storage: { path: dir, maxBytes: 10_000 },
+        paths: {
+          catalog: join(dir, 'relay-catalog.json'),
+          status: join(dir, 'relay-status.json')
+        },
+        admission: {
+          channels: [],
+          owners: []
+        },
+        discovery: {
+          enabled: true,
+          maxChannels: 5,
+          maxChannelsPerOwner: 2
+        }
+      },
+      logger,
+      runtimeFactory: async () => runtime,
+      mirrorChannel: async () => ({ bytesDownloaded: 0, videosFound: 0, videosDownloaded: 0 }),
+      writeStatusFile: async () => {},
+      setIntervalFn
+    })
+
+    await service.start()
+    await scheduled.fn()
+
+    const warning = logger.entries.find((entry) => (
+      entry.component === 'status' &&
+      entry.level === 'warn' &&
+      entry.msg === 'Relay DHT has no discovered peers and is not bootstrapped'
+    ))
+    t.ok(warning)
+    t.is(warning.data.peers, 0)
+    t.is(warning.data.bootstrapped, false)
+    t.is(warning.data.firewalled, true)
+    t.is(warning.data.online, true)
+    t.is(warning.data.ephemeral, null)
+    t.is(warning.data.publicFeedDiscoveryJoined, true)
+    t.is(warning.data.peerPoolJoined, true)
+    t.is(warning.data.swarmListenResolved, true)
+    t.alike(warning.data.hyperswarm, {
+      recentPeers: [],
+      recentUpdates: [],
+      recentConnections: [],
+      peerStates: [],
+      allConnections: []
     })
 
     await service.close()


### PR DESCRIPTION
## Summary
- surface DHT bootstrap state in relay runtime status, including `ephemeral`
- emit an explicit heartbeat warning when the relay has zero discovered peers and `dht.bootstrapped === false`
- include Hyperswarm diagnostics in the no-peer/no-bootstrap warning so the next logs show whether discovery is failing before peer events

## Why
The latest relay logs show a different failure mode than the previous discovered-peer/no-socket case:

```json
"peers":0,
"connections":0,
"discoveredPeers":0,
"dht":{"bootstrapped":false,"firewalled":true,"online":true},
"publicFeedDiscoveryJoined":true,
"peerPoolJoined":true
```

The relay is seeded and serving cached entries, but it is not discovering peers at all. The existing heartbeat collapsed that into repeated zero counters, which was too lossy.

## Verification
```bash
node --test packages/cli/test/service.test.mjs
node --test packages/backend/test/storage-startup-regression.test.mjs
npm test --prefix packages/cli -- --timeout=30000
npm run lint:changed
git diff --check
```
