### PR TITLE
revert(relay): do not remux local mirror videos

### DIFF
--- a/packages/cli/src/local-drive-mirror.js
+++ b/packages/cli/src/local-drive-mirror.js
@@ -1,18 +1,8 @@
 import { readdirSync, statSync } from '#fs'
 import { basename, extname, join } from '#path'
-import { spawn as defaultSpawn } from '#subprocess'
-
-const defaultPath = {
-  join,
-  dirname(path) {
-    const parts = String(path || '').split('/')
-    parts.pop()
-    return parts.join('/') || '/'
-  }
-}
+const defaultPath = { join }
 
 const DEFAULT_VIDEO_EXTENSIONS = new Set(['.mp4', '.m4v', '.mov', '.webm', '.mkv', '.avi'])
-const DIRECT_PLAY_EXTENSIONS = new Set(['.mp4', '.m4v', '.mov', '.webm'])
 
 const MIME_BY_EXT = {
   '.mp4': 'video/mp4',
@@ -21,71 +11,6 @@ const MIME_BY_EXT = {
   '.webm': 'video/webm',
   '.mkv': 'video/x-matroska',
   '.avi': 'video/x-msvideo'
-}
-
-function isDirectPlayPath(filePath) {
-  return DIRECT_PLAY_EXTENSIONS.has(extname(String(filePath || '')).toLowerCase())
-}
-
-function remuxedOutputPath(filePath, { path = defaultPath } = {}) {
-  const source = String(filePath || '')
-  const ext = extname(source)
-  const base = ext ? basename(source).slice(0, -ext.length) : basename(source)
-  return path.join(path.dirname(source), `.peartube-remux-${base || 'video'}.mp4`)
-}
-
-async function remuxLocalVideoForWebPlayback(filePath, {
-  ffmpegPath = null,
-  fs = { statSync },
-  path = defaultPath,
-  spawnFn = defaultSpawn,
-  logger = null
-} = {}) {
-  if (isDirectPlayPath(filePath)) {
-    return { filePath, cleanup: null, remuxed: false, mimeType: mimeTypeForPath(filePath) }
-  }
-
-  const bin = ffmpegPath || 'ffmpeg'
-  const outputPath = remuxedOutputPath(filePath, { path })
-  const args = [
-    '-hide_banner',
-    '-loglevel', 'error',
-    '-y',
-    '-i', filePath,
-    '-map', '0:v:0',
-    '-map', '0:a:0?',
-    '-c:v', 'copy',
-    '-c:a', 'aac',
-    '-b:a', '160k',
-    '-movflags', '+faststart',
-    outputPath
-  ]
-
-  await new Promise((resolve, reject) => {
-    const child = spawnFn(bin, args, { stdio: ['ignore', 'ignore', 'pipe'] })
-    let stderr = ''
-    child.stderr?.on?.('data', (chunk) => { stderr += String(chunk) })
-    child.on?.('error', reject)
-    child.on?.('close', (code) => {
-      if (code === 0) resolve()
-      else reject(new Error(`ffmpeg remux failed (${code}): ${stderr.trim() || 'unknown error'}`))
-    })
-  })
-
-  const stat = fs.statSync(outputPath)
-  if (!Number.isFinite(Number(stat?.size)) || Number(stat.size) <= 0) {
-    throw new Error('ffmpeg remux produced empty output')
-  }
-
-  logger?.archive?.info?.('Local drive video remuxed for web playback', { source: filePath, output: outputPath })
-  return {
-    filePath: outputPath,
-    cleanup: () => {
-      try { fs.rmSync?.(outputPath, { force: true }) } catch { /* best effort cleanup */ }
-    },
-    remuxed: true,
-    mimeType: 'video/mp4'
-  }
 }
 
 function normalizeExtensions(extensions = DEFAULT_VIDEO_EXTENSIONS) {
@@ -165,9 +90,7 @@ export async function mirrorLocalDriveToRelayChannel({
   fs = { readdirSync, statSync },
   path = defaultPath,
   state = null,
-  logger = null,
-  ffmpegPath = null,
-  spawnFn = defaultSpawn
+  logger = null
 } = {}) {
   if (!publisher) throw new Error('publisher is required')
   const videos = listLocalDriveVideos(rootPath, { fs, path, recursive, maxFiles })
@@ -179,19 +102,13 @@ export async function mirrorLocalDriveToRelayChannel({
   const failed = []
 
   for (const video of pendingVideos) {
-    let prepared = null
     try {
-      prepared = await remuxLocalVideoForWebPlayback(video.filePath, { ffmpegPath, fs, path, spawnFn, logger })
-      const importPath = prepared.filePath
-      const importMimeType = prepared.mimeType || video.mimeType
-      const importStat = importPath === video.filePath ? null : fs.statSync(importPath)
-      const importSize = Number(importStat?.size || video.size || 0) || video.size
       const result = await publisher.importVideo({
         channel: channelInfo.channel,
-        filePath: importPath,
+        filePath: video.filePath,
         title: video.title,
         description,
-        mimeType: importMimeType
+        mimeType: video.mimeType
       })
       const metadata = result?.metadata || result || {}
       const previewVideo = result?.videoId ? {
@@ -201,8 +118,8 @@ export async function mirrorLocalDriveToRelayChannel({
         path: metadata.path || `/videos/${result.videoId}.mp4`,
         uploadedAt: metadata.uploadedAt || Date.now(),
         duration: Number(metadata.duration || 0) || 0,
-        size: Number(metadata.size || importSize || 0) || 0,
-        mimeType: metadata.mimeType || importMimeType,
+        size: Number(metadata.size || video.size || 0) || 0,
+        mimeType: metadata.mimeType || video.mimeType,
         availability: 'playable',
         blobId: metadata.blobId || null,
         blobsCoreKey: metadata.blobsCoreKey || null,
@@ -210,14 +127,12 @@ export async function mirrorLocalDriveToRelayChannel({
         thumbnailBlobsCoreKey: metadata.thumbnailBlobsCoreKey || null,
         thumbnailMimeType: metadata.thumbnailMimeType || null
       } : null
-      imported.push({ ...video, videoId: result?.videoId || null, previewVideo, remuxed: Boolean(prepared.remuxed) })
+      imported.push({ ...video, videoId: result?.videoId || null, previewVideo })
       state?.seen?.set(video.filePath, fingerprintVideo(video))
-      logger?.archive?.info?.('Local drive video imported', { file: video.filePath, videoId: result?.videoId || null, remuxed: Boolean(prepared.remuxed) })
+      logger?.archive?.info?.('Local drive video imported', { file: video.filePath, videoId: result?.videoId || null })
     } catch (err) {
       failed.push({ ...video, error: err?.message || String(err) })
       logger?.archive?.error?.('Local drive video import failed', { file: video.filePath, error: err?.message || String(err) })
-    } finally {
-      try { prepared?.cleanup?.() } catch { /* best effort cleanup */ }
     }
   }
 

--- a/packages/cli/src/service.js
+++ b/packages/cli/src/service.js
@@ -65,8 +65,6 @@ export async function createRelayService({
         path: runtimePathModule,
         logger,
         state: localMirrorState,
-        ffmpegPath: config.archive?.ffmpegPath,
-        spawnFn: spawnFn || undefined,
         publisher: createLocalDrivePublisher(runtimeFsModule)
       })
       if (result?.imported || result?.failed) {

--- a/packages/cli/test/local-drive-mirror.test.mjs
+++ b/packages/cli/test/local-drive-mirror.test.mjs
@@ -19,34 +19,13 @@ function makeFs(tree, sizes = {}) {
     },
     statSync(path) {
       return { size: sizes[path] ?? 1024, mtimeMs: 1 }
-    },
-    rmSync(path) {
-      delete sizes[path]
     }
-  }
-}
-
-function makeSpawn({ onSpawn } = {}) {
-  return (bin, args) => {
-    const listeners = new Map()
-    const child = {
-      stderr: { on() {} },
-      on(event, cb) { listeners.set(event, cb) }
-    }
-    onSpawn?.(bin, args)
-    queueMicrotask(() => listeners.get('close')?.(0))
-    return child
   }
 }
 
 const pathShim = {
   join(...parts) {
     return parts.join('/').replace(/\/+/g, '/')
-  },
-  dirname(path) {
-    const parts = String(path).split('/')
-    parts.pop()
-    return parts.join('/') || '/'
   }
 }
 
@@ -115,58 +94,6 @@ test('mirrorLocalDriveToRelayChannel imports, publishes, and seeds preview refs'
     ['seed', ['cc'.repeat(32), 'dd'.repeat(32)]]
   ])
 })
-test('mirrorLocalDriveToRelayChannel remuxes non-web containers before import', async (t) => {
-  const sizes = {
-    '/drive/movie.mkv': 300,
-    '/drive/.peartube-remux-movie.mp4': 240
-  }
-  const fs = makeFs({
-    '/drive': [dirent('movie.mkv', 'file')]
-  }, sizes)
-  const spawns = []
-  const imports = []
-  const publisher = {
-    async ensureAnonymousChannel() {
-      return { channel: { id: 'channel' }, channelKey: 'aa'.repeat(32), publicBeeKey: 'bb'.repeat(32) }
-    },
-    async importVideo({ filePath, mimeType }) {
-      imports.push({ filePath, mimeType })
-      return {
-        videoId: 'movie',
-        metadata: {
-          uploadedAt: 123,
-          size: sizes[filePath],
-          mimeType,
-          blobId: '0:3:0:240',
-          blobsCoreKey: 'cc'.repeat(32)
-        }
-      }
-    },
-    async publishChannel(channelInfo, options) {
-      t.is(options.previewVideos[0].mimeType, 'video/mp4')
-      t.is(options.previewVideos[0].size, 240)
-    },
-    async seedChannel(channelInfo) {
-      t.is(channelInfo.previewVideos[0].mimeType, 'video/mp4')
-    }
-  }
-
-  const result = await mirrorLocalDriveToRelayChannel({
-    rootPath: '/drive',
-    publisher,
-    fs,
-    path: pathShim,
-    spawnFn: makeSpawn({ onSpawn: (bin, args) => spawns.push({ bin, args }) }),
-    ffmpegPath: '/usr/bin/ffmpeg'
-  })
-
-  t.is(result.imported, 1)
-  t.alike(imports, [{ filePath: '/drive/.peartube-remux-movie.mp4', mimeType: 'video/mp4' }])
-  t.is(spawns.length, 1)
-  t.is(spawns[0].bin, '/usr/bin/ffmpeg')
-  t.ok(spawns[0].args.includes('-movflags'))
-  t.ok(spawns[0].args.includes('+faststart'))
-})
 
 
 test('mirrorLocalDriveToRelayChannel skips already mirrored file fingerprints', async (t) => {
@@ -177,9 +104,6 @@ test('mirrorLocalDriveToRelayChannel skips already mirrored file fingerprints', 
     },
     statSync(path) {
       return { size: sizes[path], mtimeMs: sizes[path] }
-    },
-    rmSync(path) {
-      delete sizes[path]
     }
   }
   const state = createLocalDriveMirrorState()
@@ -190,7 +114,7 @@ test('mirrorLocalDriveToRelayChannel skips already mirrored file fingerprints', 
     },
     async importVideo({ filePath }) {
       imports.push(filePath)
-      return { videoId: `video-${imports.length}`, metadata: { size: sizes[filePath], blobId: `blob-${imports.length}`, blobsCoreKey: 'cc'.repeat(32), mimeType: 'video/mp4' } }
+      return { videoId: `video-${imports.length}`, metadata: { size: sizes[filePath], blobId: `blob-${imports.length}`, blobsCoreKey: 'cc'.repeat(32) } }
     },
     async publishChannel() {},
     async seedChannel() {}

--- a/packages/cli/test/service.test.mjs
+++ b/packages/cli/test/service.test.mjs
@@ -605,17 +605,11 @@ test('createRelayService watches configured local mirror directory', async (t) =
     },
     statSync(path) {
       return { size: sizes[path], mtimeMs: sizes[path] }
-    },
-    rmSync() {}
+    }
   }
   const pathModule = {
     join(...parts) {
       return parts.join('/').replace(/\/+/g, '/')
-    },
-    dirname(path) {
-      const parts = String(path).split('/')
-      parts.pop()
-      return parts.join('/') || '/'
     }
   }
   function setIntervalFn(fn, ms) {
@@ -666,7 +660,8 @@ test('createRelayService watches configured local mirror directory', async (t) =
     t.ok(logger.entries.some((entry) => entry.component === 'archive' && entry.msg === 'Local directory mirror started'))
     t.ok(intervals.some((entry) => entry.ms === 5000))
 
-    await new Promise((resolve) => setImmediate(resolve))
+    await Promise.resolve()
+    await Promise.resolve()
     t.is(imports.length, 1, 'initial local mirror scan starts in the background')
     t.is(submitCalls, 0, 'startup does not wait for initial local mirror publish')
 


### PR DESCRIPTION
## Summary
- Reverts PR #145 completely.
- Local mirror imports the original files as-is again.
- Removes ffmpeg remux behavior and its tests/plumbing.

## Why
User explicitly does not want PearTube/Booraka to remux videos ever. Playback debugging should happen in transport/range/player handling, not by mutating media on import.

## Tests
- `node --test packages/cli/test/local-drive-mirror.test.mjs packages/cli/test/service.test.mjs`
- `npm run lint:changed`
- `git diff --check`
