### PR TITLE
feat(relay): mirror local drive videos

### DIFF
--- a/packages/cli/bin.js
+++ b/packages/cli/bin.js
@@ -38,6 +38,7 @@ function printHelp() {
     '  run       Run the relay service',
     '  ui       Run the relay archive WebUI',
     '  archive  Queue or run anonymous YouTube archive jobs',
+    '  mirror-local  Import local video files into the relay channel',
     '  validate  Validate and print the normalized relay config',
     '  status    Print relay status from the local catalog',
     '  init      Write an example config file',
@@ -52,6 +53,8 @@ function printHelp() {
     '  --channel <key>',
     '  --owner <key>',
     '  --url <youtube-url>',
+    '  --path <local-directory>',
+    '  --max-files <n>',
     '  --channel-name <name>',
     '  --title <title>',
     '  --description <text>',
@@ -133,6 +136,25 @@ async function archiveCommand(flags) {
   }
 }
 
+async function mirrorLocalCommand(flags) {
+  if (!flags.path) throw new Error('--path is required')
+  const config = await loadRelayConfig(flags)
+  const { startRelay } = await import('./src/index.js')
+  const relay = await startRelay({ config })
+  try {
+    const result = await relay.mirrorLocalDrive({
+      path: flags.path,
+      channelName: flags.channelName || flags.title || 'Local Drive Mirror',
+      description: flags.description || '',
+      recursive: flags.recursive !== false,
+      maxFiles: flags.maxFiles
+    })
+    writeLine(JSON.stringify(result, null, 2) + '\n')
+  } finally {
+    await relay.close()
+  }
+}
+
 async function validateCommand(flags) {
   const config = await loadRelayConfig(flags)
   const output = JSON.stringify(config, null, 2)
@@ -181,6 +203,9 @@ async function main() {
       break
     case 'archive':
       await archiveCommand(flags)
+      break
+    case 'mirror-local':
+      await mirrorLocalCommand(flags)
       break
     case 'validate':
       await validateCommand(flags)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,7 +10,7 @@
     "peartube-peer-bare": "bare-bin.js"
   },
   "scripts": {
-    "test": "brittle test/admission.test.mjs test/archive-ui.test.mjs test/archive.test.mjs test/cli.test.mjs test/config.test.mjs test/relay-seeding.test.mjs test/service.test.mjs test/status.test.mjs",
+    "test": "brittle test/admission.test.mjs test/archive-ui.test.mjs test/archive.test.mjs test/cli.test.mjs test/config.test.mjs test/local-drive-mirror.test.mjs test/relay-seeding.test.mjs test/service.test.mjs test/status.test.mjs",
     "build:standalone": "node ./scripts/build-standalone.mjs",
     "build:standalone:linux-x64": "RELAY_STANDALONE_HOST=linux-x64 node ./scripts/build-standalone.mjs",
     "build:standalone:linux-arm64": "RELAY_STANDALONE_HOST=linux-arm64 node ./scripts/build-standalone.mjs",

--- a/packages/cli/src/argv.js
+++ b/packages/cli/src/argv.js
@@ -121,6 +121,16 @@ export function parseArgv(argv = []) {
       continue
     }
 
+    if (arg === '--path') {
+      flags.path = consumeValue()
+      continue
+    }
+
+    if (arg === '--max-files') {
+      flags.maxFiles = consumeValue()
+      continue
+    }
+
     if (arg === '--channel-name') {
       flags.channelName = consumeValue()
       continue

--- a/packages/cli/src/local-drive-mirror.js
+++ b/packages/cli/src/local-drive-mirror.js
@@ -1,0 +1,139 @@
+import { readdirSync, statSync } from '#fs'
+import { basename, extname, join } from '#path'
+const defaultPath = { join }
+
+const DEFAULT_VIDEO_EXTENSIONS = new Set(['.mp4', '.m4v', '.mov', '.webm', '.mkv', '.avi'])
+
+const MIME_BY_EXT = {
+  '.mp4': 'video/mp4',
+  '.m4v': 'video/mp4',
+  '.mov': 'video/quicktime',
+  '.webm': 'video/webm',
+  '.mkv': 'video/x-matroska',
+  '.avi': 'video/x-msvideo'
+}
+
+function normalizeExtensions(extensions = DEFAULT_VIDEO_EXTENSIONS) {
+  const values = extensions instanceof Set ? [...extensions] : extensions
+  return new Set([...values].map((ext) => String(ext || '').trim().toLowerCase()).filter(Boolean).map((ext) => ext.startsWith('.') ? ext : `.${ext}`))
+}
+
+function titleFromPath(filePath) {
+  const name = basename(String(filePath || '')).trim()
+  const ext = extname(name)
+  return (ext ? name.slice(0, -ext.length) : name) || 'Local video'
+}
+
+function mimeTypeForPath(filePath) {
+  return MIME_BY_EXT[extname(String(filePath || '')).toLowerCase()] || 'video/mp4'
+}
+
+export function listLocalDriveVideos(rootPath, {
+  fs = { readdirSync, statSync },
+  path = defaultPath,
+  recursive = true,
+  extensions = DEFAULT_VIDEO_EXTENSIONS,
+  maxFiles = Infinity
+} = {}) {
+  const root = String(rootPath || '').trim()
+  if (!root) throw new Error('local drive path is required')
+  const allowed = normalizeExtensions(extensions)
+  const results = []
+
+  function walk(dir) {
+    if (results.length >= maxFiles) return
+    const entries = fs.readdirSync(dir, { withFileTypes: true })
+    for (const entry of entries) {
+      if (results.length >= maxFiles) break
+      if (!entry || entry.name.startsWith('.')) continue
+      const fullPath = path.join(dir, entry.name)
+      if (entry.isDirectory?.()) {
+        if (recursive) walk(fullPath)
+        continue
+      }
+      if (!entry.isFile?.()) continue
+      const ext = extname(entry.name).toLowerCase()
+      if (!allowed.has(ext)) continue
+      const stat = fs.statSync(fullPath)
+      if (!Number.isFinite(Number(stat?.size)) || Number(stat.size) <= 0) continue
+      results.push({
+        filePath: fullPath,
+        title: titleFromPath(fullPath),
+        mimeType: mimeTypeForPath(fullPath),
+        size: Number(stat.size),
+        mtimeMs: Number(stat.mtimeMs || 0) || 0
+      })
+    }
+  }
+
+  walk(root)
+  return results.sort((a, b) => a.filePath.localeCompare(b.filePath))
+}
+
+export async function mirrorLocalDriveToRelayChannel({
+  rootPath,
+  publisher,
+  channelName = 'Local Drive Mirror',
+  description = '',
+  recursive = true,
+  maxFiles = Infinity,
+  fs = { readdirSync, statSync },
+  path = defaultPath,
+  logger = null
+} = {}) {
+  if (!publisher) throw new Error('publisher is required')
+  const videos = listLocalDriveVideos(rootPath, { fs, path, recursive, maxFiles })
+  const channelInfo = await publisher.ensureAnonymousChannel({ channelName })
+  const imported = []
+  const failed = []
+
+  for (const video of videos) {
+    try {
+      const result = await publisher.importVideo({
+        channel: channelInfo.channel,
+        filePath: video.filePath,
+        title: video.title,
+        description,
+        mimeType: video.mimeType
+      })
+      const metadata = result?.metadata || result || {}
+      const previewVideo = result?.videoId ? {
+        id: result.videoId,
+        title: video.title,
+        description,
+        path: metadata.path || `/videos/${result.videoId}.mp4`,
+        uploadedAt: metadata.uploadedAt || Date.now(),
+        duration: Number(metadata.duration || 0) || 0,
+        size: Number(metadata.size || video.size || 0) || 0,
+        mimeType: metadata.mimeType || video.mimeType,
+        availability: 'playable',
+        blobId: metadata.blobId || null,
+        blobsCoreKey: metadata.blobsCoreKey || null,
+        thumbnailBlobId: metadata.thumbnailBlobId || null,
+        thumbnailBlobsCoreKey: metadata.thumbnailBlobsCoreKey || null,
+        thumbnailMimeType: metadata.thumbnailMimeType || null
+      } : null
+      imported.push({ ...video, videoId: result?.videoId || null, previewVideo })
+      logger?.archive?.info?.('Local drive video imported', { file: video.filePath, videoId: result?.videoId || null })
+    } catch (err) {
+      failed.push({ ...video, error: err?.message || String(err) })
+      logger?.archive?.error?.('Local drive video import failed', { file: video.filePath, error: err?.message || String(err) })
+    }
+  }
+
+  const previewVideos = imported.map((entry) => entry.previewVideo).filter(Boolean)
+  if (previewVideos.length > 0) {
+    await publisher.publishChannel(channelInfo)
+    await publisher.seedChannel({ ...channelInfo, previewVideos })
+  }
+
+  return {
+    channelKey: channelInfo.channelKey,
+    publicBeeKey: channelInfo.publicBeeKey || null,
+    scanned: videos.length,
+    imported: imported.length,
+    failed: failed.length,
+    videos: imported.map(({ filePath, title, size, mimeType, videoId }) => ({ filePath, title, size, mimeType, videoId })),
+    failures: failed.map(({ filePath, error }) => ({ filePath, error }))
+  }
+}

--- a/packages/cli/src/service.js
+++ b/packages/cli/src/service.js
@@ -4,6 +4,7 @@ import { RelayCatalog } from './catalog.js'
 import { buildRelayStatus, writeRelayStatus } from './status.js'
 import { createArchiveConsole } from './archive-console.js'
 import { createArchiveJobStore, createArchiveManager, createArchivePublisher, createYtDlpDownloader } from './archive-manager.js'
+import { mirrorLocalDriveToRelayChannel } from './local-drive-mirror.js'
 
 export async function createRelayService({
   config,
@@ -324,6 +325,27 @@ export async function createRelayService({
       const job = await manager.enqueue(input)
       if (runNow) return manager.runJob(job.id)
       return job
+    },
+    async mirrorLocalDrive(input = {}) {
+      const runtimeFsModule = fsModule || await import('#fs')
+      const runtimePathModule = pathModule || await import('#path')
+      return mirrorLocalDriveToRelayChannel({
+        rootPath: input.path || input.rootPath,
+        channelName: input.channelName || 'Local Drive Mirror',
+        description: input.description || '',
+        recursive: input.recursive !== false,
+        maxFiles: Number.isFinite(Number(input.maxFiles)) ? Number(input.maxFiles) : Infinity,
+        fs: runtimeFsModule,
+        path: runtimePathModule,
+        logger,
+        publisher: createArchivePublisher({
+          identityManager: runtime.identityManager,
+          uploadManager: runtime.uploadManager,
+          api: runtime.api,
+          runtime,
+          fs: runtimeFsModule
+        })
+      })
     },
     getStatus() {
       return currentStatus || buildRelayStatus({

--- a/packages/cli/src/shims/fs.bare.js
+++ b/packages/cli/src/shims/fs.bare.js
@@ -2,6 +2,7 @@ export {
   createReadStream,
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   rmSync,
   statSync,

--- a/packages/cli/src/shims/fs.node.js
+++ b/packages/cli/src/shims/fs.node.js
@@ -2,6 +2,7 @@ export {
   createReadStream,
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   rmSync,
   statSync,

--- a/packages/cli/src/shims/path.bare.js
+++ b/packages/cli/src/shims/path.bare.js
@@ -1,3 +1,5 @@
 export {
+  basename,
+  extname,
   join
 } from 'bare-path'

--- a/packages/cli/src/shims/path.node.js
+++ b/packages/cli/src/shims/path.node.js
@@ -1,3 +1,5 @@
 export {
+  basename,
+  extname,
   join
 } from 'node:path'

--- a/packages/cli/test/cli.test.mjs
+++ b/packages/cli/test/cli.test.mjs
@@ -51,7 +51,7 @@ test('package.json defines standalone relay build scripts', async (t) => {
   const packageJsonPath = join(__dirname, '..', 'package.json')
   const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf8'))
 
-  t.is(pkg.scripts['test'], 'brittle test/admission.test.mjs test/archive-ui.test.mjs test/archive.test.mjs test/cli.test.mjs test/config.test.mjs test/relay-seeding.test.mjs test/service.test.mjs test/status.test.mjs')
+  t.is(pkg.scripts['test'], 'brittle test/admission.test.mjs test/archive-ui.test.mjs test/archive.test.mjs test/cli.test.mjs test/config.test.mjs test/local-drive-mirror.test.mjs test/relay-seeding.test.mjs test/service.test.mjs test/status.test.mjs')
   t.is(pkg.imports['#subprocess'].bare, './src/shims/subprocess.bare.js')
   t.is(pkg.imports['#subprocess'].default, './src/shims/subprocess.node.js')
   t.is(pkg.imports['#http'].bare, './src/shims/http.bare.js')

--- a/packages/cli/test/local-drive-mirror.test.mjs
+++ b/packages/cli/test/local-drive-mirror.test.mjs
@@ -1,0 +1,95 @@
+import test from 'brittle'
+
+import { listLocalDriveVideos, mirrorLocalDriveToRelayChannel } from '../src/local-drive-mirror.js'
+
+function dirent(name, type) {
+  return {
+    name,
+    isDirectory: () => type === 'dir',
+    isFile: () => type === 'file'
+  }
+}
+
+function makeFs(tree, sizes = {}) {
+  return {
+    readdirSync(path) {
+      const entries = tree[path]
+      if (!entries) throw new Error(`ENOENT: ${path}`)
+      return entries
+    },
+    statSync(path) {
+      return { size: sizes[path] ?? 1024, mtimeMs: 1 }
+    }
+  }
+}
+
+const pathShim = {
+  join(...parts) {
+    return parts.join('/').replace(/\/+/g, '/')
+  }
+}
+
+test('listLocalDriveVideos recursively finds supported video files', (t) => {
+  const fs = makeFs({
+    '/drive': [dirent('a.mp4', 'file'), dirent('notes.txt', 'file'), dirent('nested', 'dir'), dirent('.hidden.mp4', 'file')],
+    '/drive/nested': [dirent('b.MKV', 'file'), dirent('empty.webm', 'file')]
+  }, {
+    '/drive/a.mp4': 100,
+    '/drive/nested/b.MKV': 200,
+    '/drive/nested/empty.webm': 0
+  })
+
+  const videos = listLocalDriveVideos('/drive', { fs, path: pathShim })
+  t.alike(videos.map((video) => ({ filePath: video.filePath, title: video.title, mimeType: video.mimeType, size: video.size })), [
+    { filePath: '/drive/a.mp4', title: 'a', mimeType: 'video/mp4', size: 100 },
+    { filePath: '/drive/nested/b.MKV', title: 'b', mimeType: 'video/x-matroska', size: 200 }
+  ])
+})
+
+test('mirrorLocalDriveToRelayChannel imports, publishes, and seeds preview refs', async (t) => {
+  const fs = makeFs({
+    '/drive': [dirent('one.mp4', 'file'), dirent('two.webm', 'file')]
+  }, {
+    '/drive/one.mp4': 100,
+    '/drive/two.webm': 200
+  })
+  const calls = []
+  const publisher = {
+    async ensureAnonymousChannel({ channelName }) {
+      calls.push(['ensure', channelName])
+      return { channel: { id: 'channel' }, channelKey: 'aa'.repeat(32), publicBeeKey: 'bb'.repeat(32) }
+    },
+    async importVideo({ filePath, title, mimeType }) {
+      calls.push(['import', filePath, title, mimeType])
+      return {
+        videoId: title,
+        metadata: {
+          uploadedAt: 123,
+          size: filePath.endsWith('one.mp4') ? 100 : 200,
+          mimeType,
+          blobId: `blob:${title}`,
+          blobsCoreKey: title === 'one' ? 'cc'.repeat(32) : 'dd'.repeat(32)
+        }
+      }
+    },
+    async publishChannel(channelInfo) {
+      calls.push(['publish', channelInfo.channelKey])
+    },
+    async seedChannel(channelInfo) {
+      calls.push(['seed', channelInfo.previewVideos.map((video) => video.blobsCoreKey)])
+    }
+  }
+
+  const result = await mirrorLocalDriveToRelayChannel({ rootPath: '/drive', publisher, fs, path: pathShim, channelName: 'Mirror' })
+
+  t.is(result.scanned, 2)
+  t.is(result.imported, 2)
+  t.is(result.failed, 0)
+  t.alike(calls, [
+    ['ensure', 'Mirror'],
+    ['import', '/drive/one.mp4', 'one', 'video/mp4'],
+    ['import', '/drive/two.webm', 'two', 'video/webm'],
+    ['publish', 'aa'.repeat(32)],
+    ['seed', ['cc'.repeat(32), 'dd'.repeat(32)]]
+  ])
+})


### PR DESCRIPTION
## Summary
- add `peartube-relay mirror-local --path <dir>` for importing local video files into the relay channel
- recursively scans common video extensions and imports through the existing relay upload/publish path
- publishes the relay channel and seeds preview blob refs after import so playback refs are announced
- extend runtime shims for directory walking/path helpers in node/bare builds

## Test plan
- `node --test packages/cli/test/local-drive-mirror.test.mjs packages/cli/test/cli.test.mjs`
- `npm test --prefix packages/cli -- --timeout=30000`
- `npm run lint:changed`
- `git diff --check`
