### PR TITLE
fix(p2p): improve hard-network diagnostics and prewarm playback

### DIFF
--- a/packages/app/app/(tabs)/discover.tsx
+++ b/packages/app/app/(tabs)/discover.tsx
@@ -115,6 +115,7 @@ export default function VerticalDiscoveryScreen() {
   const pendingPlayKeyRef = useRef<string | null>(null)
   const hydratedChannelsRef = useRef<Set<string>>(new Set())
   const feedLoadInFlightRef = useRef(false)
+  const inflightPlaybackWarmups = useRef<Set<string>>(new Set())
 
   const activeVideo = videos[activeIndex]
   const activeVideoKey = activeVideo ? `${activeVideo.channelKey}:${activeVideo.id}` : null
@@ -330,9 +331,14 @@ export default function VerticalDiscoveryScreen() {
   useEffect(() => {
     const warmPlaybackUrl = async (video: VideoData) => {
       const { cacheKey, playbackRequest } = makePlaybackRequest(video)
-      if (cacheKey && getCachedVideoUrl(cacheKey)) return
-      const result = await rpc?.preparePlayback?.(playbackRequest)
-      if (result?.url && cacheKey) setCachedVideoUrl(cacheKey, result.url)
+      if (!cacheKey || getCachedVideoUrl(cacheKey) || inflightPlaybackWarmups.current.has(cacheKey)) return
+      inflightPlaybackWarmups.current.add(cacheKey)
+      try {
+        const result = await rpc?.preparePlayback?.(playbackRequest)
+        if (result?.url && cacheKey) setCachedVideoUrl(cacheKey, result.url)
+      } finally {
+        inflightPlaybackWarmups.current.delete(cacheKey)
+      }
     }
 
     const nextVideos = videos.slice(activeIndex + 1, activeIndex + 5)

--- a/packages/app/app/(tabs)/index.tsx
+++ b/packages/app/app/(tabs)/index.tsx
@@ -151,6 +151,7 @@ export default function HomeScreen() {
   const thumbnailCacheRef = useRef(thumbnailCache)
   thumbnailCacheRef.current = thumbnailCache
   const inflightThumbnailFetches = useRef<Set<string>>(new Set())
+  const inflightPlaybackWarmups = useRef<Set<string>>(new Set())
   const appState = useRef<AppStateStatus>(AppState.currentState)
 
   // Fetch thumbnail for a video (non-blocking)
@@ -192,6 +193,37 @@ export default function HomeScreen() {
       }
     }
   }, [fetchThumbnail])
+
+  const warmPlaybackUrl = useCallback(async (video: VideoData) => {
+    if (!rpc || !video?.channelKey) return
+    const videoRef = (video.path && typeof video.path === 'string' && video.path.startsWith('/'))
+      ? video.path
+      : video.id
+    const videoAny = video as any
+    const cacheKey = makeVideoUrlCacheKey(
+      video.channelKey,
+      videoRef,
+      videoAny.blobId || undefined,
+      videoAny.blobsCoreKey || undefined,
+    )
+    if (!cacheKey || getCachedVideoUrl(cacheKey) || inflightPlaybackWarmups.current.has(cacheKey)) return
+    inflightPlaybackWarmups.current.add(cacheKey)
+    try {
+      const result = await rpc.preparePlayback({
+        channelKey: video.channelKey,
+        videoId: videoRef,
+        publicBeeKey: videoAny.publicBeeKey || undefined,
+        blobId: videoAny.blobId || undefined,
+        blobsCoreKey: videoAny.blobsCoreKey || undefined,
+        mimeType: videoAny.mimeType || undefined,
+      })
+      if (result?.url) setCachedVideoUrl(cacheKey, result.url)
+    } catch {
+      // Best-effort URL warming; playback still resolves on tap.
+    } finally {
+      inflightPlaybackWarmups.current.delete(cacheKey)
+    }
+  }, [rpc])
 
   // Effects that depend on loadPublicFeed/refreshFeed are declared below those callbacks.
 
@@ -846,6 +878,13 @@ export default function HomeScreen() {
         thumbnailUrl: thumbnailCache[cacheKey] || v.thumbnailUrl || v.thumbnail || null
       }
     })
+
+  useEffect(() => {
+    const nextVideos = feedVideosWithThumbs.slice(0, 4)
+    for (const video of nextVideos) {
+      void warmPlaybackUrl(video)
+    }
+  }, [feedVideosWithThumbs, warmPlaybackUrl])
 
   const backendConnecting = !ready
   const backendLoading = Boolean(loading)

