### PR TITLE
fix(relay): publish local drive videos without catalog restore

### DIFF
--- a/packages/cli/src/local-drive-mirror.js
+++ b/packages/cli/src/local-drive-mirror.js
@@ -32,6 +32,17 @@ function fingerprintVideo(video) {
   return `${video.filePath}:${video.size}:${video.mtimeMs}`
 }
 
+function getSeenFingerprint(record) {
+  if (!record) return null
+  if (typeof record === 'string') return record
+  return record.fingerprint || null
+}
+
+function getSeenPreviewVideo(record) {
+  if (!record || typeof record !== 'object') return null
+  return record.previewVideo || null
+}
+
 export function createLocalDriveMirrorState(seed = null) {
   return {
     seen: new Map(seed?.seen || [])
@@ -95,7 +106,7 @@ export async function mirrorLocalDriveToRelayChannel({
   if (!publisher) throw new Error('publisher is required')
   const videos = listLocalDriveVideos(rootPath, { fs, path, recursive, maxFiles })
   const pendingVideos = state?.seen
-    ? videos.filter((video) => state.seen.get(video.filePath) !== fingerprintVideo(video))
+    ? videos.filter((video) => getSeenFingerprint(state.seen.get(video.filePath)) !== fingerprintVideo(video))
     : videos
   const channelInfo = await publisher.ensureAnonymousChannel({ channelName })
   const imported = []
@@ -128,7 +139,12 @@ export async function mirrorLocalDriveToRelayChannel({
         thumbnailMimeType: metadata.thumbnailMimeType || null
       } : null
       imported.push({ ...video, videoId: result?.videoId || null, previewVideo })
-      state?.seen?.set(video.filePath, fingerprintVideo(video))
+      if (state?.seen) {
+        state.seen.set(video.filePath, {
+          fingerprint: fingerprintVideo(video),
+          previewVideo
+        })
+      }
       logger?.archive?.info?.('Local drive video imported', { file: video.filePath, videoId: result?.videoId || null })
     } catch (err) {
       failed.push({ ...video, error: err?.message || String(err) })
@@ -136,7 +152,10 @@ export async function mirrorLocalDriveToRelayChannel({
     }
   }
 
-  const previewVideos = imported.map((entry) => entry.previewVideo).filter(Boolean)
+  const importedPreviewByPath = new Map(imported.map((entry) => [entry.filePath, entry.previewVideo]).filter(([, preview]) => Boolean(preview)))
+  const previewVideos = videos
+    .map((video) => importedPreviewByPath.get(video.filePath) || getSeenPreviewVideo(state?.seen?.get(video.filePath)))
+    .filter(Boolean)
   if (previewVideos.length > 0) {
     await publisher.publishChannel(channelInfo, { previewVideos })
     await publisher.seedChannel({ ...channelInfo, previewVideos })

--- a/packages/cli/src/runtime.js
+++ b/packages/cli/src/runtime.js
@@ -126,8 +126,7 @@ export async function createRelayRuntime({ config, logger }) {
       candidateHandler({
         channelKey: entry.driveKey,
         publicBeeKey: entry.publicBeeKey || null,
-        source: entry.relayRole === 'cache' || entry.source === 'relay-cache' ? 'relay-cache' : 'discovered',
-        relayServing: Boolean(entry.relayServing),
+        source: entry.source === 'relay-cache' ? 'relay-cache' : 'discovered',
         previewVideos: Array.isArray(entry.previewVideos) ? entry.previewVideos : []
       })
     }
@@ -192,31 +191,6 @@ export async function createRelayRuntime({ config, logger }) {
       }
       if (typeof this.api.getFeedSnapshotEntries === 'function') {
         publicFeed.setFeedSnapshotProvider((entries) => this.api.getFeedSnapshotEntries(entries, { limitPerChannel: 3 }))
-      }
-
-      // Restore mirrored/cached channels as relay catalog entries, not as
-      // user-published channels. This keeps the relay contract explicit: it is
-      // serving/cache infrastructure for these publicBee/blob cores.
-      for (const channel of cacheManager.getChannels()) {
-        if (!channel?.driveKey || !channel?.publicBeeKey) continue
-        try {
-          const seedStats = await seeder.seedChannel(channel)
-          await publicFeed.submitRelayCatalogEntry({
-            ...(seedStats?.catalogEntry || {}),
-            driveKey: channel.driveKey,
-            publicBeeKey: channel.publicBeeKey,
-            channelName: seedStats?.catalogEntry?.channelName || channel.channelName || null,
-            videoCount: seedStats?.videos || channel.videoCount || 0,
-            previewVideos: seedStats?.catalogEntry?.previewVideos || channel.previewVideos || [],
-            relayRole: 'cache',
-            relayServing: true,
-          })
-        } catch (err) {
-          logger.runtime?.debug('Failed to restore cached mirrored channel', {
-            channelKey: channel.driveKey,
-            error: err?.message || String(err)
-          })
-        }
       }
 
       logger.runtime?.info('Relay runtime started', this.getNetworkStats())
@@ -322,12 +296,6 @@ export async function createRelayRuntime({ config, logger }) {
         swarmOfflineReason: ctx.swarm?._peartubeOfflineReason || null,
         swarmListenResolved: Boolean(ctx.swarm?._peartubeListenResolved),
         seeding: seeder.getStats(),
-        relayCatalogEntries: Array.from(publicFeed.entries?.values?.() || []).filter(e => e?.relayRole === 'cache' || e?.source === 'relay-cache').length,
-        relayServingEntries: Array.from(publicFeed.entries?.values?.() || []).filter(e => e?.relayServing).length,
-        relayPlayablePreviewVideos: Array.from(publicFeed.entries?.values?.() || []).reduce((total, e) => {
-          const videos = Array.isArray(e?.previewVideos) ? e.previewVideos : []
-          return total + videos.filter(v => v?.availability === 'playable' && v?.blobId && v?.blobsCoreKey).length
-        }, 0)
       }
     },
     async close() {

--- a/packages/cli/test/local-drive-mirror.test.mjs
+++ b/packages/cli/test/local-drive-mirror.test.mjs
@@ -96,7 +96,7 @@ test('mirrorLocalDriveToRelayChannel imports, publishes, and seeds preview refs'
 })
 
 
-test('mirrorLocalDriveToRelayChannel skips already mirrored file fingerprints', async (t) => {
+test('mirrorLocalDriveToRelayChannel republishes and reseeds cached local previews on unchanged scans', async (t) => {
   const sizes = { '/drive/one.mp4': 100 }
   const fs = {
     readdirSync() {
@@ -108,6 +108,8 @@ test('mirrorLocalDriveToRelayChannel skips already mirrored file fingerprints', 
   }
   const state = createLocalDriveMirrorState()
   const imports = []
+  const published = []
+  const seeded = []
   const publisher = {
     async ensureAnonymousChannel() {
       return { channel: { id: 'channel' }, channelKey: 'aa'.repeat(32), publicBeeKey: 'bb'.repeat(32) }
@@ -116,8 +118,12 @@ test('mirrorLocalDriveToRelayChannel skips already mirrored file fingerprints', 
       imports.push(filePath)
       return { videoId: `video-${imports.length}`, metadata: { size: sizes[filePath], blobId: `blob-${imports.length}`, blobsCoreKey: 'cc'.repeat(32) } }
     },
-    async publishChannel() {},
-    async seedChannel() {}
+    async publishChannel(_channelInfo, options) {
+      published.push(options.previewVideos.map((video) => video.blobId))
+    },
+    async seedChannel(channelInfo) {
+      seeded.push(channelInfo.previewVideos.map((video) => video.blobsCoreKey))
+    }
   }
 
   const first = await mirrorLocalDriveToRelayChannel({ rootPath: '/drive', publisher, fs, path: pathShim, state })
@@ -130,4 +136,6 @@ test('mirrorLocalDriveToRelayChannel skips already mirrored file fingerprints', 
   t.is(second.skipped, 1)
   t.is(third.imported, 1)
   t.alike(imports, ['/drive/one.mp4', '/drive/one.mp4'])
+  t.alike(published, [['blob-1'], ['blob-1'], ['blob-2']])
+  t.alike(seeded, [['cc'.repeat(32)], ['cc'.repeat(32)], ['cc'.repeat(32)]])
 })

--- a/packages/cli/test/runtime-no-relay-catalog.test.mjs
+++ b/packages/cli/test/runtime-no-relay-catalog.test.mjs
@@ -1,0 +1,14 @@
+import test from 'brittle'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const runtimeSource = readFileSync(join(here, '../src/runtime.js'), 'utf8')
+
+test('relay runtime does not restore cached channels as relay catalog feed entries', (t) => {
+  t.absent(runtimeSource.includes('submitRelayCatalogEntry'))
+  t.absent(runtimeSource.includes('relayRole'))
+  t.absent(runtimeSource.includes('relayServing'))
+  t.absent(runtimeSource.includes('relayCatalogEntries'))
+})


### PR DESCRIPTION
## Summary
- stop relay runtime from restoring cached channels as relay-catalog feed entries on startup
- remove relay catalog/temp-value status paths from runtime diagnostics
- keep local drive preview refs in mirror state so unchanged scans still republish/reseed visible videos
- add regressions for local drive republish/reseed and no runtime relay catalog restore path

## Test Plan
- `node packages/cli/test/local-drive-mirror.test.mjs`
- `node packages/cli/test/runtime-no-relay-catalog.test.mjs`
- `npm test --prefix packages/cli -- --timeout=30000`
- `npm run lint:changed`
- `git diff --check`
