### PR TITLE
fix(shorts): guard weird playback races

### DIFF
--- a/packages/app/app/(tabs)/discover.tsx
+++ b/packages/app/app/(tabs)/discover.tsx
@@ -58,6 +58,24 @@ interface FeedEntry {
     thumbnailMimeType?: string | null
   }>
 }
+function getFeedEntrySignature(entry: FeedEntry) {
+  const previewSignature = (entry.previewVideos || []).map((video) => [
+    video.id,
+    video.uploadedAt || 0,
+    video.duration || 0,
+    video.blobId || '',
+    video.blobsCoreKey || '',
+    video.availability || '',
+    video.thumbnailBlobId || '',
+    video.thumbnailBlobsCoreKey || '',
+  ].join(':')).join(',')
+  return [
+    entry.channelKey || entry.driveKey,
+    entry.publicBeeKey || '',
+    entry.channelName || '',
+    previewSignature,
+  ].join('|')
+}
 
 
 function getVideoRef(video: VideoData) {
@@ -116,6 +134,7 @@ export default function VerticalDiscoveryScreen() {
   const [shortsChromeVisible, setShortsChromeVisible] = useState(true)
   const shortsPlayerRef = useRef<any>(null)
   const pendingPlayKeyRef = useRef<string | null>(null)
+  const playbackRequestSeqRef = useRef(0)
   const hydratedChannelsRef = useRef<Set<string>>(new Set())
   const feedLoadInFlightRef = useRef(false)
   const inflightPlaybackWarmups = useRef<Set<string>>(new Set())
@@ -231,9 +250,9 @@ export default function VerticalDiscoveryScreen() {
       const entries = Array.isArray((result as any)?.entries) ? (result as any).entries : []
       if (entries.length > 0) setCacheRestoredOnly(false)
       setFeedEntries((prev) => {
-        const prevKeys = prev.map((entry) => entry.channelKey || entry.driveKey).join('|')
-        const nextKeys = entries.map((entry: FeedEntry) => entry.channelKey || entry.driveKey).join('|')
-        return prevKeys === nextKeys ? prev : entries
+        const prevSignature = prev.map(getFeedEntrySignature).join('\n')
+        const nextSignature = entries.map(getFeedEntrySignature).join('\n')
+        return prevSignature === nextSignature ? prev : entries
       })
       seedFromFeedEntries(entries)
       for (const entry of entries.slice(0, 24)) {
@@ -266,6 +285,7 @@ export default function VerticalDiscoveryScreen() {
     void shortsPlayerRef.current?.stop?.()
     void shortsPlayerRef.current?.pause?.()
     pendingPlayKeyRef.current = null
+    playbackRequestSeqRef.current += 1
     setShortsVideoUrl(null)
     setShortsLoading(false)
   }, [])
@@ -288,12 +308,15 @@ export default function VerticalDiscoveryScreen() {
     const playKey = `${video.channelKey}:${video.id}`
     if (pendingPlayKeyRef.current === playKey) return
     pendingPlayKeyRef.current = playKey
+    const requestSeq = ++playbackRequestSeqRef.current
+    const isStalePlaybackRequest = () => pendingPlayKeyRef.current !== playKey || playbackRequestSeqRef.current !== requestSeq
 
     try {
       handoffToShorts()
       const cachedUrl = cacheKey ? getCachedVideoUrl(cacheKey) : null
       if (cachedUrl) {
         void rpc.preparePlayback(playbackRequest).catch(() => undefined)
+        if (isStalePlaybackRequest()) return
         setShortsVideoUrl(cachedUrl)
         setShortsPlaybackSession((prev) => prev + 1)
         setShortsLoading(false)
@@ -301,16 +324,21 @@ export default function VerticalDiscoveryScreen() {
       }
       setShortsLoading(true)
       const result = await rpc.preparePlayback(playbackRequest)
+      if (isStalePlaybackRequest()) return
       if (result?.url) {
         if (cacheKey) setCachedVideoUrl(cacheKey, result.url)
         setShortsVideoUrl(result.url)
         setShortsPlaybackSession((prev) => prev + 1)
       }
     } catch (err) {
-      console.log('[VerticalDiscovery] Playback failed:', (err as any)?.message || err)
+      if (!isStalePlaybackRequest()) {
+        console.log('[VerticalDiscovery] Playback failed:', (err as any)?.message || err)
+      }
     } finally {
-      pendingPlayKeyRef.current = null
-      setShortsLoading(false)
+      if (!isStalePlaybackRequest()) {
+        pendingPlayKeyRef.current = null
+        setShortsLoading(false)
+      }
     }
   }, [handoffToShorts, makePlaybackRequest, rpc])
 

--- a/packages/app/components/discovery/VerticalShortsPlayer.tsx
+++ b/packages/app/components/discovery/VerticalShortsPlayer.tsx
@@ -46,6 +46,7 @@ export const VerticalShortsPlayer = memo(function VerticalShortsPlayer({
   const [hasPlaybackError, setHasPlaybackError] = useState(false)
   const [isPaused, setIsPaused] = useState(false)
   const [seekPosition, setSeekPosition] = useState<number | undefined>(undefined)
+  const [pendingSeekMs, setPendingSeekMs] = useState<number | undefined>(undefined)
   const [progressBarWidth, setProgressBarWidth] = useState(0)
   const [playbackProgress, setPlaybackProgress] = useState({ currentTime: 0, duration: 0 })
   const videoKey = getShortsVideoKey(video, videoUrl)
@@ -55,6 +56,7 @@ export const VerticalShortsPlayer = memo(function VerticalShortsPlayer({
     setVideoSize(null)
     setIsPaused(false)
     setSeekPosition(undefined)
+    setPendingSeekMs(undefined)
     setPlaybackProgress({ currentTime: 0, duration: 0 })
   }, [videoKey])
 
@@ -76,10 +78,11 @@ export const VerticalShortsPlayer = memo(function VerticalShortsPlayer({
     const currentTime = Math.max(0, Number(event?.currentTime || 0))
     const duration = Math.max(0, Number(event?.duration || 0))
     setPlaybackProgress({ currentTime, duration })
-    if (duration > 0 && seekPosition !== undefined && Math.abs(currentTime - seekPosition) < 900) {
+    if (duration > 0 && pendingSeekMs !== undefined && Math.abs(currentTime - pendingSeekMs) < 900) {
       setSeekPosition(undefined)
+      setPendingSeekMs(undefined)
     }
-  }, [seekPosition])
+  }, [pendingSeekMs])
 
   const handleError = useCallback((error: any) => {
     setHasPlaybackError(true)
@@ -103,6 +106,7 @@ export const VerticalShortsPlayer = memo(function VerticalShortsPlayer({
   const restartShorts = useCallback(() => {
     setIsPaused(false)
     setSeekPosition(0)
+    setPendingSeekMs(0)
     setPlaybackProgress((prev) => ({ ...prev, currentTime: 0 }))
     void playerRef.current?.seek?.(0)
     void playerRef.current?.play?.()
@@ -117,7 +121,8 @@ export const VerticalShortsPlayer = memo(function VerticalShortsPlayer({
     const locationX = Number(event?.nativeEvent?.locationX || 0)
     const progress = clampProgress(locationX / progressBarWidth)
     const nextTime = progress * playbackProgress.duration
-    setSeekPosition(nextTime / 1000)
+    setSeekPosition(progress)
+    setPendingSeekMs(nextTime)
     setPlaybackProgress((prev) => ({ ...prev, currentTime: nextTime }))
     void playerRef.current?.seek?.(nextTime / 1000)
   }, [playbackProgress.duration, playerRef, progressBarWidth])

--- a/packages/app/tests/vertical-discovery-regression.test.mjs
+++ b/packages/app/tests/vertical-discovery-regression.test.mjs
@@ -166,6 +166,27 @@ test('shorts player has functional playback buttons and a seekable progress bar'
   assert.match(source, /accessibilityLabel="Shorts progress bar"/, 'progress bar should be accessible and testable')
 })
 
+test('shorts progress bar keeps prop seekPosition normalized while imperative seek uses seconds', () => {
+  const source = readAppFile('components/discovery/VerticalShortsPlayer.tsx')
+  const seekBlock = source.slice(source.indexOf('const handleProgressBarPress'), source.indexOf('const showPlayer'))
+
+  assert.match(seekBlock, /const progress = clampProgress\(locationX \/ progressBarWidth\)/, 'tap position should be converted to a normalized 0..1 progress value')
+  assert.match(seekBlock, /setSeekPosition\(progress\)/, 'PearInlineVideoView seekPosition prop expects a normalized ratio')
+  assert.match(seekBlock, /playerRef\.current\?\.seek\?\.\(nextTime \/ 1000\)/, 'imperative player seek should still use seconds')
+  assert.doesNotMatch(seekBlock, /setSeekPosition\(nextTime \/ 1000\)/, 'seconds must not be passed to the normalized seekPosition prop')
+  assert.match(source, /pendingSeekMs/, 'pending seek completion should compare progress events using milliseconds, not the normalized ratio')
+})
+
+test('vertical discovery ignores stale preparePlayback completions after fast swipes', () => {
+  const source = readAppFile('app/(tabs)/discover.tsx')
+  const playBlock = source.slice(source.indexOf('const playVideo = useCallback'), source.indexOf('useEffect(() => {\n    if (!activeVideo'))
+
+  assert.match(source, /const playbackRequestSeqRef = useRef\(0\)/, 'Shorts playback should track request generations')
+  assert.match(playBlock, /const requestSeq = \+\+playbackRequestSeqRef\.current/, 'each playback attempt should get a newer generation id')
+  assert.match(playBlock, /pendingPlayKeyRef\.current !== playKey \|\| playbackRequestSeqRef\.current !== requestSeq/, 'stale async preparePlayback completions should be ignored')
+  assert.match(playBlock, /if \(isStalePlaybackRequest\(\)\) return/, 'resolved stale playback URLs must not attach to the active card')
+})
+
 test('vertical discovery stabilizes card order across feed refreshes', () => {
   const source = readAppFile('app/(tabs)/discover.tsx')
   const controllerSource = readAppFile('lib/discover-feed-controller.js')
@@ -175,8 +196,19 @@ test('vertical discovery stabilizes card order across feed refreshes', () => {
   assert.match(source, /mergeUniqueFeedVideos\(prev, renderable, 80\)/, 'preview feed merges should preserve existing card order through the controller')
   assert.match(source, /mergeUniqueFeedVideos\(prev, mapped, 80\)/, 'hydrated feed merges should preserve existing card order through the controller')
   assert.match(controllerSource, /for \(const video of \[\.\.\.\(previousVideos \|\| \[\]\), \.\.\.\(incomingVideos \|\| \[\]\)\]\)/, 'controller merge should consider existing videos before incoming videos')
-  assert.match(source, /prevKeys === nextKeys \? prev : entries/, 'unchanged feed entry order should avoid unnecessary list state churn')
+  assert.match(source, /getFeedEntrySignature/, 'Discover should compare feed-entry content, not only channel order')
+  assert.doesNotMatch(source, /prevKeys === nextKeys \? prev : entries/, 'same-channel feed updates must not discard changed previews or blob refs')
   assert.match(source, /thumbnailCacheRef/, 'thumbnail cache reads should not recreate feed merge callbacks on every thumbnail resolution')
+})
+
+test('vertical discovery updates feed entries when previews change without channel order changing', () => {
+  const source = readAppFile('app/(tabs)/discover.tsx')
+
+  assert.match(source, /function getFeedEntrySignature\(entry: FeedEntry\)/, 'feed-entry signature helper should exist')
+  assert.match(source, /previewVideos/, 'signature should include preview video state')
+  assert.match(source, /blobId/, 'signature should include direct blob ids')
+  assert.match(source, /blobsCoreKey/, 'signature should include direct blob core keys')
+  assert.match(source, /prevSignature === nextSignature \? prev : entries/, 'unchanged signatures may preserve state, changed previews must update entries')
 })
 
 test('vertical discovery stops inline Shorts playback when the route unmounts or loses focus', () => {


### PR DESCRIPTION
## Summary
- fix Shorts progress-bar seek units so the prop path stays normalized while imperative seek uses seconds
- guard vertical Discover playback requests with a generation id so stale `preparePlayback` completions cannot attach the wrong URL after fast swipes
- compare vertical feed entries by preview/blob signature instead of only channel order, so same-channel preview updates refresh the Shorts feed

## UX impact
- tapping mid/end progress no longer jumps to the end because seconds were being passed into a normalized seek prop
- rapid swiping no longer risks showing/playing the previous video URL on the newly active card
- relay/feed updates that change previews or direct blob refs now update the vertical feed even when channel order is unchanged

## Tests
- `node --test packages/app/tests/vertical-discovery-regression.test.mjs`
- `npm run lint:changed`
- `git diff --check`