--- a/packages/app/tests/vertical-discovery-regression.test.mjs
+++ b/packages/app/tests/vertical-discovery-regression.test.mjs
@@ -86,7 +86,18 @@ test('vertical discovery preloads the next few videos into the playback URL cach
   assert.match(source, /const nextVideos = videos\.slice\(activeIndex \+ 1, activeIndex \+ 5\)/, 'shorts should warm the next few videos, not only one or two')
   assert.match(source, /const warmPlaybackUrl = async \(video: VideoData\)/, 'preload should use a named URL warming helper')
   assert.match(source, /const result = await rpc\?\.preparePlayback\?\.\(playbackRequest\)/, 'preload should await preparePlayback so it can keep the resolved URL')
+  assert.match(source, /inflightPlaybackWarmups\.current\.has\(cacheKey\)/, 'preload should de-dupe overlapping preparePlayback warmups')
   assert.match(source, /if \(result\?\.url && cacheKey\) setCachedVideoUrl\(cacheKey, result\.url\)/, 'preload should populate the playback URL cache for instant swipe playback')
+})
+
+test('Home Discover preloads visible feed playback URLs into the shared URL cache', () => {
+  const source = readAppFile('app/(tabs)/index.tsx')
+
+  assert.match(source, /const warmPlaybackUrl = useCallback\(async \(video: VideoData\)/, 'Home should use a named playback URL warming helper')
+  assert.match(source, /inflightPlaybackWarmups\.current\.has\(cacheKey\)/, 'Home warmups should be de-duped')
+  assert.match(source, /const nextVideos = feedVideosWithThumbs\.slice\(0, 4\)/, 'Home should warm the first few visible Discover cards')
+  assert.match(source, /const result = await rpc\.preparePlayback\(\{[\s\S]*blobId:[\s\S]*blobsCoreKey:[\s\S]*mimeType:/, 'Home warmups should preserve direct blob playback refs')
+  assert.match(source, /if \(result\?\.url\) setCachedVideoUrl\(cacheKey, result\.url\)/, 'Home warmups should populate the shared playback URL cache')
 })
 
 test('vertical discovery subscribes to backend feed-update events instead of only loading once', () => {

--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -2562,6 +2562,39 @@ export function createApi({
     getSwarmStatus() {
       const topicHex = b4a.toString(crypto.data(b4a.from(NETWORK_TOPIC_STRING, 'utf-8')), 'hex')
       const networkDebug = getNetworkStats()
+      const feedStats = publicFeed?.getStats?.() || {}
+      const doctor = {
+        dht: {
+          bootstrapped: ctx.swarm?.dht?.bootstrapped ?? null,
+          firewalled: ctx.swarm?.dht?.firewalled ?? null,
+          online: ctx.swarm?.dht?.online ?? null,
+          ephemeral: ctx.swarm?.dht?.ephemeral ?? null,
+        },
+        discovery: {
+          peerPoolJoined: Boolean(ctx.peerPoolDiscovery),
+          publicFeedDiscoveryJoined: Boolean(publicFeed?.feedDiscovery),
+          discoveredPeers: feedStats.directPeerDial?.discoveredPeers || 0,
+          recentPeers: networkDebug?.hyperswarm?.recentPeers || [],
+        },
+        socket: {
+          swarmPeers: ctx.swarm?.peers?.size || 0,
+          swarmConnections: ctx.swarm?.connections?.size || 0,
+          connecting: Number(ctx.swarm?.connecting || 0),
+          recentConnections: networkDebug?.hyperswarm?.recentConnections || [],
+          peerStates: networkDebug?.hyperswarm?.peerStates || [],
+        },
+        feed: {
+          feedConnections: publicFeed?.feedConnections?.size || 0,
+          feedEntries: publicFeed?.entries?.size || 0,
+          directPeerDial: feedStats.directPeerDial || null,
+        },
+        recommendedBoundary: null,
+      }
+      if (doctor.discovery.discoveredPeers === 0 && doctor.dht.bootstrapped === false) doctor.recommendedBoundary = 'dht-bootstrap'
+      else if (doctor.discovery.discoveredPeers > 0 && doctor.socket.swarmConnections === 0) doctor.recommendedBoundary = 'transport-socket'
+      else if (doctor.socket.swarmConnections > 0 && doctor.feed.feedConnections === 0) doctor.recommendedBoundary = 'protomux-feed-open'
+      else if (doctor.feed.feedConnections > 0 && doctor.feed.feedEntries === 0) doctor.recommendedBoundary = 'feed-gossip'
+      else doctor.recommendedBoundary = 'content-playback-or-ui'
       return {
         swarmConnections: ctx.swarm?.connections?.size || 0,
         swarmPeers: ctx.swarm?.peers?.size || 0,
@@ -2569,6 +2602,7 @@ export function createApi({
         feedEntries: publicFeed?.entries?.size || 0,
         feedTopicHex: topicHex,
         network: networkDebug,
+        doctor,
         swarmOffline: Boolean(ctx.swarm?._peartubeOffline),
         swarmOfflineReason: ctx.swarm?._peartubeOfflineReason || null,
         swarmListenResolved: Boolean(ctx.swarm?._peartubeListenResolved),

--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -21,7 +21,7 @@ import b4a from 'b4a'
 import { NETWORK_TOPIC_STRING, PROTOCOL_NAME } from './types.js';
 import { logger } from './logger.js'
 import { hashFeedEntries, hashPreviewVideos } from './hash-utils.js'
-import { peerPublicKey, swarmHasConnection } from './swarm-peer-dial.js'
+import { peerPublicKey, swarmHasConnection, swarmQueuePeer, swarmRememberPeer } from './swarm-peer-dial.js'
 
 const log = logger('PublicFeed')
 const PUBLIC_FEED_CATALOG_VERSION = 1
@@ -73,8 +73,16 @@ export class PublicFeedManager {
     this._nextAvailabilityRequestId = 1;
     /** @type {Map<string, { resolve: Function, timeout: any }>} */
     this.pendingAvailabilityRequests = new Map();
-    /** @type {Map<string, any>} Remembered Hyperswarm peer candidates for diagnostics only. */
+    /** @type {Map<string, any>} Remembered Hyperswarm peer candidates for diagnostics/recovery. */
     this._discoveredPeers = new Map();
+    /** @type {Map<string, any>} Remembered discovered peer objects with relay-address hints. */
+    this._discoveredPeerHints = new Map();
+    /** @type {Array<{at: number, action: string, reason?: string, discoveredPeers: number, connections: number, queued: number}>} */
+    this._recoveryEvents = [];
+    /** @type {number} */
+    this._lastRecoveryAt = 0;
+    /** @type {number} */
+    this._recoveryCooldownMs = 30000;
     /** @type {Map<string, number>} */
     this._directPeerLastDialedAt = new Map();
     /** @type {Map<string, string>} */
@@ -480,11 +488,23 @@ export class PublicFeedManager {
     this._connectionStartedAt.delete(conn)
   }
 
-  _rememberPeerPublicKey(publicKey) {
+  _rememberPeerPublicKey(publicKey, peer = null, topic = null) {
     if (!publicKey) return null
     const keyHex = b4a.toString(publicKey, 'hex')
     if (!keyHex || keyHex === b4a.toString(this.swarm?.keyPair?.publicKey || [], 'hex')) return null
     this._discoveredPeers.set(keyHex, publicKey)
+    if (peer && typeof peer === 'object') {
+      const relayAddresses = Array.isArray(peer.relayAddresses) ? peer.relayAddresses : []
+      const existing = this._discoveredPeerHints.get(keyHex) || {}
+      this._discoveredPeerHints.set(keyHex, {
+        peer,
+        topic,
+        relayAddresses,
+        relayAddressesSeen: Math.max(Number(existing.relayAddressesSeen || 0), relayAddresses.length),
+        firstSeenAt: existing.firstSeenAt || this._now(),
+        lastSeenAt: this._now(),
+      })
+    }
     return { keyHex, publicKey }
   }
 
@@ -499,12 +519,13 @@ export class PublicFeedManager {
     if (topic && !this._isNetworkTopic(topic)) return false
     if (!this.swarm) return false
     const publicKey = this._peerEntryPublicKey(peer)
-    const remembered = this._rememberPeerPublicKey(publicKey)
+    const remembered = this._rememberPeerPublicKey(publicKey, peer, topic)
     if (!remembered) {
       this._directPeerDialStats.skipped++
       this._directPeerDialStats.lastReason = 'self-or-missing-key'
       return false
     }
+    this._rememberDiscoveredPeerInSwarm(peer, topic, remembered.keyHex)
     if (this._hasActivePeerConnection(remembered.keyHex, remembered.publicKey)) {
       this._directPeerDialStats.skipped++
       this._directPeerDialStats.lastReason = 'already-connected-peer'
@@ -512,9 +533,88 @@ export class PublicFeedManager {
     return true
   }
 
-  _swarmDialState(keyHex) {
+  _rememberDiscoveredPeerInSwarm(peer, topic, keyHex) {
+    if (!this.swarm || !peer || typeof peer !== 'object') return null
+    try {
+      return swarmRememberPeer(this.swarm, peer, topic) || this.swarm.peers?.get?.(keyHex) || null
+    } catch (err) {
+      this._directPeerLastDialError.set(keyHex, err?.message || String(err))
+      if (err?.stack) this._directPeerLastDialErrorStack.set(keyHex, err.stack)
+      return null
+    }
+  }
+
+  _queueRememberedPeer(keyHex, peerInfo, reason = 'recovery') {
+    if (!peerInfo || this._hasActivePeerConnection(keyHex, this._discoveredPeers.get(keyHex))) return false
+    if (peerInfo.queued || peerInfo.waiting) return false
+    try {
+      const queued = swarmQueuePeer(this.swarm, peerInfo)
+      if (queued) {
+        this._directPeerDialStats.attempted++
+        this._directPeerDialStats.queued++
+        this._directPeerDialStats.lastReason = reason
+        this._directPeerDialStats.lastDialedAt = this._now()
+        this._directPeerLastDialedAt.set(keyHex, this._now())
+        return true
+      }
+    } catch (err) {
+      this._directPeerDialStats.failed++
+      this._directPeerDialStats.lastReason = 'queue-error'
+      this._directPeerLastDialError.set(keyHex, err?.message || String(err))
+      if (err?.stack) this._directPeerLastDialErrorStack.set(keyHex, err.stack)
+    }
+    return false
+  }
+
+  runBoundedPeerRecovery(reason = 'heartbeat') {
+    if (!this.swarm || this._discoveredPeers.size === 0) return { queued: 0, reason: 'no-discovered-peers' }
+    const now = this._now()
+    if (now - this._lastRecoveryAt < this._recoveryCooldownMs) return { queued: 0, reason: 'cooldown' }
+    if ((this.swarm.connections?.size || 0) > 0 || this.feedConnections.size > 0) return { queued: 0, reason: 'already-connected' }
+    this._lastRecoveryAt = now
+    let queued = 0
+    for (const [keyHex, publicKey] of this._discoveredPeers) {
+      let peerInfo = this.swarm.peers?.get?.(keyHex) || null
+      const hint = this._discoveredPeerHints.get(keyHex)
+      if (!peerInfo && hint?.peer) peerInfo = this._rememberDiscoveredPeerInSwarm(hint.peer, hint.topic, keyHex)
+      if (!peerInfo && typeof this.swarm.joinPeer === 'function') {
+        try {
+          this.swarm.joinPeer(publicKey)
+          this._directPeerDialStats.attempted++
+          this._directPeerDialStats.queued++
+          this._directPeerDialStats.lastReason = reason
+          this._directPeerDialStats.lastDialedAt = now
+          this._directPeerLastDialedAt.set(keyHex, now)
+          queued++
+          continue
+        } catch (err) {
+          this._directPeerDialStats.failed++
+          this._directPeerLastDialError.set(keyHex, err?.message || String(err))
+          if (err?.stack) this._directPeerLastDialErrorStack.set(keyHex, err.stack)
+        }
+      }
+      if (peerInfo && this._queueRememberedPeer(keyHex, peerInfo, reason)) queued++
+      if (queued >= 8) break
+    }
+    const event = {
+      at: now,
+      action: 'bounded-peer-recovery',
+      reason,
+      discoveredPeers: this._discoveredPeers.size,
+      connections: this.swarm.connections?.size || 0,
+      queued,
+    }
+    this._recoveryEvents.push(event)
+    while (this._recoveryEvents.length > 10) this._recoveryEvents.shift()
+    return event
+  }
+
+  _swarmDialState(keyHex, publicKey = null) {
     const peers = this.swarm?.peers
-    const peerInfo = peers && typeof peers.get === 'function' ? peers.get(keyHex) : null
+    let peerInfo = peers && typeof peers.get === 'function' ? peers.get(keyHex) : null
+    if (!peerInfo && peers && typeof peers.get === 'function' && publicKey) {
+      try { peerInfo = peers.get(publicKey) } catch { peerInfo = null }
+    }
     if (!peerInfo || typeof peerInfo !== 'object') return null
 
     const relayAddresses = Array.isArray(peerInfo.relayAddresses) ? peerInfo.relayAddresses : []
@@ -537,16 +637,20 @@ export class PublicFeedManager {
   getDirectPeerDialStats() {
     const peers = []
     for (const [keyHex] of this._discoveredPeers) {
-      const swarm = this._swarmDialState(keyHex)
+      const publicKey = this._discoveredPeers.get(keyHex)
+      const swarm = this._swarmDialState(keyHex, publicKey)
+      const hint = this._discoveredPeerHints.get(keyHex)
       peers.push({
         key: keyHex.slice(0, 16),
         attempts: swarm?.attempts || 0,
+        discoveredRelayAddresses: Number(hint?.relayAddressesSeen || 0),
+        lastSeenAt: hint?.lastSeenAt || null,
         lastDialedAt: this._directPeerLastDialedAt.get(keyHex) || null,
         lastQueuedAt: null,
         lastError: this._directPeerLastDialError.get(keyHex) || null,
         lastErrorStack: this._directPeerLastDialErrorStack.get(keyHex) || null,
         pending: Boolean(swarm?.queued || swarm?.waiting),
-        connected: this._hasActivePeerConnection(keyHex, this._discoveredPeers.get(keyHex)),
+        connected: this._hasActivePeerConnection(keyHex, publicKey),
         swarm,
       })
     }
@@ -563,6 +667,9 @@ export class PublicFeedManager {
       swarmConnecting: Number(this.swarm?.connecting || 0),
       swarmExplicitPeers: this.swarm?.explicitPeers?.size || 0,
       swarmQueueSize: this.swarm?._queue?.length || 0,
+      recoveryEvents: this._recoveryEvents.slice(-5),
+      recoveryCooldownMs: this._recoveryCooldownMs,
+      lastRecoveryAt: this._lastRecoveryAt || null,
       peers,
     }
   }
@@ -750,6 +857,8 @@ export class PublicFeedManager {
       }
       this.pendingAvailabilityRequests.clear()
       this._discoveredPeers.clear()
+      this._discoveredPeerHints.clear()
+      this._recoveryEvents.length = 0
       this._directPeerLastDialedAt.clear()
       this._directPeerLastDialError.clear()
       this._directPeerLastDialErrorStack.clear()

--- a/packages/backend/src/swarm-peer-dial.js
+++ b/packages/backend/src/swarm-peer-dial.js
@@ -77,3 +77,57 @@ export function swarmHasConnection(swarm, keyHex, publicKey = null) {
   }
   return false
 }
+
+
+export function swarmRememberPeer(swarm, peer, topic = null) {
+  if (!swarm || !peer) return null
+  const publicKey = peerPublicKey(peer)
+  const keyHex = publicKey ? b4a.toString(publicKey, 'hex') : null
+  if (!publicKey || !keyHex) return null
+  let peerInfo = swarm.peers?.get?.(keyHex) || null
+  if (!peerInfo && swarm.peers && typeof swarm.peers.get === 'function') {
+    try { peerInfo = swarm.peers.get(publicKey) || null } catch { peerInfo = null }
+  }
+  if (!peerInfo && typeof swarm._upsertPeer === 'function') {
+    try {
+      peerInfo = swarm._upsertPeer(publicKey, Array.isArray(peer.relayAddresses) ? peer.relayAddresses : undefined)
+    } catch {
+      peerInfo = null
+    }
+  }
+  if (!peerInfo && swarm.peers && typeof swarm.peers.set === 'function') {
+    peerInfo = {
+      publicKey,
+      relayAddresses: Array.isArray(peer.relayAddresses) ? peer.relayAddresses : [],
+      topics: [],
+    }
+    swarm.peers.set(keyHex, peerInfo)
+  }
+  if (!peerInfo) return null
+  const relayAddresses = Array.isArray(peer.relayAddresses) ? peer.relayAddresses : []
+  if (relayAddresses.length > 0 && (!Array.isArray(peerInfo.relayAddresses) || peerInfo.relayAddresses.length === 0)) {
+    peerInfo.relayAddresses = relayAddresses
+  }
+  if (topic) {
+    if (typeof peerInfo._topic === 'function') peerInfo._topic(topic)
+    else {
+      if (!Array.isArray(peerInfo.topics)) peerInfo.topics = []
+      if (!peerInfo.topics.some((seen) => b4a.equals(seen, topic))) peerInfo.topics.push(topic)
+    }
+  }
+  return peerInfo
+}
+
+export function swarmQueuePeer(swarm, peerInfo) {
+  if (!swarm || !peerInfo) return false
+  peerInfo.explicit = true
+  if (typeof peerInfo._updatePriority === 'function') {
+    try { peerInfo._updatePriority() } catch { /* best effort */ }
+  }
+  if (typeof swarm._enqueue === 'function') return Boolean(swarm._enqueue(peerInfo))
+  if (typeof swarm.joinPeer === 'function' && peerInfo.publicKey) {
+    swarm.joinPeer(peerInfo.publicKey)
+    return true
+  }
+  return false
+}

--- a/packages/backend/test/public-feed-manager.test.mjs
+++ b/packages/backend/test/public-feed-manager.test.mjs
@@ -337,6 +337,54 @@ test('direct peer diagnostics include Hyperswarm queue state', () => {
   }
 })
 
+
+test('PublicFeedManager preserves relay-address hints and queues remembered peer without joinPeer fallback', () => {
+  const publicKey = b4a.alloc(32, 21)
+  const keyHex = b4a.toString(publicKey, 'hex')
+  const relayAddresses = [{ host: 'relay.test', port: 49737 }]
+  const swarm = createSwarm()
+  const manager = new PublicFeedManager(swarm, createMetaDb())
+
+  try {
+    assert.equal(manager.handleDiscoveredPeer({ publicKey, relayAddresses }, NETWORK_TOPIC), true)
+    assert.equal(swarm.fallbackJoinPeerCalls.length, 0)
+    assert.equal(swarm.joinPeerCalls.length, 0)
+    const peerInfo = swarm.peers.get(keyHex)
+    assert.equal(peerInfo.relayAddresses.length, 1)
+    assert.equal(peerInfo.topics.length, 1)
+    const stats = manager.getStats().directPeerDial
+    assert.equal(stats.discoveredPeers, 1)
+    assert.equal(stats.peers[0].discoveredRelayAddresses, 1)
+    assert.equal(stats.peers[0].swarm.relayAddresses, 1)
+    assert.equal(stats.lastReason, null)
+  } finally {
+    manager.stop()
+  }
+})
+
+test('PublicFeedManager bounded recovery requeues remembered peers when discovery has no socket', () => {
+  const publicKey = b4a.alloc(32, 22)
+  const keyHex = b4a.toString(publicKey, 'hex')
+  const swarm = createSwarm()
+  const manager = new PublicFeedManager(swarm, createMetaDb())
+
+  try {
+    assert.equal(manager.handleDiscoveredPeer({ publicKey, relayAddresses: [{ host: 'relay.test', port: 1 }] }, NETWORK_TOPIC), true)
+    const peerInfo = swarm.peers.get(keyHex)
+    peerInfo.queued = false
+    swarm.joinPeerCalls.length = 0
+    const recovery = manager.runBoundedPeerRecovery('test-recovery')
+    assert.equal(recovery.queued, 1)
+    assert.equal(swarm.joinPeerCalls.length, 1)
+    const stats = manager.getStats().directPeerDial
+    assert.equal(stats.recoveryEvents.length, 1)
+    assert.equal(stats.recoveryEvents[0].reason, 'test-recovery')
+    assert.equal(stats.lastReason, 'test-recovery')
+  } finally {
+    manager.stop()
+  }
+})
+
 test('PublicFeedManager.start joins shared PearTube network topic for feed-peer discovery', async () => {
   const swarm = createSwarm()
   const manager = new PublicFeedManager(swarm, createMetaDb())

--- a/packages/cli/src/runtime.js
+++ b/packages/cli/src/runtime.js
@@ -1,3 +1,50 @@
+function buildNetworkDoctor({
+  dht,
+  peerPoolJoined,
+  publicFeedDiscoveryJoined,
+  directPeerDial,
+  networkDebug,
+  swarmPeers,
+  swarmConnections,
+  connecting,
+  feedConnections,
+  feedEntries
+}) {
+  const doctor = {
+    dht: {
+      bootstrapped: dht?.bootstrapped ?? null,
+      firewalled: dht?.firewalled ?? null,
+      online: dht?.online ?? null,
+      ephemeral: dht?.ephemeral ?? null,
+    },
+    discovery: {
+      peerPoolJoined: Boolean(peerPoolJoined),
+      publicFeedDiscoveryJoined: Boolean(publicFeedDiscoveryJoined),
+      discoveredPeers: directPeerDial?.discoveredPeers || 0,
+      recentPeers: networkDebug?.hyperswarm?.recentPeers || [],
+    },
+    socket: {
+      swarmPeers: swarmPeers || 0,
+      swarmConnections: swarmConnections || 0,
+      connecting: connecting || 0,
+      recentConnections: networkDebug?.hyperswarm?.recentConnections || [],
+      peerStates: networkDebug?.hyperswarm?.peerStates || [],
+    },
+    feed: {
+      feedConnections: feedConnections || 0,
+      feedEntries: feedEntries || 0,
+      directPeerDial: directPeerDial || null,
+    },
+    recommendedBoundary: null,
+  }
+  if (doctor.discovery.discoveredPeers === 0 && doctor.dht.bootstrapped === false) doctor.recommendedBoundary = 'dht-bootstrap'
+  else if (doctor.discovery.discoveredPeers > 0 && doctor.socket.swarmConnections === 0) doctor.recommendedBoundary = 'transport-socket'
+  else if (doctor.socket.swarmConnections > 0 && doctor.feed.feedConnections === 0) doctor.recommendedBoundary = 'protomux-feed-open'
+  else if (doctor.feed.feedConnections > 0 && doctor.feed.feedEntries === 0) doctor.recommendedBoundary = 'feed-gossip'
+  else doctor.recommendedBoundary = 'content-playback-or-ui'
+  return doctor
+}
+
 export async function createRelayRuntime({ config, logger }) {
   const [
     { initializeStorage, loadChannel, loadPublicBee, getNetworkStats },
@@ -236,6 +283,9 @@ export async function createRelayRuntime({ config, logger }) {
 
       return resolved
     },
+    runPeerRecovery(reason = 'relay-runtime') {
+      return publicFeed.runBoundedPeerRecovery?.(reason) || { queued: 0, reason: 'unsupported' }
+    },
     getNetworkStats() {
       const feedStats = publicFeed.getStats?.() || {}
       const storageStats = getNetworkStats?.() || {}
@@ -255,6 +305,18 @@ export async function createRelayRuntime({ config, logger }) {
         blindPeer: blindPeer.getStats?.() || null,
         peerPoolJoined: Boolean(ctx.peerPoolDiscovery),
         directPeerDial: feedStats.directPeerDial || null,
+        doctor: buildNetworkDoctor({
+          dht: ctx.swarm?.dht,
+          peerPoolJoined: Boolean(ctx.peerPoolDiscovery),
+          publicFeedDiscoveryJoined: Boolean(publicFeed?.feedDiscovery),
+          directPeerDial: feedStats.directPeerDial || null,
+          networkDebug: storageStats,
+          swarmPeers: ctx.swarm?.peers?.size || 0,
+          swarmConnections: ctx.swarm?.connections?.size || 0,
+          connecting: Number(ctx.swarm?.connecting || 0),
+          feedConnections: publicFeed.feedConnections?.size || 0,
+          feedEntries: feedStats.totalEntries || 0,
+        }),
         hyperswarm: storageStats?.hyperswarm || null,
         swarmOffline: Boolean(ctx.swarm?._peartubeOffline),
         swarmOfflineReason: ctx.swarm?._peartubeOfflineReason || null,

--- a/packages/cli/src/service.js
+++ b/packages/cli/src/service.js
@@ -336,6 +336,12 @@ export async function createRelayService({
               hyperswarm: heartbeatStatus.runtime.hyperswarm || null
             })
           }
+          if ((heartbeatStatus.runtime.peers || 0) > 0 && (heartbeatStatus.runtime.connections || 0) === 0) {
+            const recovery = runtime.runPeerRecovery?.('relay-heartbeat') || null
+            if (recovery && recovery.reason !== 'cooldown' && recovery.reason !== 'already-connected') {
+              logger.status.warn('Relay attempted bounded peer recovery', recovery)
+            }
+          }
           logger.status.info('Relay heartbeat', {
             peers: heartbeatStatus.runtime.peers,
             connections: heartbeatStatus.runtime.connections,

--- a/packages/cli/src/status.js
+++ b/packages/cli/src/status.js
@@ -40,6 +40,7 @@ export function buildRelayStatus({ config, catalog, runtimeStats = {} }) {
       blindPeer: runtimeStats.blindPeer || runtimeStats.seeding?.blindPeer || null,
       peerPoolJoined: Boolean(runtimeStats.peerPoolJoined),
       directPeerDial: runtimeStats.directPeerDial || null,
+      doctor: runtimeStats.doctor || runtimeStats.swarmDoctor || null,
       hyperswarm: runtimeStats.hyperswarm || null,
       swarmOffline: Boolean(runtimeStats.swarmOffline),
       swarmOfflineReason: runtimeStats.swarmOfflineReason || null,
@@ -93,6 +94,7 @@ export function formatRelayStatus(status) {
     `dht: bootstrapped=${status.runtime.dht.bootstrapped} firewalled=${status.runtime.dht.firewalled} online=${status.runtime.dht.online}`,
     `network: offline=${status.runtime.swarmOffline} reason=${status.runtime.swarmOfflineReason || 'none'} listenResolved=${status.runtime.swarmListenResolved} peerPoolJoined=${status.runtime.peerPoolJoined} publicFeedDiscoveryJoined=${status.runtime.publicFeedDiscoveryJoined}`,
     `directPeerDial: discovered=${status.runtime.directPeerDial?.discoveredPeers || 0} pending=${status.runtime.directPeerDial?.pending || 0} queued=${status.runtime.directPeerDial?.queued || 0} skipped=${status.runtime.directPeerDial?.skipped || 0} failed=${status.runtime.directPeerDial?.failed || 0} connected=${status.runtime.directPeerDial?.connected || 0} lastReason=${status.runtime.directPeerDial?.lastReason || 'none'} lastError=${firstDialError || 'none'}`,
+    `doctor: boundary=${status.runtime.doctor?.recommendedBoundary || 'unknown'} discovered=${status.runtime.doctor?.discovery?.discoveredPeers ?? status.runtime.directPeerDial?.discoveredPeers ?? 0} sockets=${status.runtime.doctor?.socket?.swarmConnections ?? status.runtime.connections ?? 0} feedConnections=${status.runtime.doctor?.feed?.feedConnections ?? status.runtime.feedConnections ?? 0}`,
     `blindPeer: enabled=${Boolean(status.runtime.blindPeer?.enabled)} key=${status.runtime.blindPeer?.publicKey || 'none'} mirroredCores=${status.runtime.blindPeer?.mirroredCores || 0} mirroredAutobases=${status.runtime.blindPeer?.mirroredAutobases || 0}`,
     `seeding: channels=${status.runtime.seeding.channels} videos=${status.runtime.seeding.videos} publicBeeCores=${status.runtime.seeding.publicBeeCores} blobCores=${status.runtime.seeding.blobCores} discoveryHandles=${status.runtime.seeding.discoveryHandles}`
   ]

--- a/packages/cli/test/status.test.mjs
+++ b/packages/cli/test/status.test.mjs
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { RelayCatalog } from '../src/catalog.js'
-import { buildRelayStatus, readRelayStatus, writeRelayStatus } from '../src/status.js'
+import { buildRelayStatus, formatRelayStatus, readRelayStatus, writeRelayStatus } from '../src/status.js'
 
 function makeTempDir(prefix) {
   return mkdtempSync(join(tmpdir(), prefix))
@@ -125,6 +125,40 @@ test('readRelayStatus returns persisted runtime stats when present', async (t) =
     t.is(loaded.runtime.feedPeers, 4)
     t.is(loaded.runtime.feedConnections, 4)
     t.is(loaded.runtime.feedEntries, 12)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+
+test('buildRelayStatus surfaces network doctor boundary diagnostics', async (t) => {
+  const dir = makeTempDir('peartube-relay-status-doctor-')
+
+  try {
+    const catalog = await RelayCatalog.open({ storagePath: dir })
+    const status = buildRelayStatus({
+      config: {
+        mode: 'public',
+        policy: 'discovery',
+        storage: { path: dir, maxBytes: 16_384 }
+      },
+      catalog,
+      runtimeStats: {
+        peers: 2,
+        connections: 0,
+        feedConnections: 0,
+        doctor: {
+          recommendedBoundary: 'transport-socket',
+          discovery: { discoveredPeers: 2 },
+          socket: { swarmConnections: 0 },
+          feed: { feedConnections: 0 }
+        }
+      }
+    })
+
+    t.is(status.runtime.doctor.recommendedBoundary, 'transport-socket')
+    const formatted = formatRelayStatus(status)
+    t.ok(formatted.includes('doctor: boundary=transport-socket discovered=2 sockets=0 feedConnections=0'))
   } finally {
     rmSync(dir, { recursive: true, force: true })
   }


### PR DESCRIPTION
## Summary
- preserve shared-topic discovered peer relay-address hints in Hyperswarm peer state without reviving legacy topics or fixed ports
- add bounded heartbeat recovery that requeues remembered peers only when discovered peers exist but no sockets/feed channels are open
- expose a network doctor boundary in app/relay status: DHT bootstrap vs transport socket vs Protomux feed vs feed gossip vs playback/UI
- prewarm Home Discover and Shorts playback URLs for the next visible videos using direct blob refs and shared URL cache

## Verification
- `node --test packages/backend/test/public-feed-manager.test.mjs packages/app/tests/vertical-discovery-regression.test.mjs packages/cli/test/status.test.mjs packages/cli/test/service.test.mjs`
- `npm test --prefix packages/cli -- --timeout=30000`
- `npm run lint:changed`
- `git diff --check`
