### PR TITLE
fix(app): return stale listVideos errors

### DIFF
--- a/packages/app/backend/mobile-handlers.mjs
+++ b/packages/app/backend/mobile-handlers.mjs
@@ -64,7 +64,7 @@ export function attachMobileHandlers(B, deps) {
   // --- Video handlers ---
   B.listVideos = async (r) => {
     const ck = r?.channelKey || ''; if (!ck) return { videos: [] }
-    let raw = []; try { raw = await api.listVideos(ck, r.publicBeeKey) } catch { return { videos: [] } }
+    let raw = []; try { raw = await api.listVideos(ck, r.publicBeeKey) } catch (err) { return { success: false, error: err?.message || String(err), stale: true, videos: [] } }
     return { videos: (raw || []).map((v) => {
       const id = v?.id ? String(v.id) : ''; if (!id) return null
       return {

--- a/packages/app/backend/mobile-handlers.test.mjs
+++ b/packages/app/backend/mobile-handlers.test.mjs
@@ -133,6 +133,28 @@ test('listVideos forwards video availability metadata from backend api', async (
   })
 })
 
+test('listVideos returns explicit stale error when backend api list fails', async () => {
+  const backend = {}
+  const deps = createDeps({
+    api: {
+      async listVideos(channelKey, publicBeeKey) {
+        assert.equal(channelKey, 'channel-key')
+        assert.equal(publicBeeKey, 'public-bee-key')
+        throw new Error('manifest unavailable')
+      },
+    },
+  })
+
+  attachMobileHandlers(backend, deps)
+
+  assert.deepEqual(await backend.listVideos({ channelKey: 'channel-key', publicBeeKey: 'public-bee-key' }), {
+    success: false,
+    error: 'manifest unavailable',
+    stale: true,
+    videos: [],
+  })
+})
+
 test('preparePlayback forwards direct blob playback fields to the backend api', async () => {
   const backend = {}
   const captured = []

--- a/packages/app/workers/desktop/index.ts
+++ b/packages/app/workers/desktop/index.ts
@@ -451,7 +451,7 @@ B.updateVideoMetadata = async (r: any) => { const a = identityManager.getActiveI
 B.updateChannelAvatar = async (r: any) => { const a = identityManager.getActiveIdentity(); if (!a?.driveKey) return { success: false, error: 'No active channel' }; const buf = fs.readFileSync(r.filePath); return api.updateChannelAvatar(a.driveKey, buf, r.mimeType || 'image/jpeg') }
 B.listVideos = async (r: any) => {
   const ck = r?.channelKey || ''; if (!ck) return { videos: [] }
-  let raw: any[] = []; try { raw = await api.listVideos(ck, r.publicBeeKey) } catch { return { videos: [] } }
+  let raw: any[] = []; try { raw = await api.listVideos(ck, r.publicBeeKey) } catch (err: any) { return { success: false, error: err?.message || String(err), stale: true, videos: [] } }
   return { videos: (raw || []).map((v: any) => {
     const id = v?.id ? String(v.id) : ''; if (!id) return null
     return {

--- a/packages/backend/src/mobile-handlers.js
+++ b/packages/backend/src/mobile-handlers.js
@@ -59,7 +59,7 @@ export function attachMobileHandlers(B, deps) {
 
   B.listVideos = async (r) => {
     const ck = r?.channelKey || ''; if (!ck) return { videos: [] }
-    let raw = []; try { raw = await api.listVideos(ck, r.publicBeeKey) } catch { return { videos: [] } }
+    let raw = []; try { raw = await api.listVideos(ck, r.publicBeeKey) } catch (err) { return { success: false, error: err?.message || String(err), stale: true, videos: [] } }
     return { videos: (raw || []).map((v) => {
       const id = v?.id ? String(v.id) : ''; if (!id) return null
       return {


### PR DESCRIPTION
## Summary
- returns an explicit stale/error result when listVideos cannot load a channel manifest
- keeps the empty videos fallback but no longer makes backend failures indistinguishable from genuinely empty channels
- applies the behavior to mobile app handlers, backend shared handlers, and desktop worker handlers

## Test Plan
- node --test packages/app/backend/mobile-handlers.test.mjs
- npm run lint:changed
- git diff --check

Closes #156
