### PR TITLE
feat(relay): expose simple archive catalog

### DIFF
--- a/packages/app/app/(tabs)/index.tsx
+++ b/packages/app/app/(tabs)/index.tsx
@@ -38,6 +38,10 @@ import {
   readFeedSnapshotFromDisk,
   writeFeedSnapshotToDisk,
 } from '@/lib/feed-snapshot-storage'
+import {
+  fetchRelayCatalogEntries,
+  readRelayCatalogUrlFromDisk,
+} from '@/lib/simple-relay-catalog'
 
 // Public feed types
 interface FeedEntry {
@@ -45,7 +49,9 @@ interface FeedEntry {
   channelKey?: string  // Alias for driveKey from RPC
   publicBeeKey?: string  // Fast path key for viewers (auto-replicating Hyperbee)
   addedAt: number
-  source: 'peer' | 'local'
+  source: 'peer' | 'local' | 'relay-cache'
+  relayRole?: string | null
+  relayServing?: boolean
   peerCount?: number
   channelName?: string | null
   videoCount?: number
@@ -219,14 +225,31 @@ export default function HomeScreen() {
       const result = await Promise.race([feedPromise, timeoutPromise])
 
       if (result?.entries) {
-        console.log('[Home] getPublicFeed entries:', result.entries.map((e: any) => ({
+        const entries = Array.isArray(result.entries) ? result.entries : []
+        let relayEntries: any[] = []
+        const relayCatalogUrl = await readRelayCatalogUrlFromDisk()
+        if (relayCatalogUrl) {
+          relayEntries = await fetchRelayCatalogEntries(relayCatalogUrl)
+        }
+        const p2pByKey = new Map(entries.map((entry: any) => [entry?.channelKey || entry?.driveKey, entry]))
+        const mergedEntries = [...relayEntries, ...entries].filter((entry, index, all) => {
+          const key = entry?.channelKey || entry?.driveKey
+          return key && all.findIndex((candidate) => (candidate?.channelKey || candidate?.driveKey) === key) === index
+        }).map((entry: any) => {
+          const key = entry?.channelKey || entry?.driveKey
+          const p2pEntry = key ? p2pByKey.get(key) : null
+          return entry.source === 'relay-cache' && p2pEntry
+            ? { ...entry, ...p2pEntry, previewVideos: entry.previewVideos || p2pEntry.previewVideos }
+            : entry
+        }) as FeedEntry[]
+        console.log('[Home] getPublicFeed entries:', mergedEntries.map((e: any) => ({
           channelKey: e.channelKey || e.driveKey,
           source: e.source,
           peerCount: e.peerCount,
           hasBee: !!e.publicBeeKey,
         })))
-        setFeedEntries(result.entries)
-        for (const request of getMissingChannelMetaRequests(result.entries, channelMetaRef.current, 15)) {
+        setFeedEntries(mergedEntries)
+        for (const request of getMissingChannelMetaRequests(mergedEntries, channelMetaRef.current, 15)) {
           loadChannelMeta(request.channelKey, request.publicBeeKey)
         }
       }

--- a/packages/app/app/(tabs)/settings.tsx
+++ b/packages/app/app/(tabs)/settings.tsx
@@ -9,6 +9,12 @@ import { Feather } from '@expo/vector-icons'
 import { useApp, colors } from '../_layout'
 import { CastHeaderButton } from '@/components/cast'
 import { useTabBarMetrics } from '@/lib/tabBarHeight'
+import {
+  clearRelayCatalogUrlFromDisk,
+  normalizeRelayCatalogUrl,
+  readRelayCatalogUrlFromDisk,
+  writeRelayCatalogUrlToDisk,
+} from '@/lib/simple-relay-catalog'
 
 interface StorageStats {
   usedBytes: number
@@ -56,6 +62,8 @@ export default function SettingsScreen() {
   const canManageTranscodeSettings = isPear && typeof (rpc as any)?.getTranscodeSettings === 'function'
   const [transcodeSettings, setTranscodeSettings] = useState<TranscodeSettings | null>(null)
   const [transcodeSettingsLoading, setTranscodeSettingsLoading] = useState(false)
+  const [relayCatalogUrl, setRelayCatalogUrl] = useState('')
+  const [relayCatalogSaving, setRelayCatalogSaving] = useState(false)
 
   // Check if channel is published
   const checkPublishStatus = useCallback(async () => {
@@ -121,6 +129,43 @@ export default function SettingsScreen() {
   useEffect(() => {
     loadTranscodeSettings()
   }, [loadTranscodeSettings])
+
+  useEffect(() => {
+    let mounted = true
+    void readRelayCatalogUrlFromDisk().then((url) => {
+      if (mounted && url) setRelayCatalogUrl(url)
+    })
+    return () => { mounted = false }
+  }, [])
+
+  const saveRelayCatalogUrl = useCallback(async () => {
+    const normalized = normalizeRelayCatalogUrl(relayCatalogUrl)
+    if (!normalized) {
+      Alert.alert('Invalid relay catalog URL', 'Use the relay WebUI catalog URL, e.g. http://server:8174/catalog.json')
+      return
+    }
+    setRelayCatalogSaving(true)
+    try {
+      const ok = await writeRelayCatalogUrlToDisk(normalized)
+      if (!ok) throw new Error('save failed')
+      setRelayCatalogUrl(normalized)
+      Alert.alert('Saved', 'Discover will merge this relay catalog into the feed.')
+    } catch {
+      Alert.alert('Error', 'Failed to save relay catalog URL')
+    } finally {
+      setRelayCatalogSaving(false)
+    }
+  }, [relayCatalogUrl])
+
+  const clearRelayCatalogUrl = useCallback(async () => {
+    setRelayCatalogSaving(true)
+    try {
+      await clearRelayCatalogUrlFromDisk()
+      setRelayCatalogUrl('')
+    } finally {
+      setRelayCatalogSaving(false)
+    }
+  }, [])
 
   const handleVideoToolboxDecodeToggle = async (enabled: boolean) => {
     if (!canManageTranscodeSettings) return
@@ -615,6 +660,47 @@ export default function SettingsScreen() {
               </Text>
             </>
           )}
+        </View>
+
+        {/* Divider */}
+        <View className="h-2 bg-pear-bg-card" />
+
+        {/* Simple Relay Catalog */}
+        <View className="px-5 py-5">
+          <Text className="text-caption-medium text-pear-text-muted mb-4 uppercase tracking-wide">Relay Catalog</Text>
+          <View className="bg-pear-bg-elevated rounded-xl p-4 mb-3">
+            <Text className="text-label text-pear-text mb-2">Simple relay catalog URL</Text>
+            <Text className="text-caption text-pear-text-muted mb-3">
+              Paste the relay WebUI catalog URL here to show archived relay videos without relying on live P2P feed discovery.
+            </Text>
+            <TextInput
+              placeholder="http://server:8174/catalog.json"
+              value={relayCatalogUrl}
+              onChangeText={setRelayCatalogUrl}
+              placeholderTextColor={colors.textMuted}
+              autoCapitalize="none"
+              autoCorrect={false}
+              className="bg-pear-bg-input border border-pear-border rounded-lg px-4 py-3 text-body text-pear-text mb-3"
+            />
+            <View className="flex-row gap-3">
+              <Pressable
+                onPress={saveRelayCatalogUrl}
+                disabled={relayCatalogSaving || !relayCatalogUrl.trim()}
+                className={`flex-1 flex-row items-center justify-center gap-2 bg-pear-primary rounded-lg py-2.5 ${(relayCatalogSaving || !relayCatalogUrl.trim()) ? 'opacity-50' : ''}`}
+              >
+                <Feather name="save" color="white" size={16} />
+                <Text className="text-white text-label">{relayCatalogSaving ? 'Saving...' : 'Save'}</Text>
+              </Pressable>
+              <Pressable
+                onPress={clearRelayCatalogUrl}
+                disabled={relayCatalogSaving || !relayCatalogUrl.trim()}
+                className={`flex-1 flex-row items-center justify-center gap-2 bg-pear-bg-card border border-pear-border rounded-lg py-2.5 ${(relayCatalogSaving || !relayCatalogUrl.trim()) ? 'opacity-50' : ''}`}
+              >
+                <Feather name="x" color={colors.textMuted} size={16} />
+                <Text className="text-pear-text-muted text-label">Clear</Text>
+              </Pressable>
+            </View>
+          </View>
         </View>
 
         {/* Divider */}

--- a/packages/app/lib/simple-relay-catalog.ts
+++ b/packages/app/lib/simple-relay-catalog.ts
@@ -1,0 +1,147 @@
+export const SIMPLE_RELAY_CATALOG_URL_FILE = 'peartube-simple-relay-catalog-url.txt'
+
+function normalizeFsModule(mod: any): any {
+  return mod?.default ?? mod
+}
+
+export async function getFileSystem(): Promise<any | null> {
+  if (typeof process !== 'undefined' && process?.versions?.node && !(globalThis as any)?.navigator?.product) return null
+  try {
+    const legacy = await import('expo-file-system/legacy')
+    return normalizeFsModule(legacy)
+  } catch {
+    try {
+      const fs = await import('expo-file-system')
+      return normalizeFsModule(fs)
+    } catch {
+      return null
+    }
+  }
+}
+
+function getConfigUri(fs: any): string | null {
+  const base = fs?.documentDirectory || fs?.Paths?.document?.uri || fs?.cacheDirectory || fs?.Paths?.cache?.uri
+  if (typeof base !== 'string' || base.length === 0) return null
+  return `${base.replace(/\/?$/, '/')}${SIMPLE_RELAY_CATALOG_URL_FILE}`
+}
+
+export function normalizeRelayCatalogUrl(value: string | null | undefined): string | null {
+  const raw = String(value || '').trim()
+  if (!raw) return null
+  try {
+    const url = new URL(raw)
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return null
+    return url.toString()
+  } catch {
+    return null
+  }
+}
+
+export async function readRelayCatalogUrlFromDisk(): Promise<string | null> {
+  const fs = await getFileSystem()
+  if (!fs || typeof fs.readAsStringAsync !== 'function') return null
+  const uri = getConfigUri(fs)
+  if (!uri) return null
+  try {
+    return normalizeRelayCatalogUrl(await fs.readAsStringAsync(uri, { encoding: 'utf8' }))
+  } catch {
+    return null
+  }
+}
+
+export async function writeRelayCatalogUrlToDisk(value: string): Promise<boolean> {
+  const normalized = normalizeRelayCatalogUrl(value)
+  if (!normalized) return false
+  const fs = await getFileSystem()
+  if (!fs || typeof fs.writeAsStringAsync !== 'function') return false
+  const uri = getConfigUri(fs)
+  if (!uri) return false
+  try {
+    await fs.writeAsStringAsync(uri, normalized, { encoding: 'utf8' })
+    return true
+  } catch {
+    return false
+  }
+}
+
+export async function clearRelayCatalogUrlFromDisk(): Promise<boolean> {
+  const fs = await getFileSystem()
+  if (!fs) return false
+  const uri = getConfigUri(fs)
+  if (!uri) return false
+  try {
+    if (typeof fs.deleteAsync === 'function') {
+      await fs.deleteAsync(uri, { idempotent: true })
+      return true
+    }
+    if (typeof fs.writeAsStringAsync === 'function') {
+      await fs.writeAsStringAsync(uri, '', { encoding: 'utf8' })
+      return true
+    }
+    return false
+  } catch {
+    return false
+  }
+}
+
+export function entriesFromRelayCatalog(catalog: any): any[] {
+  const channels = Array.isArray(catalog?.channels)
+    ? catalog.channels
+    : Object.values(catalog?.channels || {})
+
+  return channels
+    .map((channel: any) => {
+      const channelKey = channel?.channelKey || channel?.driveKey
+      const publicBeeKey = channel?.publicBeeKey || null
+      if (typeof channelKey !== 'string' || channelKey.length === 0) return null
+      const previewVideos = (Array.isArray(channel?.previewVideos)
+        ? channel.previewVideos
+        : Array.isArray(channel?.videos)
+          ? channel.videos
+          : [])
+        .filter((video: any) => video && typeof video.id === 'string' && video.id.length > 0)
+        .map((video: any) => ({
+          ...video,
+          channelKey,
+          driveKey: channelKey,
+          publicBeeKey: video.publicBeeKey || publicBeeKey,
+          availability: video.availability || 'playable',
+        }))
+      return {
+        driveKey: channelKey,
+        channelKey,
+        publicBeeKey,
+        channelName: channel?.channelName || channel?.name || 'Relay Archive',
+        source: 'relay-cache',
+        relayRole: 'cache',
+        relayServing: true,
+        peerCount: Number(channel?.peerCount || 0) || 0,
+        videoCount: Number(channel?.videoCount || previewVideos.length || 0) || 0,
+        manifestUpdatedAt: Number(channel?.manifestUpdatedAt || channel?.mirroredAt || channel?.updatedAt || Date.now()) || Date.now(),
+        lastSeen: Number(channel?.lastSeen || channel?.lastSeenAt || channel?.mirroredAt || Date.now()) || Date.now(),
+        previewVideos,
+      }
+    })
+    .filter(Boolean)
+}
+
+export async function fetchRelayCatalogEntries(catalogUrl: string, timeoutMs = 4000): Promise<any[]> {
+  const normalized = normalizeRelayCatalogUrl(catalogUrl)
+  if (!normalized || typeof fetch !== 'function') return []
+
+  const controller = typeof AbortController !== 'undefined' ? new AbortController() : null
+  const timeout = controller ? setTimeout(() => controller.abort(), timeoutMs) : null
+  try {
+    const response = await fetch(normalized, {
+      headers: { accept: 'application/json' },
+      signal: controller?.signal,
+    } as any)
+    if (!response?.ok) return []
+    const catalog = await response.json()
+    return entriesFromRelayCatalog(catalog)
+  } catch {
+    return []
+  } finally {
+    if (timeout) clearTimeout(timeout)
+  }
+}

--- a/packages/app/tests/simple-relay-catalog.test.mjs
+++ b/packages/app/tests/simple-relay-catalog.test.mjs
@@ -1,0 +1,44 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { entriesFromRelayCatalog, normalizeRelayCatalogUrl } from '../lib/simple-relay-catalog.ts'
+
+test('normalizeRelayCatalogUrl accepts only http(s) URLs', () => {
+  assert.equal(normalizeRelayCatalogUrl(' http://relay.example/catalog.json '), 'http://relay.example/catalog.json')
+  assert.equal(normalizeRelayCatalogUrl('https://relay.example/catalog.json'), 'https://relay.example/catalog.json')
+  assert.equal(normalizeRelayCatalogUrl('file:///tmp/catalog.json'), null)
+  assert.equal(normalizeRelayCatalogUrl(''), null)
+})
+
+test('entriesFromRelayCatalog maps relay channels to feed entries with previews', () => {
+  const entries = entriesFromRelayCatalog({
+    channels: {
+      abc: {
+        channelKey: 'channel-a',
+        publicBeeKey: 'bee-a',
+        channelName: 'Relay Archive',
+        mirroredAt: 123,
+        videos: [{
+          id: 'video-a',
+          title: 'Video A',
+          availability: 'playable',
+          blobId: '0:8:0:1024',
+          blobsCoreKey: 'aa'.repeat(32),
+        }],
+      },
+    },
+  })
+
+  assert.deepEqual(entries.map((entry) => ({
+    channelKey: entry.channelKey,
+    publicBeeKey: entry.publicBeeKey,
+    source: entry.source,
+    relayServing: entry.relayServing,
+    videos: entry.previewVideos.map((video) => video.id),
+  })), [{
+    channelKey: 'channel-a',
+    publicBeeKey: 'bee-a',
+    source: 'relay-cache',
+    relayServing: true,
+    videos: ['video-a'],
+  }])
+})

--- a/packages/cli/src/archive-console.js
+++ b/packages/cli/src/archive-console.js
@@ -73,6 +73,37 @@ export async function createArchiveConsole({
         return
       }
 
+      if (req.method === 'GET' && req.url === '/catalog.json') {
+        const channels = service.catalog?.getChannels?.() || []
+        const previewsByChannel = await store.getCompletedVideoPreviewsByChannel?.()
+        const catalogChannels = channels.map((channel) => {
+          const previewVideos = Array.isArray(channel.previewVideos) && channel.previewVideos.length > 0
+            ? channel.previewVideos
+            : (previewsByChannel?.get?.(channel.channelKey) || [])
+          return {
+            ...channel,
+            source: channel.source || 'relay-cache',
+            relayRole: channel.relayRole || 'cache',
+            relayServing: true,
+            videoCount: Number(channel.videoCount || previewVideos.length || channel.videosDownloaded || channel.videosFound || 0) || 0,
+            manifestUpdatedAt: Number(channel.manifestUpdatedAt || channel.mirroredAt || channel.lastSeenAt || Date.now()) || Date.now(),
+            previewVideos
+          }
+        })
+        res.writeHead(200, {
+          'content-type': 'application/json; charset=utf-8',
+          'access-control-allow-origin': '*',
+          'cache-control': 'no-store'
+        })
+        res.end(JSON.stringify({
+          schema: 'peartube.simpleRelayCatalog',
+          version: 1,
+          updatedAt: Date.now(),
+          channels: catalogChannels
+        }, null, 2))
+        return
+      }
+
       if (req.method === 'POST' && req.url === '/archive') {
         const form = parseForm(await collectBody(req))
         await manager.enqueue(form)

--- a/packages/cli/src/archive-manager.js
+++ b/packages/cli/src/archive-manager.js
@@ -142,6 +142,23 @@ export function createArchiveJobStore({ metaDb }) {
       const updated = jobs.map((job) => job.id === id ? publicJob({ ...job, ...patch, updatedAt: now() }) : job)
       await writeJobsRaw(updated)
       return updated.find((job) => job.id === id) || null
+    },
+    async getCompletedVideoPreviewsByChannel() {
+      const jobs = await readJobsRaw()
+      const byChannel = new Map()
+      for (const job of jobs) {
+        if (job?.status !== 'completed') continue
+        if (!job?.channelKey || !job?.previewVideo?.id) continue
+        const list = byChannel.get(job.channelKey) || []
+        list.push({
+          ...job.previewVideo,
+          publicBeeKey: job.publicBeeKey || job.previewVideo.publicBeeKey || null,
+          channelKey: job.channelKey,
+          driveKey: job.channelKey,
+        })
+        byChannel.set(job.channelKey, list)
+      }
+      return byChannel
     }
   }
 }
@@ -347,18 +364,36 @@ export function createArchiveManager({ store, downloader, publisher, logger = nu
           title: privateInput.title || downloaded.title,
           description: privateInput.description || downloaded.description
         })
+        const importedMetadata = imported?.metadata || imported
 
         if (privateInput.publish !== false) {
           await publisher.publishChannel(channelInfo)
           await publisher.seedChannel(channelInfo)
         }
 
+        const previewVideo = imported?.videoId ? {
+          id: imported.videoId,
+          title: privateInput.title || downloaded.title || imported.videoId,
+          description: privateInput.description || downloaded.description || '',
+          path: importedMetadata.path || `/videos/${imported.videoId}.mp4`,
+          uploadedAt: importedMetadata.uploadedAt || now(),
+          duration: Number(importedMetadata.duration || downloaded.duration || 0) || 0,
+          size: Number(importedMetadata.size || downloaded.size || 0) || 0,
+          mimeType: importedMetadata.mimeType || downloaded.mimeType || 'video/mp4',
+          availability: 'playable',
+          blobId: importedMetadata.blobId || null,
+          blobsCoreKey: importedMetadata.blobsCoreKey || null,
+          thumbnailBlobId: importedMetadata.thumbnailBlobId || null,
+          thumbnailBlobsCoreKey: importedMetadata.thumbnailBlobsCoreKey || null,
+          thumbnailMimeType: importedMetadata.thumbnailMimeType || null
+        } : null
         const completed = await store.updateJob(id, {
           status: 'completed',
           title: privateInput.title || downloaded.title,
           videoId: imported.videoId,
           channelKey: channelInfo.channelKey,
           publicBeeKey: channelInfo.publicBeeKey || null,
+          previewVideo,
           completedAt: now(),
           error: null
         })

--- a/packages/cli/src/archive-ui.js
+++ b/packages/cli/src/archive-ui.js
@@ -38,6 +38,8 @@ export function renderArchiveWebHome(model = {}) {
   const status = model.status || {}
   const seeding = status.seeding || {}
   const jobs = Array.isArray(model.jobs) ? model.jobs : []
+  const publicBaseUrl = typeof model.publicBaseUrl === 'string' ? model.publicBaseUrl : ''
+  const catalogUrl = publicBaseUrl ? `${publicBaseUrl.replace(/\/$/, '')}/catalog.json` : '/catalog.json'
   const rows = jobs.length
     ? jobs.map((job) => `
         <li>
@@ -61,8 +63,9 @@ export function renderArchiveWebHome(model = {}) {
     main { max-width: 980px; margin: 0 auto; padding: 42px 20px 80px; }
     h1 { margin: 0 0 8px; font-size: clamp(32px, 5vw, 58px); letter-spacing: -0.05em; }
     p { color: #aab3c5; line-height: 1.55; }
+    a { color: #9effd0; }
     .stats { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 12px; margin: 28px 0; }
-    .stat, form, .queue { border: 1px solid rgba(255,255,255,0.12); background: rgba(12,15,25,0.76); border-radius: 18px; padding: 18px; box-shadow: 0 20px 80px rgba(0,0,0,0.24); }
+    .stat, form, .queue, .catalog { border: 1px solid rgba(255,255,255,0.12); background: rgba(12,15,25,0.76); border-radius: 18px; padding: 18px; box-shadow: 0 20px 80px rgba(0,0,0,0.24); }
     .stat b { display: block; font-size: 28px; }
     form { display: grid; gap: 14px; margin: 24px 0; }
     label { display: grid; gap: 6px; color: #c8d1e4; font-weight: 650; }
@@ -86,6 +89,12 @@ export function renderArchiveWebHome(model = {}) {
       <div class="stat"><span>Peers</span><b>${escapeHtml(status.peers || 0)}</b></div>
       <div class="stat"><span>Feed entries</span><b>${escapeHtml(status.feedEntries || 0)}</b></div>
       <div class="stat"><span>Seeded videos</span><b>${escapeHtml(seeding.videos || 0)}</b></div>
+    </section>
+    <section class="catalog">
+      <h2>Simple relay catalog</h2>
+      <p>Clients can import this URL directly instead of waiting for live P2P feed gossip. This is the fallback path for unreliable relay discovery.</p>
+      <p><a href="${escapeHtml(catalogUrl)}">${escapeHtml(catalogUrl)}</a></p>
+      <code>${escapeHtml(catalogUrl)}</code>
     </section>
     <form method="post" action="/archive">
       <label>Video or channel URL<input name="url" required placeholder="https://www.youtube.com/watch?v=..."></label>

--- a/packages/cli/src/service.js
+++ b/packages/cli/src/service.js
@@ -107,7 +107,10 @@ export async function createRelayService({
         videosFound: mirrorStats?.videosFound || 0,
         videosDownloaded: mirrorStats?.videosDownloaded || 0,
         mirroredAt: Date.now(),
-        lastError: null
+        lastError: null,
+        previewVideos: Array.isArray(mirrorStats?.previewVideos) ? mirrorStats.previewVideos : undefined,
+        videoCount: Number(mirrorStats?.videoCount || mirrorStats?.videosDownloaded || mirrorStats?.videosFound || 0) || 0,
+        manifestUpdatedAt: Date.now()
       })
 
       if (resolved.publicBeeKey) {


### PR DESCRIPTION
## Summary

Drastically simplifies the relay fallback path by adding a plain HTTP archive catalog alongside the existing P2P relay behavior.

Instead of requiring live Hyperswarm feed discovery before archived videos can appear, the relay WebUI now exposes:

- `GET /catalog.json`
- schema: `peartube.simpleRelayCatalog`
- CORS-enabled, no-store JSON
- channel records with `publicBeeKey`, `previewVideos`, relay/cache markers, and video counts

The mobile/desktop app gets a simple Settings field for the relay catalog URL. Home/Discover merges catalog entries into the normal feed before live P2P entries, while preserving P2P entries when they exist.

This keeps P2P as the real playback/content path, but stops the UI from depending on fragile live feed discovery just to know that the relay archive exists.

## Changes

- Add relay WebUI `/catalog.json` endpoint.
- Store completed archive job preview metadata for catalog fallback.
- Backfill catalog previews from completed archive jobs when channel catalog records do not already include preview videos.
- Add app-side `simple-relay-catalog` helper:
  - URL normalization
  - persisted catalog URL
  - fetch/timeout handling
  - catalog → feed entry mapping
- Add Settings UI for a simple relay catalog URL.
- Merge relay catalog entries into Home/Discover feed.
- Add regression tests for catalog URL validation and catalog entry mapping.

## Verification

```bash
node --test packages/app/tests/simple-relay-catalog.test.mjs packages/app/tests/feed-hydration.test.mjs
npm test --prefix packages/cli -- --timeout=30000
npm run lint:changed
git diff --check
```

Results:

- App targeted tests: 15/15 pass
- CLI suite: 71/71 pass, 368/368 asserts
- lint:changed: pass
- diff check: pass
