### PR TITLE
feat(identity): add signed channel root descriptors

### DIFF
--- a/packages/backend/src/channel-descriptor.js
+++ b/packages/backend/src/channel-descriptor.js
@@ -1,0 +1,124 @@
+import b4a from 'b4a'
+import IdentityKey from 'keet-identity-key'
+
+export const CHANNEL_ROOT_DESCRIPTOR_SCHEMA = 'peartube.channel.root.v1'
+export const SIGNED_CHANNEL_ROOT_DESCRIPTOR_SCHEMA = 'peartube.channel.root.signed.v1'
+
+const HEX_32_RE = /^[0-9a-f]{64}$/i
+
+function canonicalHex (value, name) {
+  if (b4a.isBuffer(value) || value instanceof Uint8Array) {
+    if (value.byteLength !== 32) throw new Error(`${name} must be a 32-byte key`)
+    return b4a.toString(value, 'hex')
+  }
+  if (typeof value !== 'string' || !HEX_32_RE.test(value)) {
+    throw new Error(`${name} must be a 32-byte hex key`)
+  }
+  return value.toLowerCase()
+}
+
+function assertNonNegativeInteger (value, name) {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative safe integer`)
+  }
+  return value
+}
+
+function sortPlain (value) {
+  if (Array.isArray(value)) return value.map(sortPlain)
+  if (!value || typeof value !== 'object') return value
+  const out = {}
+  for (const key of Object.keys(value).sort()) {
+    const v = value[key]
+    if (v !== undefined) out[key] = sortPlain(v)
+  }
+  return out
+}
+
+export function encodeCanonicalJson (value) {
+  return Buffer.from(JSON.stringify(sortPlain(value)))
+}
+
+export function createChannelRootDescriptor ({
+  identityPublicKey,
+  channelId,
+  metadataKey,
+  mediaKey,
+  seq = 0,
+  createdAt = Date.now(),
+  updatedAt = createdAt,
+  profile = null,
+  capabilities = null
+}) {
+  const identityHex = canonicalHex(identityPublicKey, 'identityPublicKey')
+  const metadataHex = canonicalHex(metadataKey, 'metadataKey')
+  const mediaHex = canonicalHex(mediaKey, 'mediaKey')
+  const normalizedChannelId = channelId ? canonicalHex(channelId, 'channelId') : identityHex
+
+  return {
+    schema: CHANNEL_ROOT_DESCRIPTOR_SCHEMA,
+    channelId: normalizedChannelId,
+    identityPublicKey: identityHex,
+    metadataKey: metadataHex,
+    mediaKey: mediaHex,
+    seq: assertNonNegativeInteger(seq, 'seq'),
+    createdAt: assertNonNegativeInteger(createdAt, 'createdAt'),
+    updatedAt: assertNonNegativeInteger(updatedAt, 'updatedAt'),
+    profile: profile && typeof profile === 'object' ? sortPlain(profile) : null,
+    capabilities: capabilities && typeof capabilities === 'object'
+      ? sortPlain(capabilities)
+      : {
+          metadata: 'hyperbee',
+          media: 'hyperdrive',
+          thumbnails: 'inline-or-media-path'
+        }
+  }
+}
+
+export async function signChannelRootDescriptor ({ descriptor, deviceKeyPair, deviceProof }) {
+  if (!descriptor || descriptor.schema !== CHANNEL_ROOT_DESCRIPTOR_SCHEMA) {
+    throw new Error('descriptor must be a channel root descriptor')
+  }
+  if (!deviceKeyPair?.publicKey || !deviceKeyPair?.secretKey) {
+    throw new Error('deviceKeyPair with publicKey and secretKey is required')
+  }
+  const proofBuffer = normalizeProof(deviceProof)
+  const attestation = IdentityKey.attestData(encodeCanonicalJson(descriptor), deviceKeyPair, proofBuffer)
+  return {
+    schema: SIGNED_CHANNEL_ROOT_DESCRIPTOR_SCHEMA,
+    descriptor,
+    proof: b4a.toString(proofBuffer, 'hex'),
+    attestation: b4a.toString(attestation, 'hex')
+  }
+}
+
+export async function verifySignedChannelRootDescriptor (signed) {
+  try {
+    if (!signed || signed.schema !== SIGNED_CHANNEL_ROOT_DESCRIPTOR_SCHEMA) {
+      return { valid: false, error: 'invalid signed descriptor schema' }
+    }
+    const descriptor = createChannelRootDescriptor(signed.descriptor || {})
+    const attestation = b4a.from(signed.attestation, 'hex')
+    const verified = IdentityKey.verify(attestation, encodeCanonicalJson(descriptor), {
+      expectedIndentity: b4a.from(descriptor.identityPublicKey, 'hex')
+    })
+    if (!verified) return { valid: false, error: 'attestation verification failed' }
+
+    return {
+      valid: true,
+      descriptor,
+      identityPublicKey: b4a.toString(verified.identityPublicKey, 'hex'),
+      devicePublicKey: b4a.toString(verified.devicePublicKey, 'hex'),
+      receipt: verified.receipt ? b4a.toString(verified.receipt, 'hex') : null
+    }
+  } catch (err) {
+    return { valid: false, error: err?.message || String(err) }
+  }
+}
+
+function normalizeProof (proof) {
+  if (!proof) throw new Error('deviceProof is required')
+  if (b4a.isBuffer(proof) || proof instanceof Uint8Array) return b4a.from(proof)
+  if (typeof proof === 'string') return b4a.from(proof, 'hex')
+  throw new Error('deviceProof must be a buffer or hex string')
+}

--- a/packages/backend/src/identity.js
+++ b/packages/backend/src/identity.js
@@ -14,6 +14,10 @@ import {
   validateMnemonic as validatePearTubeMnemonic,
   deriveIdentity
 } from './peartube-identity.js'
+import {
+  createChannelRootDescriptor,
+  signChannelRootDescriptor
+} from './channel-descriptor.js'
 
 // Lazy load IdentityKey to support both Node.js and Bare runtime
 let IdentityKey = null
@@ -201,6 +205,44 @@ export function createIdentityManager({ ctx }) {
         log.info(' Local blob drive ready')
       }
 
+      if (!channel.blobsKeyHex) {
+        await channel.ensureLocalBlobDrive({ deviceName: name })
+      }
+
+      let signedDescriptor = null
+      try {
+        const metadataKey = channel.publicBeeKey || await channel.getPublicBeeKey()
+        const mediaKey = channel.blobsKeyHex
+        if (metadataKey && mediaKey) {
+          const descriptor = createChannelRootDescriptor({
+            identityPublicKey: publicKey,
+            metadataKey,
+            mediaKey,
+            seq: 1,
+            createdAt,
+            updatedAt: Date.now(),
+            profile: { name }
+          })
+          const deviceProof = await this.attestDevice(keypair, ctx.swarm.keyPair.publicKey)
+          signedDescriptor = await signChannelRootDescriptor({
+            descriptor,
+            deviceKeyPair: ctx.swarm.keyPair,
+            deviceProof
+          })
+          if (channel.publicBee?.writable) {
+            await channel.publicBee.bee.put('channel/root', signedDescriptor)
+            await channel.publicBee.setMetadata({
+              channelId: descriptor.channelId,
+              identityPublicKey: publicKey,
+              mediaKey,
+              signedDescriptor
+            })
+          }
+        }
+      } catch (err) {
+        log.warn(' Signed channel root descriptor skipped:', err?.message)
+      }
+
       // Create identity record
       // SECURITY: Do NOT persist secretKey - it can be re-derived from mnemonic if needed.
       // The mnemonic is shown once at creation time and should be backed up by the user.
@@ -216,7 +258,9 @@ export function createIdentityManager({ ctx }) {
         createdAt,
         // secretKey removed for security - derive from mnemonic when needed
         isActive: false,
-        hdDerived
+        hdDerived,
+        channelId: signedDescriptor?.descriptor?.channelId || publicKey,
+        signedDescriptor
       };
 
       identities.push(identity);
@@ -241,6 +285,8 @@ export function createIdentityManager({ ctx }) {
         success: true,
         publicKey,
         driveKey: channelKeyHex,
+        channelId: signedDescriptor?.descriptor?.channelId || publicKey,
+        signedDescriptor,
         mnemonic
       };
     },
@@ -261,7 +307,9 @@ export function createIdentityManager({ ctx }) {
       // Ensure we have the channel cached/loaded (best-effort)
       try {
         await loadChannel(ctx, channelKeyHex)
-      } catch {}
+      } catch (err) {
+        log.debug(' Paired channel preload skipped:', err?.message)
+      }
 
       const keypair = crypto.keyPair()
       const publicKey = b4a.toString(keypair.publicKey, 'hex')

--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -22,6 +22,10 @@ import { NETWORK_TOPIC_STRING, PROTOCOL_NAME } from './types.js';
 import { logger } from './logger.js'
 import { hashFeedEntries, hashPreviewVideos } from './hash-utils.js'
 import { swarmHasConnection, swarmRememberPeer } from './swarm-peer-dial.js'
+import {
+  SIGNED_CHANNEL_ROOT_DESCRIPTOR_SCHEMA,
+  CHANNEL_ROOT_DESCRIPTOR_SCHEMA
+} from './channel-descriptor.js'
 
 const log = logger('PublicFeed')
 const PUBLIC_FEED_CATALOG_VERSION = 1
@@ -188,6 +192,41 @@ export class PublicFeedManager {
       }))
   }
 
+  _normalizeSignedDescriptor(signed) {
+    if (!signed || typeof signed !== 'object') return null
+    if (signed.schema !== SIGNED_CHANNEL_ROOT_DESCRIPTOR_SCHEMA) return null
+    const descriptor = signed.descriptor
+    if (!descriptor || descriptor.schema !== CHANNEL_ROOT_DESCRIPTOR_SCHEMA) return null
+    const isValidKey = (k) => typeof k === 'string' && /^[a-f0-9]{64}$/i.test(k)
+    if (!isValidKey(descriptor.channelId)) return null
+    if (!isValidKey(descriptor.identityPublicKey)) return null
+    if (!isValidKey(descriptor.metadataKey)) return null
+    if (!isValidKey(descriptor.mediaKey)) return null
+    const seq = Number(descriptor.seq || 0)
+    if (!Number.isSafeInteger(seq) || seq < 0) return null
+    return {
+      schema: SIGNED_CHANNEL_ROOT_DESCRIPTOR_SCHEMA,
+      descriptor: {
+        ...descriptor,
+        channelId: descriptor.channelId.toLowerCase(),
+        identityPublicKey: descriptor.identityPublicKey.toLowerCase(),
+        metadataKey: descriptor.metadataKey.toLowerCase(),
+        mediaKey: descriptor.mediaKey.toLowerCase(),
+        seq,
+      },
+      proof: typeof signed.proof === 'string' ? signed.proof : null,
+      attestation: typeof signed.attestation === 'string' ? signed.attestation : null,
+    }
+  }
+
+  _shouldApplySignedDescriptor(current, next) {
+    if (!next) return false
+    if (!current) return true
+    const currentSeq = Number(current?.descriptor?.seq || 0)
+    const nextSeq = Number(next?.descriptor?.seq || 0)
+    return nextSeq >= currentSeq
+  }
+
   _serializeEntry(entry) {
     const serialized = {
       schema: 'peartube.relayCatalog',
@@ -206,6 +245,8 @@ export class PublicFeedManager {
     if (previewVideos.length > 0) serialized.previewVideos = previewVideos
     const previewVideosHash = entry.previewVideosHash || hashPreviewVideos(previewVideos)
     if (previewVideosHash) serialized.previewVideosHash = previewVideosHash
+    const signedDescriptor = this._normalizeSignedDescriptor(entry.signedDescriptor)
+    if (signedDescriptor) serialized.signedDescriptor = signedDescriptor
     return serialized
   }
 
@@ -269,6 +310,16 @@ export class PublicFeedManager {
         changed = true
       } else if (!entry.manifestUpdatedAt && incomingPreviewVideos.length > 0) {
         entry.manifestUpdatedAt = Date.now()
+        changed = true
+      }
+    }
+
+    const nextSignedDescriptor = this._normalizeSignedDescriptor(snapshot.signedDescriptor)
+    if (this._shouldApplySignedDescriptor(entry.signedDescriptor, nextSignedDescriptor)) {
+      const currentSeq = Number(entry.signedDescriptor?.descriptor?.seq || -1)
+      const nextSeq = Number(nextSignedDescriptor?.descriptor?.seq || -1)
+      if (nextSeq !== currentSeq || JSON.stringify(entry.signedDescriptor) !== JSON.stringify(nextSignedDescriptor)) {
+        entry.signedDescriptor = nextSignedDescriptor
         changed = true
       }
     }
@@ -857,6 +908,7 @@ export class PublicFeedManager {
           videoCount: Number(e.videoCount || 0) || 0,
           manifestUpdatedAt: Number(e.manifestUpdatedAt || 0) || 0,
           previewVideos: this._sanitizePreviewVideos(e.previewVideos),
+          signedDescriptor: this._normalizeSignedDescriptor(e.signedDescriptor),
         }))
       await this.metaDb.put('discovered-channels-v2', entries)
 
@@ -1295,6 +1347,7 @@ export class PublicFeedManager {
       videoCount: Number(snapshot?.videoCount || 0) || 0,
       manifestUpdatedAt: Number(snapshot?.manifestUpdatedAt || 0) || 0,
       previewVideos: this._sanitizePreviewVideos(snapshot?.previewVideos),
+      signedDescriptor: this._normalizeSignedDescriptor(snapshot?.signedDescriptor),
     });
 
     // Persist (debounced) so restarts retain discovered keys.
@@ -1356,6 +1409,7 @@ export class PublicFeedManager {
           videoCount: Number(entry?.videoCount || 0) || 0,
           manifestUpdatedAt: Number(entry?.manifestUpdatedAt || 0) || 0,
           previewVideos: this._sanitizePreviewVideos(entry?.previewVideos),
+          signedDescriptor: this._normalizeSignedDescriptor(entry?.signedDescriptor),
         });
       }
       await this.metaDb.put('published-channels-v2', publishedArray);
@@ -1449,6 +1503,7 @@ export class PublicFeedManager {
       videoCount: Number(snapshot?.videoCount || 0) || 0,
       manifestUpdatedAt: Number(snapshot?.manifestUpdatedAt || 0) || 0,
       previewVideos: this._sanitizePreviewVideos(snapshot?.previewVideos),
+      signedDescriptor: this._normalizeSignedDescriptor(snapshot?.signedDescriptor),
     };
 
     let sent = 0;

--- a/packages/backend/test/channel-descriptor.test.mjs
+++ b/packages/backend/test/channel-descriptor.test.mjs
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import crypto from 'hypercore-crypto'
+import b4a from 'b4a'
+import IdentityKey from 'keet-identity-key'
+
+import {
+  createChannelRootDescriptor,
+  signChannelRootDescriptor,
+  verifySignedChannelRootDescriptor,
+  CHANNEL_ROOT_DESCRIPTOR_SCHEMA
+} from '../src/channel-descriptor.js'
+
+function hexKey (fill) {
+  return Buffer.alloc(32, fill).toString('hex')
+}
+
+test('signed channel root descriptors authorize metadata and media keys through an attested device', async () => {
+  const mnemonic = IdentityKey.generateMnemonic()
+  const identity = await IdentityKey.from({ mnemonic })
+  const device = crypto.keyPair()
+  const proof = await identity.bootstrap(device.publicKey)
+
+  const descriptor = createChannelRootDescriptor({
+    identityPublicKey: b4a.toString(identity.identityPublicKey, 'hex'),
+    metadataKey: hexKey(1),
+    mediaKey: hexKey(2),
+    seq: 7,
+    createdAt: 111,
+    updatedAt: 222,
+    profile: { name: 'Booraka' }
+  })
+
+  assert.equal(descriptor.schema, CHANNEL_ROOT_DESCRIPTOR_SCHEMA)
+  assert.equal(descriptor.channelId, b4a.toString(identity.identityPublicKey, 'hex'))
+
+  const signed = await signChannelRootDescriptor({ descriptor, deviceKeyPair: device, deviceProof: proof })
+  const verified = await verifySignedChannelRootDescriptor(signed)
+
+  assert.equal(verified.valid, true)
+  assert.equal(verified.descriptor.metadataKey, hexKey(1))
+  assert.equal(verified.descriptor.mediaKey, hexKey(2))
+  assert.equal(verified.identityPublicKey, descriptor.identityPublicKey)
+  assert.equal(verified.devicePublicKey, b4a.toString(device.publicKey, 'hex'))
+})
+
+test('descriptor verification rejects tampered metadata/media mappings', async () => {
+  const mnemonic = IdentityKey.generateMnemonic()
+  const identity = await IdentityKey.from({ mnemonic })
+  const device = crypto.keyPair()
+  const proof = await identity.bootstrap(device.publicKey)
+
+  const descriptor = createChannelRootDescriptor({
+    identityPublicKey: b4a.toString(identity.identityPublicKey, 'hex'),
+    metadataKey: hexKey(3),
+    mediaKey: hexKey(4),
+    seq: 1,
+    createdAt: 10,
+    updatedAt: 20
+  })
+  const signed = await signChannelRootDescriptor({ descriptor, deviceKeyPair: device, deviceProof: proof })
+
+  const tampered = {
+    ...signed,
+    descriptor: {
+      ...signed.descriptor,
+      mediaKey: hexKey(9)
+    }
+  }
+
+  const verified = await verifySignedChannelRootDescriptor(tampered)
+  assert.equal(verified.valid, false)
+})
+
+test('descriptor creation validates canonical 32-byte hex keys and monotonic seq fields', () => {
+  assert.throws(() => createChannelRootDescriptor({
+    identityPublicKey: 'bad',
+    metadataKey: hexKey(1),
+    mediaKey: hexKey(2)
+  }), /identityPublicKey/)
+
+  assert.throws(() => createChannelRootDescriptor({
+    identityPublicKey: hexKey(0),
+    metadataKey: hexKey(1),
+    mediaKey: hexKey(2),
+    seq: -1
+  }), /seq/)
+})

--- a/packages/backend/test/identity-descriptor-regression.test.mjs
+++ b/packages/backend/test/identity-descriptor-regression.test.mjs
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+const identitySource = await import('../src/identity.js')
+const sourceText = await import('node:fs').then(fs => fs.readFileSync(new URL('../src/identity.js', import.meta.url), 'utf8'))
+
+test('identity manager creates and stores a signed channel root descriptor for new identities', () => {
+  assert.match(sourceText, /createChannelRootDescriptor/)
+  assert.match(sourceText, /signChannelRootDescriptor/)
+  assert.match(sourceText, /signedDescriptor/)
+  assert.match(sourceText, /const mediaKey = channel\.blobsKeyHex/)
+  assert.match(sourceText, /channel\.publicBee\.bee\.put\('channel\/root'/)
+  assert.ok(identitySource.createIdentityManager)
+})

--- a/packages/backend/test/public-feed-descriptor.test.mjs
+++ b/packages/backend/test/public-feed-descriptor.test.mjs
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { PublicFeedManager } from '../src/public-feed.js'
+
+const key = (fill) => Buffer.alloc(32, fill).toString('hex')
+
+function manager () {
+  return new PublicFeedManager({ join: () => ({ flushed: async () => {} }) }, null)
+}
+
+test('public feed preserves signed channel root descriptor on local submit, persistence, and gossip', async () => {
+  const feed = manager()
+  const signedDescriptor = {
+    schema: 'peartube.channel.root.signed.v1',
+    descriptor: {
+      schema: 'peartube.channel.root.v1',
+      channelId: key(9),
+      identityPublicKey: key(9),
+      metadataKey: key(1),
+      mediaKey: key(2),
+      seq: 3,
+      createdAt: 10,
+      updatedAt: 20
+    },
+    proof: 'aa',
+    attestation: 'bb'
+  }
+
+  feed.addEntry(key(1), 'local', key(1), { signedDescriptor })
+  const entry = feed.getFeed().find(e => e.driveKey === key(1))
+  assert.deepEqual(entry.signedDescriptor, signedDescriptor)
+
+  const serialized = feed._serializeEntry(entry)
+  assert.deepEqual(serialized.signedDescriptor, signedDescriptor)
+
+  const messages = []
+  const conn = {}
+  feed.peerChannels.set(conn, { messages: [{ send: (msg) => messages.push(msg) }] })
+  feed.broadcastSubmitChannel(key(1), null, key(1), { signedDescriptor })
+  assert.deepEqual(messages[0].signedDescriptor, signedDescriptor)
+})
+
+test('public feed applies newer signed descriptors but rejects lower descriptor seq', () => {
+  const feed = manager()
+  const oldDescriptor = {
+    schema: 'peartube.channel.root.signed.v1',
+    descriptor: { schema: 'peartube.channel.root.v1', channelId: key(7), identityPublicKey: key(7), seq: 5, metadataKey: key(1), mediaKey: key(2) },
+    proof: 'aa',
+    attestation: 'bb'
+  }
+  const staleDescriptor = {
+    schema: 'peartube.channel.root.signed.v1',
+    descriptor: { schema: 'peartube.channel.root.v1', channelId: key(7), identityPublicKey: key(7), seq: 4, metadataKey: key(3), mediaKey: key(4) },
+    proof: 'cc',
+    attestation: 'dd'
+  }
+  const newerDescriptor = {
+    schema: 'peartube.channel.root.signed.v1',
+    descriptor: { schema: 'peartube.channel.root.v1', channelId: key(7), identityPublicKey: key(7), seq: 6, metadataKey: key(5), mediaKey: key(6) },
+    proof: 'ee',
+    attestation: 'ff'
+  }
+
+  feed.addEntry(key(1), 'peer', key(1), { signedDescriptor: oldDescriptor })
+  assert.equal(feed._applyEntrySnapshot(key(1), { signedDescriptor: staleDescriptor }), false)
+  assert.deepEqual(feed.entries.get(key(1)).signedDescriptor, oldDescriptor)
+
+  assert.equal(feed._applyEntrySnapshot(key(1), { signedDescriptor: newerDescriptor }), true)
+  assert.deepEqual(feed.entries.get(key(1)).signedDescriptor, newerDescriptor)
+})


### PR DESCRIPTION
## Summary
- add signed channel root descriptors backed by keet identity/device attestation
- store descriptor in the public channel bee at channel/root and identity metadata
- preserve and gossip signed descriptors through public feed entries with monotonic seq handling

## Tests
- node --test packages/backend/test/channel-descriptor.test.mjs packages/backend/test/public-feed-descriptor.test.mjs packages/backend/test/identity-descriptor-regression.test.mjs packages/backend/test/public-feed-manager.test.mjs
- node_modules/.bin/eslint --quiet packages/backend/src/channel-descriptor.js packages/backend/src/identity.js packages/backend/src/public-feed.js packages/backend/test/channel-descriptor.test.mjs packages/backend/test/identity-descriptor-regression.test.mjs packages/backend/test/public-feed-descriptor.test.mjs
- npm run lint:changed
- git diff --check