### PR TITLE
feat(relay): group mirrored imports by creator

### DIFF
--- a/packages/cli/src/archive-manager.js
+++ b/packages/cli/src/archive-manager.js
@@ -296,26 +296,38 @@ export function createArchivePublisher({ identityManager, uploadManager, api, ru
   if (!uploadManager) throw new Error('uploadManager is required')
   if (!api) throw new Error('api is required')
 
+  const sourceChannels = new Map()
+  const previousActiveIdentity = identityManager.getActiveIdentity?.()
+
   return {
-    async ensureAnonymousChannel({ channelName }) {
-      let identity = identityManager.getActiveIdentity?.()
-      if (!identity?.driveKey) {
-        const created = await identityManager.createIdentity(channelName || 'Anonymous Archive', true)
+    async ensureAnonymousChannel({ channelName, sourceIdentity = null } = {}) {
+      const sourceKey = sourceIdentity?.sourceId || null
+      if (sourceKey && sourceChannels.has(sourceKey)) return sourceChannels.get(sourceKey)
+
+      let identity = sourceKey ? previousActiveIdentity : identityManager.getActiveIdentity?.()
+      if (!identity?.driveKey || sourceKey) {
+        const created = sourceKey && typeof identityManager.createSourceIdentity === 'function'
+          ? await identityManager.createSourceIdentity(sourceIdentity, channelName || sourceIdentity.creatorName || 'Anonymous Archive')
+          : await identityManager.createIdentity(channelName || sourceIdentity?.creatorName || 'Anonymous Archive', true)
         identity = {
           publicKey: created.publicKey,
           driveKey: created.driveKey,
           channelKey: created.driveKey,
-          name: channelName || 'Anonymous Archive'
+          name: channelName || sourceIdentity?.creatorName || 'Anonymous Archive'
         }
       }
 
-      const channel = await identityManager.getActiveChannel?.()
+      const channel = sourceKey && typeof identityManager.getChannelForIdentity === 'function'
+        ? await identityManager.getChannelForIdentity(identity)
+        : await identityManager.getActiveChannel?.()
       if (!channel?.blobs) throw new Error('Anonymous channel blobs not initialized')
       const meta = await channel.getMetadata?.().catch(() => null)
       const publicBeeKey = channel.publicBeeKey || meta?.publicBeeKey || null
-      return { channel, channelKey: identity.driveKey || identity.channelKey, publicBeeKey }
+      const entry = { channel, channelKey: identity.driveKey || identity.channelKey, publicBeeKey }
+      if (sourceKey) sourceChannels.set(sourceKey, entry)
+      return entry
     },
-    async importVideo({ channel, filePath, title, description, mimeType, category, duration, thumbnail, tags, sourceType, sourceUrl, thumbnailUrl }) {
+    async importVideo({ channel, filePath, title, description, mimeType, category, duration, thumbnail, tags, sourceType, sourceUrl, sourceVideoId, creatorSourceId, creatorName, creatorHandle, thumbnailUrl }) {
       const result = await uploadManager.uploadFromPath(channel, filePath, {
         title,
         description,
@@ -326,6 +338,10 @@ export function createArchivePublisher({ identityManager, uploadManager, api, ru
         tags,
         sourceType,
         sourceUrl,
+        sourceVideoId,
+        creatorSourceId,
+        creatorName,
+        creatorHandle,
         thumbnailUrl
       }, fs)
       if (!result?.success) throw new Error(result?.error || 'Archive import failed')
@@ -390,6 +406,10 @@ export function createArchiveManager({ store, downloader, publisher, logger = nu
           duration: Number(importedMetadata.duration || downloaded.duration || 0) || 0,
           size: Number(importedMetadata.size || downloaded.size || 0) || 0,
           mimeType: importedMetadata.mimeType || downloaded.mimeType || 'video/mp4',
+          sourceVideoId: privateInput.sourceVideoId || downloaded.sourceVideoId || null,
+          creatorSourceId: privateInput.creatorSourceId || downloaded.creatorSourceId || null,
+          creatorName: privateInput.creatorName || downloaded.creatorName || null,
+          creatorHandle: privateInput.creatorHandle || downloaded.creatorHandle || null,
           availability: 'playable',
           blobId: importedMetadata.blobId || null,
           blobsCoreKey: importedMetadata.blobsCoreKey || null,

--- a/packages/cli/src/local-drive-mirror.js
+++ b/packages/cli/src/local-drive-mirror.js
@@ -85,6 +85,43 @@ function readYtDlpInfo(filePath, fs) {
   }
 }
 
+function creatorSourceIdentityForInfo(info) {
+  if (!info || typeof info !== 'object') return null
+  const channelId = normalizeText(info.channel_id || info.channelId || '', 120)
+  const uploaderId = normalizeText(info.uploader_id || info.uploaderId || '', 120)
+  const channelName = normalizeText(info.channel || info.uploader || '', 160)
+  const creatorHandle = uploaderId.startsWith('@') ? uploaderId : null
+
+  if (channelId) {
+    return {
+      platform: 'youtube',
+      sourceId: `youtube:channel:${channelId}`,
+      creatorName: channelName || channelId,
+      creatorHandle
+    }
+  }
+
+  if (creatorHandle) {
+    return {
+      platform: 'youtube',
+      sourceId: `youtube:handle:${creatorHandle}`,
+      creatorName: channelName || creatorHandle,
+      creatorHandle
+    }
+  }
+
+  if (channelName) {
+    return {
+      platform: 'youtube',
+      sourceId: `youtube:creator:${safeTag(channelName)}`,
+      creatorName: channelName,
+      creatorHandle: null
+    }
+  }
+
+  return null
+}
+
 function metadataForLocalVideo(video, fs) {
   const info = readYtDlpInfo(video.filePath, fs)
   if (!info) {
@@ -95,6 +132,11 @@ function metadataForLocalVideo(video, fs) {
       tags: ['local'],
       sourceType: 'local',
       sourceUrl: null,
+      sourceVideoId: null,
+      creatorSourceId: null,
+      creatorName: null,
+      creatorHandle: null,
+      sourceIdentity: null,
       duration: 0,
       thumbnailUrl: null
     }
@@ -102,6 +144,7 @@ function metadataForLocalVideo(video, fs) {
   const categories = Array.isArray(info.categories) ? info.categories : []
   const ytDlpTags = Array.isArray(info.tags) ? info.tags : []
   const category = normalizeText(categories[0] || info.category || 'YouTube', 80)
+  const sourceIdentity = creatorSourceIdentityForInfo(info)
   return {
     title: normalizeText(info.title, 200) || video.title,
     description: normalizeText(info.description || info.fulltitle || '', 5000),
@@ -109,6 +152,11 @@ function metadataForLocalVideo(video, fs) {
     tags: uniqueTags(['youtube', 'yt-dlp', category, ...(info.uploader ? [info.uploader] : []), ...(info.channel ? [info.channel] : []), ...ytDlpTags]),
     sourceType: 'yt-dlp',
     sourceUrl: info.sourceUrl || null,
+    sourceVideoId: normalizeText(info.id || info.display_id || '', 160) || null,
+    creatorSourceId: sourceIdentity?.sourceId || null,
+    creatorName: sourceIdentity?.creatorName || null,
+    creatorHandle: sourceIdentity?.creatorHandle || null,
+    sourceIdentity,
     duration: Number(info.duration || 0) || 0,
     thumbnailUrl: normalizeText(info.thumbnail || '', 1000) || null
   }
@@ -194,13 +242,37 @@ export async function mirrorLocalDriveToRelayChannel({
   const pendingVideos = state?.seen
     ? videos.filter((video) => getSeenFingerprint(state.seen.get(video.filePath)) !== fingerprintVideo(video))
     : videos
-  const channelInfo = await publisher.ensureAnonymousChannel({ channelName })
+  const metadataByPath = new Map(videos.map((video) => [video.filePath, metadataForLocalVideo(video, fs)]))
+  const channelInfoByKey = new Map()
   const imported = []
   const failed = []
 
+  function channelKeyForMetadata(localMetadata) {
+    return localMetadata.sourceIdentity?.sourceId || 'local'
+  }
+
+  async function channelForMetadata(localMetadata) {
+    const key = channelKeyForMetadata(localMetadata)
+    if (channelInfoByKey.has(key)) return channelInfoByKey.get(key)
+    const sourceIdentity = localMetadata.sourceIdentity || null
+    const info = await publisher.ensureAnonymousChannel({
+      channelName: sourceIdentity?.creatorName || channelName,
+      sourceIdentity
+    })
+    const entry = {
+      ...info,
+      channelName: sourceIdentity?.creatorName || channelName,
+      sourceIdentity,
+      previewVideos: []
+    }
+    channelInfoByKey.set(key, entry)
+    return entry
+  }
+
   for (const video of pendingVideos) {
     try {
-      const localMetadata = metadataForLocalVideo(video, fs)
+      const localMetadata = metadataByPath.get(video.filePath) || metadataForLocalVideo(video, fs)
+      const channelInfo = await channelForMetadata(localMetadata)
       const result = await publisher.importVideo({
         channel: channelInfo.channel,
         filePath: video.filePath,
@@ -211,6 +283,10 @@ export async function mirrorLocalDriveToRelayChannel({
         tags: localMetadata.tags,
         sourceType: localMetadata.sourceType,
         sourceUrl: localMetadata.sourceUrl,
+        sourceVideoId: localMetadata.sourceVideoId,
+        creatorSourceId: localMetadata.creatorSourceId,
+        creatorName: localMetadata.creatorName,
+        creatorHandle: localMetadata.creatorHandle,
         duration: localMetadata.duration,
         thumbnailUrl: localMetadata.thumbnailUrl
       })
@@ -229,7 +305,10 @@ export async function mirrorLocalDriveToRelayChannel({
         tags: localMetadata.tags,
         sourceType: localMetadata.sourceType,
         sourceUrl: localMetadata.sourceUrl,
-        thumbnailUrl: localMetadata.thumbnailUrl,
+        sourceVideoId: localMetadata.sourceVideoId,
+        creatorSourceId: localMetadata.creatorSourceId,
+        creatorName: localMetadata.creatorName,
+        creatorHandle: localMetadata.creatorHandle,
         availability: playbackSupport.availability,
         playbackSupport: playbackSupport.playbackSupport,
         blobId: metadata.blobId || null,
@@ -238,11 +317,15 @@ export async function mirrorLocalDriveToRelayChannel({
         thumbnailBlobsCoreKey: metadata.thumbnailBlobsCoreKey || null,
         thumbnailMimeType: metadata.thumbnailMimeType || null
       } : null
-      imported.push({ ...video, title: localMetadata.title, videoId: result?.videoId || null, previewVideo })
+      if (previewVideo) channelInfo.previewVideos.push(previewVideo)
+      imported.push({ ...video, title: localMetadata.title, videoId: result?.videoId || null, previewVideo, channelKey: channelInfo.channelKey })
       if (state?.seen) {
         state.seen.set(video.filePath, {
           fingerprint: fingerprintVideo(video),
-          previewVideo
+          previewVideo,
+          channelKey: channelInfo.channelKey,
+          publicBeeKey: channelInfo.publicBeeKey || null,
+          sourceIdentity: channelInfo.sourceIdentity || null
         })
       }
       logger?.archive?.info?.('Local drive video imported', { file: video.filePath, videoId: result?.videoId || null })
@@ -252,23 +335,41 @@ export async function mirrorLocalDriveToRelayChannel({
     }
   }
 
-  const importedPreviewByPath = new Map(imported.map((entry) => [entry.filePath, entry.previewVideo]).filter(([, preview]) => Boolean(preview)))
-  const previewVideos = videos
-    .map((video) => importedPreviewByPath.get(video.filePath) || getSeenPreviewVideo(state?.seen?.get(video.filePath)))
-    .filter(Boolean)
-  if (previewVideos.length > 0) {
-    await publisher.publishChannel(channelInfo, { previewVideos })
-    await publisher.seedChannel({ ...channelInfo, previewVideos })
+  for (const video of videos) {
+    const localMetadata = metadataByPath.get(video.filePath)
+    const cachedPreview = getSeenPreviewVideo(state?.seen?.get(video.filePath))
+    if (!cachedPreview) continue
+    const channelInfo = await channelForMetadata(localMetadata)
+    if (!channelInfo.previewVideos.some((preview) => preview.id === cachedPreview.id)) {
+      channelInfo.previewVideos.push(cachedPreview)
+    }
   }
 
+  for (const channelInfo of channelInfoByKey.values()) {
+    if (channelInfo.previewVideos.length > 0) {
+      await publisher.publishChannel(channelInfo, { previewVideos: channelInfo.previewVideos })
+      await publisher.seedChannel({ ...channelInfo, previewVideos: channelInfo.previewVideos })
+    }
+  }
+
+  const channels = [...channelInfoByKey.values()].map((entry) => ({
+    channelKey: entry.channelKey,
+    publicBeeKey: entry.publicBeeKey || null,
+    channelName: entry.channelName,
+    sourceIdentity: entry.sourceIdentity || null,
+    imported: imported.filter((video) => video.channelKey === entry.channelKey).length,
+    videos: entry.previewVideos
+  }))
+
   return {
-    channelKey: channelInfo.channelKey,
-    publicBeeKey: channelInfo.publicBeeKey || null,
+    channelKey: channels[0]?.channelKey || null,
+    publicBeeKey: channels[0]?.publicBeeKey || null,
     scanned: videos.length,
     imported: imported.length,
     skipped: videos.length - pendingVideos.length,
     failed: failed.length,
-    videos: imported.map(({ filePath, title, size, mimeType, videoId }) => ({ filePath, title, size, mimeType, videoId })),
+    channels,
+    videos: imported.map(({ filePath, title, size, mimeType, videoId, channelKey }) => ({ filePath, title, size, mimeType, videoId, channelKey })),
     failures: failed.map(({ filePath, error }) => ({ filePath, error }))
   }
 }

--- a/packages/cli/test/archive-ui.test.mjs
+++ b/packages/cli/test/archive-ui.test.mjs
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
 import { parseArgv } from '../src/argv.js'
-import { createArchiveJobStore, enqueueArchiveJob, createArchiveManager, createYtDlpDownloader } from '../src/archive-manager.js'
+import { createArchiveJobStore, enqueueArchiveJob, createArchiveManager, createArchivePublisher, createYtDlpDownloader } from '../src/archive-manager.js'
 import { renderArchiveTui, renderArchiveWebHome } from '../src/archive-ui.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -440,4 +440,71 @@ test('yt-dlp downloader rejects bogus direct Invidious output and continues fall
   t.is(calls.length, 3, 'bogus .unknown_video direct media result retries the watch page')
   t.is(calls[1].args.at(-1), 'https://invidious.projectsegfau.lt/latest_version?id=6ZVnOQ8DmFI&itag=18&local=true')
   t.is(calls[2].args.at(-1), 'https://invidious.projectsegfau.lt/watch?v=6ZVnOQ8DmFI')
+})
+
+
+test('archive publisher opens separate relay-owned channels for source identities', async (t) => {
+  const created = []
+  const uploadOptions = []
+  const channels = new Map()
+  const identityManager = {
+    getActiveIdentity() { return { publicKey: 'relay', driveKey: 'relay-drive' } },
+    async createIdentity(name) {
+      created.push({ name })
+      const driveKey = `drive-${created.length}`
+      channels.set(driveKey, { blobs: true, publicBeeKey: `bee-${created.length}` })
+      return { publicKey: `pub-${created.length}`, driveKey }
+    },
+    async getChannelForIdentity(identity) {
+      return channels.get(identity.driveKey)
+    },
+    async getActiveChannel() {
+      return { blobs: true, publicBeeKey: 'relay-bee' }
+    }
+  }
+  const publisher = createArchivePublisher({
+    identityManager,
+    uploadManager: {
+      async uploadFromPath(_channel, _filePath, options) {
+        uploadOptions.push(options)
+        return { success: true, videoId: `video-${uploadOptions.length}` }
+      }
+    },
+    api: { async submitToFeed() {} },
+    runtime: {},
+    fs: {}
+  })
+
+  const oneA = await publisher.ensureAnonymousChannel({
+    channelName: 'Creator One',
+    sourceIdentity: { platform: 'youtube', sourceId: 'youtube:channel:UC1', creatorName: 'Creator One', creatorHandle: null }
+  })
+  const two = await publisher.ensureAnonymousChannel({
+    channelName: 'Creator Two',
+    sourceIdentity: { platform: 'youtube', sourceId: 'youtube:channel:UC2', creatorName: 'Creator Two', creatorHandle: null }
+  })
+  const oneB = await publisher.ensureAnonymousChannel({
+    channelName: 'Creator One',
+    sourceIdentity: { platform: 'youtube', sourceId: 'youtube:channel:UC1', creatorName: 'Creator One', creatorHandle: null }
+  })
+
+  await publisher.importVideo({
+    channel: oneA.channel,
+    filePath: '/tmp/one.mp4',
+    title: 'One',
+    description: '',
+    mimeType: 'video/mp4',
+    sourceType: 'yt-dlp',
+    sourceUrl: 'https://www.youtube.com/watch?v=one',
+    sourceVideoId: 'one',
+    creatorSourceId: 'youtube:channel:UC1',
+    creatorName: 'Creator One'
+  })
+
+  t.alike(created.map((entry) => entry.name), ['Creator One', 'Creator Two'])
+  t.is(oneA.channelKey, 'drive-1')
+  t.is(two.channelKey, 'drive-2')
+  t.is(oneB.channelKey, 'drive-1')
+  t.is(uploadOptions[0].creatorSourceId, 'youtube:channel:UC1')
+  t.is(uploadOptions[0].sourceVideoId, 'one')
 })

--- a/packages/cli/test/local-drive-mirror.test.mjs
+++ b/packages/cli/test/local-drive-mirror.test.mjs
@@ -204,7 +204,7 @@ test('mirrorLocalDriveToRelayChannel derives safe metadata and tags from mixed l
   }
 
   const imports = []
-  let publishedPreviews = null
+  const publishedPreviews = []
   const publisher = {
     async ensureAnonymousChannel() {
       return { channel: { id: 'channel' }, channelKey: 'aa'.repeat(32), publicBeeKey: 'bb'.repeat(32) }
@@ -225,7 +225,7 @@ test('mirrorLocalDriveToRelayChannel derives safe metadata and tags from mixed l
       }
     },
     async publishChannel(_channelInfo, options) {
-      publishedPreviews = options.previewVideos
+      publishedPreviews.push(...options.previewVideos)
     },
     async seedChannel() {}
   }
@@ -251,4 +251,91 @@ test('mirrorLocalDriveToRelayChannel derives safe metadata and tags from mixed l
   t.alike(publishedPreviews[0].tags, ['youtube', 'yt-dlp', 'education', 'uploader-name', 'channel-name', 'demo', 'very-long-tag-name-that-should-be-clipped-to-a-s'])
   t.is(publishedPreviews[1].sourceType, 'local')
   t.alike(publishedPreviews[1].tags, ['local'])
+})
+
+
+test('mirrorLocalDriveToRelayChannel groups yt-dlp imports by creator channel identity', async (t) => {
+  const fs = makeFs({
+    '/drive': [dirent('alpha.mp4', 'file'), dirent('alpha.info.json', 'file'), dirent('beta.mp4', 'file'), dirent('beta.info.json', 'file')]
+  }, {
+    '/drive/alpha.mp4': 100,
+    '/drive/alpha.info.json': 50,
+    '/drive/beta.mp4': 200,
+    '/drive/beta.info.json': 50
+  })
+  fs.existsSync = (filePath) => filePath.endsWith('.info.json')
+  fs.readFileSync = (filePath) => JSON.stringify(filePath.includes('alpha')
+    ? {
+        id: 'alpha',
+        title: 'Alpha',
+        channel: 'Creator One',
+        channel_id: 'UCcreatorone',
+        uploader: 'Creator One',
+        webpage_url: 'https://www.youtube.com/watch?v=alpha'
+      }
+    : {
+        id: 'beta',
+        title: 'Beta',
+        channel: 'Creator Two',
+        channel_id: 'UCcreatortwo',
+        uploader: 'Creator Two',
+        webpage_url: 'https://www.youtube.com/watch?v=beta'
+      })
+
+  const ensured = []
+  const imports = []
+  const published = []
+  const seeded = []
+  const publisher = {
+    async ensureAnonymousChannel({ channelName, sourceIdentity }) {
+      ensured.push({ channelName, sourceIdentity })
+      const suffix = sourceIdentity.sourceId.endsWith('UCcreatorone') ? '11' : '22'
+      return { channel: { id: sourceIdentity.sourceId }, channelKey: suffix.repeat(32), publicBeeKey: suffix.repeat(32) }
+    },
+    async importVideo(input) {
+      imports.push(input)
+      return {
+        videoId: input.sourceVideoId,
+        metadata: {
+          size: input.filePath.endsWith('alpha.mp4') ? 100 : 200,
+          mimeType: input.mimeType,
+          blobId: `blob:${input.sourceVideoId}`,
+          blobsCoreKey: input.sourceVideoId === 'alpha' ? 'aa'.repeat(32) : 'bb'.repeat(32)
+        }
+      }
+    },
+    async publishChannel(channelInfo, options) {
+      published.push({ channelKey: channelInfo.channelKey, titles: options.previewVideos.map((video) => video.title) })
+    },
+    async seedChannel(channelInfo) {
+      seeded.push({ channelKey: channelInfo.channelKey, refs: channelInfo.previewVideos.map((video) => video.blobsCoreKey) })
+    }
+  }
+
+  const result = await mirrorLocalDriveToRelayChannel({ rootPath: '/drive', publisher, fs, path: pathShim, channelName: 'Fallback Mirror' })
+
+  t.is(result.scanned, 2)
+  t.is(result.imported, 2)
+  t.is(ensured.length, 2)
+  t.alike(ensured.map((entry) => entry.channelName), ['Creator One', 'Creator Two'])
+  t.alike(ensured.map((entry) => entry.sourceIdentity), [
+    { platform: 'youtube', sourceId: 'youtube:channel:UCcreatorone', creatorName: 'Creator One', creatorHandle: null },
+    { platform: 'youtube', sourceId: 'youtube:channel:UCcreatortwo', creatorName: 'Creator Two', creatorHandle: null }
+  ])
+  t.alike(imports.map((entry) => [entry.title, entry.creatorName, entry.creatorSourceId, entry.sourceVideoId]), [
+    ['Alpha', 'Creator One', 'youtube:channel:UCcreatorone', 'alpha'],
+    ['Beta', 'Creator Two', 'youtube:channel:UCcreatortwo', 'beta']
+  ])
+  t.alike(published, [
+    { channelKey: '11'.repeat(32), titles: ['Alpha'] },
+    { channelKey: '22'.repeat(32), titles: ['Beta'] }
+  ])
+  t.alike(seeded, [
+    { channelKey: '11'.repeat(32), refs: ['aa'.repeat(32)] },
+    { channelKey: '22'.repeat(32), refs: ['bb'.repeat(32)] }
+  ])
+  t.alike(result.channels.map((channel) => ({ channelName: channel.channelName, imported: channel.imported })), [
+    { channelName: 'Creator One', imported: 1 },
+    { channelName: 'Creator Two', imported: 1 }
+  ])
 })

--- a/packages/cli/test/service.test.mjs
+++ b/packages/cli/test/service.test.mjs
@@ -746,6 +746,7 @@ test('createRelayService watches configured local mirror directory', async (t) =
 
     await Promise.resolve()
     await Promise.resolve()
+    await new Promise((resolve) => setImmediate(resolve))
     t.is(imports.length, 1, 'initial local mirror scan starts in the background')
     t.is(submitCalls, 0, 'startup does not wait for initial local mirror publish')
 


### PR DESCRIPTION
## Summary
- derive creator/source identity metadata from yt-dlp `.info.json` sidecars during local mirror scans
- group mirrored imports into per-creator relay-owned channels instead of one catch-all local mirror channel
- preserve creator/source IDs on upload metadata and preview refs while keeping local/source paths private

## Test Plan
- `npx brittle test/archive-ui.test.mjs test/local-drive-mirror.test.mjs test/service.test.mjs`
- `npm test` in `packages/cli`
- `npm run lint:changed`
- `git diff --check`
