### PR TITLE
fix(shorts): keep progress visible when controls hide

### DIFF
--- a/packages/app/components/discovery/VerticalShortsPlayer.tsx
+++ b/packages/app/components/discovery/VerticalShortsPlayer.tsx
@@ -189,20 +189,22 @@ export const VerticalShortsPlayer = memo(function VerticalShortsPlayer({
         </Pressable>
       ) : null}
 
-      {showPlayer && controlsVisible ? (
-        <View style={styles.controlsOverlay} pointerEvents="box-none">
-          <View style={styles.controlButtons}>
-            <Pressable
-              onPress={isPaused ? playShorts : pauseShorts}
-              style={styles.controlButton}
-              accessibilityLabel={isPaused ? 'Play Shorts video' : 'Pause Shorts video'}
-            >
-              <Feather name={isPaused ? 'play' : 'pause'} color="#fff" size={24} />
-            </Pressable>
-            <Pressable onPress={restartShorts} style={styles.controlButton} accessibilityLabel="Restart Shorts video">
-              <Feather name="rotate-cw" color="#fff" size={22} />
-            </Pressable>
-          </View>
+      {showPlayer ? (
+        <View style={styles.progressDock} pointerEvents="box-none">
+          {controlsVisible ? (
+            <View style={styles.controlButtons} pointerEvents="box-none">
+              <Pressable
+                onPress={isPaused ? playShorts : pauseShorts}
+                style={styles.controlButton}
+                accessibilityLabel={isPaused ? 'Play Shorts video' : 'Pause Shorts video'}
+              >
+                <Feather name={isPaused ? 'play' : 'pause'} color="#fff" size={24} />
+              </Pressable>
+              <Pressable onPress={restartShorts} style={styles.controlButton} accessibilityLabel="Restart Shorts video">
+                <Feather name="rotate-cw" color="#fff" size={22} />
+              </Pressable>
+            </View>
+          ) : null}
           <Pressable
             onPress={handleProgressBarPress}
             onLayout={handleProgressBarLayout}
@@ -210,7 +212,9 @@ export const VerticalShortsPlayer = memo(function VerticalShortsPlayer({
             accessibilityRole="adjustable"
             accessibilityLabel="Shorts progress bar"
           >
-            <View style={[styles.progressFill, { width: `${effectiveProgress * 100}%` }]} />
+            <View style={[styles.progressRail]}>
+              <View style={[styles.progressFill, { width: `${effectiveProgress * 100}%` }]} />
+            </View>
           </Pressable>
         </View>
       ) : null}
@@ -253,7 +257,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     backgroundColor: 'rgba(0,0,0,0.2)',
   },
-  controlsOverlay: {
+  progressDock: {
     position: 'absolute',
     left: 0,
     right: 0,
@@ -281,8 +285,14 @@ const styles = StyleSheet.create({
     height: 18,
     justifyContent: 'center',
   },
-  progressFill: {
+  progressRail: {
     height: 3,
+    borderRadius: 999,
+    overflow: 'hidden',
+    backgroundColor: 'rgba(255,255,255,0.26)',
+  },
+  progressFill: {
+    height: '100%',
     borderRadius: 999,
     backgroundColor: colors.primary,
   },

--- a/packages/app/tests/vertical-discovery-regression.test.mjs
+++ b/packages/app/tests/vertical-discovery-regression.test.mjs
@@ -140,7 +140,7 @@ test('vertical discovery calls getFeedPreviewVideos through the controller with 
 })
 
 
-test('vertical discovery lets the shorts player hide card chrome', () => {
+test('vertical discovery lets the shorts player hide card chrome without hiding progress', () => {
   const source = readAppFile('app/(tabs)/discover.tsx')
   const playerSource = readAppFile('components/discovery/VerticalShortsPlayer.tsx')
 
@@ -150,6 +150,10 @@ test('vertical discovery lets the shorts player hide card chrome', () => {
   assert.match(source, /\{shortsChromeVisible \? \([\s\S]*styles\.bottomMeta/, 'channel/details/replay buttons should hide when Shorts controls are hidden')
   assert.match(playerSource, /toggleControlsVisibility/, 'Shorts player should toggle controls on tap')
   assert.match(playerSource, /onControlsVisibleChange\?\.\(!controlsVisible\)/, 'Shorts player should notify the parent when controls are toggled')
+  assert.match(playerSource, /pointerEvents=\"box-none\"/, 'overlay chrome must not swallow card taps outside actual controls')
+  assert.match(playerSource, /showPlayer \? \([\s\S]*styles\.progressDock/, 'every active Shorts card should keep a progress bar mounted')
+  assert.match(playerSource, /\{controlsVisible \? \([\s\S]*styles\.controlButtons/, 'buttons should be the part that hides when controls are tapped away')
+  assert.doesNotMatch(playerSource, /showPlayer && controlsVisible \? \([\s\S]*progressTrack/, 'progress bar should not disappear with the rest of the controls')
 })
 
 test('shorts player has functional playback buttons and a seekable progress bar', () => {


### PR DESCRIPTION
## Summary
- keep the Shorts progress bar mounted for every active video, even after controls are hidden
- make the progress/controls dock `pointerEvents="box-none"` so tapping empty video area toggles chrome instead of being swallowed by the overlay
- hide only the playback buttons when controls are toggled off
- add a regression that guards tap-to-hide controls and persistent progress behavior

## Tests
- `node --test packages/app/tests/vertical-discovery-regression.test.mjs`
- `npm run lint:changed`
- `git diff --check`
