### PR TITLE
refactor(relay): remove forced peer redial loop

### DIFF
--- a/packages/app/tests/native-backend-startup-regression.test.mjs
+++ b/packages/app/tests/native-backend-startup-regression.test.mjs
@@ -79,7 +79,7 @@ test('native root layout clears startup timeout and releases loading on explicit
   assert.match(catchBlock, /setLoading\(false\)/)
 })
 
-test('backend orchestrator explicitly dials peers discovered on the single shared topic', () => {
+test('backend orchestrator records peers discovered on the single shared topic', () => {
   const source = readWorkspaceFile('backend/src/orchestrator.js')
 
   assert.match(source, /ctx\.swarm\.on\('peer'/)

--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -21,7 +21,7 @@ import b4a from 'b4a'
 import { NETWORK_TOPIC_STRING, PROTOCOL_NAME } from './types.js';
 import { logger } from './logger.js'
 import { hashFeedEntries, hashPreviewVideos } from './hash-utils.js'
-import { ensureSwarmPeerConnection, peerPublicKey, swarmHasConnection } from './swarm-peer-dial.js'
+import { peerPublicKey, swarmHasConnection } from './swarm-peer-dial.js'
 
 const log = logger('PublicFeed')
 const PUBLIC_FEED_CATALOG_VERSION = 1
@@ -73,9 +73,7 @@ export class PublicFeedManager {
     this._nextAvailabilityRequestId = 1;
     /** @type {Map<string, { resolve: Function, timeout: any }>} */
     this.pendingAvailabilityRequests = new Map();
-    /** @type {Map<string, number>} */
-    this._directPeerRetryCounts = new Map();
-    /** @type {Map<string, any>} */
+    /** @type {Map<string, any>} Remembered Hyperswarm peer candidates for diagnostics only. */
     this._discoveredPeers = new Map();
     /** @type {Map<string, number>} */
     this._directPeerLastDialedAt = new Map();
@@ -83,10 +81,6 @@ export class PublicFeedManager {
     this._directPeerLastDialError = new Map();
     /** @type {Map<string, string>} */
     this._directPeerLastDialErrorStack = new Map();
-    /** @type {Map<string, number>} */
-    this._directPeerLastQueuedAt = new Map();
-    /** @type {Set<string>} */
-    this._directPeerPending = new Set();
     /** @type {{attempted: number, queued: number, skipped: number, failed: number, connected: number, lastReason: string | null, lastDialedAt: number | null}} */
     this._directPeerDialStats = {
       attempted: 0,
@@ -97,12 +91,6 @@ export class PublicFeedManager {
       lastReason: null,
       lastDialedAt: null,
     };
-    /** @type {number} */
-    this._directPeerPendingTimeoutMs = 15000;
-    /** @type {number} */
-    this._maxDirectPeerRetries = 3;
-    /** @type {number} */
-    this._maxDirectPeers = 16;
     /** @type {() => number} */
     this._now = () => Date.now();
     /** @type {any | null} */
@@ -457,19 +445,10 @@ export class PublicFeedManager {
   _markPeerConnected(publicKey) {
     const remembered = this._rememberPeerPublicKey(publicKey)
     if (!remembered) return
-    this._directPeerPending.delete(remembered.keyHex)
-    this._directPeerLastQueuedAt.delete(remembered.keyHex)
-    this._directPeerRetryCounts.delete(remembered.keyHex)
     this._directPeerLastDialError.delete(remembered.keyHex)
     this._directPeerLastDialErrorStack.delete(remembered.keyHex)
     this._directPeerDialStats.connected++
     this._directPeerDialStats.lastReason = 'connected'
-  }
-
-  _pendingDialExpired(keyHex) {
-    if (!this._directPeerPending.has(keyHex)) return true
-    const queuedAt = this._directPeerLastQueuedAt.get(keyHex) || 0
-    return this._now() - queuedAt >= this._directPeerPendingTimeoutMs
   }
 
   _connectionLabel(conn, info = null) {
@@ -509,132 +488,28 @@ export class PublicFeedManager {
     return { keyHex, publicKey }
   }
 
-  _harvestSwarmPeersForDial() {
-    let remembered = 0
-    for (const peer of this._swarmPeerEntries()) {
-      if (!this._peerEntryHasNetworkTopic(peer)) continue
-      const publicKey = this._peerEntryPublicKey(peer)
-      const keyHex = publicKey ? b4a.toString(publicKey, 'hex') : null
-      const wasRemembered = keyHex ? this._discoveredPeers.has(keyHex) : false
-      const rememberedPeer = this._rememberPeerPublicKey(publicKey)
-      if (rememberedPeer && !wasRemembered && !this._peerEntryIsConnected(peer)) remembered++
-    }
-    return remembered
-  }
-
   /**
-   * Remember a discovered peer and explicitly dial it when the shared topic has
-   * found peers but Hyperswarm has not promoted them into connections yet.
-   * This keeps the hard-cutover architecture on one topic while making the
-   * Protomux feed channel less dependent on passive connection timing.
+   * Remember a shared-topic peer candidate. Hyperswarm owns dialing and retry
+   * lifecycle after discovery; PublicFeedManager only uses opened sockets.
    * @param {any} peer
    * @param {Buffer | Uint8Array | string | null} [topic]
    * @returns {boolean}
    */
-  _queueDiscoveredPeer(peer, topic) {
-    const publicKey = this._peerEntryPublicKey(peer)
-    if (!publicKey || !this.swarm) return null
-    return this._rememberPeerPublicKey(publicKey)
-  }
-
   handleDiscoveredPeer(peer, topic = null) {
     if (topic && !this._isNetworkTopic(topic)) return false
     if (!this.swarm) return false
-
-    const remembered = this._queueDiscoveredPeer(peer, topic)
-    if (!remembered) return false
-    if (this._hasActivePeerConnection(remembered.keyHex, remembered.publicKey)) return false
-
-    return this._dialDiscoveredPeer(remembered.keyHex, remembered.publicKey, peer, topic)
-  }
-
-  _dialDiscoveredPeer(keyHex, publicKey, peer = publicKey, topic = null) {
-    this._directPeerDialStats.attempted++
-    if (!publicKey || !this.swarm) {
-      this._directPeerDialStats.skipped++
-      this._directPeerDialStats.lastReason = 'swarm-unavailable'
-      return false
-    }
-    if (!keyHex || keyHex === b4a.toString(this.swarm.keyPair?.publicKey || [], 'hex')) {
+    const publicKey = this._peerEntryPublicKey(peer)
+    const remembered = this._rememberPeerPublicKey(publicKey)
+    if (!remembered) {
       this._directPeerDialStats.skipped++
       this._directPeerDialStats.lastReason = 'self-or-missing-key'
       return false
     }
-    if (this._hasActivePeerConnection(keyHex, publicKey)) {
-      this._directPeerPending.delete(keyHex)
-      this._directPeerLastQueuedAt.delete(keyHex)
+    if (this._hasActivePeerConnection(remembered.keyHex, remembered.publicKey)) {
       this._directPeerDialStats.skipped++
       this._directPeerDialStats.lastReason = 'already-connected-peer'
-      return false
     }
-    if (this._directPeerPending.has(keyHex) && !this._pendingDialExpired(keyHex)) {
-      this._directPeerDialStats.skipped++
-      this._directPeerDialStats.lastReason = 'dial-already-pending'
-      return false
-    }
-    if ((this.swarm.connections?.size || 0) >= this._maxDirectPeers) {
-      this._directPeerDialStats.skipped++
-      this._directPeerDialStats.lastReason = 'max-direct-peers'
-      return false
-    }
-    const attempts = this._directPeerRetryCounts.get(keyHex) || 0
-    if (this._maxDirectPeerRetries > 0 && attempts >= this._maxDirectPeerRetries) {
-      this._directPeerDialStats.skipped++
-      this._directPeerDialStats.lastReason = 'max-direct-peer-retries'
-      return false
-    }
-    // Once a peer is marked explicit, Hyperswarm owns transport retry/backoff.
-    // The app-level nudge is capped so relay heartbeats do not create noisy
-    // redial loops when the DHT transport is failing below the feed protocol.
-    try {
-      const result = ensureSwarmPeerConnection(this.swarm, peer || publicKey, topic)
-      if (!result.queued) {
-        this._directPeerDialStats.skipped++
-        this._directPeerDialStats.lastReason = result.reason || 'queue-skipped'
-        if (result.error) {
-          this._directPeerLastDialError.set(keyHex, result.errorMessage || result.error)
-          this._directPeerLastDialErrorStack.set(keyHex, result.error)
-        }
-        return false
-      }
-      const now = this._now()
-      this._directPeerRetryCounts.set(keyHex, attempts + 1)
-      this._directPeerLastDialedAt.set(keyHex, now)
-      this._directPeerLastQueuedAt.set(keyHex, now)
-      this._directPeerPending.add(keyHex)
-      this._directPeerLastDialError.delete(keyHex)
-      this._directPeerLastDialErrorStack.delete(keyHex)
-      this._directPeerDialStats.queued++
-      this._directPeerDialStats.lastReason = 'queued'
-      this._directPeerDialStats.lastDialedAt = now
-      console.log('[PublicFeed] Direct peer dial queued from shared topic:', keyHex.slice(0, 16), 'attempt=', attempts + 1)
-      return true
-    } catch (err) {
-      const message = err?.message || String(err)
-      this._directPeerDialStats.failed++
-      this._directPeerDialStats.lastReason = 'joinPeer-error'
-      this._directPeerLastDialError.set(keyHex, message)
-      if (err?.stack) this._directPeerLastDialErrorStack.set(keyHex, err.stack)
-      console.log('[PublicFeed] Direct peer dial failed:', keyHex.slice(0, 16), message)
-      return false
-    }
-  }
-
-  _redialDiscoveredPeers({ force = false } = {}) {
-    if (!this.swarm || typeof this.swarm.joinPeer !== 'function') return 0
-    const harvested = this._harvestSwarmPeersForDial()
-    if (harvested > 0) console.log('[PublicFeed] Harvested swarm peers for direct dial:', harvested)
-    if (!this._discoveredPeers.size) return 0
-    let dialed = 0
-    for (const [keyHex, publicKey] of this._discoveredPeers) {
-      if ((this.swarm.connections?.size || 0) >= this._maxDirectPeers) break
-      if (this._dialDiscoveredPeer(keyHex, publicKey)) dialed++
-    }
-    return dialed
-  }
-
-  forceRedialDiscoveredPeers() {
-    return this._redialDiscoveredPeers({ force: true })
+    return true
   }
 
   _swarmDialState(keyHex) {
@@ -662,28 +537,26 @@ export class PublicFeedManager {
   getDirectPeerDialStats() {
     const peers = []
     for (const [keyHex] of this._discoveredPeers) {
-      const pending = this._directPeerPending.has(keyHex) && !this._pendingDialExpired(keyHex)
+      const swarm = this._swarmDialState(keyHex)
       peers.push({
         key: keyHex.slice(0, 16),
-        attempts: this._directPeerRetryCounts.get(keyHex) || 0,
+        attempts: swarm?.attempts || 0,
         lastDialedAt: this._directPeerLastDialedAt.get(keyHex) || null,
-        lastQueuedAt: this._directPeerLastQueuedAt.get(keyHex) || null,
+        lastQueuedAt: null,
         lastError: this._directPeerLastDialError.get(keyHex) || null,
         lastErrorStack: this._directPeerLastDialErrorStack.get(keyHex) || null,
-        pending,
+        pending: Boolean(swarm?.queued || swarm?.waiting),
         connected: this._hasActivePeerConnection(keyHex, this._discoveredPeers.get(keyHex)),
-        swarm: this._swarmDialState(keyHex),
+        swarm,
       })
     }
 
     return {
       ...this._directPeerDialStats,
       discoveredPeers: this._discoveredPeers.size,
-      pending: Array.from(this._discoveredPeers.keys())
-        .filter((keyHex) => this._directPeerPending.has(keyHex) && !this._pendingDialExpired(keyHex))
-        .length,
-      maxDirectPeers: this._maxDirectPeers,
-      maxDirectPeerRetries: this._maxDirectPeerRetries,
+      pending: peers.filter((peer) => peer.pending).length,
+      maxDirectPeers: null,
+      maxDirectPeerRetries: null,
       swarmPeers: this.swarm?.peers?.size || 0,
       swarmConnections: this.swarm?.connections?.size || 0,
       swarmAllConnections: this.swarm?._allConnections?.size || 0,
@@ -816,10 +689,6 @@ export class PublicFeedManager {
     for (const conn of this.swarm.connections) {
       this.handleConnection(conn, {});
     }
-    const redialedPeers = this._redialDiscoveredPeers()
-    if (redialedPeers) {
-      console.log('[PublicFeed] Redialed shared-topic peers on startup:', redialedPeers)
-    }
     this._startGossipLoop()
     console.log('[PublicFeed] ===== PUBLIC FEED STARTED =====');
   }
@@ -834,13 +703,10 @@ export class PublicFeedManager {
     try {
       this._gossipInterval = setInterval(() => {
         if (!this.started) return
-        const redialed = this._redialDiscoveredPeers()
         const openConns = this._openFeedConnections()
         if (openConns.length === 0) {
           if (this.peerChannels.size > 0) {
-            console.log('[PublicFeed] Periodic feed gossip skipped unopened channels=', this.peerChannels.size, 'redialed=', redialed)
-          } else if (redialed) {
-            console.log('[PublicFeed] Periodic feed gossip announced= 0 requested= 0 redialed=', redialed)
+            console.log('[PublicFeed] Periodic feed gossip skipped unopened channels=', this.peerChannels.size)
           }
           return
         }
@@ -854,8 +720,8 @@ export class PublicFeedManager {
           }
         }
         const requested = this.requestFeedsFromPeers()
-        if (announced || requested || redialed) {
-          console.log('[PublicFeed] Periodic feed gossip announced=', announced, 'requested=', requested, 'redialed=', redialed)
+        if (announced || requested) {
+          console.log('[PublicFeed] Periodic feed gossip announced=', announced, 'requested=', requested)
         }
       }, this._gossipIntervalMs)
       if (typeof this._gossipInterval?.unref === 'function') this._gossipInterval.unref()
@@ -883,13 +749,10 @@ export class PublicFeedManager {
         try { pending.resolve([]) } catch {}
       }
       this.pendingAvailabilityRequests.clear()
-      this._directPeerRetryCounts.clear()
       this._discoveredPeers.clear()
       this._directPeerLastDialedAt.clear()
       this._directPeerLastDialError.clear()
       this._directPeerLastDialErrorStack.clear()
-      this._directPeerLastQueuedAt.clear()
-      this._directPeerPending.clear()
       if (this._persistTimer) clearTimeout(this._persistTimer)
       if (this._gossipInterval) clearInterval(this._gossipInterval)
       this.feedDiscovery?.destroy?.()

--- a/packages/backend/src/storage.js
+++ b/packages/backend/src/storage.js
@@ -459,7 +459,6 @@ function installSwarmPeerDiscoveryEmitter(swarm) {
   if (typeof swarm._handlePeer !== 'function' || typeof swarm.emit !== 'function') return false
 
   const handlePeer = swarm._handlePeer
-  swarm._peartubeHandlePeerWithoutEmit = handlePeer
   swarm._handlePeer = function peartubeHandlePeer(peer, topic) {
     const result = handlePeer.call(this, peer, topic)
     try {

--- a/packages/backend/src/swarm-peer-dial.js
+++ b/packages/backend/src/swarm-peer-dial.js
@@ -44,36 +44,6 @@ export function swarmConnectionLike(entry) {
   )
 }
 
-function relayAddressesFromPeer(peer) {
-  return Array.isArray(peer?.relayAddresses) && peer.relayAddresses.length > 0 ? peer.relayAddresses : null
-}
-
-function upsertPeerWithoutEmit(swarm, peer, publicKey, topic) {
-  if (!swarm || !publicKey || !peer || typeof peer !== 'object') return null
-  if (b4a.isBuffer(peer) || peer instanceof Uint8Array) return null
-
-  const relayAddresses = relayAddressesFromPeer(peer)
-  const keyHex = b4a.toString(publicKey, 'hex')
-  const existing = swarm.peers?.get?.(keyHex) || null
-  if (!relayAddresses) {
-    if (existing && topic && typeof existing._topic === 'function') existing._topic(topic)
-    return existing
-  }
-
-  if (typeof swarm._upsertPeer === 'function') {
-    const peerInfo = swarm._upsertPeer(publicKey, relayAddresses)
-    if (peerInfo && topic && typeof peerInfo._topic === 'function') peerInfo._topic(topic)
-    return peerInfo
-  }
-
-  const handlePeer = swarm._peartubeHandlePeerWithoutEmit
-  if (topic && typeof handlePeer === 'function') {
-    return handlePeer.call(swarm, { publicKey, relayAddresses }, topic) || null
-  }
-
-  return null
-}
-
 export function swarmHasConnection(swarm, keyHex, publicKey = null) {
   if (!swarm || !keyHex) return false
   const connections = swarm.connections
@@ -106,51 +76,4 @@ export function swarmHasConnection(swarm, keyHex, publicKey = null) {
     }
   }
   return false
-}
-
-export function ensureSwarmPeerConnection(swarm, peer, topic = null) {
-  const publicKey = peerPublicKey(peer)
-  if (!swarm || !publicKey) return { queued: false, reason: 'missing-peer' }
-  const keyHex = b4a.toString(publicKey, 'hex')
-  if (!keyHex || keyHex === b4a.toString(swarm.keyPair?.publicKey || [], 'hex')) {
-    return { queued: false, reason: 'self-or-missing-key', keyHex, publicKey }
-  }
-  if (swarmHasConnection(swarm, keyHex)) {
-    return { queued: false, reason: 'already-connected-peer', keyHex, publicKey }
-  }
-
-  try {
-    const preservedPeerInfo = topic ? upsertPeerWithoutEmit(swarm, peer, publicKey, topic) : null
-
-    const peerInfo = preservedPeerInfo || swarm.peers?.get?.(keyHex)
-    if (peerInfo?.queued) {
-      peerInfo.explicit = true
-      swarm.explicitPeers?.add?.(peerInfo)
-      return { queued: true, reason: 'queued', keyHex, publicKey }
-    }
-    if (peerInfo && typeof swarm._enqueue === 'function' && typeof peerInfo._updatePriority === 'function') {
-      peerInfo.explicit = true
-      swarm.explicitPeers?.add?.(peerInfo)
-      if (!swarm._allConnections?.has?.(publicKey) && peerInfo._updatePriority()) {
-        const queued = swarm._enqueue(peerInfo) !== false
-        return { queued, reason: queued ? 'queued' : 'enqueue-skipped', keyHex, publicKey }
-      }
-      return { queued: false, reason: 'already-connecting', keyHex, publicKey }
-    }
-
-    if (typeof swarm.joinPeer === 'function') {
-      swarm.joinPeer(publicKey)
-      return { queued: true, reason: 'queued', keyHex, publicKey }
-    }
-    return { queued: false, reason: 'joinPeer-unavailable', keyHex, publicKey }
-  } catch (err) {
-    return {
-      queued: false,
-      reason: 'queue-error',
-      keyHex,
-      publicKey,
-      errorMessage: err?.message || String(err),
-      error: err?.stack || err?.message || String(err)
-    }
-  }
 }

--- a/packages/backend/test/public-feed-manager.test.mjs
+++ b/packages/backend/test/public-feed-manager.test.mjs
@@ -7,7 +7,6 @@ import b4a from 'b4a'
 
 import Protomux from 'protomux'
 
-import { ensureSwarmPeerConnection } from '../src/swarm-peer-dial.js'
 import { PublicFeedManager } from '../src/public-feed.js'
 import { NETWORK_TOPIC_STRING } from '../src/types.js'
 const DRIVE_KEY = '11'.repeat(32)
@@ -130,15 +129,19 @@ function createMemoryConnectionPair() {
   return [a, b]
 }
 
-test('PublicFeedManager explicitly dials peers discovered on the shared topic', () => {
+test('PublicFeedManager records peers discovered on the shared topic without app-level redialing', () => {
   const swarm = createSwarm()
   const manager = new PublicFeedManager(swarm, createMetaDb())
   const publicKey = b4a.alloc(32, 7)
 
   try {
     assert.equal(manager.handleDiscoveredPeer({ publicKey }, NETWORK_TOPIC), true)
-    assert.equal(swarm.joinPeerCalls.length, 1)
-    assert.equal(b4a.toString(swarm.joinPeerCalls[0], 'hex'), b4a.toString(publicKey, 'hex'))
+    assert.equal(swarm.joinPeerCalls.length, 0)
+    const stats = manager.getStats().directPeerDial
+    assert.equal(stats.discoveredPeers, 1)
+    assert.equal(stats.queued, 0)
+    assert.equal(stats.pending, 0)
+    assert.equal(stats.peers[0].key, b4a.toString(publicKey, 'hex').slice(0, 16))
   } finally {
     manager.stop()
   }
@@ -158,70 +161,24 @@ test('PublicFeedManager ignores peers discovered on non-app topics', () => {
   }
 })
 
-test('PublicFeedManager directly dials discovered peers that are known but not connected', () => {
-  const publicKey = b4a.alloc(32, 13)
-  const keyHex = b4a.toString(publicKey, 'hex')
-  const swarm = createSwarm()
-  swarm.peers.set(keyHex, { publicKey })
-  const manager = new PublicFeedManager(swarm, createMetaDb())
-
-  try {
-    assert.equal(manager.handleDiscoveredPeer({ publicKey }), true)
-    assert.equal(swarm.joinPeerCalls.length, 1)
-    assert.equal(b4a.toString(swarm.joinPeerCalls[0], 'hex'), keyHex)
-  } finally {
-    manager.stop()
-  }
-})
-
-test('PublicFeedManager keeps discovered relay address hints before explicit joinPeer redial', () => {
+test('PublicFeedManager keeps discovered relay address hints as Hyperswarm diagnostics', () => {
   const publicKey = b4a.alloc(32, 14)
   const keyHex = b4a.toString(publicKey, 'hex')
   const relayAddresses = [{ host: '167.86.111.230', port: 49737 }]
   const swarm = createSwarm()
+  swarm._handlePeer({ publicKey, relayAddresses }, NETWORK_TOPIC)
   const manager = new PublicFeedManager(swarm, createMetaDb())
+  swarm.joinPeerCalls.length = 0
 
   try {
     assert.equal(manager.handleDiscoveredPeer({ publicKey, relayAddresses }, NETWORK_TOPIC), true)
-    assert.equal(swarm.joinPeerCalls.length, 1)
+    assert.equal(swarm.joinPeerCalls.length, 0)
     assert.equal(swarm.peers.get(keyHex).relayAddresses, relayAddresses)
     assert.deepEqual(swarm.peers.get(keyHex).topics, [NETWORK_TOPIC])
     assert.equal(manager.getStats().directPeerDial.peers[0].swarm.relayAddresses, 1)
   } finally {
     manager.stop()
   }
-})
-
-test('ensureSwarmPeerConnection preserves relay hints without calling wrapped _handlePeer', () => {
-  const publicKey = b4a.alloc(32, 15)
-  const keyHex = b4a.toString(publicKey, 'hex')
-  const relayAddresses = [{ host: '150.136.237.154', port: 38619 }]
-  const swarm = createSwarm()
-  let handled = 0
-  const originalHandlePeer = swarm._handlePeer
-  swarm._handlePeer = (peer, topic) => {
-    handled++
-    return originalHandlePeer.call(swarm, peer, topic)
-  }
-
-  const rawResult = ensureSwarmPeerConnection(swarm, { publicKey, relayAddresses }, NETWORK_TOPIC)
-  assert.equal(rawResult.queued, true)
-  assert.equal(handled, 0)
-  assert.equal(swarm.peers.get(keyHex).relayAddresses, relayAddresses)
-
-  const peerInfo = swarm.peers.get(keyHex)
-  peerInfo.queued = false
-  peerInfo.attempts = 0
-  const peerInfoResult = ensureSwarmPeerConnection(swarm, peerInfo, NETWORK_TOPIC)
-  assert.equal(peerInfoResult.queued, true)
-  assert.equal(handled, 0)
-
-  const mapEntry = { key: keyHex, value: peerInfo }
-  peerInfo.queued = false
-  peerInfo.attempts = 0
-  const mapEntryResult = ensureSwarmPeerConnection(swarm, mapEntry, NETWORK_TOPIC)
-  assert.equal(mapEntryResult.queued, true)
-  assert.equal(handled, 0)
 })
 
 test('PublicFeedManager does not recurse through the storage peer emitter wrapper', () => {
@@ -247,7 +204,6 @@ test('PublicFeedManager does not recurse through the storage peer emitter wrappe
     for (const listener of listeners.get(event) || []) listener(...args)
     return true
   }
-  swarm._peartubeHandlePeerWithoutEmit = originalHandlePeer
   swarm._handlePeer = function wrappedHandlePeer(peer, topic) {
     const result = originalHandlePeer.call(this, peer, topic)
     this.emit('peer', peer, topic)
@@ -264,18 +220,18 @@ test('PublicFeedManager does not recurse through the storage peer emitter wrappe
 
     const stats = manager.getStats().directPeerDial
     assert.equal(emitted, 1)
-    assert.equal(stats.queued, 1)
+    assert.equal(stats.queued, 0)
     assert.equal(stats.failed, 0)
-    assert.equal(stats.skipped, 0)
+    assert.equal(stats.discoveredPeers, 1)
     assert.equal(stats.peers[0].lastError, null)
     assert.equal(swarm.peers.get(keyHex).relayAddresses, relayAddresses)
-    assert.equal(manager.getStats().directPeerDial.peers[0].swarm.relayAddresses, 3)
+    assert.equal(stats.peers[0].swarm.relayAddresses, 3)
   } finally {
     manager.stop()
   }
 })
 
-test('PublicFeedManager skips direct dials for actively connected peers across swarm shapes', () => {
+test('PublicFeedManager reports active peer connections across swarm shapes without dialing', () => {
   const publicKey = b4a.alloc(32, 8)
   const keyHex = b4a.toString(publicKey, 'hex')
   const cases = [
@@ -294,8 +250,9 @@ test('PublicFeedManager skips direct dials for actively connected peers across s
     const manager = new PublicFeedManager(swarm, createMetaDb())
 
     try {
-      assert.equal(manager.handleDiscoveredPeer({ publicKey }), false)
+      assert.equal(manager.handleDiscoveredPeer({ publicKey }), true)
       assert.equal(swarm.joinPeerCalls.length, 0)
+      assert.equal(manager.getStats().directPeerDial.peers[0].connected, true)
     } finally {
       manager.stop()
     }
@@ -310,8 +267,8 @@ test('PublicFeedManager does not treat stale Hyperswarm _allConnections keys as 
 
   try {
     assert.equal(manager.handleDiscoveredPeer({ publicKey }), true)
-    assert.equal(swarm.joinPeerCalls.length, 1)
-    assert.equal(manager.getStats().directPeerDial.lastReason, 'queued')
+    assert.equal(swarm.joinPeerCalls.length, 0)
+    assert.equal(manager.getStats().directPeerDial.peers[0].connected, false)
   } finally {
     manager.stop()
   }
@@ -325,135 +282,14 @@ test('PublicFeedManager does not treat pending Hyperswarm _allConnections entrie
 
   try {
     assert.equal(manager.handleDiscoveredPeer({ publicKey }), true)
-    assert.equal(swarm.joinPeerCalls.length, 1)
+    assert.equal(swarm.joinPeerCalls.length, 0)
     assert.equal(manager.getStats().directPeerDial.peers[0].connected, false)
   } finally {
     manager.stop()
   }
 })
 
-test('PublicFeedManager.start remembers existing discovered swarm peers for direct dialing', async () => {
-  const publicKey = b4a.alloc(32, 14)
-  const keyHex = b4a.toString(publicKey, 'hex')
-  const swarm = createSwarm()
-  swarm.peers.set(keyHex, { publicKey, topics: [NETWORK_TOPIC] })
-  const manager = new PublicFeedManager(swarm, createMetaDb())
-
-  try {
-    await manager.start()
-    assert.equal(swarm.joinPeerCalls.length, 1)
-    assert.equal(b4a.toString(swarm.joinPeerCalls[0], 'hex'), keyHex)
-  } finally {
-    manager.stop()
-  }
-})
-
-test('periodic gossip re-dials remembered shared-topic peers when sockets dropped', () => {
-  const publicKey = b4a.alloc(32, 10)
-  const swarm = createSwarm()
-  const manager = new PublicFeedManager(swarm, createMetaDb())
-  let now = 1000
-  manager._now = () => now
-
-  try {
-    assert.equal(manager.handleDiscoveredPeer({ publicKey }), true)
-    assert.equal(swarm.joinPeerCalls.length, 1)
-    now += manager._directPeerPendingTimeoutMs + 1
-    assert.equal(manager._redialDiscoveredPeers(), 1)
-    assert.equal(swarm.joinPeerCalls.length, 2)
-  } finally {
-    manager.stop()
-  }
-})
-
-test('forceRedialDiscoveredPeers caps app-level redials after pending dial windows expire', () => {
-  const publicKey = b4a.alloc(32, 11)
-  const swarm = createSwarm()
-  const manager = new PublicFeedManager(swarm, createMetaDb())
-  let now = 1000
-  manager._now = () => now
-
-  try {
-    assert.equal(manager.handleDiscoveredPeer({ publicKey }), true)
-    assert.equal(manager._redialDiscoveredPeers(), 0)
-    now += manager._directPeerPendingTimeoutMs + 1
-    assert.equal(manager._redialDiscoveredPeers(), 1)
-    now += manager._directPeerPendingTimeoutMs + 1
-    assert.equal(manager._redialDiscoveredPeers(), 1)
-    now += manager._directPeerPendingTimeoutMs + 1
-    assert.equal(manager._redialDiscoveredPeers(), 0)
-    assert.equal(swarm.joinPeerCalls.length, 3)
-
-    assert.equal(manager.forceRedialDiscoveredPeers(), 0)
-    assert.equal(swarm.joinPeerCalls.length, 3)
-    now += manager._directPeerPendingTimeoutMs + 1
-    assert.equal(manager.forceRedialDiscoveredPeers(), 0)
-    assert.equal(swarm.joinPeerCalls.length, 3)
-
-    const stats = manager.getStats().directPeerDial
-    assert.equal(stats.discoveredPeers, 1)
-    assert.equal(stats.queued, 3)
-    assert.equal(stats.lastReason, 'max-direct-peer-retries')
-    assert.equal(stats.peers[0].attempts, 3)
-  } finally {
-    manager.stop()
-  }
-})
-
-test('forceRedialDiscoveredPeers harvests swarm.peers candidates when no peer event was remembered', () => {
-  const publicKey = b4a.alloc(32, 13)
-  const swarm = createSwarm()
-  swarm.peers.set(b4a.toString(publicKey, 'hex'), { publicKey, topics: [NETWORK_TOPIC] })
-  const manager = new PublicFeedManager(swarm, createMetaDb())
-
-  try {
-    assert.equal(manager.forceRedialDiscoveredPeers(), 1)
-    assert.equal(swarm.joinPeerCalls.length, 1)
-    const stats = manager.getStats().directPeerDial
-    assert.equal(stats.discoveredPeers, 1)
-    assert.equal(stats.queued, 1)
-    assert.equal(stats.peers[0].key, b4a.toString(publicKey, 'hex').slice(0, 16))
-  } finally {
-    manager.stop()
-  }
-})
-
-test('forceRedialDiscoveredPeers skips swarm.peers candidates from non-app topics', () => {
-  const publicKey = b4a.alloc(32, 18)
-  const swarm = createSwarm()
-  swarm.peers.set(b4a.toString(publicKey, 'hex'), { publicKey, topics: [OTHER_TOPIC] })
-  const manager = new PublicFeedManager(swarm, createMetaDb())
-
-  try {
-    assert.equal(manager.forceRedialDiscoveredPeers(), 0)
-    assert.equal(swarm.joinPeerCalls.length, 0)
-    assert.equal(manager.getStats().directPeerDial.discoveredPeers, 0)
-  } finally {
-    manager.stop()
-  }
-})
-
-test('direct peer dial diagnostics expose skipped joinPeer failures', () => {
-  const publicKey = b4a.alloc(32, 12)
-  const swarm = createSwarm()
-  swarm.joinPeer = () => { throw new Error('dial unavailable') }
-  const manager = new PublicFeedManager(swarm, createMetaDb())
-
-  try {
-    assert.equal(manager.handleDiscoveredPeer({ publicKey }), false)
-    const stats = manager.getStats().directPeerDial
-    assert.equal(stats.discoveredPeers, 1)
-    assert.equal(stats.failed, 0)
-    assert.equal(stats.skipped, 1)
-    assert.equal(stats.lastReason, 'queue-error')
-    assert.match(stats.peers[0].lastError, /dial unavailable/)
-    assert.match(stats.peers[0].lastErrorStack, /dial unavailable/)
-  } finally {
-    manager.stop()
-  }
-})
-
-test('direct peer dial diagnostics include Hyperswarm queue state', () => {
+test('direct peer diagnostics include Hyperswarm queue state', () => {
   const publicKey = b4a.alloc(32, 13)
   const keyHex = b4a.toString(publicKey, 'hex')
   const swarm = createSwarm()
@@ -482,6 +318,7 @@ test('direct peer dial diagnostics include Hyperswarm queue state', () => {
     assert.equal(stats.swarmAllConnections, 1)
     assert.equal(stats.swarmExplicitPeers, 1)
     assert.equal(stats.swarmQueueSize, 2)
+    assert.equal(stats.pending, 1)
     assert.deepEqual(stats.peers[0].swarm, {
       attempts: 2,
       queued: true,
@@ -514,54 +351,30 @@ test('PublicFeedManager.start joins shared PearTube network topic for feed-peer 
   }
 })
 
-test('discovered peer dials remain pending until the Hyperswarm socket arrives', () => {
+test('discovered peer diagnostics become connected when the Hyperswarm socket arrives', () => {
   const publicKey = b4a.alloc(32, 14)
   const swarm = createSwarm()
   const manager = new PublicFeedManager(swarm, createMetaDb())
-  manager._now = () => 12345
 
   try {
     assert.equal(manager.handleDiscoveredPeer({ publicKey }), true)
-    assert.equal(swarm.joinPeerCalls.length, 1)
-    assert.equal(manager.handleDiscoveredPeer({ publicKey }), false)
-    assert.equal(swarm.joinPeerCalls.length, 1)
+    assert.equal(swarm.joinPeerCalls.length, 0)
 
-    const pendingStats = manager.getStats().directPeerDial
-    assert.equal(pendingStats.pending, 1)
-    assert.equal(pendingStats.lastReason, 'dial-already-pending')
-    assert.equal(pendingStats.peers[0].pending, true)
-    assert.equal(pendingStats.peers[0].connected, false)
+    const discoveredStats = manager.getStats().directPeerDial
+    assert.equal(discoveredStats.pending, 0)
+    assert.equal(discoveredStats.peers[0].connected, false)
 
     const conn = createConnection()
     conn.remotePublicKey = publicKey
+    swarm.connections.add(conn)
     manager.handleConnection(conn, { publicKey })
 
     const connectedStats = manager.getStats().directPeerDial
     assert.equal(connectedStats.pending, 0)
     assert.equal(connectedStats.peers[0].pending, false)
+    assert.equal(connectedStats.peers[0].connected, true)
     assert.equal(connectedStats.lastReason, 'connected')
     assert.equal(connectedStats.connected, 1)
-  } finally {
-    manager.stop()
-  }
-})
-
-test('expired pending discovered peer dials are retried', () => {
-  const publicKey = b4a.alloc(32, 15)
-  const swarm = createSwarm()
-  const manager = new PublicFeedManager(swarm, createMetaDb())
-  let now = 1000
-  manager._now = () => now
-
-  try {
-    assert.equal(manager.handleDiscoveredPeer({ publicKey }), true)
-    assert.equal(manager._redialDiscoveredPeers(), 0)
-    assert.equal(swarm.joinPeerCalls.length, 1)
-
-    now += manager._directPeerPendingTimeoutMs + 1
-    assert.equal(manager._redialDiscoveredPeers(), 1)
-    assert.equal(swarm.joinPeerCalls.length, 2)
-    assert.equal(manager.getStats().directPeerDial.pending, 1)
   } finally {
     manager.stop()
   }
@@ -958,32 +771,26 @@ test('periodic feed gossip resends HAVE_FEED and NEED_FEED on existing client co
   }
 })
 
-test('periodic feed gossip re-dials discovered peers after their connection closes', async () => {
+test('periodic feed gossip does not perform app-level redials after sockets close', async () => {
   const swarm = createSwarm()
   const manager = new PublicFeedManager(swarm, createMetaDb())
   const publicKey = b4a.alloc(32, 9)
-  const keyHex = b4a.toString(publicKey, 'hex')
   const conn = createConnection()
-  let now = 1000
 
   manager._gossipIntervalMs = 10
-  manager._now = () => now
 
   try {
     await manager.start()
     assert.equal(manager.handleDiscoveredPeer({ publicKey }), true)
-    assert.equal(swarm.joinPeerCalls.length, 1)
+    assert.equal(swarm.joinPeerCalls.length, 0)
 
-    swarm.peers.set(keyHex, { publicKey })
-    manager.handleConnection(conn, {})
+    manager.handleConnection(conn, { publicKey })
     conn.emit('close')
-    swarm.peers.delete(keyHex)
-    now += manager._directPeerPendingTimeoutMs + 1
 
     await new Promise((resolve) => setTimeout(resolve, 35))
 
-    assert.ok(swarm.joinPeerCalls.length >= 2, 'gossip loop should re-dial a remembered peer after disconnect')
-    assert.equal(b4a.toString(swarm.joinPeerCalls.at(-1), 'hex'), keyHex)
+    assert.equal(swarm.joinPeerCalls.length, 0, 'gossip loop should not redial; Hyperswarm owns socket retry')
+    assert.equal(manager.getStats().directPeerDial.discoveredPeers, 1)
   } finally {
     manager.stop()
   }

--- a/packages/backend/test/storage-startup-regression.test.mjs
+++ b/packages/backend/test/storage-startup-regression.test.mjs
@@ -91,7 +91,7 @@ test('storage exposes public bee content discovery retention for cached serving 
   assert.match(storageSource, /retainSwarmDiscovery\(ctx, core\.discoveryKey/)
 })
 
-test('storage exposes Hyperswarm peer discovery as a peer event for feed fallback dialing', () => {
+test('storage exposes Hyperswarm peer discovery as a diagnostic peer event', () => {
   assert.match(
     storageSource,
     /function installSwarmPeerDiscoveryEmitter\(swarm\)/,
@@ -106,11 +106,6 @@ test('storage exposes Hyperswarm peer discovery as a peer event for feed fallbac
     storageSource,
     /swarm\.emit\('peer', peer, topic\)/,
     'adapter should emit peer events with the discovered peer and topic'
-  )
-  assert.match(
-    storageSource,
-    /_peartubeHandlePeerWithoutEmit/,
-    'adapter should retain the raw Hyperswarm handler for internal relay hint upserts'
   )
 })
 

--- a/packages/cli/src/service.js
+++ b/packages/cli/src/service.js
@@ -226,8 +226,7 @@ export async function createRelayService({
           const heartbeatStatus = await persistStatus()
           const directPeerDial = heartbeatStatus.runtime.directPeerDial || {}
           if ((heartbeatStatus.runtime.peers || 0) > 0 && (heartbeatStatus.runtime.connections || 0) === 0) {
-            const redialed = runtime.publicFeed?.forceRedialDiscoveredPeers?.() || 0
-            logger.status.warn('Relay discovered peers without sockets; forced direct redial', {
+            logger.status.warn('Relay discovered peers without sockets', {
               peers: heartbeatStatus.runtime.peers,
               connections: heartbeatStatus.runtime.connections,
               discoveredPeers: directPeerDial.discoveredPeers || 0,
@@ -242,8 +241,7 @@ export async function createRelayService({
               swarmExplicitPeers: directPeerDial.swarmExplicitPeers || 0,
               swarmQueueSize: directPeerDial.swarmQueueSize || 0,
               dialPeers: Array.isArray(directPeerDial.peers) ? directPeerDial.peers : [],
-              hyperswarm: heartbeatStatus.runtime.hyperswarm || null,
-              redialed
+              hyperswarm: heartbeatStatus.runtime.hyperswarm || null
             })
           }
           const dht = heartbeatStatus.runtime.dht || {}

--- a/packages/cli/test/cli.test.mjs
+++ b/packages/cli/test/cli.test.mjs
@@ -197,15 +197,15 @@ test('relay runtime source wires client-equivalent feed availability providers',
   t.ok(content.includes('publicFeed.setFeedSnapshotProvider'), 'relay runtime should gossip compact playable feed snapshots')
   t.ok(content.includes('this.api.getFeedSnapshotEntries(entries, { limitPerChannel: 3 })'), 'relay feed snapshot provider should use the same API path as clients')
   t.ok(content.includes("ctx.swarm.on('peer'"), 'relay runtime should react to shared-topic peer discoveries')
-  t.ok(content.includes('publicFeed.handleDiscoveredPeer(peer, topic)'), 'relay runtime should explicitly dial shared-topic discovered peers with discovery topic context')
+  t.ok(content.includes('publicFeed.handleDiscoveredPeer(peer, topic)'), 'relay runtime should record shared-topic discovered peers with discovery topic context')
 })
 
-test('legacy relay init passes discovery topic context into public feed dialing', async (t) => {
+test('legacy relay init passes discovery topic context into public feed diagnostics', async (t) => {
   const initPath = join(__dirname, '..', 'src', 'init.js')
   const content = readFileSync(initPath, 'utf8')
 
   t.ok(content.includes("ctx.swarm.on('peer', (peer, topic)"), 'legacy relay init should keep the Hyperswarm discovery topic')
-  t.ok(content.includes('publicFeed.handleDiscoveredPeer(peer, topic)'), 'legacy relay init should preserve relay address hints before redialing')
+  t.ok(content.includes('publicFeed.handleDiscoveredPeer(peer, topic)'), 'legacy relay init should preserve discovery topic context in peer diagnostics')
 })
 
 test('Dockerfile packages the yt-dlp POT provider plugin for noninteractive YouTube bot checks', async (t) => {

--- a/packages/cli/test/service.test.mjs
+++ b/packages/cli/test/service.test.mjs
@@ -320,10 +320,10 @@ test('relay heartbeat logs Hyperswarm dial diagnostics when peers have no socket
     },
     directPeerDial: {
       discoveredPeers: 2,
-      queued: 4,
+      queued: 0,
       skipped: 1,
       failed: 0,
-      lastReason: 'queued',
+      lastReason: 'observed',
       swarmConnecting: 1,
       swarmAllConnections: 1,
       swarmExplicitPeers: 2,
@@ -331,11 +331,6 @@ test('relay heartbeat logs Hyperswarm dial diagnostics when peers have no socket
       peers: [{ key: 'peer-a', swarm: { attempts: 2, relayAddresses: 1 } }]
     }
   })
-  runtime.publicFeed = {
-    forceRedialDiscoveredPeers() {
-      return 2
-    }
-  }
   const logger = createFakeLogger()
   let scheduled = null
 
@@ -377,7 +372,7 @@ test('relay heartbeat logs Hyperswarm dial diagnostics when peers have no socket
     const warning = logger.entries.find((entry) => (
       entry.component === 'status' &&
       entry.level === 'warn' &&
-      entry.msg === 'Relay discovered peers without sockets; forced direct redial'
+      entry.msg === 'Relay discovered peers without sockets'
     ))
     t.ok(warning)
     t.is(warning.data.swarmConnecting, 1)


### PR DESCRIPTION
## Summary
- remove PublicFeedManager's app-level direct-redial/retry loop and let Hyperswarm own peer dialing after shared-topic discovery
- keep peer discovery records as diagnostics only, while feed gossip runs only over opened Protomux feed channels
- remove the retained unwrapped `_handlePeer` hook and the unused `ensureSwarmPeerConnection` helper path
- update relay heartbeat/test wording so peers-without-sockets is observational, not an automatic forced redial side effect

## Why
Local Node + local container probes showed the relay image/path can discover peers, open sockets, open feed channels, and receive feed entries when the network/devices are healthy. The repeated direct-redial machinery was mostly chasing a deployed Docker/server networking failure and made the relay harder to reason about.

## Verification
```bash
node --test packages/backend/test/public-feed-manager.test.mjs packages/backend/test/storage-startup-regression.test.mjs packages/app/tests/native-backend-startup-regression.test.mjs packages/cli/test/service.test.mjs
npm test --prefix packages/cli -- --timeout=30000
npm run lint:changed
git diff --check
```
