### PR TITLE
fix(relay): surface real YouTube creator names

### DIFF
--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -1362,23 +1362,43 @@ export class PublicFeedManager {
    * @param {string} driveKey - The Autobase channel key
    * @param {string} [publicBeeKey] - The public Hyperbee key (for viewers)
    */
-  async submitChannel(driveKey, publicBeeKey = null) {
-    if (this.addEntry(driveKey, 'local', publicBeeKey)) {
+  async submitChannel(driveKey, publicBeeKey = null, options = {}) {
+    let snapshot = null
+    if (this.feedSnapshotProvider) {
+      const resolved = await this._resolveFeedSnapshots([{ driveKey, publicBeeKey }], null).catch(() => null)
+      snapshot = Array.isArray(resolved) ? resolved[0] || null : null
+    }
+
+    const explicitSnapshot = options && typeof options === 'object'
+      ? {
+          channelName: typeof options.channelName === 'string' ? options.channelName.trim() : null,
+          videoCount: Number.isFinite(options.videoCount) ? Number(options.videoCount) : undefined,
+          manifestUpdatedAt: Number.isFinite(options.manifestUpdatedAt) ? Number(options.manifestUpdatedAt) : undefined,
+          previewVideos: Array.isArray(options.previewVideos) ? this._sanitizePreviewVideos(options.previewVideos) : undefined,
+        }
+      : null
+
+    snapshot = {
+      ...(explicitSnapshot || {}),
+      ...(snapshot || {}),
+    }
+
+    if (this.addEntry(driveKey, 'local', publicBeeKey, snapshot)) {
       console.log('[PublicFeed] Submitted local channel:', driveKey.slice(0, 16), 'publicBee:', publicBeeKey?.slice(0, 16) || 'none');
       this.onFeedUpdate?.();
     } else if (publicBeeKey) {
       // Entry existed but we're adding publicBeeKey
       const entry = this.entries.get(driveKey)
+      let changed = false
       if (entry && !entry.publicBeeKey) {
         entry.publicBeeKey = publicBeeKey
+        changed = true
         console.log('[PublicFeed] Updated existing entry with publicBeeKey:', publicBeeKey.slice(0, 16));
       }
-    }
-
-    let snapshot = null
-    if (this.feedSnapshotProvider) {
-      const resolved = await this._resolveFeedSnapshots([{ driveKey, publicBeeKey }], null).catch(() => null)
-      snapshot = Array.isArray(resolved) ? resolved[0] || null : null
+      if (entry && this._applyEntrySnapshot(driveKey, { ...snapshot, publicBeeKey: entry.publicBeeKey || publicBeeKey })) {
+        changed = true
+      }
+      if (changed) this.onFeedUpdate?.();
     }
 
     // Persist to database so it survives restart (use v2 format with publicBeeKey)

--- a/packages/backend/test/public-feed-manager.test.mjs
+++ b/packages/backend/test/public-feed-manager.test.mjs
@@ -954,6 +954,32 @@ test('serving manifest snapshots preserve unverified playback metadata', async (
   }
 })
 
+test('submitChannel stores explicit channel names before provider hydration', async () => {
+  const manager = new PublicFeedManager(createSwarm(), createMetaDb())
+
+  try {
+    await manager.submitChannel(DRIVE_KEY, PUBLIC_BEE_KEY, {
+      channelName: 'Actual YouTube Creator',
+      previewVideos: [{
+        id: 'preview-named',
+        title: 'Named Preview',
+        uploadedAt: 99,
+        blobId: '0:8:0:1024',
+        blobsCoreKey: '55'.repeat(32),
+        mimeType: 'video/mp4',
+        availability: 'playable',
+      }],
+    })
+
+    const feed = manager.getFeed()
+    assert.equal(feed.length, 1)
+    assert.equal(feed[0].channelName, 'Actual YouTube Creator')
+    assert.equal(feed[0].previewVideos[0].id, 'preview-named')
+  } finally {
+    manager.stop()
+  }
+})
+
 
 test('requestAvailabilityHints merges playable responses from feed peers (including relayed peers on same channel)', async () => {
   const swarm = createSwarm()

--- a/packages/cli/src/archive/publisher.js
+++ b/packages/cli/src/archive/publisher.js
@@ -14,6 +14,9 @@ function buildSourceMarker(source) {
 
 function defaultChannelName(source) {
   if (source.label) return source.label
+  if (source.creatorName) return source.creatorName
+  if (source.channelName) return source.channelName
+  if (source.uploader) return source.uploader
   if (source.kind === 'handle') return source.identifier
   if (source.kind === 'channel') return `YouTube channel ${source.identifier.slice(0, 12)}`
   if (source.kind === 'playlist') return `YouTube playlist ${source.identifier.slice(0, 12)}`
@@ -42,9 +45,12 @@ async function resolvePublicBeeKey(channel) {
   return typeof publicBeeKey === 'string' && publicBeeKey.length > 0 ? publicBeeKey : null
 }
 
-async function listChannelPreviewVideos(channel, limit = 3) {
+async function listChannelPreviewVideos(channelEntry, limit = 3) {
+  const channel = channelEntry?.channel || channelEntry
   if (!channel || typeof channel.listVideos !== 'function') return []
   const videos = await channel.listVideos().catch(() => [])
+  const channelMeta = await channel.getMetadata?.().catch(() => null)
+  const channelName = channelEntry?.channelName || channelMeta?.name || null
   if (!Array.isArray(videos)) return []
   return videos
     .filter((video) => video?.id && video?.blobId && video?.blobsCoreKey)
@@ -63,7 +69,8 @@ async function listChannelPreviewVideos(channel, limit = 3) {
       blobsCoreKey: String(video.blobsCoreKey),
       thumbnailBlobId: video?.thumbnailBlobId || null,
       thumbnailBlobsCoreKey: video?.thumbnailBlobsCoreKey || null,
-      thumbnailMimeType: video?.thumbnailMimeType || null
+      thumbnailMimeType: video?.thumbnailMimeType || null,
+      channelName
     }))
 }
 
@@ -77,14 +84,22 @@ async function announceArchiveChannel(runtime, channelEntry, logger, sourceId, o
   if (!publicBeeKey) return
 
   const previewVideos = Array.isArray(options.previewVideos)
-    ? options.previewVideos.filter(Boolean)
-    : await listChannelPreviewVideos(channel)
+    ? options.previewVideos.filter(Boolean).map((video) => ({
+        ...video,
+        channelName: video?.channelName || channelEntry.channelName || null,
+      }))
+    : await listChannelPreviewVideos(channelEntry)
 
   try {
     if (previewVideos.length > 0) {
-      await runtime.publicFeed?.submitChannel?.(channelKey, publicBeeKey, { previewVideos })
+      await runtime.publicFeed?.submitChannel?.(channelKey, publicBeeKey, {
+        channelName: channelEntry.channelName || null,
+        previewVideos,
+      })
     } else {
-      await runtime.publicFeed?.submitChannel?.(channelKey, publicBeeKey)
+      await runtime.publicFeed?.submitChannel?.(channelKey, publicBeeKey, {
+        channelName: channelEntry.channelName || null,
+      })
     }
   } catch (err) {
     logger?.archive?.debug?.('Public-feed submit failed', {
@@ -120,7 +135,7 @@ async function announceArchiveChannel(runtime, channelEntry, logger, sourceId, o
  */
 export { resolvePublicBeeKey, announceArchiveChannel }
 
-export function createArchivePublisher({ ctx, uploadManager, runtime, fs, logger, state = null }) {
+export function createArchivePublisher({ ctx, uploadManager, runtime, fs, logger, state = null, createChannelFn = null }) {
   if (!ctx) throw new Error('ctx is required')
   if (!uploadManager) throw new Error('uploadManager is required')
   if (!runtime) throw new Error('runtime is required')
@@ -132,7 +147,7 @@ export function createArchivePublisher({ ctx, uploadManager, runtime, fs, logger
     if (channelCache.has(source.sourceId)) return channelCache.get(source.sourceId)
 
     const writerKeyName = buildWriterKeyName(source.sourceId)
-    const { createChannel } = await import('@peartube/backend/storage')
+    const createChannel = createChannelFn || (await import('@peartube/backend/storage')).createChannel
 
     const created = await createChannel(ctx, {
       encrypt: false,
@@ -169,7 +184,12 @@ export function createArchivePublisher({ ctx, uploadManager, runtime, fs, logger
       })
     }
 
-    const entry = { channel, channelKey, publicBeeKey }
+    const entry = {
+      channel,
+      channelKey,
+      publicBeeKey,
+      channelName: defaultChannelName(source)
+    }
 
     await announceArchiveChannel(runtime, entry, logger, source.sourceId)
 
@@ -197,7 +217,11 @@ export function createArchivePublisher({ ctx, uploadManager, runtime, fs, logger
   }
 
   async function publishVideo({ source, ytEntry, files }) {
-    const channelEntry = await ensureSourceChannel(source)
+    const sourceForChannel = {
+      ...source,
+      creatorName: ytEntry?.uploader || source?.creatorName || null
+    }
+    const channelEntry = await ensureSourceChannel(sourceForChannel)
     const { channel } = channelEntry
 
     if (!files?.videoFile) {

--- a/packages/cli/test/archive.test.mjs
+++ b/packages/cli/test/archive.test.mjs
@@ -4,7 +4,7 @@ import { resolveRelayConfig } from '../src/config.js'
 import { buildSourceId, buildWriterKeyName, classifySourceUrl } from '../src/archive/source-id.js'
 import { ARCHIVE_STATUS, createArchiveState } from '../src/archive/state.js'
 import { createArchiver } from '../src/archive/index.js'
-import { announceArchiveChannel } from '../src/archive/publisher.js'
+import { announceArchiveChannel, createArchivePublisher } from '../src/archive/publisher.js'
 
 function makeFakeMetaDb() {
   const map = new Map()
@@ -72,6 +72,7 @@ test('archive publisher announces and seeds after public bee content changes', a
   const channelEntry = {
     channelKey: 'aa'.repeat(32),
     publicBeeKey: null,
+    channelName: 'Configured Label',
     channel: {
       async getPublicBeeKey() {
         return 'bb'.repeat(32)
@@ -98,7 +99,7 @@ test('archive publisher announces and seeds after public bee content changes', a
   const runtime = {
     publicFeed: {
       async submitChannel(driveKey, publicBeeKey, options) {
-        calls.push(['submit', driveKey, publicBeeKey, videoCount, options?.previewVideos?.map((video) => video.blobId) || []])
+        calls.push(['submit', driveKey, publicBeeKey, videoCount, options?.previewVideos?.map((video) => video.blobId) || [], options?.channelName || null, options?.previewVideos?.map((video) => video.channelName || null) || []])
       }
     },
     cacheManager: {
@@ -119,15 +120,59 @@ test('archive publisher announces and seeds after public bee content changes', a
 
   t.is(channelEntry.publicBeeKey, 'bb'.repeat(32))
   t.alike(calls, [
-    ['submit', 'aa'.repeat(32), 'bb'.repeat(32), 0, []],
+    ['submit', 'aa'.repeat(32), 'bb'.repeat(32), 0, [], 'Configured Label', []],
     ['pin', 'aa'.repeat(32), 'bb'.repeat(32), 0],
     ['seed', 'aa'.repeat(32), 'bb'.repeat(32), 0, []],
-    ['submit', 'aa'.repeat(32), 'bb'.repeat(32), 1, ['0:4:0:4096']],
+    ['submit', 'aa'.repeat(32), 'bb'.repeat(32), 1, ['0:4:0:4096'], 'Configured Label', ['Configured Label']],
     ['pin', 'aa'.repeat(32), 'bb'.repeat(32), 1],
     ['seed', 'aa'.repeat(32), 'bb'.repeat(32), 1, ['0:4:0:4096']],
   ])
 })
 
+test('archive publisher derives YouTube channel name from yt-dlp uploader metadata', async (t) => {
+  const channels = []
+  const source = {
+    sourceId: 'youtube:UCactual',
+    url: 'https://www.youtube.com/channel/UCactual',
+    type: 'youtube',
+    kind: 'channel',
+    identifier: 'UCactual'
+  }
+  const channel = {
+    writable: true,
+    async getMetadata() { return {} },
+    async updateMetadata(meta) { channels.push(meta) },
+    async ensureLocalBlobDrive() {},
+    async getPublicBeeKey() { return 'bb'.repeat(32) },
+    async listVideos() { return [] }
+  }
+  const publisher = createArchivePublisher({
+    ctx: {},
+    uploadManager: {
+      async uploadFromPath(_channel, _filePath, options) {
+        return { success: true, videoId: options.title }
+      },
+    },
+    runtime: {
+      publicFeed: { async submitChannel() {} },
+      cacheManager: { async pinChannel() {} },
+      seeder: { async seedChannel() {} },
+    },
+    fs: makeFakeFs({ '/tmp/video.mp4': 'video bytes' }),
+    logger: makeFakeLogger(),
+    state: null,
+    createChannelFn: async () => ({ channel, channelKeyHex: 'aa'.repeat(32) })
+  })
+
+  await publisher.publishVideo({
+    source,
+    ytEntry: { id: 'yt1', title: 'Video', uploader: 'Actual Creator', duration: 1 },
+    files: { videoFile: '/tmp/video.mp4' }
+  })
+
+  t.is(channels.length, 1)
+  t.is(channels[0].name, 'Actual Creator')
+})
 test('classifySourceUrl recognises YouTube channels, handles, and playlists', (t) => {
   t.alike(classifySourceUrl('https://www.youtube.com/@somechannel'), {
     type: 'youtube',


### PR DESCRIPTION
## Summary
- preserve explicit archive channel names in public-feed submissions before slower provider hydration
- derive archive channel metadata from yt-dlp uploader/creator metadata when available
- include channel names on preview videos so feed cards show the actual YouTube creator/channel instead of generic IDs

## Test Plan
- `node --check src/archive/publisher.js` from `packages/cli`
- `npm exec -- brittle test/archive.test.mjs` from `packages/cli`
- `node --check src/public-feed.js` from `packages/backend`
- `npm exec -- node --test test/public-feed-manager.test.mjs` from `packages/backend`
- `npm run lint:changed`
- `./node_modules/.bin/eslint --quiet packages/backend/src/public-feed.js packages/cli/src/archive/publisher.js`
- `git diff --check`

Note: full root `npm run lint -- --quiet ...` incorrectly lints the whole repo because the script hardcodes `eslint .`; it still fails on existing unrelated app/backend/platform lint debt. Targeted eslint for the changed source files passes.
