### PR TITLE
fix(app): remove simple relay catalog discovery flow

### DIFF
--- a/packages/app/app/(tabs)/index.tsx
+++ b/packages/app/app/(tabs)/index.tsx
@@ -38,11 +38,6 @@ import {
   readFeedSnapshotFromDisk,
   writeFeedSnapshotToDisk,
 } from '@/lib/feed-snapshot-storage'
-import {
-  fetchRelayCatalogEntries,
-  readRelayCatalogUrlFromDisk,
-} from '@/lib/simple-relay-catalog'
-
 // Public feed types
 interface FeedEntry {
   driveKey: string
@@ -257,22 +252,9 @@ export default function HomeScreen() {
       const result = await Promise.race([feedPromise, timeoutPromise])
 
       if (result?.entries) {
-        const entries = Array.isArray(result.entries) ? result.entries : []
-        let relayEntries: any[] = []
-        const relayCatalogUrl = await readRelayCatalogUrlFromDisk()
-        if (relayCatalogUrl) {
-          relayEntries = await fetchRelayCatalogEntries(relayCatalogUrl)
-        }
-        const p2pByKey = new Map(entries.map((entry: any) => [entry?.channelKey || entry?.driveKey, entry]))
-        const mergedEntries = [...relayEntries, ...entries].filter((entry, index, all) => {
+        const mergedEntries = (Array.isArray(result.entries) ? result.entries : []).filter((entry, index, all) => {
           const key = entry?.channelKey || entry?.driveKey
           return key && all.findIndex((candidate) => (candidate?.channelKey || candidate?.driveKey) === key) === index
-        }).map((entry: any) => {
-          const key = entry?.channelKey || entry?.driveKey
-          const p2pEntry = key ? p2pByKey.get(key) : null
-          return entry.source === 'relay-cache' && p2pEntry
-            ? { ...entry, ...p2pEntry, previewVideos: entry.previewVideos || p2pEntry.previewVideos }
-            : entry
         }) as FeedEntry[]
         console.log('[Home] getPublicFeed entries:', mergedEntries.map((e: any) => ({
           channelKey: e.channelKey || e.driveKey,

--- a/packages/app/app/(tabs)/settings.tsx
+++ b/packages/app/app/(tabs)/settings.tsx
@@ -9,13 +9,6 @@ import { Feather } from '@expo/vector-icons'
 import { useApp, colors } from '../_layout'
 import { CastHeaderButton } from '@/components/cast'
 import { useTabBarMetrics } from '@/lib/tabBarHeight'
-import {
-  clearRelayCatalogUrlFromDisk,
-  normalizeRelayCatalogUrl,
-  readRelayCatalogUrlFromDisk,
-  writeRelayCatalogUrlToDisk,
-} from '@/lib/simple-relay-catalog'
-
 interface StorageStats {
   usedBytes: number
   maxBytes: number
@@ -62,8 +55,6 @@ export default function SettingsScreen() {
   const canManageTranscodeSettings = isPear && typeof (rpc as any)?.getTranscodeSettings === 'function'
   const [transcodeSettings, setTranscodeSettings] = useState<TranscodeSettings | null>(null)
   const [transcodeSettingsLoading, setTranscodeSettingsLoading] = useState(false)
-  const [relayCatalogUrl, setRelayCatalogUrl] = useState('')
-  const [relayCatalogSaving, setRelayCatalogSaving] = useState(false)
 
   // Check if channel is published
   const checkPublishStatus = useCallback(async () => {
@@ -129,43 +120,6 @@ export default function SettingsScreen() {
   useEffect(() => {
     loadTranscodeSettings()
   }, [loadTranscodeSettings])
-
-  useEffect(() => {
-    let mounted = true
-    void readRelayCatalogUrlFromDisk().then((url) => {
-      if (mounted && url) setRelayCatalogUrl(url)
-    })
-    return () => { mounted = false }
-  }, [])
-
-  const saveRelayCatalogUrl = useCallback(async () => {
-    const normalized = normalizeRelayCatalogUrl(relayCatalogUrl)
-    if (!normalized) {
-      Alert.alert('Invalid relay catalog URL', 'Use the relay WebUI catalog URL, e.g. http://server:8174/catalog.json')
-      return
-    }
-    setRelayCatalogSaving(true)
-    try {
-      const ok = await writeRelayCatalogUrlToDisk(normalized)
-      if (!ok) throw new Error('save failed')
-      setRelayCatalogUrl(normalized)
-      Alert.alert('Saved', 'Discover will merge this relay catalog into the feed.')
-    } catch {
-      Alert.alert('Error', 'Failed to save relay catalog URL')
-    } finally {
-      setRelayCatalogSaving(false)
-    }
-  }, [relayCatalogUrl])
-
-  const clearRelayCatalogUrl = useCallback(async () => {
-    setRelayCatalogSaving(true)
-    try {
-      await clearRelayCatalogUrlFromDisk()
-      setRelayCatalogUrl('')
-    } finally {
-      setRelayCatalogSaving(false)
-    }
-  }, [])
 
   const handleVideoToolboxDecodeToggle = async (enabled: boolean) => {
     if (!canManageTranscodeSettings) return
@@ -661,50 +615,6 @@ export default function SettingsScreen() {
             </>
           )}
         </View>
-
-        {/* Divider */}
-        <View className="h-2 bg-pear-bg-card" />
-
-        {/* Simple Relay Catalog */}
-        <View className="px-5 py-5">
-          <Text className="text-caption-medium text-pear-text-muted mb-4 uppercase tracking-wide">Relay Catalog</Text>
-          <View className="bg-pear-bg-elevated rounded-xl p-4 mb-3">
-            <Text className="text-label text-pear-text mb-2">Simple relay catalog URL</Text>
-            <Text className="text-caption text-pear-text-muted mb-3">
-              Paste the relay WebUI catalog URL here to show archived relay videos without relying on live P2P feed discovery.
-            </Text>
-            <TextInput
-              placeholder="http://server:8174/catalog.json"
-              value={relayCatalogUrl}
-              onChangeText={setRelayCatalogUrl}
-              placeholderTextColor={colors.textMuted}
-              autoCapitalize="none"
-              autoCorrect={false}
-              className="bg-pear-bg-input border border-pear-border rounded-lg px-4 py-3 text-body text-pear-text mb-3"
-            />
-            <View className="flex-row gap-3">
-              <Pressable
-                onPress={saveRelayCatalogUrl}
-                disabled={relayCatalogSaving || !relayCatalogUrl.trim()}
-                className={`flex-1 flex-row items-center justify-center gap-2 bg-pear-primary rounded-lg py-2.5 ${(relayCatalogSaving || !relayCatalogUrl.trim()) ? 'opacity-50' : ''}`}
-              >
-                <Feather name="save" color="white" size={16} />
-                <Text className="text-white text-label">{relayCatalogSaving ? 'Saving...' : 'Save'}</Text>
-              </Pressable>
-              <Pressable
-                onPress={clearRelayCatalogUrl}
-                disabled={relayCatalogSaving || !relayCatalogUrl.trim()}
-                className={`flex-1 flex-row items-center justify-center gap-2 bg-pear-bg-card border border-pear-border rounded-lg py-2.5 ${(relayCatalogSaving || !relayCatalogUrl.trim()) ? 'opacity-50' : ''}`}
-              >
-                <Feather name="x" color={colors.textMuted} size={16} />
-                <Text className="text-pear-text-muted text-label">Clear</Text>
-              </Pressable>
-            </View>
-          </View>
-        </View>
-
-        {/* Divider */}
-        <View className="h-2 bg-pear-bg-card" />
 
         {/* Devices Section */}
         <View className="px-5 py-5">

--- a/packages/app/tests/no-simple-relay-catalog-regression.test.mjs
+++ b/packages/app/tests/no-simple-relay-catalog-regression.test.mjs
@@ -1,0 +1,26 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const appRoot = join(here, '..')
+
+function read(rel) {
+  return readFileSync(join(appRoot, rel), 'utf8')
+}
+
+test('Home feed no longer imports or merges Simple relay catalog entries', () => {
+  const source = read('app/(tabs)/index.tsx')
+  assert.doesNotMatch(source, /simple-relay-catalog/)
+  assert.doesNotMatch(source, /fetchRelayCatalogEntries/)
+  assert.doesNotMatch(source, /readRelayCatalogUrlFromDisk/)
+})
+
+test('Settings no longer exposes Simple relay catalog URL as discovery UX', () => {
+  const source = read('app/(tabs)/settings.tsx')
+  assert.doesNotMatch(source, /Simple relay catalog URL/)
+  assert.doesNotMatch(source, /catalog\.json/)
+  assert.doesNotMatch(source, /saveRelayCatalogUrl/)
+})


### PR DESCRIPTION
## Summary
- removes Simple relay catalog imports and merge behavior from the Home/Discover feed
- removes the Simple relay catalog URL settings UI
- adds a regression that normal app discovery does not depend on the relay catalog escape hatch

## Test Plan
- node --test packages/app/tests/no-simple-relay-catalog-regression.test.mjs
- npm run lint:changed
- git diff --check

Closes #155
