### PR TITLE
fix(relay): publish local mirror direct previews

### DIFF
--- a/packages/cli/src/archive/publisher.js
+++ b/packages/cli/src/archive/publisher.js
@@ -42,7 +42,32 @@ async function resolvePublicBeeKey(channel) {
   return typeof publicBeeKey === 'string' && publicBeeKey.length > 0 ? publicBeeKey : null
 }
 
-async function announceArchiveChannel(runtime, channelEntry, logger, sourceId) {
+async function listChannelPreviewVideos(channel, limit = 3) {
+  if (!channel || typeof channel.listVideos !== 'function') return []
+  const videos = await channel.listVideos().catch(() => [])
+  if (!Array.isArray(videos)) return []
+  return videos
+    .filter((video) => video?.id && video?.blobId && video?.blobsCoreKey)
+    .slice(0, limit)
+    .map((video) => ({
+      id: String(video.id),
+      title: video?.title ? String(video.title) : 'Untitled',
+      description: video?.description || '',
+      path: video?.path || `/videos/${video.id}.mp4`,
+      uploadedAt: Number(video?.uploadedAt || 0) || 0,
+      duration: Number(video?.duration || 0) || 0,
+      size: Number(video?.size || 0) || 0,
+      mimeType: video?.mimeType || 'video/mp4',
+      availability: 'playable',
+      blobId: String(video.blobId),
+      blobsCoreKey: String(video.blobsCoreKey),
+      thumbnailBlobId: video?.thumbnailBlobId || null,
+      thumbnailBlobsCoreKey: video?.thumbnailBlobsCoreKey || null,
+      thumbnailMimeType: video?.thumbnailMimeType || null
+    }))
+}
+
+async function announceArchiveChannel(runtime, channelEntry, logger, sourceId, options = {}) {
   const { channel, channelKey } = channelEntry || {}
   if (!channel || !channelKey) return
 
@@ -51,8 +76,16 @@ async function announceArchiveChannel(runtime, channelEntry, logger, sourceId) {
 
   if (!publicBeeKey) return
 
+  const previewVideos = Array.isArray(options.previewVideos)
+    ? options.previewVideos.filter(Boolean)
+    : await listChannelPreviewVideos(channel)
+
   try {
-    await runtime.publicFeed?.submitChannel?.(channelKey, publicBeeKey)
+    if (previewVideos.length > 0) {
+      await runtime.publicFeed?.submitChannel?.(channelKey, publicBeeKey, { previewVideos })
+    } else {
+      await runtime.publicFeed?.submitChannel?.(channelKey, publicBeeKey)
+    }
   } catch (err) {
     logger?.archive?.debug?.('Public-feed submit failed', {
       sourceId,
@@ -68,7 +101,10 @@ async function announceArchiveChannel(runtime, channelEntry, logger, sourceId) {
     })
   }
   try {
-    await runtime.seeder?.seedChannel?.({ driveKey: channelKey, publicBeeKey })
+    const seedEntry = previewVideos.length > 0
+      ? { driveKey: channelKey, publicBeeKey, previewVideos }
+      : { driveKey: channelKey, publicBeeKey }
+    await runtime.seeder?.seedChannel?.(seedEntry)
   } catch (err) {
     logger?.archive?.debug?.('Seed channel failed', {
       sourceId,

--- a/packages/cli/src/local-drive-mirror.js
+++ b/packages/cli/src/local-drive-mirror.js
@@ -138,7 +138,7 @@ export async function mirrorLocalDriveToRelayChannel({
 
   const previewVideos = imported.map((entry) => entry.previewVideo).filter(Boolean)
   if (previewVideos.length > 0) {
-    await publisher.publishChannel(channelInfo)
+    await publisher.publishChannel(channelInfo, { previewVideos })
     await publisher.seedChannel({ ...channelInfo, previewVideos })
   }
 

--- a/packages/cli/test/archive.test.mjs
+++ b/packages/cli/test/archive.test.mjs
@@ -78,13 +78,27 @@ test('archive publisher announces and seeds after public bee content changes', a
       },
       async getMetadata() {
         return { publicBeeKey: 'bb'.repeat(32) }
+      },
+      async listVideos() {
+        return videoCount > 0
+          ? [{
+              id: 'local-1',
+              title: 'Local 1',
+              path: '/videos/local-1.mp4',
+              uploadedAt: 123,
+              size: 4096,
+              mimeType: 'video/mp4',
+              blobId: '0:4:0:4096',
+              blobsCoreKey: 'cc'.repeat(32)
+            }]
+          : []
       }
     }
   }
   const runtime = {
     publicFeed: {
-      async submitChannel(driveKey, publicBeeKey) {
-        calls.push(['submit', driveKey, publicBeeKey, videoCount])
+      async submitChannel(driveKey, publicBeeKey, options) {
+        calls.push(['submit', driveKey, publicBeeKey, videoCount, options?.previewVideos?.map((video) => video.blobId) || []])
       }
     },
     cacheManager: {
@@ -94,7 +108,7 @@ test('archive publisher announces and seeds after public bee content changes', a
     },
     seeder: {
       async seedChannel(channel) {
-        calls.push(['seed', channel.driveKey, channel.publicBeeKey, videoCount])
+        calls.push(['seed', channel.driveKey, channel.publicBeeKey, videoCount, channel.previewVideos?.map((video) => video.blobId) || []])
       }
     }
   }
@@ -105,12 +119,12 @@ test('archive publisher announces and seeds after public bee content changes', a
 
   t.is(channelEntry.publicBeeKey, 'bb'.repeat(32))
   t.alike(calls, [
-    ['submit', 'aa'.repeat(32), 'bb'.repeat(32), 0],
+    ['submit', 'aa'.repeat(32), 'bb'.repeat(32), 0, []],
     ['pin', 'aa'.repeat(32), 'bb'.repeat(32), 0],
-    ['seed', 'aa'.repeat(32), 'bb'.repeat(32), 0],
-    ['submit', 'aa'.repeat(32), 'bb'.repeat(32), 1],
+    ['seed', 'aa'.repeat(32), 'bb'.repeat(32), 0, []],
+    ['submit', 'aa'.repeat(32), 'bb'.repeat(32), 1, ['0:4:0:4096']],
     ['pin', 'aa'.repeat(32), 'bb'.repeat(32), 1],
-    ['seed', 'aa'.repeat(32), 'bb'.repeat(32), 1],
+    ['seed', 'aa'.repeat(32), 'bb'.repeat(32), 1, ['0:4:0:4096']],
   ])
 })
 

--- a/packages/cli/test/local-drive-mirror.test.mjs
+++ b/packages/cli/test/local-drive-mirror.test.mjs
@@ -72,8 +72,8 @@ test('mirrorLocalDriveToRelayChannel imports, publishes, and seeds preview refs'
         }
       }
     },
-    async publishChannel(channelInfo) {
-      calls.push(['publish', channelInfo.channelKey])
+    async publishChannel(channelInfo, options) {
+      calls.push(['publish', channelInfo.channelKey, options.previewVideos.map((video) => video.blobId)])
     },
     async seedChannel(channelInfo) {
       calls.push(['seed', channelInfo.previewVideos.map((video) => video.blobsCoreKey)])
@@ -90,7 +90,7 @@ test('mirrorLocalDriveToRelayChannel imports, publishes, and seeds preview refs'
     ['ensure', 'Mirror'],
     ['import', '/drive/one.mp4', 'one', 'video/mp4'],
     ['import', '/drive/two.webm', 'two', 'video/webm'],
-    ['publish', 'aa'.repeat(32)],
+    ['publish', 'aa'.repeat(32), ['blob:one', 'blob:two']],
     ['seed', ['cc'.repeat(32), 'dd'.repeat(32)]]
   ])
 })


### PR DESCRIPTION
## Summary
- include direct blob preview refs when archive/local mirror channels are re-announced
- pass local mirror imported preview refs through publishChannel so feed gossip carries playable blob IDs immediately
- keep relay seeding those exact preview blob cores for playback availability

## Tests
- node --test packages/app/tests/vertical-discovery-regression.test.mjs
- npm test --prefix packages/cli -- --timeout=30000
- npm run lint:changed
- git diff --check