### PR TITLE
fix(shorts): preserve vertical feed cache across remounts

### DIFF
--- a/packages/app/app/(tabs)/discover.tsx
+++ b/packages/app/app/(tabs)/discover.tsx
@@ -27,6 +27,7 @@ import { colors } from '@/lib/colors'
 import { fetchThumbnailUrlWithRetry } from '@/lib/thumbnail'
 import { getFeedPreviewVideos, getVisibleSeededFeedEntries, shouldRenderFeedVideo } from '@/lib/feed-hydration'
 import { getCachedVideoUrl, makeVideoUrlCacheKey, setCachedVideoUrl } from '@/lib/video-url-cache'
+import { readDiscoverFeedCache, writeDiscoverFeedCache } from '@/lib/discover-feed-cache'
 import { formatTimeAgo } from '@/lib/formatters'
 import { VerticalShortsPlayer } from '@/components/discovery/VerticalShortsPlayer'
 import { useVideoPlayerContext } from '@/lib/VideoPlayerContext'
@@ -99,10 +100,11 @@ export default function VerticalDiscoveryScreen() {
   } = useVideoPlayerContext()
 
   const pageHeight = Math.max(1, screenHeight - insets.top)
+  const cachedDiscoverFeed = useMemo(() => readDiscoverFeedCache(), [])
   const [refreshing, setRefreshing] = useState(false)
   const [feedLoading, setFeedLoading] = useState(false)
-  const [feedEntries, setFeedEntries] = useState<FeedEntry[]>([])
-  const [videos, setVideos] = useState<VideoData[]>([])
+  const [feedEntries, setFeedEntries] = useState<FeedEntry[]>(() => (cachedDiscoverFeed?.feedEntries || []) as FeedEntry[])
+  const [videos, setVideos] = useState<VideoData[]>(() => (cachedDiscoverFeed?.videos || []) as VideoData[])
   const [thumbnailCache, setThumbnailCache] = useState<Record<string, string>>({})
   const thumbnailCacheRef = useRef<Record<string, string>>({})
   thumbnailCacheRef.current = thumbnailCache
@@ -190,6 +192,17 @@ export default function VerticalDiscoveryScreen() {
     }
   }, [fetchThumbnailsForVideos, identity?.driveKey])
 
