### PR TITLE
refactor(app): extract video overlay derived helpers

### DIFF
--- a/packages/app/components/VideoPlayerOverlayImpl.tsx
+++ b/packages/app/components/VideoPlayerOverlayImpl.tsx
@@ -339,7 +339,8 @@ export function VideoPlayerOverlay() {
     if (playerLogKeyRef.current === logKey) return
     playerLogKeyRef.current = logKey
     if (typeof window !== 'undefined') {
-      ;(window as any).__PEARTUBE_PLAYER__ = {
+      const windowState = window as any
+      windowState.__PEARTUBE_PLAYER__ = {
         player,
         videoId: currentVideo.id,
         channelKey,
@@ -2143,6 +2144,9 @@ export function VideoPlayerOverlay() {
       >
         {/* Drag handle - top bar */}
         <div
+          role="button"
+          tabIndex={0}
+          aria-label="Move mini player"
           style={{
             position: 'absolute',
             top: 0,
@@ -2151,6 +2155,11 @@ export function VideoPlayerOverlay() {
             height: 32,
             cursor: isDraggingMiniPlayer ? 'grabbing' : 'grab',
             zIndex: 10,
+          }}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              maximizeFromMini()
+            }
           }}
           onMouseDown={handleMiniPlayerDragStart}
         />
@@ -2201,6 +2210,9 @@ export function VideoPlayerOverlay() {
 
           {/* Hover overlay with play/pause */}
           <div
+            role="button"
+            tabIndex={0}
+            aria-label={effectiveIsPlaying ? 'Pause video' : 'Play video'}
             style={{
               position: 'absolute',
               top: 0,
@@ -2216,6 +2228,12 @@ export function VideoPlayerOverlay() {
             }}
             className="mini-player-overlay"
             onClick={handlePlayPause}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault()
+                handlePlayPause()
+              }
+            }}
           >
             <div
               style={{
@@ -2271,7 +2289,18 @@ export function VideoPlayerOverlay() {
           }}
         >
           {/* Title and channel */}
-          <div style={{ flex: 1, minWidth: 0, cursor: 'pointer' }} onClick={maximizeFromMini}>
+          <div
+            role="button"
+            tabIndex={0}
+            style={{ flex: 1, minWidth: 0, cursor: 'pointer' }}
+            onClick={maximizeFromMini}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault()
+                maximizeFromMini()
+              }
+            }}
+          >
             <div
               style={{
                 fontSize: 13,

--- a/packages/app/components/VideoPlayerOverlayImpl.tsx
+++ b/packages/app/components/VideoPlayerOverlayImpl.tsx
@@ -29,28 +29,27 @@ import { getPlayerPageVideoHeight } from '@/lib/video-layout'
 import { useTabBarMetrics } from '@/lib/tabBarHeight'
 import { useCast } from '@/lib/cast'
 import { DevicePickerModal } from '@/components/cast'
+import {
+  computeMiniSize,
+  computeMiniBounds,
+  getCornerAnchors,
+  getMobileMiniPlayerSnapPosition,
+  resolveSnapTarget,
+  type MiniBounds,
+  type MiniPlayerCorner,
+  type Anchor,
+} from './video-player/overlayDerivedState'
 
 // Import modular video-player components
 import {
   // Constants
   MINI_PIP_MARGIN,
   MINI_PIP_CORNER_RADIUS,
-  MINI_PIP_COMPACT_WIDTH_FRACTION,
-  MINI_PIP_COMPACT_WIDTH_MIN,
-  MINI_PIP_COMPACT_WIDTH_MAX,
-  MINI_PIP_EXPANDED_WIDTH_FRACTION,
-  MINI_PIP_EXPANDED_WIDTH_MIN,
-  MINI_PIP_EXPANDED_WIDTH_MAX,
   TAB_BAR_HEIGHT,
 
   SPRING_CONFIG_BOUNCY,
   SPRING_CONFIG_TIGHT,
   SPRING_CONFIG_MINI_SNAP,
-  SNAP_LOW_SPEED,
-  SNAP_FLING_SPEED,
-  SNAP_TOSS_HORIZON,
-  SNAP_FLING_HORIZON,
-  SNAP_HYSTERESIS_PX,
   MINI_DRAG_SCALE,
   MINI_SHADOW_DOCKED,
   MINI_SHADOW_DRAGGING,
@@ -94,167 +93,7 @@ const Ionicons = ExpoIonicons
 const CHANNEL_META_CACHE_TTL_MS = 5 * 60 * 1000
 const channelMetaNameCache = new Map<string, { name: string | null; expiresAt: number }>()
 const ZERO_EDGE_INSETS = Object.freeze({ top: 0, right: 0, bottom: 0, left: 0 })
-type MiniPlayerCorner = 'bottom-right' | 'bottom-left' | 'top-right' | 'top-left'
-
-// ── Responsive mini-player geometry worklets ──────────────────────────
-
-interface MiniBounds {
-  leftBound: number
-  rightBound: number
-  topBound: number
-  bottomBound: number
-}
-
-interface Anchor { x: number; y: number; corner: MiniPlayerCorner }
-
-function computeMiniSize(screenWidth: number, aspectRatio: number, sizeMode: 'compact' | 'expanded' = 'compact') {
-  'worklet'
-  const ar = aspectRatio > 0 ? aspectRatio : 16 / 9
-  const fraction = sizeMode === 'expanded' ? MINI_PIP_EXPANDED_WIDTH_FRACTION : MINI_PIP_COMPACT_WIDTH_FRACTION
-  const minW = sizeMode === 'expanded' ? MINI_PIP_EXPANDED_WIDTH_MIN : MINI_PIP_COMPACT_WIDTH_MIN
-  const maxW = sizeMode === 'expanded' ? MINI_PIP_EXPANDED_WIDTH_MAX : MINI_PIP_COMPACT_WIDTH_MAX
-  const w = Math.max(minW, Math.min(maxW, Math.round(screenWidth * fraction)))
-  const h = Math.round(w / ar)
-  return { width: w, height: h }
-}
-
-function computeMiniBounds(
-  screenWidth: number,
-  screenHeight: number,
-  insetTop: number,
-  insetRight: number,
-  insetBottom: number,
-  insetLeft: number,
-  bottomChrome: number,
-  miniWidth: number,
-  miniHeight: number,
-): MiniBounds {
-  'worklet'
-  const margin = MINI_PIP_MARGIN
-  const bottomMargin = Math.max(insetBottom + margin, bottomChrome + margin)
-  return {
-    leftBound: insetLeft + margin,
-    rightBound: screenWidth - insetRight - margin - miniWidth,
-    topBound: insetTop + margin,
-    bottomBound: screenHeight - bottomMargin - miniHeight,
-  }
-}
-
-function getCornerAnchors(bounds: MiniBounds): [Anchor, Anchor, Anchor, Anchor] {
-  'worklet'
-  return [
-    { x: bounds.leftBound,  y: bounds.topBound,    corner: 'top-left' },
-    { x: bounds.rightBound, y: bounds.topBound,    corner: 'top-right' },
-    { x: bounds.leftBound,  y: bounds.bottomBound, corner: 'bottom-left' },
-    { x: bounds.rightBound, y: bounds.bottomBound, corner: 'bottom-right' },
-  ]
-}
-
-function resolveSnapTarget(
-  releaseX: number,
-  releaseY: number,
-  vx: number,
-  vy: number,
-  anchors: readonly Anchor[],
-  miniWidth: number,
-  miniHeight: number,
-  currentCorner: MiniPlayerCorner,
-  bounds: MiniBounds,
-): Anchor {
-  'worklet'
-  const speed = Math.sqrt(vx * vx + vy * vy)
-
-  // Projection horizon by velocity regime
-  let horizon = 0
-  if (speed >= SNAP_FLING_SPEED) {
-    horizon = SNAP_FLING_HORIZON
-  } else if (speed >= SNAP_LOW_SPEED) {
-    horizon = SNAP_TOSS_HORIZON
-  }
-
-  // Project release point, clamp to legal bounds
-  let targetX = releaseX + vx * horizon
-  let targetY = releaseY + vy * horizon
-  targetX = Math.max(bounds.leftBound, Math.min(bounds.rightBound, targetX))
-  targetY = Math.max(bounds.topBound, Math.min(bounds.bottomBound, targetY))
-
-  // Target card center
-  const tcx = targetX + miniWidth / 2
-  const tcy = targetY + miniHeight / 2
-
-  // Score each anchor by squared Euclidean center distance
-  let bestAnchor = anchors[0]
-  let bestScore = Infinity
-  let currentAnchorScore = Infinity
-
-  for (let i = 0; i < anchors.length; i++) {
-    const acx = anchors[i].x + miniWidth / 2
-    const acy = anchors[i].y + miniHeight / 2
-    const score = (acx - tcx) * (acx - tcx) + (acy - tcy) * (acy - tcy)
-    if (score < bestScore) {
-      bestScore = score
-      bestAnchor = anchors[i]
-    }
-    if (anchors[i].corner === currentCorner) {
-      currentAnchorScore = score
-    }
-  }
-
-  // Hysteresis: on slow release, prefer current corner if it's close enough
-  if (speed < SNAP_LOW_SPEED && currentAnchorScore < Infinity) {
-    const bestDist = Math.sqrt(bestScore)
-    const currentDist = Math.sqrt(currentAnchorScore)
-    if (currentDist - bestDist < SNAP_HYSTERESIS_PX) {
-      for (let i = 0; i < anchors.length; i++) {
-        if (anchors[i].corner === currentCorner) return anchors[i]
-      }
-    }
-  }
-
-  return bestAnchor
-}
-
-// ── JS-side snap position helper ──────────────────────────────────────
-
-function getMobileMiniPlayerSnapPosition({
-  corner,
-  screenWidth,
-  screenHeight,
-  topInset,
-  rightInset,
-  bottomInset,
-  leftInset,
-  bottomOffset,
-  aspectRatio,
-  sizeMode,
-}: {
-  corner: MiniPlayerCorner
-  screenWidth: number
-  screenHeight: number
-  topInset: number
-  rightInset: number
-  bottomInset: number
-  leftInset: number
-  bottomOffset: number
-  aspectRatio: number
-  sizeMode: 'compact' | 'expanded'
-}) {
-  const { width: miniWidth, height: miniHeight } = computeMiniSize(screenWidth, aspectRatio, sizeMode)
-  const bounds = computeMiniBounds(
-    screenWidth,
-    screenHeight,
-    topInset,
-    rightInset,
-    bottomInset,
-    leftInset,
-    bottomOffset,
-    miniWidth,
-    miniHeight,
-  )
-  const anchors = getCornerAnchors(bounds)
-  const anchor = anchors.find(a => a.corner === corner) ?? anchors[3] // default BR
-  return { x: anchor.x, y: anchor.y, width: miniWidth, height: miniHeight }
-}
+// ── Responsive mini-player geometry helpers live in ./video-player/overlayDerivedState ──
 
 export function VideoPlayerOverlay() {
   const insets = useContext(SafeAreaInsetsContext) ?? ZERO_EDGE_INSETS

--- a/packages/app/components/video-player/overlayDerivedState.ts
+++ b/packages/app/components/video-player/overlayDerivedState.ts
@@ -1,0 +1,166 @@
+import {
+  MINI_PIP_MARGIN,
+  MINI_PIP_COMPACT_WIDTH_FRACTION,
+  MINI_PIP_COMPACT_WIDTH_MIN,
+  MINI_PIP_COMPACT_WIDTH_MAX,
+  MINI_PIP_EXPANDED_WIDTH_FRACTION,
+  MINI_PIP_EXPANDED_WIDTH_MIN,
+  MINI_PIP_EXPANDED_WIDTH_MAX,
+  SNAP_LOW_SPEED,
+  SNAP_FLING_SPEED,
+  SNAP_TOSS_HORIZON,
+  SNAP_FLING_HORIZON,
+  SNAP_HYSTERESIS_PX,
+} from './constants'
+
+export type MiniPlayerCorner = 'bottom-right' | 'bottom-left' | 'top-right' | 'top-left'
+
+export interface MiniBounds {
+  leftBound: number
+  rightBound: number
+  topBound: number
+  bottomBound: number
+}
+
+export interface Anchor { x: number; y: number; corner: MiniPlayerCorner }
+
+export function computeMiniSize(screenWidth: number, aspectRatio: number, sizeMode: 'compact' | 'expanded' = 'compact') {
+  'worklet'
+  const ar = aspectRatio > 0 ? aspectRatio : 16 / 9
+  const fraction = sizeMode === 'expanded' ? MINI_PIP_EXPANDED_WIDTH_FRACTION : MINI_PIP_COMPACT_WIDTH_FRACTION
+  const minW = sizeMode === 'expanded' ? MINI_PIP_EXPANDED_WIDTH_MIN : MINI_PIP_COMPACT_WIDTH_MIN
+  const maxW = sizeMode === 'expanded' ? MINI_PIP_EXPANDED_WIDTH_MAX : MINI_PIP_COMPACT_WIDTH_MAX
+  const w = Math.max(minW, Math.min(maxW, Math.round(screenWidth * fraction)))
+  const h = Math.round(w / ar)
+  return { width: w, height: h }
+}
+
+export function computeMiniBounds(
+  screenWidth: number,
+  screenHeight: number,
+  insetTop: number,
+  insetRight: number,
+  insetBottom: number,
+  insetLeft: number,
+  bottomChrome: number,
+  miniWidth: number,
+  miniHeight: number,
+): MiniBounds {
+  'worklet'
+  const margin = MINI_PIP_MARGIN
+  const bottomMargin = Math.max(insetBottom + margin, bottomChrome + margin)
+  return {
+    leftBound: insetLeft + margin,
+    rightBound: screenWidth - insetRight - margin - miniWidth,
+    topBound: insetTop + margin,
+    bottomBound: screenHeight - bottomMargin - miniHeight,
+  }
+}
+
+export function getCornerAnchors(bounds: MiniBounds): [Anchor, Anchor, Anchor, Anchor] {
+  'worklet'
+  return [
+    { x: bounds.leftBound,  y: bounds.topBound,    corner: 'top-left' },
+    { x: bounds.rightBound, y: bounds.topBound,    corner: 'top-right' },
+    { x: bounds.leftBound,  y: bounds.bottomBound, corner: 'bottom-left' },
+    { x: bounds.rightBound, y: bounds.bottomBound, corner: 'bottom-right' },
+  ]
+}
+
+export function resolveSnapTarget(
+  releaseX: number,
+  releaseY: number,
+  vx: number,
+  vy: number,
+  anchors: readonly Anchor[],
+  miniWidth: number,
+  miniHeight: number,
+  currentCorner: MiniPlayerCorner,
+  bounds: MiniBounds,
+): Anchor {
+  'worklet'
+  const speed = Math.sqrt(vx * vx + vy * vy)
+
+  let horizon = 0
+  if (speed >= SNAP_FLING_SPEED) {
+    horizon = SNAP_FLING_HORIZON
+  } else if (speed >= SNAP_LOW_SPEED) {
+    horizon = SNAP_TOSS_HORIZON
+  }
+
+  let targetX = releaseX + vx * horizon
+  let targetY = releaseY + vy * horizon
+  targetX = Math.max(bounds.leftBound, Math.min(bounds.rightBound, targetX))
+  targetY = Math.max(bounds.topBound, Math.min(bounds.bottomBound, targetY))
+
+  const tcx = targetX + miniWidth / 2
+  const tcy = targetY + miniHeight / 2
+  let bestAnchor = anchors[0]
+  let bestScore = Infinity
+  let currentAnchorScore = Infinity
+
+  for (let i = 0; i < anchors.length; i++) {
+    const acx = anchors[i].x + miniWidth / 2
+    const acy = anchors[i].y + miniHeight / 2
+    const score = (acx - tcx) * (acx - tcx) + (acy - tcy) * (acy - tcy)
+    if (score < bestScore) {
+      bestScore = score
+      bestAnchor = anchors[i]
+    }
+    if (anchors[i].corner === currentCorner) {
+      currentAnchorScore = score
+    }
+  }
+
+  if (speed < SNAP_LOW_SPEED && currentAnchorScore < Infinity) {
+    const bestDist = Math.sqrt(bestScore)
+    const currentDist = Math.sqrt(currentAnchorScore)
+    if (currentDist - bestDist < SNAP_HYSTERESIS_PX) {
+      for (let i = 0; i < anchors.length; i++) {
+        if (anchors[i].corner === currentCorner) return anchors[i]
+      }
+    }
+  }
+
+  return bestAnchor
+}
+
+export function getMobileMiniPlayerSnapPosition({
+  corner,
+  screenWidth,
+  screenHeight,
+  topInset,
+  rightInset,
+  bottomInset,
+  leftInset,
+  bottomOffset,
+  aspectRatio,
+  sizeMode,
+}: {
+  corner: MiniPlayerCorner
+  screenWidth: number
+  screenHeight: number
+  topInset: number
+  rightInset: number
+  bottomInset: number
+  leftInset: number
+  bottomOffset: number
+  aspectRatio: number
+  sizeMode: 'compact' | 'expanded'
+}) {
+  const { width: miniWidth, height: miniHeight } = computeMiniSize(screenWidth, aspectRatio, sizeMode)
+  const bounds = computeMiniBounds(
+    screenWidth,
+    screenHeight,
+    topInset,
+    rightInset,
+    bottomInset,
+    leftInset,
+    bottomOffset,
+    miniWidth,
+    miniHeight,
+  )
+  const anchors = getCornerAnchors(bounds)
+  const anchor = anchors.find(a => a.corner === corner) ?? anchors[3]
+  return { x: anchor.x, y: anchor.y, width: miniWidth, height: miniHeight }
+}

--- a/packages/app/tests/mobile-player-page-layout-regression.test.mjs
+++ b/packages/app/tests/mobile-player-page-layout-regression.test.mjs
@@ -146,24 +146,30 @@ test('Android mini-player layout is only disabled when split-player playback is 
 
 test('mobile mini-player drag snaps to safe-area corners', () => {
   const overlaySource = readAppFile('components/VideoPlayerOverlayImpl.tsx')
+  const derivedSource = readAppFile('components/video-player/overlayDerivedState.ts')
 
   assert.match(
     overlaySource,
-    /function getMobileMiniPlayerSnapPosition\(\{\s*corner,\s*screenWidth,\s*screenHeight,\s*topInset,\s*rightInset,\s*bottomInset,\s*leftInset,\s*bottomOffset,\s*aspectRatio,\s*sizeMode,/,
+    /getMobileMiniPlayerSnapPosition/,
+    'overlay should use the dedicated corner snap helper',
+  )
+  assert.match(
+    derivedSource,
+    /export function getMobileMiniPlayerSnapPosition\(\{\s*corner,\s*screenWidth,\s*screenHeight,\s*topInset,\s*rightInset,\s*bottomInset,\s*leftInset,\s*bottomOffset,\s*aspectRatio,\s*sizeMode,/,
     'mobile mini-player placement should be derived from a dedicated corner snap helper',
   )
   assert.match(
-    overlaySource,
+    derivedSource,
     /const bounds = computeMiniBounds\(\s*screenWidth,\s*screenHeight,\s*topInset,\s*rightInset,\s*bottomInset,\s*leftInset,\s*bottomOffset,\s*miniWidth,\s*miniHeight,/,
     'mobile snap helper should derive bounds from safe-area insets, tab bar offset, and dynamic mini-player size',
   )
   assert.match(
-    overlaySource,
+    derivedSource,
     /topBound: insetTop \+ margin,/,
     'mobile top-corner snapping should stay below the safe-area inset',
   )
   assert.match(
-    overlaySource,
+    derivedSource,
     /bottomBound: screenHeight - bottomMargin - miniHeight,/,
     'mobile bottom-corner snapping should stay above the tab bar and bottom inset',
   )

--- a/packages/app/tests/video-overlay-derived-helpers.test.mjs
+++ b/packages/app/tests/video-overlay-derived-helpers.test.mjs
@@ -1,0 +1,30 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const appRoot = path.resolve(__dirname, '..')
+
+function readAppFile(relativePath) {
+  return fs.readFileSync(path.join(appRoot, relativePath), 'utf8')
+}
+
+test('VideoPlayerOverlay delegates mini-player geometry helpers to derived helper module', () => {
+  const overlaySource = readAppFile('components/VideoPlayerOverlayImpl.tsx')
+  const helperSource = readAppFile('components/video-player/overlayDerivedState.ts')
+
+  assert.match(overlaySource, /from '\.\/video-player\/overlayDerivedState'/, 'overlay should import extracted derived helpers')
+  assert.doesNotMatch(overlaySource, /function computeMiniSize\(/, 'computeMiniSize should not remain inline in the overlay component')
+  assert.doesNotMatch(overlaySource, /function computeMiniBounds\(/, 'computeMiniBounds should not remain inline in the overlay component')
+  assert.doesNotMatch(overlaySource, /function resolveSnapTarget\(/, 'resolveSnapTarget should not remain inline in the overlay component')
+  assert.doesNotMatch(overlaySource, /function getMobileMiniPlayerSnapPosition\(/, 'getMobileMiniPlayerSnapPosition should not remain inline in the overlay component')
+
+  assert.match(helperSource, /export function computeMiniSize\(/, 'helper module should export computeMiniSize')
+  assert.match(helperSource, /export function computeMiniBounds\(/, 'helper module should export computeMiniBounds')
+  assert.match(helperSource, /export function resolveSnapTarget\(/, 'helper module should export resolveSnapTarget')
+  assert.match(helperSource, /export function getMobileMiniPlayerSnapPosition\(/, 'helper module should export mobile snap position helper')
+  assert.match(helperSource, /'worklet'/, 'worklet helpers should retain worklet directives')
+})


### PR DESCRIPTION
## Summary
- Extract mini-player geometry/snap derived helpers from `VideoPlayerOverlayImpl` into `components/video-player/overlayDerivedState.ts`
- Keep worklet directives and existing snap behavior intact
- Add a regression that verifies the overlay delegates these helpers to the extracted module
- Update the existing mobile mini-player safe-area regression to assert helper behavior in the new module

## Test Plan
- `node --test packages/app/tests/video-overlay-derived-helpers.test.mjs packages/app/tests/mobile-player-page-layout-regression.test.mjs packages/app/tests/video-player-loading-clears-regression.test.mjs packages/app/tests/video-player-overlay-safe-area-fallback.test.mjs packages/app/tests/video-player-scrubber-redesign-regression.test.mjs`
- `npm run lint:changed`
- `git diff --check`

Closes #73
