### PR TITLE
refactor(app): extract vertical Discover feed controller

### DIFF
--- a/packages/app/app/(tabs)/discover.tsx
+++ b/packages/app/app/(tabs)/discover.tsx
@@ -25,7 +25,13 @@ import { useApp } from '../_layout'
 import { usePlatform } from '@/lib/PlatformProvider'
 import { colors } from '@/lib/colors'
 import { fetchThumbnailUrlWithRetry } from '@/lib/thumbnail'
-import { getFeedPreviewVideos, getVisibleSeededFeedEntries, shouldRenderFeedVideo } from '@/lib/feed-hydration'
+import {
+  getVerticalFeedPreviewVideos,
+  mapHydratedVerticalFeedVideos,
+  mergeUniqueFeedVideos,
+  warmNextPlaybackUrls,
+  withFeedTimeout,
+} from '@/lib/discover-feed-controller'
 import { getCachedVideoUrl, makeVideoUrlCacheKey, setCachedVideoUrl } from '@/lib/video-url-cache'
 import { readDiscoverFeedCache, writeDiscoverFeedCache } from '@/lib/discover-feed-cache'
 import { formatTimeAgo } from '@/lib/formatters'
@@ -53,12 +59,6 @@ interface FeedEntry {
   }>
 }
 
-function withTimeout<T>(promise: Promise<T>, ms: number, fallback: T): Promise<T> {
-  return Promise.race([
-    promise,
-    new Promise<T>((resolve) => setTimeout(() => resolve(fallback), ms)),
-  ])
-}
 
 function getVideoRef(video: VideoData) {
   return video.path && typeof video.path === 'string' && video.path.startsWith('/')
@@ -167,28 +167,14 @@ export default function VerticalDiscoveryScreen() {
   }, [blobServerPort, rpc])
 
   const seedFromFeedEntries = useCallback((entries: FeedEntry[]) => {
-    const visibleEntries = getVisibleSeededFeedEntries(entries as any)
-    const previewVideos = getFeedPreviewVideos(
-      visibleEntries as any,
-      {},
-      identity?.driveKey || undefined,
-      40,
-    ) as VideoData[]
-
-    const renderable = previewVideos
-      .filter((video) => shouldRenderFeedVideo({
-        video,
-        identityDriveKey: identity?.driveKey || undefined,
-      }))
-      .slice(0, 40)
+    const renderable = getVerticalFeedPreviewVideos(entries as any, {
+      identityDriveKey: identity?.driveKey || undefined,
+      channelMeta: {},
+      limit: 40,
+    }) as VideoData[]
 
     if (renderable.length > 0) {
-      setVideos((prev) => {
-        const existingKeys = new Set(prev.map((video) => `${video.channelKey}:${video.id}`))
-        const appended = renderable.filter((video) => !existingKeys.has(`${video.channelKey}:${video.id}`))
-        if (appended.length === 0) return prev
-        return [...prev, ...appended].slice(0, 80)
-      })
+      setVideos((prev) => mergeUniqueFeedVideos(prev, renderable, 80))
       if (renderable.length > 0) setCacheRestoredOnly(false)
       void fetchThumbnailsForVideos(renderable)
     }
@@ -212,7 +198,7 @@ export default function VerticalDiscoveryScreen() {
 
     try {
       const timeoutToken = Symbol('vertical-channel-timeout')
-      const result = await withTimeout(
+      const result = await withFeedTimeout(
         rpc.listVideos({ channelKey, publicBeeKey: entry.publicBeeKey || undefined }),
         3500,
         timeoutToken as any,
@@ -220,25 +206,12 @@ export default function VerticalDiscoveryScreen() {
       if (result === timeoutToken) return
       hydratedChannelsRef.current.add(channelKey)
       const channelVideos = Array.isArray((result as any)?.videos) ? (result as any).videos : []
-      const mapped = channelVideos
-        .filter((video: any) => shouldRenderFeedVideo({
-          video: { ...video, channelKey },
-          identityDriveKey: identity?.driveKey || undefined,
-        }))
-        .map((video: any) => ({
-          ...video,
-          channelKey,
-          publicBeeKey: entry.publicBeeKey || undefined,
-          channel: { name: entry.channelName || 'Channel' },
-        }))
+      const mapped = mapHydratedVerticalFeedVideos(entry, channelVideos, {
+        identityDriveKey: identity?.driveKey || undefined,
+      }) as VideoData[]
 
       if (mapped.length > 0) {
-        setVideos((prev) => {
-          const existingKeys = new Set(prev.map((video) => `${video.channelKey}:${video.id}`))
-          const appended = mapped.filter((video) => !existingKeys.has(`${video.channelKey}:${video.id}`))
-          if (appended.length === 0) return prev
-          return [...prev, ...appended].slice(0, 80)
-        })
+        setVideos((prev) => mergeUniqueFeedVideos(prev, mapped, 80))
         if (mapped.length > 0) setCacheRestoredOnly(false)
         void fetchThumbnailsForVideos(mapped)
       }
@@ -253,7 +226,7 @@ export default function VerticalDiscoveryScreen() {
     setFeedLoading(true)
     try {
       const timeoutToken = Symbol('vertical-feed-timeout')
-      const result = await withTimeout(rpc.getPublicFeed({}), 4000, timeoutToken as any)
+      const result = await withFeedTimeout(rpc.getPublicFeed({}), 4000, timeoutToken as any)
       if (result === timeoutToken) return
       const entries = Array.isArray((result as any)?.entries) ? (result as any).entries : []
       if (entries.length > 0) setCacheRestoredOnly(false)
@@ -348,22 +321,16 @@ export default function VerticalDiscoveryScreen() {
   }, [activeVideo, playVideo, ready])
 
   useEffect(() => {
-    const warmPlaybackUrl = async (video: VideoData) => {
-      const { cacheKey, playbackRequest } = makePlaybackRequest(video)
-      if (!cacheKey || getCachedVideoUrl(cacheKey) || inflightPlaybackWarmups.current.has(cacheKey)) return
-      inflightPlaybackWarmups.current.add(cacheKey)
-      try {
-        const result = await rpc?.preparePlayback?.(playbackRequest)
-        if (result?.url && cacheKey) setCachedVideoUrl(cacheKey, result.url)
-      } finally {
-        inflightPlaybackWarmups.current.delete(cacheKey)
-      }
-    }
-
-    const nextVideos = videos.slice(activeIndex + 1, activeIndex + 5)
-    for (const video of nextVideos) {
-      void warmPlaybackUrl(video).catch(() => undefined)
-    }
+    if (!rpc) return
+    void warmNextPlaybackUrls({
+      videos,
+      activeIndex,
+      makePlaybackRequest,
+      getCachedVideoUrl,
+      setCachedVideoUrl,
+      preparePlayback: rpc.preparePlayback?.bind(rpc),
+      inflightPlaybackWarmups,
+    })
   }, [activeIndex, makePlaybackRequest, rpc, videos])
 
   const onRefresh = useCallback(async () => {

--- a/packages/app/lib/discover-feed-controller.d.ts
+++ b/packages/app/lib/discover-feed-controller.d.ts
@@ -1,0 +1,35 @@
+export function withFeedTimeout<T>(promise: Promise<T>, ms: number, fallback: T): Promise<T>
+
+export function mergeUniqueFeedVideos<T extends { channelKey?: string; driveKey?: string; id?: string; path?: string }>(
+  previousVideos?: T[],
+  incomingVideos?: T[],
+  limit?: number,
+): T[]
+
+export function getVerticalFeedPreviewVideos<T = any>(
+  entries: any[],
+  options?: {
+    identityDriveKey?: string
+    channelMeta?: Record<string, any>
+    limit?: number
+  },
+): T[]
+
+export function mapHydratedVerticalFeedVideos<T = any>(
+  entry: any,
+  videoList: T[],
+  options?: { identityDriveKey?: string },
+): T[]
+
+export function clearHydratedFeedChannels(hydratedChannelsRef: { current?: { clear?: () => void } } | null | undefined): void
+
+export function warmNextPlaybackUrls(options: {
+  videos: any[]
+  activeIndex: number
+  makePlaybackRequest: (video: any) => { cacheKey?: string | null; playbackRequest: any }
+  getCachedVideoUrl: (cacheKey: string) => string | null | undefined
+  setCachedVideoUrl: (cacheKey: string, url: string) => void
+  preparePlayback?: (request: any) => Promise<{ url?: string | null } | null | undefined>
+  windowSize?: number
+  inflightPlaybackWarmups?: { current?: Set<string> } | null
+}): Promise<void>

--- a/packages/app/lib/discover-feed-controller.js
+++ b/packages/app/lib/discover-feed-controller.js
@@ -1,0 +1,88 @@
+import {
+  getFeedPreviewVideos,
+  getVisibleSeededFeedEntries,
+  shouldRenderFeedVideo,
+} from './feed-hydration.js'
+
+export function withFeedTimeout(promise, ms, fallback) {
+  return Promise.race([
+    promise,
+    new Promise((resolve) => setTimeout(() => resolve(fallback), ms)),
+  ])
+}
+
+export function mergeUniqueFeedVideos(previousVideos = [], incomingVideos = [], limit = 80) {
+  const byKey = new Map()
+
+  for (const video of [...(previousVideos || []), ...(incomingVideos || [])]) {
+    if (!video) continue
+    const channelKey = video.channelKey || video.driveKey || ''
+    const identifier = video.id || video.path || ''
+    if (!identifier) continue
+    byKey.set(`${channelKey}:${identifier}`, video)
+  }
+
+  return Array.from(byKey.values()).slice(0, limit)
+}
+
+export function getVerticalFeedPreviewVideos(entries, { identityDriveKey, channelMeta = {}, limit = 40 } = {}) {
+  const visibleEntries = getVisibleSeededFeedEntries(entries || [], Infinity)
+  const previewVideos = getFeedPreviewVideos(
+    visibleEntries,
+    channelMeta,
+    identityDriveKey,
+    limit,
+  )
+
+  return previewVideos
+    .filter((video) => shouldRenderFeedVideo({ video, identityDriveKey }))
+    .slice(0, limit)
+}
+
+export function mapHydratedVerticalFeedVideos(entry, videoList, { identityDriveKey } = {}) {
+  const channelKey = entry?.channelKey || entry?.driveKey
+  if (!channelKey || !Array.isArray(videoList)) return []
+
+  return videoList
+    .filter((video) => shouldRenderFeedVideo({
+      video: { ...video, channelKey },
+      identityDriveKey,
+    }))
+    .map((video) => ({
+      ...video,
+      channelKey,
+      publicBeeKey: entry.publicBeeKey || undefined,
+      channel: { name: entry.channelName || 'Channel' },
+    }))
+}
+
+export function clearHydratedFeedChannels(hydratedChannelsRef) {
+  hydratedChannelsRef?.current?.clear?.()
+}
+
+export async function warmNextPlaybackUrls({
+  videos,
+  activeIndex,
+  makePlaybackRequest,
+  getCachedVideoUrl,
+  setCachedVideoUrl,
+  preparePlayback,
+  windowSize = 4,
+  inflightPlaybackWarmups = null,
+}) {
+  const nextVideos = (videos || []).slice(activeIndex + 1, activeIndex + 1 + windowSize)
+
+  await Promise.allSettled(nextVideos.map(async (video) => {
+    const { cacheKey, playbackRequest } = makePlaybackRequest(video)
+    if (cacheKey && getCachedVideoUrl(cacheKey)) return null
+    if (cacheKey && inflightPlaybackWarmups?.current?.has?.(cacheKey)) return null
+    if (cacheKey) inflightPlaybackWarmups?.current?.add?.(cacheKey)
+    try {
+      const result = await preparePlayback?.(playbackRequest)
+      if (result?.url && cacheKey) setCachedVideoUrl(cacheKey, result.url)
+      return result?.url || null
+    } finally {
+      if (cacheKey) inflightPlaybackWarmups?.current?.delete?.(cacheKey)
+    }
+  }))
+}

--- a/packages/app/tests/discover-feed-controller.test.mjs
+++ b/packages/app/tests/discover-feed-controller.test.mjs
@@ -1,0 +1,127 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  clearHydratedFeedChannels,
+  getVerticalFeedPreviewVideos,
+  mapHydratedVerticalFeedVideos,
+  mergeUniqueFeedVideos,
+  warmNextPlaybackUrls,
+  withFeedTimeout,
+} from '../lib/discover-feed-controller.js'
+
+test('vertical feed controller falls back when feed RPC times out', async () => {
+  const fallback = { entries: [] }
+  const result = await withFeedTimeout(new Promise(() => {}), 5, fallback)
+
+  assert.equal(result, fallback)
+})
+
+test('vertical feed controller dedupes preview and hydrated videos by channel/video key', () => {
+  const merged = mergeUniqueFeedVideos([
+    { id: 'a', channelKey: 'one', title: 'old' },
+    { id: 'b', channelKey: 'one', title: 'keep' },
+  ], [
+    { id: 'a', channelKey: 'one', title: 'new' },
+    { id: 'c', channelKey: 'two', title: 'add' },
+  ])
+
+  assert.deepEqual(merged.map((video) => [video.channelKey, video.id, video.title]), [
+    ['one', 'a', 'new'],
+    ['one', 'b', 'keep'],
+    ['two', 'c', 'add'],
+  ])
+})
+
+test('vertical feed controller filters preview videos through renderability policy', () => {
+  const videos = getVerticalFeedPreviewVideos([
+    {
+      driveKey: 'stale-remote',
+      peerCount: 0,
+      previewVideos: [{ id: 'stale', availability: 'playable', uploadedAt: 30 }],
+    },
+    {
+      driveKey: 'live-remote',
+      peerCount: 2,
+      publicBeeKey: 'bee-live',
+      channelName: 'Live',
+      previewVideos: [
+        { id: 'playable', availability: 'playable', uploadedAt: 20 },
+        { id: 'unknown', availability: 'unknown', uploadedAt: 10 },
+      ],
+    },
+  ], { identityDriveKey: 'local', limit: 10 })
+
+  assert.deepEqual(videos.map((video) => ({
+    id: video.id,
+    channelKey: video.channelKey,
+    publicBeeKey: video.publicBeeKey,
+  })), [
+    { id: 'playable', channelKey: 'live-remote', publicBeeKey: 'bee-live' },
+  ])
+})
+
+test('vertical feed controller maps hydrated videos with channel metadata and renderability policy', () => {
+  const mapped = mapHydratedVerticalFeedVideos({
+    driveKey: 'remote',
+    publicBeeKey: 'bee-remote',
+    channelName: 'Remote Channel',
+  }, [
+    { id: 'playable', availability: 'playable' },
+    { id: 'unknown', availability: 'unknown' },
+  ], { identityDriveKey: 'local' })
+
+  assert.deepEqual(mapped, [{
+    id: 'playable',
+    availability: 'playable',
+    channelKey: 'remote',
+    publicBeeKey: 'bee-remote',
+    channel: { name: 'Remote Channel' },
+  }])
+})
+
+test('vertical feed refresh clears hydrated channel state through controller helper', () => {
+  const hydratedChannelsRef = { current: new Set(['one', 'two']) }
+
+  clearHydratedFeedChannels(hydratedChannelsRef)
+
+  assert.equal(hydratedChannelsRef.current.size, 0)
+})
+
+test('vertical feed controller prewarms next playback URLs best-effort', async () => {
+  const prepared = []
+  const cached = new Map([['one:a', 'http://cached/a']])
+
+  await warmNextPlaybackUrls({
+    videos: [
+      { id: 'current', channelKey: 'one' },
+      { id: 'a', channelKey: 'one' },
+      { id: 'b', channelKey: 'one' },
+      { id: 'c', channelKey: 'two' },
+    ],
+    activeIndex: 0,
+    makePlaybackRequest(video) {
+      return {
+        cacheKey: `${video.channelKey}:${video.id}`,
+        playbackRequest: { channelKey: video.channelKey, videoId: video.id },
+      }
+    },
+    getCachedVideoUrl(cacheKey) {
+      return cached.get(cacheKey)
+    },
+    setCachedVideoUrl(cacheKey, url) {
+      cached.set(cacheKey, url)
+    },
+    async preparePlayback(request) {
+      prepared.push(request)
+      if (request.videoId === 'c') throw new Error('network flake')
+      return { url: `http://prepared/${request.videoId}` }
+    },
+  })
+
+  assert.deepEqual(prepared, [
+    { channelKey: 'one', videoId: 'b' },
+    { channelKey: 'two', videoId: 'c' },
+  ])
+  assert.equal(cached.get('one:b'), 'http://prepared/b')
+})

--- a/packages/app/tests/vertical-discovery-regression.test.mjs
+++ b/packages/app/tests/vertical-discovery-regression.test.mjs
@@ -101,12 +101,15 @@ test('vertical discovery hydrates beyond sparse previews without permanently poi
 
 test('vertical discovery preloads the next few videos into the playback URL cache', () => {
   const source = readAppFile('app/(tabs)/discover.tsx')
+  const controllerSource = readAppFile('lib/discover-feed-controller.js')
 
-  assert.match(source, /const nextVideos = videos\.slice\(activeIndex \+ 1, activeIndex \+ 5\)/, 'shorts should warm the next few videos, not only one or two')
-  assert.match(source, /const warmPlaybackUrl = async \(video: VideoData\)/, 'preload should use a named URL warming helper')
-  assert.match(source, /const result = await rpc\?\.preparePlayback\?\.\(playbackRequest\)/, 'preload should await preparePlayback so it can keep the resolved URL')
-  assert.match(source, /inflightPlaybackWarmups\.current\.has\(cacheKey\)/, 'preload should de-dupe overlapping preparePlayback warmups')
-  assert.match(source, /if \(result\?\.url && cacheKey\) setCachedVideoUrl\(cacheKey, result\.url\)/, 'preload should populate the playback URL cache for instant swipe playback')
+  assert.match(source, /warmNextPlaybackUrls\(\{[\s\S]*videos,[\s\S]*activeIndex,[\s\S]*makePlaybackRequest/, 'shorts should warm the next few videos through the feed controller')
+  assert.match(source, /preparePlayback:\s*rpc\.preparePlayback\?\.bind\(rpc\)/, 'preload should route through backend preparePlayback')
+  assert.match(source, /inflightPlaybackWarmups/, 'preload should keep de-dupe state in the screen')
+  assert.match(controllerSource, /const nextVideos = \(videos \|\| \[\]\)\.slice\(activeIndex \+ 1, activeIndex \+ 1 \+ windowSize\)/, 'controller should warm the next few videos, not only one or two')
+  assert.match(controllerSource, /inflightPlaybackWarmups\?\.current\?\.has\?\.\(cacheKey\)/, 'controller preload should de-dupe overlapping preparePlayback warmups')
+  assert.match(controllerSource, /const result = await preparePlayback\?\.\(playbackRequest\)/, 'controller preload should await preparePlayback so it can keep the resolved URL')
+  assert.match(controllerSource, /if \(result\?\.url && cacheKey\) setCachedVideoUrl\(cacheKey, result\.url\)/, 'controller preload should populate the playback URL cache for instant swipe playback')
 })
 
 test('Home Discover preloads visible feed playback URLs into the shared URL cache', () => {
@@ -127,11 +130,13 @@ test('vertical discovery subscribes to backend feed-update events instead of onl
   assert.match(source, /if \(typeof unsubscribe === 'function'\) unsubscribe\(\)/, 'Discover should unsubscribe from feed events on unmount')
 })
 
-test('vertical discovery calls getFeedPreviewVideos with the shared feed-preview signature', () => {
+test('vertical discovery calls getFeedPreviewVideos through the controller with the shared feed-preview signature', () => {
   const source = readAppFile('app/(tabs)/discover.tsx')
+  const controllerSource = readAppFile('lib/discover-feed-controller.js')
 
-  assert.match(source, /getFeedPreviewVideos\(\s*visibleEntries as any,\s*\{\},\s*identity\?\.driveKey \|\| undefined,\s*40,\s*\)/, 'Shorts route should pass channelMeta, identityDriveKey, and limit separately')
-  assert.doesNotMatch(source, /getFeedPreviewVideos\(visibleEntries as any, \{\s*identityDriveKey:/, 'Shorts route should not pass an options object into the shared helper')
+  assert.match(source, /getVerticalFeedPreviewVideos\(entries as any, \{[\s\S]*identityDriveKey:[\s\S]*channelMeta:[\s\S]*limit: 40/, 'Shorts route should delegate preview extraction to the feed controller')
+  assert.match(controllerSource, /getFeedPreviewVideos\(\s*visibleEntries,\s*channelMeta,\s*identityDriveKey,\s*limit,\s*\)/, 'controller should pass channelMeta, identityDriveKey, and limit separately')
+  assert.doesNotMatch(controllerSource, /getFeedPreviewVideos\(visibleEntries, \{\s*identityDriveKey:/, 'controller should not pass an options object into the shared helper')
 })
 
 
@@ -163,11 +168,13 @@ test('shorts player has functional playback buttons and a seekable progress bar'
 
 test('vertical discovery stabilizes card order across feed refreshes', () => {
   const source = readAppFile('app/(tabs)/discover.tsx')
+  const controllerSource = readAppFile('lib/discover-feed-controller.js')
 
   assert.match(source, /feedLoadInFlightRef/, 'Discover should ignore overlapping feed loads instead of racing state updates')
   assert.doesNotMatch(source, /hydratedChannelsRef\.current\.clear\(\)/, 'manual refresh should not clear hydrated channels and make cards disappear/reappear')
-  assert.match(source, /const existingKeys = new Set\(prev\.map\(\(video\) => `\$\{video\.channelKey\}:\$\{video\.id\}`\)\)/, 'feed merges should preserve the existing card order')
-  assert.match(source, /return \[\.\.\.prev, \.\.\.appended\]\.slice\(0, 80\)/, 'newly discovered cards should append rather than reorder the visible deck')
+  assert.match(source, /mergeUniqueFeedVideos\(prev, renderable, 80\)/, 'preview feed merges should preserve existing card order through the controller')
+  assert.match(source, /mergeUniqueFeedVideos\(prev, mapped, 80\)/, 'hydrated feed merges should preserve existing card order through the controller')
+  assert.match(controllerSource, /for \(const video of \[\.\.\.\(previousVideos \|\| \[\]\), \.\.\.\(incomingVideos \|\| \[\]\)\]\)/, 'controller merge should consider existing videos before incoming videos')
   assert.match(source, /prevKeys === nextKeys \? prev : entries/, 'unchanged feed entry order should avoid unnecessary list state churn')
   assert.match(source, /thumbnailCacheRef/, 'thumbnail cache reads should not recreate feed merge callbacks on every thumbnail resolution')
 })


### PR DESCRIPTION
## Summary
- Replaces the stale/conflicting #107 branch with a clean branch from current `origin/main`
- Extracts vertical Discover feed loading/mapping/dedupe/prewarm logic into `discover-feed-controller`
- Keeps the Shorts UI behavior-preserving while making feed timeout fallback, renderability filtering, refresh clearing, and prewarm behavior testable
- Leaves the earlier #161 video overlay helper extraction intact by cherry-picking only the current-base Discover controller change

## Test Plan
- `node --test packages/app/tests/discover-feed-controller.test.mjs packages/app/tests/vertical-discovery-regression.test.mjs`
- `npx eslint --quiet packages/app/app/(tabs)/discover.tsx packages/app/lib/discover-feed-controller.d.ts packages/app/lib/discover-feed-controller.js packages/app/tests/discover-feed-controller.test.mjs packages/app/tests/vertical-discovery-regression.test.mjs`
- `git diff --check`

Closes #71
Supersedes #107
