### PR TITLE
fix(relay): seed all known preview blob cores

### DIFF
--- a/packages/cli/src/archive-manager.js
+++ b/packages/cli/src/archive-manager.js
@@ -323,11 +323,15 @@ export function createArchivePublisher({ identityManager, uploadManager, api, ru
     async publishChannel({ channelKey }) {
       return api.submitToFeed(channelKey)
     },
-    async seedChannel({ channelKey, publicBeeKey }) {
+    async seedChannel({ channelKey, publicBeeKey, previewVideos }) {
       if (channelKey && publicBeeKey) {
         await runtime?.cacheManager?.addChannel?.(channelKey, publicBeeKey, 'private').catch(() => {})
         await runtime?.publicFeed?.submitChannel?.(channelKey, publicBeeKey).catch(() => {})
-        await runtime?.seeder?.seedChannel?.({ driveKey: channelKey, publicBeeKey }).catch(() => {})
+        await runtime?.seeder?.seedChannel?.({
+          driveKey: channelKey,
+          publicBeeKey,
+          previewVideos: Array.isArray(previewVideos) ? previewVideos : []
+        }).catch(() => {})
       }
     }
   }
@@ -366,11 +370,6 @@ export function createArchiveManager({ store, downloader, publisher, logger = nu
         })
         const importedMetadata = imported?.metadata || imported
 
-        if (privateInput.publish !== false) {
-          await publisher.publishChannel(channelInfo)
-          await publisher.seedChannel(channelInfo)
-        }
-
         const previewVideo = imported?.videoId ? {
           id: imported.videoId,
           title: privateInput.title || downloaded.title || imported.videoId,
@@ -387,6 +386,11 @@ export function createArchiveManager({ store, downloader, publisher, logger = nu
           thumbnailBlobsCoreKey: importedMetadata.thumbnailBlobsCoreKey || null,
           thumbnailMimeType: importedMetadata.thumbnailMimeType || null
         } : null
+        if (privateInput.publish !== false) {
+          await publisher.publishChannel(channelInfo)
+          await publisher.seedChannel({ ...channelInfo, previewVideos: previewVideo ? [previewVideo] : [] })
+        }
+
         const completed = await store.updateJob(id, {
           status: 'completed',
           title: privateInput.title || downloaded.title,

--- a/packages/cli/src/seeding.js
+++ b/packages/cli/src/seeding.js
@@ -22,9 +22,45 @@ function cloneStats(stats) {
   return { ...stats }
 }
 
-function addCoreKey(set, value) {
+function addCoreKey(set, value, kind = 'blob') {
   if (!isValidHexKey(value)) return false
-  set.add(value.toLowerCase())
+  const key = value.toLowerCase()
+  if (!set.has(key)) set.set(key, kind)
+  return true
+}
+
+function addPreviewCoreKeys(set, previews) {
+  if (!Array.isArray(previews)) return 0
+  let added = 0
+  for (const video of previews) {
+    if (addCoreKey(set, video?.blobsCoreKey, 'blob')) added += 1
+    if (addCoreKey(set, video?.thumbnailBlobsCoreKey, 'thumbnail')) added += 1
+  }
+  return added
+}
+
+function getVideoKey(video) {
+  return String(video?.id || video?.path || video?.videoId || video?.blobId || '')
+}
+
+function pushPreview(previews, video) {
+  if (!video?.id || !video?.blobId || !video?.blobsCoreKey) return false
+  const id = getVideoKey(video)
+  if (previews.some((existing) => getVideoKey(existing) === id)) return false
+  previews.push({
+    id: String(video.id),
+    title: video?.title ? String(video.title) : 'Untitled',
+    uploadedAt: Number(video?.uploadedAt || 0) || 0,
+    duration: Number(video?.duration || 0) || 0,
+    thumbnail: video?.thumbnail || null,
+    blobId: String(video.blobId),
+    blobsCoreKey: String(video.blobsCoreKey),
+    mimeType: video?.mimeType || 'video/mp4',
+    availability: 'playable',
+    thumbnailBlobId: video?.thumbnailBlobId || null,
+    thumbnailBlobsCoreKey: video?.thumbnailBlobsCoreKey || null,
+    thumbnailMimeType: video?.thumbnailMimeType || null
+  })
   return true
 }
 
@@ -94,36 +130,38 @@ export function createRelaySeeder({ ctx, loadPublicBee, logger = {}, blindPeer =
 
       const videos = await bee?.listVideos?.().catch(() => [])
       const meta = await bee?.getMetadata?.().catch(() => null)
-      const blobCoreKeys = new Set()
+      const blobCoreKeys = new Map()
       const previewVideos = []
-      if (Array.isArray(videos)) {
-        stats.videos = videos.length
-        for (const video of videos) {
-          addCoreKey(blobCoreKeys, video?.blobsCoreKey)
-          addCoreKey(blobCoreKeys, video?.thumbnailBlobsCoreKey)
-          if (previewVideos.length < 3 && video?.id && video?.blobId && video?.blobsCoreKey) {
-            previewVideos.push({
-              id: String(video.id),
-              title: video?.title ? String(video.title) : 'Untitled',
-              uploadedAt: Number(video?.uploadedAt || 0) || 0,
-              duration: Number(video?.duration || 0) || 0,
-              thumbnail: video?.thumbnail || null,
-              blobId: String(video.blobId),
-              blobsCoreKey: String(video.blobsCoreKey),
-              mimeType: video?.mimeType || 'video/mp4',
-              availability: 'playable',
-              thumbnailBlobId: video?.thumbnailBlobId || null,
-              thumbnailBlobsCoreKey: video?.thumbnailBlobsCoreKey || null,
-              thumbnailMimeType: video?.thumbnailMimeType || null
-            })
-          }
+
+      // Seed every core reference we know, not only what PublicBee.listVideos() returns.
+      // Playback often starts from public-feed/catalog previews; if those refs are
+      // newer than a slow/stale PublicBee read, the relay still needs to advertise
+      // the exact blob cores the phone will dial.
+      addPreviewCoreKeys(blobCoreKeys, channel?.previewVideos)
+      addPreviewCoreKeys(blobCoreKeys, channel?.videos)
+      addPreviewCoreKeys(blobCoreKeys, channel?.catalogEntry?.previewVideos)
+      addPreviewCoreKeys(blobCoreKeys, channel?.feedEntry?.previewVideos)
+
+      if (Array.isArray(channel?.previewVideos)) {
+        for (const video of channel.previewVideos) {
+          if (previewVideos.length >= 3) break
+          pushPreview(previewVideos, video)
         }
       }
 
-      for (const keyHex of blobCoreKeys) {
+      if (Array.isArray(videos)) {
+        stats.videos = Math.max(videos.length, previewVideos.length)
+        for (const video of videos) {
+          addCoreKey(blobCoreKeys, video?.blobsCoreKey, 'blob')
+          addCoreKey(blobCoreKeys, video?.thumbnailBlobsCoreKey, 'thumbnail')
+          if (previewVideos.length < 3) pushPreview(previewVideos, video)
+        }
+      }
+
+      for (const [keyHex, kind] of blobCoreKeys) {
         const core = await resolveBlobCore(keyHex)
         if (core?.discoveryKey) {
-          retainDiscovery(core.discoveryKey, `blob:${keyHex.slice(0, 16)}`)
+          retainDiscovery(core.discoveryKey, `${kind}:${keyHex.slice(0, 16)}`)
           try { blindPeer?.addCore?.(core, { announce: true, referrer: b4a.from(publicBeeKey, 'hex') }) } catch {}
           stats.blobCores += 1
         }

--- a/packages/cli/src/service.js
+++ b/packages/cli/src/service.js
@@ -118,7 +118,8 @@ export async function createRelayService({
         await runtime.publicFeed?.submitChannel?.(resolved.channelKey, resolved.publicBeeKey).catch(() => {})
         await runtime.seeder?.seedChannel?.({
           driveKey: resolved.channelKey,
-          publicBeeKey: resolved.publicBeeKey
+          publicBeeKey: resolved.publicBeeKey,
+          previewVideos: Array.isArray(mirrorStats?.previewVideos) ? mirrorStats.previewVideos : []
         }).catch(() => {})
       }
 

--- a/packages/cli/test/relay-seeding.test.mjs
+++ b/packages/cli/test/relay-seeding.test.mjs
@@ -131,6 +131,69 @@ test('relay seeder refreshes all cached channels and deduplicates retained joins
   t.is(swarm.joins.length, 2)
 })
 
+
+test('relay seeder also seeds preview/catalog blob refs when PublicBee is sparse', async (t) => {
+  const publicBeeCore = createCore('99')
+  const previewVideoCore = createCore('aa')
+  const previewThumbnailCore = createCore('ab')
+  const catalogVideoCore = createCore('ac')
+  const swarm = createSwarm()
+  const ctx = {
+    swarm,
+    store: {
+      get(key) {
+        const keyHex = Buffer.isBuffer(key) ? key.toString('hex') : String(key)
+        if (keyHex.startsWith('aa')) return previewVideoCore
+        if (keyHex.startsWith('ab')) return previewThumbnailCore
+        if (keyHex.startsWith('ac')) return catalogVideoCore
+        throw new Error(`unexpected core key ${keyHex}`)
+      }
+    }
+  }
+  const seeder = createRelaySeeder({
+    ctx,
+    loadPublicBee: async () => ({
+      core: publicBeeCore,
+      async listVideos() {
+        return []
+      }
+    }),
+    logger: { info() {}, warn() {}, debug() {} }
+  })
+
+  const stats = await seeder.seedChannel({
+    driveKey: 'aa'.padEnd(64, '0'),
+    publicBeeKey: 'bb'.padEnd(64, '0'),
+    previewVideos: [{
+      id: 'preview-video',
+      blobId: '0:1:0:10',
+      blobsCoreKey: 'aa'.padEnd(64, '0'),
+      thumbnailBlobId: '1:1:0:5',
+      thumbnailBlobsCoreKey: 'ab'.padEnd(64, '0')
+    }],
+    catalogEntry: {
+      previewVideos: [{
+        id: 'catalog-video',
+        blobId: '2:1:0:10',
+        blobsCoreKey: 'ac'.padEnd(64, '0')
+      }]
+    }
+  })
+
+  t.is(stats.channels, 1)
+  t.is(stats.publicBeeCores, 1)
+  t.is(stats.blobCores, 3)
+  t.is(stats.discoveryHandles, 4)
+  t.is(stats.catalogEntry.previewVideos.length, 1)
+  t.is(stats.catalogEntry.previewVideos[0].id, 'preview-video')
+  t.alike(swarm.joins.map((join) => join.discoveryKey), [
+    publicBeeCore.discoveryKey,
+    previewVideoCore.discoveryKey,
+    previewThumbnailCore.discoveryKey,
+    catalogVideoCore.discoveryKey
+  ])
+})
+
 test('relay seeder registers mirrored cores with relay blind peer', async (t) => {
   const publicBeeCore = createCore('66')
   const videoCore = createCore('77')


### PR DESCRIPTION
## Summary
- Make relay seeding harvest blob refs from every known preview/catalog/feed video source, not only `PublicBee.listVideos()`
- Pass archive/import and mirror preview refs into the seeder immediately so the relay advertises the exact `blobsCoreKey` phones will dial for playback
- Keep registering PublicBee/video/thumbnail cores with retained swarm discovery and blind peer

## Why
Mobile can see relay videos from feed/catalog previews while playback fails with no peers if the relay is not announcing the exact preview `blobsCoreKey`. PublicBee hydration can be sparse/stale/slow, so preview refs must be treated as seedable content refs too.

## Test Plan
- `node --test packages/cli/test/relay-seeding.test.mjs`
- `npm test --prefix packages/cli -- --timeout=30000`
- `npm run lint:changed`
- `git diff --check`