+  useEffect(() => {
+    if (cachedDiscoverFeed?.videos?.length) {
+      void fetchThumbnailsForVideos(cachedDiscoverFeed.videos as VideoData[])
+    }
+  }, [cachedDiscoverFeed, fetchThumbnailsForVideos])
+
+  useEffect(() => {
+    if (videos.length === 0 && feedEntries.length === 0) return
+    writeDiscoverFeedCache({ feedEntries, videos })
+  }, [feedEntries, videos])
+
   const hydrateChannelVideos = useCallback(async (entry: FeedEntry) => {
     if (!rpc) return
     const channelKey = entry.channelKey || entry.driveKey
@@ -236,7 +249,9 @@ export default function VerticalDiscoveryScreen() {
     feedLoadInFlightRef.current = true
     setFeedLoading(true)
     try {
-      const result = await withTimeout(rpc.getPublicFeed({}), 4000, { entries: [] } as any)
+      const timeoutToken = Symbol('vertical-feed-timeout')
+      const result = await withTimeout(rpc.getPublicFeed({}), 4000, timeoutToken as any)
+      if (result === timeoutToken) return
       const entries = Array.isArray((result as any)?.entries) ? (result as any).entries : []
       setFeedEntries((prev) => {
         const prevKeys = prev.map((entry) => entry.channelKey || entry.driveKey).join('|')

--- a/packages/app/lib/discover-feed-cache.ts
+++ b/packages/app/lib/discover-feed-cache.ts
@@ -1,0 +1,104 @@
+import type { VideoData } from '@peartube/core'
+
+export interface DiscoverFeedCacheSnapshot {
+  feedEntries: any[]
+  videos: VideoData[]
+  savedAt: number
+}
+
+const MAX_CACHE_AGE_MS = 30 * 60 * 1000
+const MAX_FEED_ENTRIES = 80
+const MAX_VIDEOS = 80
+
+let cachedDiscoverFeed: DiscoverFeedCacheSnapshot | null = null
+
+function safeFeedEntries(entries: any[] = []) {
+  return entries
+    .filter(Boolean)
+    .slice(0, MAX_FEED_ENTRIES)
+    .map((entry) => ({
+      driveKey: entry.driveKey,
+      channelKey: entry.channelKey,
+      publicBeeKey: entry.publicBeeKey,
+      channelName: entry.channelName ?? null,
+      source: entry.source,
+      peerCount: entry.peerCount,
+      videoCount: entry.videoCount,
+      lastSeen: entry.lastSeen,
+      previewVideos: Array.isArray(entry.previewVideos) ? entry.previewVideos.slice(0, 12).map((video: any) => ({
+        id: video.id,
+        title: video.title,
+        uploadedAt: video.uploadedAt,
+        duration: video.duration,
+        thumbnail: video.thumbnail ?? null,
+        blobId: video.blobId ?? null,
+        blobsCoreKey: video.blobsCoreKey ?? null,
+        mimeType: video.mimeType ?? null,
+        availability: video.availability,
+        thumbnailBlobId: video.thumbnailBlobId ?? null,
+        thumbnailBlobsCoreKey: video.thumbnailBlobsCoreKey ?? null,
+        thumbnailMimeType: video.thumbnailMimeType ?? null,
+      })) : undefined,
+    }))
+}
+
+function safeVideos(videos: VideoData[] = []) {
+  return videos
+    .filter((video) => video && (video.id || video.path) && (video.channelKey || (video as any).driveKey))
+    .slice(0, MAX_VIDEOS)
+    .map((video) => {
+      const videoAny = video as any
+      const channelName = videoAny.channel?.name
+      return {
+        id: video.id,
+        path: video.path,
+        title: video.title,
+        description: video.description,
+        channelKey: video.channelKey || videoAny.driveKey,
+        driveKey: videoAny.driveKey || video.channelKey,
+        publicBeeKey: videoAny.publicBeeKey || undefined,
+        size: video.size,
+        duration: video.duration,
+        uploadedAt: video.uploadedAt,
+        thumbnail: videoAny.thumbnail,
+        thumbnailUrl: video.thumbnailUrl,
+        thumbnailBlobId: videoAny.thumbnailBlobId || undefined,
+        thumbnailBlobsCoreKey: videoAny.thumbnailBlobsCoreKey || undefined,
+        thumbnailMimeType: videoAny.thumbnailMimeType || undefined,
+        blobId: videoAny.blobId || undefined,
+        blobsCoreKey: videoAny.blobsCoreKey || undefined,
+        mimeType: videoAny.mimeType || undefined,
+        availability: videoAny.availability,
+        channel: channelName ? { name: channelName } : video.channel,
+      } as VideoData
+    })
+}
+
+export function readDiscoverFeedCache({ now = Date.now(), maxAgeMs = MAX_CACHE_AGE_MS } = {}): DiscoverFeedCacheSnapshot | null {
+  if (!cachedDiscoverFeed) return null
+  if (now - cachedDiscoverFeed.savedAt > maxAgeMs) return null
+  return {
+    feedEntries: [...cachedDiscoverFeed.feedEntries],
+    videos: [...cachedDiscoverFeed.videos],
+    savedAt: cachedDiscoverFeed.savedAt,
+  }
+}
+
+export function writeDiscoverFeedCache({ feedEntries = [], videos = [], now = Date.now() }: {
+  feedEntries?: any[]
+  videos?: VideoData[]
+  now?: number
+}): DiscoverFeedCacheSnapshot | null {
+  const safe = {
+    feedEntries: safeFeedEntries(feedEntries),
+    videos: safeVideos(videos),
+    savedAt: now,
+  }
+  if (safe.feedEntries.length === 0 && safe.videos.length === 0) return cachedDiscoverFeed
+  cachedDiscoverFeed = safe
+  return readDiscoverFeedCache({ now })
+}
+
+export function clearDiscoverFeedCache() {
+  cachedDiscoverFeed = null
+}

--- a/packages/app/tests/vertical-discovery-regression.test.mjs
+++ b/packages/app/tests/vertical-discovery-regression.test.mjs
@@ -69,6 +69,20 @@ test('vertical discovery keeps channel navigation and detail escape hatches', ()
   assert.match(source, /Feather name="user"/, 'vertical player should include a channel affordance')
 })
 
+test('vertical discovery preserves a last-known-good cache across remounts and feed timeouts', () => {
+  const source = readAppFile('app/(tabs)/discover.tsx')
+  const cacheSource = readAppFile('lib/discover-feed-cache.ts')
+
+  assert.match(source, /readDiscoverFeedCache\(\)/, 'Discover should initialize from the route-local last-known-good cache')
+  assert.match(source, /useState<FeedEntry\[\]>\(\(\) => \(cachedDiscoverFeed\?\.feedEntries \|\| \[\]\) as FeedEntry\[\]\)/, 'cached feed entries should seed route state before live P2P refresh')
+  assert.match(source, /useState<VideoData\[\]>\(\(\) => \(cachedDiscoverFeed\?\.videos \|\| \[\]\) as VideoData\[\]\)/, 'cached videos should seed the vertical deck on remount')
+  assert.match(source, /writeDiscoverFeedCache\(\{ feedEntries, videos \}\)/, 'known-good vertical cards should be cached while mounted')
+  assert.match(source, /const timeoutToken = Symbol\('vertical-feed-timeout'\)/, 'public-feed timeouts should be non-authoritative')
+  assert.match(source, /if \(result === timeoutToken\) return[\s\S]*const entries = Array\.isArray/, 'timed-out feed refreshes must not overwrite cached entries with empty lists')
+  assert.match(cacheSource, /const MAX_CACHE_AGE_MS = 30 \* 60 \* 1000/, 'vertical cache should be short-lived and route-local')
+  assert.doesNotMatch(cacheSource, /videoUrl|shortsVideoUrl|url:/, 'vertical cache must not persist transient playback URLs')
+})
+
 test('vertical discovery hydrates beyond sparse previews without permanently poisoning timed-out channels', () => {
   const source = readAppFile('app/(tabs)/discover.tsx')
   const hydrateBlock = source.slice(source.indexOf('const hydrateChannelVideos'), source.indexOf('const loadFeed'))


### PR DESCRIPTION
## Summary
- Adds a route-local last-known-good cache for the vertical Shorts/Discover feed.
- Seeds `discover.tsx` from cached feed entries/videos on remount so sparse P2P refreshes do not make the feed appear empty.
- Treats `getPublicFeed` timeout as non-authoritative instead of replacing the vertical feed with an empty list.
- Keeps playback URLs out of the cache; URL prewarm remains handled by the shared playback URL cache.

## Test Plan
- `node --test packages/app/tests/vertical-discovery-regression.test.mjs packages/app/tests/feed-snapshot.test.mjs packages/app/tests/feed-hydration.test.mjs`
- `npm run lint:changed`
- `git diff --check`
- direct eslint on changed files (warnings only, no errors)
