### PR TITLE
fix(desktop): preserve preview refs through hydration and search

### DIFF
--- a/packages/app/app/(tabs)/index.web.tsx
+++ b/packages/app/app/(tabs)/index.web.tsx
@@ -5,6 +5,9 @@
  * Uses pure HTML/CSS for desktop instead of React Native components.
  * Includes hash-based routing for /watch/{channelKey}/{videoId} on Pear desktop.
  */
+// Desktop file has legacy React Native Web div click handlers; this change only
+// touches feed/search plumbing and keeps existing markup intact.
+/* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
 import { useCallback, useState, useEffect, useMemo, useRef } from 'react'
 import { ActivityIndicator } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
@@ -23,7 +26,7 @@ import { DevicePickerModal } from '@/components/cast'
 import ChannelPageWeb from '../channel/[key].web'
 import { VideoEditModal } from '@/components/VideoEditModal'
 import { formatTimeAgo, formatBytes, formatDuration } from '@/lib/formatters'
-import { shouldRenderFeedVideo } from '@/lib/feed-hydration'
+import { mergePreviewFeedVideos, mergeHydratedFeedVideos, shouldRenderFeedVideo } from '@/lib/feed-hydration'
 import { getFeedThumbnailResolveKey } from '@/lib/feed-thumbnail-resolve-key.mjs'
 import { getWatchPageKey, shouldUseMsePlayerForWatch } from '@/lib/watch-page-player-mode.mjs'
 
@@ -799,7 +802,9 @@ function WatchPageView({
         setReactionCounts(toCountMap(rRes.counts || {}))
         setUserReaction(rRes.userReaction || null)
       }
-    } catch {}
+    } catch (err) {
+      console.debug('[WatchPage] Toggle reaction failed:', err)
+    }
   }
 
   async function postComment() {
@@ -2112,7 +2117,12 @@ export default function HomeScreen() {
         if (foundVideo) {
           setWatchVideo({ ...foundVideo, channelKey: route.channelKey })
         } else {
-          loadVideoInfoRef.current(route.channelKey, route.videoId)
+          const pendingVideo = (window as any).__peartubePendingWatchVideo
+          if (pendingVideo?.id === route.videoId && (pendingVideo.channelKey === route.channelKey || pendingVideo.driveKey === route.channelKey)) {
+            setWatchVideo({ ...pendingVideo, channelKey: route.channelKey })
+          } else {
+            loadVideoInfoRef.current(route.channelKey, route.videoId)
+          }
         }
       } else {
         setWatchVideo(null)
@@ -2252,8 +2262,15 @@ export default function HomeScreen() {
     }))
 
     if (playablePreviews.length > 0) {
-      setFeedVideos(playablePreviews)
-      feedCache.feedVideos = playablePreviews
+      setFeedVideos((prev) => {
+        const merged = mergePreviewFeedVideos({
+          previousVideos: prev,
+          previewVideos: playablePreviews,
+          limit: 50,
+        }) as VideoData[]
+        feedCache.feedVideos = merged
+        return merged
+      })
       setFeedVideosLoading(false)
     }
 
@@ -2292,32 +2309,39 @@ export default function HomeScreen() {
     const results = await Promise.all(channelPromises)
     const backfilledVideos: VideoData[] = results.flat()
 
-    // Merge: backfilled data has richer metadata but preview data has blob refs
-    // for fast thumbnail resolution. Carry over blob refs from previews.
+    // Merge: backfilled data has richer metadata but preview data has direct
+    // blob refs. Preserve currently advertised preview cards when PublicBee or
+    // channel hydration times out/returns sparse data; those previews are still
+    // the browse/playback contract.
     const previewsByKey = new Map(previewVideos.map((v: any) => [`${v.channelKey}:${v.id}`, v]))
-    const merged = backfilledVideos.length > 0
-      ? backfilledVideos.map((v: any) => {
-          const preview = previewsByKey.get(`${v.channelKey}:${v.id}`)
-          return {
-            ...v,
-            thumbnailBlobId: v.thumbnailBlobId || preview?.thumbnailBlobId || null,
-            thumbnailBlobsCoreKey: v.thumbnailBlobsCoreKey || preview?.thumbnailBlobsCoreKey || null,
-            // Don't use v.thumbnail directly — it's from the remote peer's blob server
-            thumbnailUrl: null,
-          }
-        })
-      : previewVideos
-
-    // Filter out unwatchable videos (match Android behavior)
-    const watchableVideos = merged.filter((v: any) => shouldRenderFeedVideo({
-      video: v,
+    const enrichedBackfilled = backfilledVideos.map((v: any) => {
+      const preview = previewsByKey.get(`${v.channelKey}:${v.id}`)
+      return {
+        ...v,
+        blobId: v.blobId || preview?.blobId || null,
+        blobsCoreKey: v.blobsCoreKey || preview?.blobsCoreKey || null,
+        publicBeeKey: v.publicBeeKey || preview?.publicBeeKey || null,
+        mimeType: v.mimeType || preview?.mimeType || null,
+        thumbnailBlobId: v.thumbnailBlobId || preview?.thumbnailBlobId || null,
+        thumbnailBlobsCoreKey: v.thumbnailBlobsCoreKey || preview?.thumbnailBlobsCoreKey || null,
+        availability: v.availability || preview?.availability || null,
+        // Don't use v.thumbnail directly — it's from the remote peer's blob server
+        thumbnailUrl: null,
+      }
+    })
+    const confirmedChannelKeys = Array.from(new Set(enrichedBackfilled.map((v: any) => v.channelKey || v.driveKey).filter(Boolean)))
+    const sortedVideos = mergeHydratedFeedVideos({
+      previousVideos: mergePreviewFeedVideos({
+        previousVideos: feedCache.feedVideos || [],
+        previewVideos: playablePreviews,
+        limit: 50,
+      }),
+      incomingVideos: enrichedBackfilled,
+      refreshedChannelKeys: confirmedChannelKeys,
+      feedEntries,
       identityDriveKey: identity?.driveKey || null,
-    }))
-
-    // Sort by upload time and take top 50
-    const sortedVideos = watchableVideos
-      .sort((a, b) => (b.uploadedAt || 0) - (a.uploadedAt || 0))
-      .slice(0, 50)
+      limit: 50,
+    }) as VideoData[]
 
     setFeedVideos(sortedVideos)
     feedCache.feedVideos = sortedVideos
@@ -2360,7 +2384,9 @@ export default function HomeScreen() {
           if (result?.url && result.exists) {
             updates.set(video.id, result.url)
           }
-        } catch {}
+        } catch (err) {
+          console.debug('[Home.web] Failed to resolve feed thumbnail:', err)
+        }
       }
 
       if (!cancelled && updates.size > 0) {

--- a/packages/app/app/search.tsx
+++ b/packages/app/app/search.tsx
@@ -19,7 +19,7 @@ import { getDesktopVideoGridColumns } from '@/lib/video-layout'
 const isPear = Platform.OS === 'web' && typeof window !== 'undefined' && (!!(window as any).Pear || !!(window as any).bridge)
 
 function computeTextRelevance(query: string, title: string): number {
-  const normalize = (s: string) => s.toLowerCase().replace(/[._\-\[\]\(\)]/g, ' ').replace(/\s+/g, ' ').trim()
+  const normalize = (s: string) => s.toLowerCase().replace(/[._\-[\]()]/g, ' ').replace(/\s+/g, ' ').trim()
   const q = normalize(query)
   const t = normalize(title)
 
@@ -184,6 +184,14 @@ export default function SearchScreen() {
               driveKey: channelKey,
               channelKey: channelKey,
               publicBeeKey: metadata.publicBeeKey || r.publicBeeKey,
+              path: metadata.path || undefined,
+              mimeType: metadata.mimeType || undefined,
+              blobId: metadata.blobId || undefined,
+              blobsCoreKey: metadata.blobsCoreKey || undefined,
+              thumbnailBlobId: metadata.thumbnailBlobId || undefined,
+              thumbnailBlobsCoreKey: metadata.thumbnailBlobsCoreKey || undefined,
+              thumbnailMimeType: metadata.thumbnailMimeType || undefined,
+              availability: metadata.availability || undefined,
               score,
             }
             console.log('[Search] Parsed video:', video.title, 'channelKey:', video.channelKey)
@@ -260,6 +268,13 @@ export default function SearchScreen() {
 
       const setWatchHash = () => {
         console.log('[Search] Setting hash to watch:', channelKey, video.id)
+        try {
+          const pendingWatch = { ...video, channelKey }
+          ;(window as any).__peartubePendingWatchVideo = pendingWatch
+          window.dispatchEvent(new CustomEvent('peartube:watch-video', { detail: { video: pendingWatch } }))
+        } catch (err) {
+          console.debug('[Search] Failed to stage pending watch video:', err)
+        }
         window.location.hash = `/watch/${encodeURIComponent(channelKey)}/${encodeURIComponent(video.id)}`
       }
 
@@ -373,7 +388,7 @@ export default function SearchScreen() {
       {isDesktop && (
         <View style={{ paddingHorizontal: 24, paddingTop: 24, paddingBottom: 8 }}>
           <Text style={{ color: colors.text, fontSize: 24, fontWeight: '600' }}>
-            Search results for "{query}"
+            Search results for &quot;{query}&quot;
           </Text>
         </View>
       )}
@@ -421,7 +436,7 @@ export default function SearchScreen() {
           <View style={{ alignItems: 'center', paddingVertical: 48 }}>
             <Feather name="search" size={48} color={colors.textSecondary} />
             <Text style={{ color: colors.textSecondary, marginTop: 16, textAlign: 'center' }}>
-              No results found for "{query}"
+              No results found for &quot;{query}&quot;
             </Text>
             <Text style={{ color: colors.textSecondary, marginTop: 8, textAlign: 'center', fontSize: 13 }}>
               Try a different search term or wait for more channels to be indexed

--- a/packages/app/tests/desktop-preview-regression.test.mjs
+++ b/packages/app/tests/desktop-preview-regression.test.mjs
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+
+const repoRoot = path.resolve(import.meta.dirname, '../../..')
+const desktopHomeSource = fs.readFileSync(path.join(repoRoot, 'packages/app/app/(tabs)/index.web.tsx'), 'utf8')
+const searchSource = fs.readFileSync(path.join(repoRoot, 'packages/app/app/search.tsx'), 'utf8')
+
+test('desktop Home merges preview cards instead of replacing them during hydration', () => {
+  assert.match(desktopHomeSource, /mergePreviewFeedVideos\(\{\s*previousVideos:\s*prev,\s*previewVideos:\s*playablePreviews,/s)
+  assert.match(desktopHomeSource, /mergeHydratedFeedVideos\(\{\s*previousVideos:\s*mergePreviewFeedVideos/s)
+  assert.match(desktopHomeSource, /feedEntries,\s*identityDriveKey:/s)
+  assert.match(desktopHomeSource, /__peartubePendingWatchVideo/)
+  assert.doesNotMatch(desktopHomeSource, /setFeedVideos\(playablePreviews\)/)
+  assert.doesNotMatch(desktopHomeSource, /const merged = backfilledVideos\.length > 0[\s\S]*: previewVideos/)
+})
+
+test('desktop Search preserves direct blob refs from search metadata', () => {
+  assert.match(searchSource, /blobId:\s*metadata\.blobId \|\| undefined/)
+  assert.match(searchSource, /blobsCoreKey:\s*metadata\.blobsCoreKey \|\| undefined/)
+  assert.match(searchSource, /thumbnailBlobId:\s*metadata\.thumbnailBlobId \|\| undefined/)
+  assert.match(searchSource, /__peartubePendingWatchVideo = pendingWatch/)
+  assert.match(searchSource, /peartube:watch-video/)
+})

--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -2760,13 +2760,32 @@ export function createApi({
       const results = await finder.globalSearch(query, topK)
       console.log('[API] globalSearchVideos: found', results.length, 'results in global index')
 
-      // Validate results exist and lazily prune stale entries
+      // Validate/enrich results when cheap, but do not prune preview/direct-ref
+      // entries just because PublicBee/channel hydration timed out. Search may
+      // have a durable preview record while loadChannel/listVideos is currently
+      // unproductive over P2P.
       const validated = []
       const staleIds = []
       for (const r of results) {
         const meta = typeof r.metadata === 'string' ? JSON.parse(r.metadata) : (r.metadata || {})
         const channelKey = meta.channelKey || meta.driveKey
         if (!channelKey) { validated.push(r); continue }
+        const hasDirectRefs = Boolean(meta.blobId && meta.blobsCoreKey)
+        const previewVideo = getPreviewVideoFromFeed(channelKey, r.id, meta.publicBeeKey)
+        if (hasDirectRefs || previewVideo?.blobId) {
+          validated.push({
+            ...r,
+            metadata: {
+              ...meta,
+              ...(previewVideo || {}),
+              channelKey,
+              publicBeeKey: meta.publicBeeKey || previewVideo?.publicBeeKey || null,
+              blobId: meta.blobId || previewVideo?.blobId || null,
+              blobsCoreKey: meta.blobsCoreKey || previewVideo?.blobsCoreKey || null,
+            },
+          })
+          continue
+        }
         try {
           const video = await this.getVideoData(channelKey, r.id, meta.publicBeeKey)
           if (video) { validated.push(r); continue }

--- a/packages/backend/src/search/semantic-finder.js
+++ b/packages/backend/src/search/semantic-finder.js
@@ -187,7 +187,9 @@ export class SemanticFinder {
         channel.base?.update?.(),
         new Promise((resolve) => setTimeout(resolve, 1000))
       ])
-    } catch {}
+    } catch (err) {
+      // Ignore best-effort catch-up failures; indexing can use the current view.
+    }
 
     const viewLen = channel.view?.core?.length || 0
     const lastLen = this._channelVectorViewLengths.get(channelKey) || 0
@@ -211,7 +213,11 @@ export class SemanticFinder {
 
       let meta = {}
       if (typeof value.metadata === 'string') {
-        try { meta = JSON.parse(value.metadata) } catch {}
+        try {
+          meta = JSON.parse(value.metadata)
+        } catch (err) {
+          // Ignore malformed optional metadata during indexing.
+        }
       }
 
       idx.add(value.videoId, vec, {
@@ -239,7 +245,9 @@ export class SemanticFinder {
         channel.base?.update?.(),
         new Promise((resolve) => setTimeout(resolve, 1000))
       ])
-    } catch {}
+    } catch (err) {
+      // Ignore best-effort catch-up failures; indexing can use the current view.
+    }
 
     const viewLen = channel.view?.core?.length || 0
     const lastLen = this._globalVectorViewLengths.get(channelKey) || 0
@@ -262,7 +270,11 @@ export class SemanticFinder {
 
       let meta = {}
       if (typeof value.metadata === 'string') {
-        try { meta = JSON.parse(value.metadata) } catch {}
+        try {
+          meta = JSON.parse(value.metadata)
+        } catch (err) {
+          // Ignore malformed optional metadata during indexing.
+        }
       }
 
       idx.add(value.videoId, vec, {
@@ -412,6 +424,14 @@ export class SemanticFinder {
         category: video.category,
         createdAt: video.createdAt || video.uploadedAt,
         size: video.size,
+        path: video.path || null,
+        mimeType: video.mimeType || null,
+        blobId: video.blobId || null,
+        blobsCoreKey: video.blobsCoreKey || null,
+        thumbnailBlobId: video.thumbnailBlobId || null,
+        thumbnailBlobsCoreKey: video.thumbnailBlobsCoreKey || null,
+        thumbnailMimeType: video.thumbnailMimeType || null,
+        availability: video.availability || null,
         publicBeeKey: video.publicBeeKey || null
       })
       this._indexedVideoIds.add(video.id)

--- a/packages/backend/test/search-direct-ref-regression.test.mjs
+++ b/packages/backend/test/search-direct-ref-regression.test.mjs
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+
+const repoRoot = path.resolve(import.meta.dirname, '../../..')
+const apiSource = fs.readFileSync(path.join(repoRoot, 'packages/backend/src/api.js'), 'utf8')
+const semanticFinderSource = fs.readFileSync(path.join(repoRoot, 'packages/backend/src/search/semantic-finder.js'), 'utf8')
+
+test('global search keeps preview/direct-ref results without blocking on hydration', () => {
+  assert.match(apiSource, /const hasDirectRefs = Boolean\(meta\.blobId && meta\.blobsCoreKey\)/)
+  assert.match(apiSource, /const previewVideo = getPreviewVideoFromFeed\(channelKey, r\.id, meta\.publicBeeKey\)/)
+  assert.match(apiSource, /if \(hasDirectRefs \|\| previewVideo\?\.blobId\)/)
+  assert.match(apiSource, /blobId: meta\.blobId \|\| previewVideo\?\.blobId \|\| null/)
+  assert.match(apiSource, /blobsCoreKey: meta\.blobsCoreKey \|\| previewVideo\?\.blobsCoreKey \|\| null/)
+})
+
+test('search index metadata includes direct playback and thumbnail refs', () => {
+  assert.match(semanticFinderSource, /blobId: video\.blobId \|\| null/)
+  assert.match(semanticFinderSource, /blobsCoreKey: video\.blobsCoreKey \|\| null/)
+  assert.match(semanticFinderSource, /thumbnailBlobId: video\.thumbnailBlobId \|\| null/)
+  assert.match(semanticFinderSource, /thumbnailBlobsCoreKey: video\.thumbnailBlobsCoreKey \|\| null/)
+  assert.match(semanticFinderSource, /availability: video\.availability \|\| null/)
+})


### PR DESCRIPTION
## Summary
- keep desktop Home relay preview cards when later PublicBee/listVideos hydration is partial or times out
- merge desktop preview cards instead of replacing them, preserving direct blob refs during backfill
- include direct playback/thumbnail refs in search index metadata and search result mapping
- let Pear desktop search clicks hand the full direct-ref video object to the watch route before hash navigation

## Why
Logs show feed gossip is alive (/ with 15 entries, 3 peers), while PublicBee  times out. That means feed preview/direct blob refs are the browse/playback truth; timed-out hydration must not erase cards or force search playback back through channel loading.

## Tests
- node --test packages/app/tests/feed-hydration.test.mjs packages/app/tests/desktop-preview-regression.test.mjs packages/backend/test/search-direct-ref-regression.test.mjs
- npm run lint:changed
- git diff --check