### PR TITLE
fix(playback): return URL before P2P warmup

### DIFF
--- a/packages/backend/src/blob-playback-service.js
+++ b/packages/backend/src/blob-playback-service.js
@@ -96,18 +96,21 @@ export class BlobPlaybackService {
     warmup,
     getStats,
   }) {
-    let warmupStarted = true
-
-    try {
-      await Promise.resolve(warmup?.(driveKey, videoPath, publicBeeKey))
-    } catch (err) {
-      warmupStarted = false
-      console.log('[BlobPlaybackService] preparePlayback warmup failed:', err?.message || err)
-    }
+    let warmupStarted = false
 
     const result = resolveUrl
       ? await resolveUrl(driveKey, videoPath, publicBeeKey, blobId, blobsCoreKey, mimeType)
       : this.resolveDirectBlobUrl({ blobsCoreKey, blobId, mimeType })
+
+    try {
+      const warmupPromise = Promise.resolve(warmup?.(driveKey, videoPath, publicBeeKey))
+      warmupStarted = Boolean(warmup)
+      warmupPromise.catch((err) => {
+        console.log('[BlobPlaybackService] preparePlayback warmup failed:', err?.message || err)
+      })
+    } catch (err) {
+      console.log('[BlobPlaybackService] preparePlayback warmup failed:', err?.message || err)
+    }
 
     return {
       url: result.url,

--- a/packages/backend/test/playback-api.test.mjs
+++ b/packages/backend/test/playback-api.test.mjs
@@ -2,7 +2,7 @@ import test from 'brittle'
 
 import { createApi } from '../src/api.js'
 
-test('preparePlayback returns a playable URL even when warmup fails', async (t) => {
+test('preparePlayback returns a playable URL before warmup settles or fails', async (t) => {
   const api = createApi({ ctx: {} })
   const calls = []
 
@@ -57,12 +57,12 @@ test('preparePlayback returns a playable URL even when warmup fails', async (t) 
       elapsed: 0,
       isComplete: false,
     },
-    warmupStarted: false,
+    warmupStarted: true,
   })
 
   t.alike(calls, [
-    ['prefetchVideo', ['channel-key', 'videos/demo.mp4', 'public-bee-key']],
     ['getVideoUrl', ['channel-key', 'videos/demo.mp4', 'public-bee-key', 'blob-id', 'blobs-core-key', 'video/mp4']],
+    ['prefetchVideo', ['channel-key', 'videos/demo.mp4', 'public-bee-key']],
     ['getVideoStats', ['channel-key', 'videos/demo.mp4']],
   ])
 })

--- a/packages/backend/test/playback-service.test.mjs
+++ b/packages/backend/test/playback-service.test.mjs
@@ -4,6 +4,7 @@ import { BlobPlaybackService } from '../src/blob-playback-service.js'
 
 const VALID_KEY = 'a'.repeat(64)
 const VALID_BLOB = '1:2:3:4'
+const VALID_URL = 'http://127.0.0.1:4321/blob.mp4?token=***'
 
 function createCtx() {
   const calls = []
@@ -25,7 +26,7 @@ function createCtx() {
         port: 4321,
         getLink(key, options) {
           calls.push(['getLink', key.toString('hex'), options])
-          return `http://${options.host}:${options.port}/blob.mp4?token=secret`
+          return VALID_URL
         },
       },
       store: {
@@ -49,7 +50,7 @@ test('direct blob refs return a URL before background warmup settles', async (t)
     mimeType: 'video/mp4',
   })
 
-  t.alike(result, { url: 'http://127.0.0.1:4321/blob.mp4?token=secret' })
+  t.alike(result, { url: VALID_URL })
   t.is(calls[0][0], 'getLink')
   t.is(calls[1][0], 'store.get')
 
@@ -69,7 +70,7 @@ test('metadata fallback resolves direct refs when metadata includes blobsCoreKey
     mimeType: 'video/webm',
   })
 
-  t.is(result.url, 'http://127.0.0.1:4321/blob.mp4?token=secret')
+  t.is(result.url, VALID_URL)
   t.alike(calls[0][2].blob, { blockOffset: 1, blockLength: 2, byteOffset: 3, byteLength: 4 })
   t.is(calls[0][2].type, 'video/webm')
 })
@@ -90,13 +91,43 @@ test('channel metadata fallback uses getBlobEntry without blocking on prefetch w
 
   const result = await service.resolveFromMetadata({ id: 'legacy-video', blobId: VALID_BLOB }, { channel })
 
-  t.is(result.url, 'http://127.0.0.1:4321/blob.mp4?token=secret')
+  t.is(result.url, VALID_URL)
   t.alike(seen, ['legacy-video'])
 })
 
-test('preparePlayback starts warmup best-effort and still returns URL when warmup rejects', async (t) => {
+test('preparePlayback starts warmup in the background and returns URL before warmup settles', async (t) => {
   const { ctx } = createCtx()
   const service = new BlobPlaybackService({ ctx })
+  let warmupStarted = false
+  let releaseWarmup
+  const warmupPromise = new Promise((resolve) => { releaseWarmup = resolve })
+
+  const result = await service.preparePlayback({
+    driveKey: 'channel-key',
+    videoPath: 'videos/demo.mp4',
+    publicBeeKey: 'public-bee-key',
+    blobId: VALID_BLOB,
+    blobsCoreKey: VALID_KEY,
+    mimeType: 'video/mp4',
+    getStats: () => ({ progress: 0, peerCount: 2 }),
+    warmup: () => {
+      warmupStarted = true
+      return warmupPromise
+    },
+  })
+
+  t.is(result.url, VALID_URL)
+  t.alike(result.stats, { progress: 0, peerCount: 2 })
+  t.is(result.warmupStarted, true)
+  t.ok(warmupStarted)
+  releaseWarmup()
+  await warmupPromise
+})
+
+test('preparePlayback returns URL even when background warmup later rejects', async (t) => {
+  const { ctx } = createCtx()
+  const service = new BlobPlaybackService({ ctx })
+
   const result = await service.preparePlayback({
     driveKey: 'channel-key',
     videoPath: 'videos/demo.mp4',
@@ -110,10 +141,9 @@ test('preparePlayback starts warmup best-effort and still returns URL when warmu
     },
   })
 
-  t.alike(result, {
-    url: 'http://127.0.0.1:4321/blob.mp4?token=secret',
-    stats: { progress: 0 },
-    warmupStarted: false,
-  })
-}
-)
+  t.is(result.url, VALID_URL)
+  t.alike(result.stats, { progress: 0 })
+  t.is(result.warmupStarted, true)
+
+  await Promise.resolve()
+})


### PR DESCRIPTION
## Summary
- Makes `preparePlayback()` resolve the local blob-server URL before starting P2P/cache warmup.
- Keeps warmup best-effort in the background so a video with connected peers/direct blob refs does not sit behind the generic mobile “Connecting to P2P” gate.
- Updates playback API/service regressions to assert URL-first behavior and warmup ordering.

## Why
Mobile can show peers connected for a video while still stuck waiting because the watch path awaited `prefetchVideo()` before returning the playable local URL. Peer/block warmup should improve startup, not block player construction.

## Test Plan
- `node --test packages/backend/test/playback-service.test.mjs packages/backend/test/playback-api.test.mjs packages/app/tests/playback-url-instant-regression.test.mjs packages/app/tests/video-player-loading-clears-regression.test.mjs packages/app/tests/channel-view-playback-regression.test.mjs packages/app/tests/root-layout-p2p-connecting-regression.test.mjs`
- `npm run lint:changed`
- `git diff --check`
