### PR TITLE
fix(relay): relocate legacy blind peer storage

### DIFF
--- a/packages/backend/src/relay-blind-peer.js
+++ b/packages/backend/src/relay-blind-peer.js
@@ -60,7 +60,8 @@ export async function createRelayBlindPeer({
   }
 
   try {
-    const blindPeer = new BlindPeer(`${storagePath}/blind-peer`, {
+    const blindPeerPath = `${storagePath}/corestore/blind-peer`
+    const blindPeer = new BlindPeer(blindPeerPath, {
       store: ctx.store,
       swarm: ctx.swarm,
       wakeup: ctx.wakeup || undefined,

--- a/packages/backend/src/storage-layout.js
+++ b/packages/backend/src/storage-layout.js
@@ -1,6 +1,6 @@
-function createArchiveDirPath(storagePath, pathModule, fsModule) {
+function createArchiveDirPath(storagePath, pathModule, fsModule, prefix = 'logs-legacy') {
   const dbDir = pathModule.join(storagePath, 'db')
-  const baseName = `logs-legacy-${Date.now()}`
+  const baseName = `${prefix}-${Date.now()}`
   let candidate = pathModule.join(dbDir, baseName)
   let counter = 1
 
@@ -38,6 +38,33 @@ function moveDirectoryContents(srcDir, destDir, fsModule, pathModule) {
 
     moveFileWithFallback(srcPath, destPath, fsModule)
   }
+}
+
+export function relocateLegacyBlindPeerDir(storagePath, fsModule, pathModule) {
+  if (!storagePath || !fsModule || !pathModule) return null
+
+  const legacyBlindPeerDir = pathModule.join(storagePath, 'blind-peer')
+  const corestoreBlindPeerDir = pathModule.join(storagePath, 'corestore', 'blind-peer')
+  const dbBlindPeerDir = pathModule.join(storagePath, 'db', 'blind-peer')
+
+  let legacyStats = null
+  try {
+    legacyStats = fsModule.statSync(legacyBlindPeerDir)
+  } catch {}
+
+  if (!legacyStats?.isDirectory?.()) return null
+  fsModule.mkdirSync(pathModule.dirname(corestoreBlindPeerDir), { recursive: true })
+
+  if (!fsModule.existsSync(corestoreBlindPeerDir) && !fsModule.existsSync(dbBlindPeerDir)) {
+    fsModule.renameSync(legacyBlindPeerDir, corestoreBlindPeerDir)
+    return corestoreBlindPeerDir
+  }
+
+  fsModule.mkdirSync(pathModule.join(storagePath, 'db'), { recursive: true })
+  const archiveDir = createArchiveDirPath(storagePath, pathModule, fsModule, 'blind-peer-legacy')
+  moveDirectoryContents(legacyBlindPeerDir, archiveDir, fsModule, pathModule)
+  fsModule.rmdirSync(legacyBlindPeerDir)
+  return archiveDir
 }
 
 export function relocateLegacyLogsDir(storagePath, fsModule, pathModule) {

--- a/packages/backend/src/storage.js
+++ b/packages/backend/src/storage.js
@@ -13,7 +13,7 @@ import { MultiWriterChannel, ChannelPairer } from './channel/index.js'
 import { PublicChannelBee } from './channel/public-channel-bee.js'
 import { loadPublicBeeFromCache } from './public-bee-loader.js'
 import { logger } from './logger.js'
-import { relocateLegacyLogsDir } from './storage-layout.js'
+import { relocateLegacyBlindPeerDir, relocateLegacyLogsDir } from './storage-layout.js'
 import { cleanupFailedCorestoreOpen } from './corestore-cleanup.js'
 import {
   loadBareOrNodeFsModule,
@@ -797,6 +797,18 @@ export async function initializeStorage(config) {
   if (isEmbeddedBareKitStoragePath()) {
     await appendDebugLine('[storage] relocateLegacyLogsDir skipped for embedded BareKit storage')
   } else {
+    try {
+      await appendDebugLine('[storage] relocateLegacyBlindPeerDir start')
+      const relocatedBlindPeerDir = relocateLegacyBlindPeerDir(storagePath, fs, path)
+      await appendDebugLine(`[storage] relocateLegacyBlindPeerDir done moved=${relocatedBlindPeerDir || 'none'}`)
+      if (relocatedBlindPeerDir) {
+        console.log('[Storage] Relocated legacy blind-peer dir to avoid Corestore migration conflict:', relocatedBlindPeerDir)
+      }
+    } catch (error) {
+      await appendDebugLine(`[storage] relocateLegacyBlindPeerDir failed ${describeDebugError(error)}`)
+      console.warn('[Storage] Failed to relocate legacy blind-peer dir before Corestore init:', error?.message)
+    }
+
     try {
       await appendDebugLine('[storage] relocateLegacyLogsDir start')
       const relocatedLogsDir = relocateLegacyLogsDir(storagePath, fs, path)

--- a/packages/backend/test/relay-blind-peer.test.mjs
+++ b/packages/backend/test/relay-blind-peer.test.mjs
@@ -42,7 +42,7 @@ test('createRelayBlindPeer starts a native blind peer on the relay swarm/store',
   assert.equal(relay.enabled, true)
   assert.equal(relay.publicKey, '07'.repeat(32))
   assert.equal(calls.length, 1)
-  assert.equal(calls[0].path, '/tmp/relay/blind-peer')
+  assert.equal(calls[0].path, '/tmp/relay/corestore/blind-peer')
   assert.equal(calls[0].opts.store, ctx.store)
   assert.equal(calls[0].opts.swarm, ctx.swarm)
   assert.equal(calls[0].opts.wakeup, ctx.wakeup)

--- a/packages/backend/test/storage-layout.test.mjs
+++ b/packages/backend/test/storage-layout.test.mjs
@@ -3,7 +3,7 @@ import os from 'node:os'
 import path from 'node:path'
 import fs from 'node:fs'
 
-import { relocateLegacyLogsDir } from '../src/storage-layout.js'
+import { relocateLegacyBlindPeerDir, relocateLegacyLogsDir } from '../src/storage-layout.js'
 
 test('relocateLegacyLogsDir archives conflicting top-level logs into db', async (t) => {
   const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'peartube-storage-layout-'))
@@ -34,6 +34,43 @@ test('relocateLegacyLogsDir is a no-op without db/logs', async (t) => {
 
   t.is(relocatedDir, null)
   t.ok(fs.existsSync(legacyLogsDir))
+
+  fs.rmSync(tmpRoot, { recursive: true, force: true })
+})
+
+test('relocateLegacyBlindPeerDir moves top-level blind-peer into corestore namespace', async (t) => {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'peartube-storage-layout-'))
+  const legacyBlindPeerDir = path.join(tmpRoot, 'blind-peer')
+
+  fs.mkdirSync(legacyBlindPeerDir, { recursive: true })
+  fs.writeFileSync(path.join(legacyBlindPeerDir, 'state'), 'blind-peer-state')
+
+  const relocatedDir = relocateLegacyBlindPeerDir(tmpRoot, fs, path)
+
+  t.is(relocatedDir, path.join(tmpRoot, 'corestore', 'blind-peer'))
+  t.absent(fs.existsSync(legacyBlindPeerDir))
+  t.is(fs.readFileSync(path.join(relocatedDir, 'state'), 'utf8'), 'blind-peer-state')
+
+  fs.rmSync(tmpRoot, { recursive: true, force: true })
+})
+
+test('relocateLegacyBlindPeerDir archives top-level blind-peer when db copy exists', async (t) => {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'peartube-storage-layout-'))
+  const legacyBlindPeerDir = path.join(tmpRoot, 'blind-peer')
+  const dbBlindPeerDir = path.join(tmpRoot, 'db', 'blind-peer')
+
+  fs.mkdirSync(legacyBlindPeerDir, { recursive: true })
+  fs.mkdirSync(dbBlindPeerDir, { recursive: true })
+  fs.writeFileSync(path.join(legacyBlindPeerDir, 'state'), 'legacy-blind-peer-state')
+  fs.writeFileSync(path.join(dbBlindPeerDir, 'state'), 'db-blind-peer-state')
+
+  const relocatedDir = relocateLegacyBlindPeerDir(tmpRoot, fs, path)
+
+  t.ok(relocatedDir)
+  t.ok(relocatedDir.startsWith(path.join(tmpRoot, 'db', 'blind-peer-legacy-')))
+  t.absent(fs.existsSync(legacyBlindPeerDir))
+  t.is(fs.readFileSync(path.join(relocatedDir, 'state'), 'utf8'), 'legacy-blind-peer-state')
+  t.is(fs.readFileSync(path.join(dbBlindPeerDir, 'state'), 'utf8'), 'db-blind-peer-state')
 
   fs.rmSync(tmpRoot, { recursive: true, force: true })
 })


### PR DESCRIPTION
## Summary
- Relocates stale top-level `blind-peer` storage before Corestore opens, preventing Corestore's embedded-storage migration from repeatedly trying to move it into `db/blind-peer`.
- Keeps new blind-peer state under `corestore/blind-peer`.
- Adds storage-layout regressions for both clean legacy moves and conflicting legacy/db copies.

## Test Plan
- `node --test packages/backend/test/storage-layout.test.mjs packages/backend/test/relay-blind-peer.test.mjs packages/cli/test/service.test.mjs packages/cli/test/local-drive-mirror.test.mjs`
- `npm test --prefix packages/cli -- --timeout=30000`
- `npm run lint:changed`
- `git diff --check`
