### PR TITLE
fix(p2p): stop app-level redial recovery

### DIFF
--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -21,7 +21,7 @@ import b4a from 'b4a'
 import { NETWORK_TOPIC_STRING, PROTOCOL_NAME } from './types.js';
 import { logger } from './logger.js'
 import { hashFeedEntries, hashPreviewVideos } from './hash-utils.js'
-import { peerPublicKey, swarmHasConnection, swarmQueuePeer, swarmRememberPeer } from './swarm-peer-dial.js'
+import { swarmHasConnection, swarmRememberPeer } from './swarm-peer-dial.js'
 
 const log = logger('PublicFeed')
 const PUBLIC_FEED_CATALOG_VERSION = 1
@@ -544,65 +544,15 @@ export class PublicFeedManager {
     }
   }
 
-  _queueRememberedPeer(keyHex, peerInfo, reason = 'recovery') {
-    if (!peerInfo || this._hasActivePeerConnection(keyHex, this._discoveredPeers.get(keyHex))) return false
-    if (peerInfo.queued || peerInfo.waiting) return false
-    try {
-      const queued = swarmQueuePeer(this.swarm, peerInfo)
-      if (queued) {
-        this._directPeerDialStats.attempted++
-        this._directPeerDialStats.queued++
-        this._directPeerDialStats.lastReason = reason
-        this._directPeerDialStats.lastDialedAt = this._now()
-        this._directPeerLastDialedAt.set(keyHex, this._now())
-        return true
-      }
-    } catch (err) {
-      this._directPeerDialStats.failed++
-      this._directPeerDialStats.lastReason = 'queue-error'
-      this._directPeerLastDialError.set(keyHex, err?.message || String(err))
-      if (err?.stack) this._directPeerLastDialErrorStack.set(keyHex, err.stack)
-    }
-    return false
-  }
-
   runBoundedPeerRecovery(reason = 'heartbeat') {
-    if (!this.swarm || this._discoveredPeers.size === 0) return { queued: 0, reason: 'no-discovered-peers' }
-    const now = this._now()
-    if (now - this._lastRecoveryAt < this._recoveryCooldownMs) return { queued: 0, reason: 'cooldown' }
-    if ((this.swarm.connections?.size || 0) > 0 || this.feedConnections.size > 0) return { queued: 0, reason: 'already-connected' }
-    this._lastRecoveryAt = now
-    let queued = 0
-    for (const [keyHex, publicKey] of this._discoveredPeers) {
-      let peerInfo = this.swarm.peers?.get?.(keyHex) || null
-      const hint = this._discoveredPeerHints.get(keyHex)
-      if (!peerInfo && hint?.peer) peerInfo = this._rememberDiscoveredPeerInSwarm(hint.peer, hint.topic, keyHex)
-      if (!peerInfo && typeof this.swarm.joinPeer === 'function') {
-        try {
-          this.swarm.joinPeer(publicKey)
-          this._directPeerDialStats.attempted++
-          this._directPeerDialStats.queued++
-          this._directPeerDialStats.lastReason = reason
-          this._directPeerDialStats.lastDialedAt = now
-          this._directPeerLastDialedAt.set(keyHex, now)
-          queued++
-          continue
-        } catch (err) {
-          this._directPeerDialStats.failed++
-          this._directPeerLastDialError.set(keyHex, err?.message || String(err))
-          if (err?.stack) this._directPeerLastDialErrorStack.set(keyHex, err.stack)
-        }
-      }
-      if (peerInfo && this._queueRememberedPeer(keyHex, peerInfo, reason)) queued++
-      if (queued >= 8) break
-    }
     const event = {
-      at: now,
-      action: 'bounded-peer-recovery',
-      reason,
+      at: this._now(),
+      action: 'observed-peers-without-sockets',
+      reason: 'hyperswarm-owned-dialing',
+      requestedReason: reason,
       discoveredPeers: this._discoveredPeers.size,
-      connections: this.swarm.connections?.size || 0,
-      queued,
+      connections: this.swarm?.connections?.size || 0,
+      queued: 0,
     }
     this._recoveryEvents.push(event)
     while (this._recoveryEvents.length > 10) this._recoveryEvents.shift()

--- a/packages/backend/test/public-feed-manager.test.mjs
+++ b/packages/backend/test/public-feed-manager.test.mjs
@@ -338,7 +338,7 @@ test('direct peer diagnostics include Hyperswarm queue state', () => {
 })
 
 
-test('PublicFeedManager preserves relay-address hints and queues remembered peer without joinPeer fallback', () => {
+test('PublicFeedManager preserves relay-address hints without app-level joinPeer fallback', () => {
   const publicKey = b4a.alloc(32, 21)
   const keyHex = b4a.toString(publicKey, 'hex')
   const relayAddresses = [{ host: 'relay.test', port: 49737 }]
@@ -362,7 +362,7 @@ test('PublicFeedManager preserves relay-address hints and queues remembered peer
   }
 })
 
-test('PublicFeedManager bounded recovery requeues remembered peers when discovery has no socket', () => {
+test('PublicFeedManager recovery is observational and does not requeue remembered peers', () => {
   const publicKey = b4a.alloc(32, 22)
   const keyHex = b4a.toString(publicKey, 'hex')
   const swarm = createSwarm()
@@ -374,12 +374,14 @@ test('PublicFeedManager bounded recovery requeues remembered peers when discover
     peerInfo.queued = false
     swarm.joinPeerCalls.length = 0
     const recovery = manager.runBoundedPeerRecovery('test-recovery')
-    assert.equal(recovery.queued, 1)
-    assert.equal(swarm.joinPeerCalls.length, 1)
+    assert.equal(recovery.queued, 0)
+    assert.equal(recovery.reason, 'hyperswarm-owned-dialing')
+    assert.equal(swarm.joinPeerCalls.length, 0)
+    assert.equal(peerInfo.queued, false)
     const stats = manager.getStats().directPeerDial
     assert.equal(stats.recoveryEvents.length, 1)
-    assert.equal(stats.recoveryEvents[0].reason, 'test-recovery')
-    assert.equal(stats.lastReason, 'test-recovery')
+    assert.equal(stats.recoveryEvents[0].requestedReason, 'test-recovery')
+    assert.equal(stats.lastReason, null)
   } finally {
     manager.stop()
   }

--- a/packages/cli/src/service.js
+++ b/packages/cli/src/service.js
@@ -338,8 +338,8 @@ export async function createRelayService({
           }
           if ((heartbeatStatus.runtime.peers || 0) > 0 && (heartbeatStatus.runtime.connections || 0) === 0) {
             const recovery = runtime.runPeerRecovery?.('relay-heartbeat') || null
-            if (recovery && recovery.reason !== 'cooldown' && recovery.reason !== 'already-connected') {
-              logger.status.warn('Relay attempted bounded peer recovery', recovery)
+            if (recovery) {
+              logger.status.warn('Relay observed peers without sockets; leaving dialing to Hyperswarm', recovery)
             }
           }
           logger.status.info('Relay heartbeat', {


### PR DESCRIPTION
## Summary
- stop heartbeat recovery from requeueing discovered peers through app-level joinPeer nudges
- keep discovered peer/relay-address diagnostics intact, but leave dialing ownership to Hyperswarm
- update regressions so recovery is observational rather than another connection manager

## Tests
- node --test packages/backend/test/public-feed-manager.test.mjs packages/backend/test/storage-startup-regression.test.mjs
- npm test --prefix packages/cli -- --timeout=30000
- npm run lint:changed
- node_modules/.bin/eslint packages/backend/src/public-feed.js packages/cli/src/service.js packages/backend/test/public-feed-manager.test.mjs
- git diff --check