### PR TITLE
fix(relay): start local mirror asynchronously

### DIFF
--- a/packages/cli/src/service.js
+++ b/packages/cli/src/service.js
@@ -281,12 +281,14 @@ export async function createRelayService({
       }
 
       if (config.archive?.localMirror?.enabled) {
-        await runLocalMirrorOnce()
         const pollMs = Math.max(1, Number(config.archive.localMirror.poll || 30)) * 1000
-        localMirrorTimer = setIntervalFn(() => runLocalMirrorOnce().catch((err) => {
+        const triggerLocalMirrorScan = () => runLocalMirrorOnce().catch((err) => {
           logger.archive.error('Local mirror periodic scan failed', { error: err?.message || String(err) })
-        }), pollMs)
+          return { error: err?.message || String(err) }
+        })
+        localMirrorTimer = setIntervalFn(triggerLocalMirrorScan, pollMs)
         localMirrorTimer?.unref?.()
+        triggerLocalMirrorScan()
         logger.archive.info('Local directory mirror started', {
           path: config.archive.localMirror.path,
           pollSeconds: Math.round(pollMs / 1000),

--- a/packages/cli/test/service.test.mjs
+++ b/packages/cli/test/service.test.mjs
@@ -568,9 +568,15 @@ test('createRelayService watches configured local mirror directory', async (t) =
     getActiveIdentity() { return { driveKey: 'drive-key' } },
     getActiveChannel() { return { blobs: true, publicBeeKey: 'public-bee' } }
   }
+  let releaseUpload = null
+  let uploadGate = new Promise((resolve) => {
+    releaseUpload = resolve
+  })
+
   runtime.uploadManager = {
     async uploadFromPath(_channel, filePath) {
       imports.push(filePath)
+      await uploadGate
       return {
         success: true,
         videoId: `video-${imports.length}`,
@@ -650,15 +656,25 @@ test('createRelayService watches configured local mirror directory', async (t) =
     })
 
     await service.start()
-    t.is(imports.length, 1)
-    t.is(submitCalls, 1)
+    t.ok(logger.entries.some((entry) => entry.component === 'relay' && entry.msg === 'Relay started'))
+    t.ok(logger.entries.some((entry) => entry.component === 'archive' && entry.msg === 'Local directory mirror started'))
     t.ok(intervals.some((entry) => entry.ms === 5000))
+
+    await Promise.resolve()
+    await Promise.resolve()
+    t.is(imports.length, 1, 'initial local mirror scan starts in the background')
+    t.is(submitCalls, 0, 'startup does not wait for initial local mirror publish')
+
+    releaseUpload()
+    await new Promise((resolve) => setImmediate(resolve))
+    t.is(submitCalls, 1)
 
     const localMirrorInterval = intervals.find((entry) => entry.ms === 5000)
     await localMirrorInterval.fn()
     t.is(imports.length, 1, 'unchanged file is not re-imported')
 
     sizes['/videos/one.mp4'] = 101
+    uploadGate = Promise.resolve()
     await localMirrorInterval.fn()
     t.is(imports.length, 2, 'changed fingerprint is imported again')
 


### PR DESCRIPTION
## Summary
- Starts the relay local-directory mirror scan in the background instead of awaiting it during service startup.
- Keeps the periodic mirror timer installed immediately, so large initial imports do not block the relay heartbeat/feed runtime from coming up.
- Updates the service regression to prove startup reaches `Relay started` / `Local directory mirror started` before the initial local file publish completes.

## Test Plan
- `node --test packages/cli/test/service.test.mjs packages/cli/test/local-drive-mirror.test.mjs packages/cli/test/config.test.mjs`
- `npm test --prefix packages/cli -- --timeout=30000`
- `npm run lint:changed`
- `git diff --check`
