### PR TITLE
fix(relay): classify local mirror uploads safely

### DIFF
--- a/packages/cli/src/archive-manager.js
+++ b/packages/cli/src/archive-manager.js
@@ -315,8 +315,19 @@ export function createArchivePublisher({ identityManager, uploadManager, api, ru
       const publicBeeKey = channel.publicBeeKey || meta?.publicBeeKey || null
       return { channel, channelKey: identity.driveKey || identity.channelKey, publicBeeKey }
     },
-    async importVideo({ channel, filePath, title, description, mimeType }) {
-      const result = await uploadManager.uploadFromPath(channel, filePath, { title, description, mimeType, category: 'archive' }, fs)
+    async importVideo({ channel, filePath, title, description, mimeType, category, duration, thumbnail, tags, sourceType, sourceUrl, thumbnailUrl }) {
+      const result = await uploadManager.uploadFromPath(channel, filePath, {
+        title,
+        description,
+        mimeType,
+        category: category || 'archive',
+        duration,
+        thumbnail,
+        tags,
+        sourceType,
+        sourceUrl,
+        thumbnailUrl
+      }, fs)
       if (!result?.success) throw new Error(result?.error || 'Archive import failed')
       return result
     },

--- a/packages/cli/src/local-drive-mirror.js
+++ b/packages/cli/src/local-drive-mirror.js
@@ -38,7 +38,10 @@ function mimeTypeForPath(filePath) {
 
 
 function normalizeText(value, maxLength = 5000) {
-  return String(value || '').replace(/[\u0000-\u001f\u007f]+/g, ' ').replace(/\s+/g, ' ').trim().slice(0, maxLength)
+  return String(value || '').split('').map((char) => {
+    const code = char.charCodeAt(0)
+    return code < 32 || code === 127 ? ' ' : char
+  }).join('').replace(/\s+/g, ' ').trim().slice(0, maxLength)
 }
 
 function safeTag(value) {

--- a/packages/cli/src/local-drive-mirror.js
+++ b/packages/cli/src/local-drive-mirror.js
@@ -1,4 +1,4 @@
-import { readdirSync, statSync } from '#fs'
+import { existsSync, readFileSync, readdirSync, statSync } from '#fs'
 import { basename, extname, join } from '#path'
 const defaultPath = { join }
 
@@ -36,6 +36,81 @@ function mimeTypeForPath(filePath) {
   return MIME_BY_EXT[extname(String(filePath || '')).toLowerCase()] || 'video/mp4'
 }
 
+
+function normalizeText(value, maxLength = 5000) {
+  return String(value || '').replace(/[\u0000-\u001f\u007f]+/g, ' ').replace(/\s+/g, ' ').trim().slice(0, maxLength)
+}
+
+function safeTag(value) {
+  const tag = normalizeText(value, 48).toLowerCase().replace(/[^a-z0-9._ -]+/g, '').replace(/\s+/g, '-').replace(/^-+|-+$/g, '')
+  return tag || null
+}
+
+function uniqueTags(values) {
+  const seen = new Set()
+  const tags = []
+  for (const value of values || []) {
+    const tag = safeTag(value)
+    if (!tag || seen.has(tag)) continue
+    seen.add(tag)
+    tags.push(tag)
+    if (tags.length >= 12) break
+  }
+  return tags
+}
+
+function infoJsonPathForVideo(filePath) {
+  const value = String(filePath || '')
+  const ext = extname(value)
+  return `${ext ? value.slice(0, -ext.length) : value}.info.json`
+}
+
+function readYtDlpInfo(filePath, fs) {
+  const infoPath = infoJsonPathForVideo(filePath)
+  try {
+    if (typeof fs.existsSync === 'function' && !fs.existsSync(infoPath)) return null
+    if (typeof fs.readFileSync !== 'function') return null
+    const parsed = JSON.parse(String(fs.readFileSync(infoPath, 'utf8') || '{}'))
+    if (!parsed || typeof parsed !== 'object') return null
+    const sourceUrl = normalizeText(parsed.webpage_url || parsed.original_url || parsed.url || '', 1000)
+    const extractor = normalizeText(parsed.extractor_key || parsed.extractor || '', 80).toLowerCase()
+    const looksLikeYtDlp = Boolean(sourceUrl || parsed.id || parsed.title || extractor)
+    if (!looksLikeYtDlp) return null
+    return { ...parsed, sourceUrl, infoPath }
+  } catch {
+    return null
+  }
+}
+
+function metadataForLocalVideo(video, fs) {
+  const info = readYtDlpInfo(video.filePath, fs)
+  if (!info) {
+    return {
+      title: video.title,
+      description: '',
+      category: 'Local',
+      tags: ['local'],
+      sourceType: 'local',
+      sourceUrl: null,
+      duration: 0,
+      thumbnailUrl: null
+    }
+  }
+  const categories = Array.isArray(info.categories) ? info.categories : []
+  const ytDlpTags = Array.isArray(info.tags) ? info.tags : []
+  const category = normalizeText(categories[0] || info.category || 'YouTube', 80)
+  return {
+    title: normalizeText(info.title, 200) || video.title,
+    description: normalizeText(info.description || info.fulltitle || '', 5000),
+    category,
+    tags: uniqueTags(['youtube', 'yt-dlp', category, ...(info.uploader ? [info.uploader] : []), ...(info.channel ? [info.channel] : []), ...ytDlpTags]),
+    sourceType: 'yt-dlp',
+    sourceUrl: info.sourceUrl || null,
+    duration: Number(info.duration || 0) || 0,
+    thumbnailUrl: normalizeText(info.thumbnail || '', 1000) || null
+  }
+}
+
 function fingerprintVideo(video) {
   return `${video.filePath}:${video.size}:${video.mtimeMs}`
 }
@@ -58,7 +133,7 @@ export function createLocalDriveMirrorState(seed = null) {
 }
 
 export function listLocalDriveVideos(rootPath, {
-  fs = { readdirSync, statSync },
+  fs = { existsSync, readFileSync, readdirSync, statSync },
   path = defaultPath,
   recursive = true,
   extensions = DEFAULT_VIDEO_EXTENSIONS,
@@ -106,7 +181,7 @@ export async function mirrorLocalDriveToRelayChannel({
   description = '',
   recursive = true,
   maxFiles = Infinity,
-  fs = { readdirSync, statSync },
+  fs = { existsSync, readFileSync, readdirSync, statSync },
   path = defaultPath,
   state = null,
   logger = null
@@ -122,24 +197,36 @@ export async function mirrorLocalDriveToRelayChannel({
 
   for (const video of pendingVideos) {
     try {
+      const localMetadata = metadataForLocalVideo(video, fs)
       const result = await publisher.importVideo({
         channel: channelInfo.channel,
         filePath: video.filePath,
-        title: video.title,
-        description,
-        mimeType: video.mimeType
+        title: localMetadata.title,
+        description: localMetadata.description || description,
+        mimeType: video.mimeType,
+        category: localMetadata.category,
+        tags: localMetadata.tags,
+        sourceType: localMetadata.sourceType,
+        sourceUrl: localMetadata.sourceUrl,
+        duration: localMetadata.duration,
+        thumbnailUrl: localMetadata.thumbnailUrl
       })
       const metadata = result?.metadata || result || {}
       const playbackSupport = getPlaybackSupportForMimeType(metadata.mimeType || video.mimeType)
       const previewVideo = result?.videoId ? {
         id: result.videoId,
-        title: video.title,
-        description,
+        title: localMetadata.title,
+        description: localMetadata.description || description,
         path: metadata.path || `/videos/${result.videoId}.mp4`,
         uploadedAt: metadata.uploadedAt || Date.now(),
-        duration: Number(metadata.duration || 0) || 0,
+        duration: Number(metadata.duration || localMetadata.duration || 0) || 0,
         size: Number(metadata.size || video.size || 0) || 0,
         mimeType: metadata.mimeType || video.mimeType,
+        category: metadata.category || localMetadata.category,
+        tags: localMetadata.tags,
+        sourceType: localMetadata.sourceType,
+        sourceUrl: localMetadata.sourceUrl,
+        thumbnailUrl: localMetadata.thumbnailUrl,
         availability: playbackSupport.availability,
         playbackSupport: playbackSupport.playbackSupport,
         blobId: metadata.blobId || null,
@@ -148,7 +235,7 @@ export async function mirrorLocalDriveToRelayChannel({
         thumbnailBlobsCoreKey: metadata.thumbnailBlobsCoreKey || null,
         thumbnailMimeType: metadata.thumbnailMimeType || null
       } : null
-      imported.push({ ...video, videoId: result?.videoId || null, previewVideo })
+      imported.push({ ...video, title: localMetadata.title, videoId: result?.videoId || null, previewVideo })
       if (state?.seen) {
         state.seen.set(video.filePath, {
           fingerprint: fingerprintVideo(video),

--- a/packages/cli/test/local-drive-mirror.test.mjs
+++ b/packages/cli/test/local-drive-mirror.test.mjs
@@ -176,3 +176,79 @@ test('mirrorLocalDriveToRelayChannel republishes and reseeds cached local previe
   t.alike(published, [['blob-1'], ['blob-1'], ['blob-2']])
   t.alike(seeded, [['cc'.repeat(32)], ['cc'.repeat(32)], ['cc'.repeat(32)]])
 })
+
+
+test('mirrorLocalDriveToRelayChannel derives safe metadata and tags from mixed local and yt-dlp files', async (t) => {
+  const fs = makeFs({
+    '/drive': [dirent('random clip 01.mp4', 'file'), dirent('abc123.webm', 'file'), dirent('abc123.info.json', 'file'), dirent('notes.txt', 'file')]
+  }, {
+    '/drive/random clip 01.mp4': 100,
+    '/drive/abc123.webm': 200,
+    '/drive/abc123.info.json': 50
+  })
+  fs.existsSync = (filePath) => filePath === '/drive/abc123.info.json'
+  fs.readFileSync = (filePath, encoding) => {
+    t.is(encoding, 'utf8')
+    if (filePath !== '/drive/abc123.info.json') throw new Error(`ENOENT: ${filePath}`)
+    return JSON.stringify({
+      title: 'YT Title',
+      description: 'Original YouTube description',
+      uploader: 'Uploader Name',
+      channel: 'Channel Name',
+      webpage_url: 'https://www.youtube.com/watch?v=abc123',
+      categories: ['Education'],
+      tags: ['demo', 'Demo', '  ', 'very-long-tag-name-that-should-be-clipped-to-a-sed-to-a-safe-length'],
+      duration: 42,
+      thumbnail: 'https://i.ytimg.com/vi/abc123/hqdefault.jpg'
+    })
+  }
+
+  const imports = []
+  let publishedPreviews = null
+  const publisher = {
+    async ensureAnonymousChannel() {
+      return { channel: { id: 'channel' }, channelKey: 'aa'.repeat(32), publicBeeKey: 'bb'.repeat(32) }
+    },
+    async importVideo(input) {
+      imports.push(input)
+      return {
+        videoId: input.title.replace(/\s+/g, '-').toLowerCase(),
+        metadata: {
+          uploadedAt: 123,
+          size: input.filePath.endsWith('.webm') ? 200 : 100,
+          mimeType: input.mimeType,
+          duration: input.duration || 0,
+          category: input.category || '',
+          blobId: `blob:${input.title}`,
+          blobsCoreKey: input.filePath.endsWith('.webm') ? 'dd'.repeat(32) : 'cc'.repeat(32)
+        }
+      }
+    },
+    async publishChannel(_channelInfo, options) {
+      publishedPreviews = options.previewVideos
+    },
+    async seedChannel() {}
+  }
+
+  const result = await mirrorLocalDriveToRelayChannel({ rootPath: '/drive', publisher, fs, path: pathShim })
+
+  t.is(result.scanned, 2)
+  t.is(imports[0].title, 'YT Title')
+  t.is(imports[0].description, 'Original YouTube description')
+  t.is(imports[0].category, 'Education')
+  t.alike(imports[0].tags, ['youtube', 'yt-dlp', 'education', 'uploader-name', 'channel-name', 'demo', 'very-long-tag-name-that-should-be-clipped-to-a-s'])
+  t.is(imports[0].sourceUrl, 'https://www.youtube.com/watch?v=abc123')
+  t.is(imports[0].sourceType, 'yt-dlp')
+  t.is(imports[0].duration, 42)
+
+  t.is(imports[1].title, 'random clip 01')
+  t.is(imports[1].description, '')
+  t.is(imports[1].category, 'Local')
+  t.alike(imports[1].tags, ['local'])
+  t.is(imports[1].sourceType, 'local')
+
+  t.is(publishedPreviews[0].sourceType, 'yt-dlp')
+  t.alike(publishedPreviews[0].tags, ['youtube', 'yt-dlp', 'education', 'uploader-name', 'channel-name', 'demo', 'very-long-tag-name-that-should-be-clipped-to-a-s'])
+  t.is(publishedPreviews[1].sourceType, 'local')
+  t.alike(publishedPreviews[1].tags, ['local'])
+})


### PR DESCRIPTION
## Summary
- classify local mirror imports as either plain local videos or yt-dlp downloads using sibling `.info.json` metadata
- carry safe title/description/category/tags/source metadata into upload and preview feed records
- pass local mirror metadata through the archive publisher instead of forcing every import into `archive`

## Test Plan
- `npm --prefix packages/cli test`
- `git diff --check`

## Notes
This is specifically to keep auto-upload/tagging tight when the local videos folder contains a mixed bag: random videos, yt-dlp outputs, non-video junk, and metadata sidecars.