### PR TITLE
fix(relay): publish cached channels as relay catalog entries

### DIFF
--- a/packages/cli/src/runtime.js
+++ b/packages/cli/src/runtime.js
@@ -159,7 +159,22 @@ export async function createRelayRuntime({ config, logger }) {
     seeder,
     identityManager: null,
     uploadManager: null,
-    api: null,
+    async publishRelayCatalogEntry(entry) {
+      if (!entry?.driveKey || !entry?.publicBeeKey) return null
+      const catalogEntry = {
+        schema: 'peartube.relayCatalog',
+        catalogVersion: 1,
+        source: 'relay-cache',
+        relayRole: 'cache',
+        relayServing: true,
+        ...entry,
+        driveKey: entry.driveKey,
+        publicBeeKey: entry.publicBeeKey,
+        previewVideos: Array.isArray(entry.previewVideos) ? entry.previewVideos : []
+      }
+      await publicFeed.submitRelayCatalogEntry?.(catalogEntry)
+      return catalogEntry
+    },
     setCandidateHandler(handler) {
       candidateHandler = handler
     },
@@ -171,7 +186,6 @@ export async function createRelayRuntime({ config, logger }) {
         policy: config.policy
       })
       await cacheManager.init()
-      await publicFeed.start()
 
       const [{ createIdentityManager }, { createUploadManager }, { createApi }] = await Promise.all([
         import('@peartube/backend/identity'),
@@ -184,14 +198,16 @@ export async function createRelayRuntime({ config, logger }) {
       this.api = createApi({ ctx, publicFeed, seedingManager: null, videoStats: null })
 
       // Use the same feed snapshot and availability-hint plumbing as the normal
-      // PearTube backend. Without these providers the relay can gossip channel
-      // keys, but phones do not learn that the relay has playable local bytes.
+      // PearTube backend before joining the feed swarm. Otherwise initial
+      // HAVE_FEED messages can omit playable relay-cache preview refs.
       if (typeof this.api.getAvailabilityHints === 'function') {
         publicFeed.setAvailabilityHintProvider((requests, conn) => this.api.getAvailabilityHints(requests, conn))
       }
       if (typeof this.api.getFeedSnapshotEntries === 'function') {
         publicFeed.setFeedSnapshotProvider((entries) => this.api.getFeedSnapshotEntries(entries, { limitPerChannel: 3 }))
       }
+
+      await publicFeed.start()
 
       logger.runtime?.info('Relay runtime started', this.getNetworkStats())
       await seeder.seedCachedChannels(cacheManager).catch((err) => {

--- a/packages/cli/src/service.js
+++ b/packages/cli/src/service.js
@@ -170,12 +170,24 @@ export async function createRelayService({
 
       if (resolved.publicBeeKey) {
         await runtime.cacheManager?.addChannel?.(resolved.channelKey, resolved.publicBeeKey, 'discovered').catch(() => {})
-        await runtime.publicFeed?.submitChannel?.(resolved.channelKey, resolved.publicBeeKey).catch(() => {})
-        await runtime.seeder?.seedChannel?.({
+        const seedStats = await runtime.seeder?.seedChannel?.({
           driveKey: resolved.channelKey,
           publicBeeKey: resolved.publicBeeKey,
           previewVideos: Array.isArray(mirrorStats?.previewVideos) ? mirrorStats.previewVideos : []
-        }).catch(() => {})
+        }).catch(() => null)
+        const catalogEntry = seedStats?.catalogEntry || {
+          schema: 'peartube.relayCatalog',
+          catalogVersion: 1,
+          driveKey: resolved.channelKey,
+          publicBeeKey: resolved.publicBeeKey,
+          source: 'relay-cache',
+          relayRole: 'cache',
+          relayServing: true,
+          previewVideos: Array.isArray(mirrorStats?.previewVideos) ? mirrorStats.previewVideos : [],
+          videoCount: Number(mirrorStats?.videoCount || mirrorStats?.videosDownloaded || mirrorStats?.videosFound || 0) || 0,
+          manifestUpdatedAt: Date.now()
+        }
+        await runtime.publishRelayCatalogEntry?.(catalogEntry).catch(() => {})
       }
 
       logger.mirror.info('Channel mirrored', {

--- a/packages/cli/test/runtime-no-relay-catalog.test.mjs
+++ b/packages/cli/test/runtime-no-relay-catalog.test.mjs
@@ -6,9 +6,12 @@ import { fileURLToPath } from 'node:url'
 const here = dirname(fileURLToPath(import.meta.url))
 const runtimeSource = readFileSync(join(here, '../src/runtime.js'), 'utf8')
 
-test('relay runtime does not restore cached channels as relay catalog feed entries', (t) => {
-  t.absent(runtimeSource.includes('submitRelayCatalogEntry'))
-  t.absent(runtimeSource.includes('relayRole'))
-  t.absent(runtimeSource.includes('relayServing'))
-  t.absent(runtimeSource.includes('relayCatalogEntries'))
+test('relay runtime publishes cached relay inventory as relay catalog feed entries', (t) => {
+  t.ok(runtimeSource.includes('publicFeed.setFeedSnapshotProvider'), 'relay feed snapshot provider should be installed')
+  t.ok(runtimeSource.indexOf('publicFeed.setFeedSnapshotProvider') < runtimeSource.indexOf('await publicFeed.start()'), 'snapshot provider should be installed before public feed start')
+  t.ok(runtimeSource.includes('publicFeed.setAvailabilityHintProvider'), 'relay availability provider should be installed')
+  t.ok(runtimeSource.indexOf('publicFeed.setAvailabilityHintProvider') < runtimeSource.indexOf('await publicFeed.start()'), 'availability provider should be installed before public feed start')
+  t.ok(runtimeSource.includes('submitRelayCatalogEntry'), 'relay runtime should publish relay cache entries through the relay catalog feed path')
+  t.ok(runtimeSource.includes('relayRole'), 'relay catalog entries should preserve relay role')
+  t.ok(runtimeSource.includes('relayServing'), 'relay catalog entries should advertise relay serving state')
 })

--- a/packages/cli/test/service.test.mjs
+++ b/packages/cli/test/service.test.mjs
@@ -181,6 +181,89 @@ test('createRelayService accepts discovered channels in public discovery mode', 
   }
 })
 
+
+test('createRelayService publishes discovered relay inventory as relay catalog feed entries', async (t) => {
+  const dir = makeTempDir('peartube-relay-service-catalog-feed-')
+  const runtime = createFakeRuntime()
+  const submitChannelCalls = []
+  const relayCatalogCalls = []
+  const seedCalls = []
+  const previewVideos = [{ id: 'video-1', blobId: 'blob-1', blobsCoreKey: 'cc'.repeat(32) }]
+
+  runtime.cacheManager = {
+    async addChannel(driveKey, publicBeeKey, source) {
+      t.is(driveKey, 'chan-relay')
+      t.is(publicBeeKey, 'bee-chan-relay')
+      t.is(source, 'discovered')
+    }
+  }
+  runtime.publicFeed = {
+    async submitChannel(...args) {
+      submitChannelCalls.push(args)
+    }
+  }
+  runtime.publishRelayCatalogEntry = async (entry) => {
+    relayCatalogCalls.push(entry)
+  }
+  runtime.seeder = {
+    async seedChannel(channel) {
+      seedCalls.push(channel)
+      return {
+        catalogEntry: {
+          schema: 'peartube.relayCatalog',
+          catalogVersion: 1,
+          driveKey: channel.driveKey,
+          publicBeeKey: channel.publicBeeKey,
+          source: 'relay-cache',
+          relayRole: 'cache',
+          relayServing: true,
+          previewVideos
+        }
+      }
+    }
+  }
+
+  try {
+    const service = await createRelayService({
+      config: {
+        mode: 'public',
+        policy: 'discovery',
+        storage: { path: dir, maxBytes: 10_000 },
+        paths: {
+          catalog: join(dir, 'relay-catalog.json'),
+          status: join(dir, 'relay-status.json')
+        },
+        admission: { channels: [], owners: [] },
+        discovery: { enabled: true, maxChannels: 5, maxChannelsPerOwner: 2 }
+      },
+      logger: createFakeLogger(),
+      runtimeFactory: async () => runtime,
+      mirrorChannel: async () => ({
+        bytesDownloaded: 4096,
+        videosFound: 1,
+        videosDownloaded: 1,
+        previewVideos,
+        videoCount: 1
+      }),
+      writeStatusFile: async () => {}
+    })
+
+    await service.start()
+    await runtime.emit({ channelKey: 'chan-relay', source: 'discovered' })
+
+    t.is(seedCalls.length, 1, 'accepted relay candidate should be seeded')
+    t.is(submitChannelCalls.length, 0, 'relay-cache candidates should not be submitted as local published channels')
+    t.is(relayCatalogCalls.length, 1, 'relay-cache candidate should be published through relay catalog feed path')
+    t.is(relayCatalogCalls[0].source, 'relay-cache')
+    t.is(relayCatalogCalls[0].relayRole, 'cache')
+    t.is(relayCatalogCalls[0].relayServing, true)
+    t.alike(relayCatalogCalls[0].previewVideos, previewVideos)
+    await service.close()
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('createRelayService starts without forcing an eager feed sync', async (t) => {
   const dir = makeTempDir('peartube-relay-service-logs-')
   const runtime = createFakeRuntime()
@@ -597,6 +680,7 @@ test('createRelayService watches configured local mirror directory', async (t) =
   }
   runtime.cacheManager = { async pinChannel() {} }
   runtime.publicFeed = { async submitChannel() {} }
+  runtime.publishRelayCatalogEntry = async () => {}
   runtime.seeder = { async seedChannel() {} }
 
   const fsModule = {


### PR DESCRIPTION
## Summary
- Publishes relay-mirrored/cache candidates through `submitRelayCatalogEntry` semantics instead of local-user `submitChannel`
- Preserves relay cache metadata (`source: relay-cache`, `relayRole: cache`, `relayServing: true`, direct preview refs) from seeder catalog snapshots
- Installs relay feed snapshot and availability providers before `publicFeed.start()` so initial HAVE_FEED gossip is enriched with playable relay refs
- Replaces the old "no relay catalog" regression with the desired relay catalog architecture guard

## Architecture issue fixed
Relay-discovered third-party channels were being announced as local published feed entries. That made cache inventory indistinguishable from relay-owned/user-published channels and could omit direct playable refs during initial feed gossip.

## Test Plan
- `node --test packages/cli/test/runtime-no-relay-catalog.test.mjs packages/cli/test/service.test.mjs`
- `npm test --prefix packages/cli -- --timeout=30000`
- `npm run lint:changed`
- `git diff --check`
