### PR TITLE
fix(relay): store blind peer under corestore

### DIFF
--- a/packages/backend/src/relay-blind-peer.js
+++ b/packages/backend/src/relay-blind-peer.js
@@ -60,7 +60,8 @@ export async function createRelayBlindPeer({
   }
 
   try {
-    const blindPeer = new BlindPeer(`${storagePath}/blind-peer`, {
+    const blindPeerPath = `${storagePath}/corestore/blind-peer`
+    const blindPeer = new BlindPeer(blindPeerPath, {
       store: ctx.store,
       swarm: ctx.swarm,
       wakeup: ctx.wakeup || undefined,

--- a/packages/backend/test/relay-blind-peer.test.mjs
+++ b/packages/backend/test/relay-blind-peer.test.mjs
@@ -42,7 +42,7 @@ test('createRelayBlindPeer starts a native blind peer on the relay swarm/store',
   assert.equal(relay.enabled, true)
   assert.equal(relay.publicKey, '07'.repeat(32))
   assert.equal(calls.length, 1)
-  assert.equal(calls[0].path, '/tmp/relay/blind-peer')
+  assert.equal(calls[0].path, '/tmp/relay/corestore/blind-peer')
   assert.equal(calls[0].opts.store, ctx.store)
   assert.equal(calls[0].opts.swarm, ctx.swarm)
   assert.equal(calls[0].opts.wakeup, ctx.wakeup)


### PR DESCRIPTION
## Summary
- Stores relay blind-peer state under the relay storage/corestore namespace instead of a top-level `blind-peer` sibling directory.
- Keeps the local mirror directory as opaque media input only; relay network/service metadata stays in relay storage.
- Updates the blind-peer regression to lock the new storage path.

## Test Plan
- `node --test packages/backend/test/relay-blind-peer.test.mjs packages/cli/test/service.test.mjs packages/cli/test/local-drive-mirror.test.mjs`
- `npm test --prefix packages/cli -- --timeout=30000`
- `npm run lint:changed`
- `git diff --check`
