### PR TITLE
fix: add shorts comments sheet and raise progress

### DIFF
--- a/packages/app/app/(tabs)/discover.tsx
+++ b/packages/app/app/(tabs)/discover.tsx
@@ -36,6 +36,7 @@ import { getCachedVideoUrl, makeVideoUrlCacheKey, setCachedVideoUrl } from '@/li
 import { readDiscoverFeedCache, writeDiscoverFeedCache } from '@/lib/discover-feed-cache'
 import { formatTimeAgo } from '@/lib/formatters'
 import { VerticalShortsPlayer } from '@/components/discovery/VerticalShortsPlayer'
+import { ShortsCommentsSheet } from '@/components/discovery/ShortsCommentsSheet'
 import { useVideoPlayerContext } from '@/lib/VideoPlayerContext'
 
 interface FeedEntry {
@@ -115,6 +116,7 @@ export default function VerticalDiscoveryScreen() {
     playerMode,
     pauseVideo,
     closeVideo,
+    setAmbientVideoContext,
   } = useVideoPlayerContext()
 
   const pageHeight = Math.max(1, screenHeight - insets.top)
@@ -132,6 +134,7 @@ export default function VerticalDiscoveryScreen() {
   const [shortsPlaybackSession, setShortsPlaybackSession] = useState(0)
   const [shortsLoading, setShortsLoading] = useState(false)
   const [shortsChromeVisible, setShortsChromeVisible] = useState(true)
+  const [commentsSheetVisible, setCommentsSheetVisible] = useState(false)
   const shortsPlayerRef = useRef<any>(null)
   const pendingPlayKeyRef = useRef<string | null>(null)
   const playbackRequestSeqRef = useRef(0)
@@ -287,6 +290,7 @@ export default function VerticalDiscoveryScreen() {
     pendingPlayKeyRef.current = null
     playbackRequestSeqRef.current += 1
     setShortsVideoUrl(null)
+    setCommentsSheetVisible(false)
     setShortsLoading(false)
   }, [])
 
@@ -317,6 +321,7 @@ export default function VerticalDiscoveryScreen() {
       if (cachedUrl) {
         void rpc.preparePlayback(playbackRequest).catch(() => undefined)
         if (isStalePlaybackRequest()) return
+        setAmbientVideoContext(video, cachedUrl)
         setShortsVideoUrl(cachedUrl)
         setShortsPlaybackSession((prev) => prev + 1)
         setShortsLoading(false)
@@ -327,6 +332,7 @@ export default function VerticalDiscoveryScreen() {
       if (isStalePlaybackRequest()) return
       if (result?.url) {
         if (cacheKey) setCachedVideoUrl(cacheKey, result.url)
+        setAmbientVideoContext(video, result.url)
         setShortsVideoUrl(result.url)
         setShortsPlaybackSession((prev) => prev + 1)
       }
@@ -340,7 +346,7 @@ export default function VerticalDiscoveryScreen() {
         setShortsLoading(false)
       }
     }
-  }, [handoffToShorts, makePlaybackRequest, rpc])
+  }, [handoffToShorts, makePlaybackRequest, rpc, setAmbientVideoContext])
 
   useEffect(() => {
     if (!activeVideo || !ready) return
@@ -407,6 +413,12 @@ export default function VerticalDiscoveryScreen() {
       },
     })
   }, [router])
+
+  const openComments = useCallback((video: VideoData) => {
+    setAmbientVideoContext(video, activeVideoKey === `${video.channelKey}:${video.id}` ? shortsVideoUrl : null)
+    setShortsChromeVisible(true)
+    setCommentsSheetVisible(true)
+  }, [activeVideoKey, setAmbientVideoContext, shortsVideoUrl])
 
   const verticalVideos = useMemo(() => videos.map((video) => {
     const cacheKey = `${video.channelKey}:${video.id}`
@@ -487,6 +499,7 @@ export default function VerticalDiscoveryScreen() {
                     isLoading={shortsLoading && activeVideoKey === `${video.channelKey}:${video.id}`}
                     thumbnailUrl={video.thumbnailUrl || null}
                     controlsVisible={shortsChromeVisible}
+                    progressBottomOffset={Math.max(insets.bottom + 140, 158)}
                     onControlsVisibleChange={setShortsChromeVisible}
                     onReplay={() => playVideo(video)}
                   />
@@ -507,9 +520,9 @@ export default function VerticalDiscoveryScreen() {
                         <Feather name="user" color="#fff" size={24} />
                         <Text style={styles.sideLabel}>Channel</Text>
                       </Pressable>
-                      <Pressable onPress={() => openDetails(video)} style={styles.sideButton}>
+                      <Pressable onPress={() => openComments(video)} style={styles.sideButton}>
                         <Feather name="message-circle" color="#fff" size={24} />
-                        <Text style={styles.sideLabel}>Details</Text>
+                        <Text style={styles.sideLabel}>Comments</Text>
                       </Pressable>
                       <Pressable onPress={() => playVideo(video)} style={styles.sideButton}>
                         <Feather name="rotate-cw" color="#fff" size={24} />
@@ -523,6 +536,7 @@ export default function VerticalDiscoveryScreen() {
           )}
         />
       )}
+      <ShortsCommentsSheet visible={commentsSheetVisible} onClose={() => setCommentsSheetVisible(false)} />
     </View>
   )
 }

--- a/packages/app/components/discovery/ShortsCommentsSheet.tsx
+++ b/packages/app/components/discovery/ShortsCommentsSheet.tsx
@@ -1,0 +1,108 @@
+import { memo } from 'react'
+import { Modal, Pressable, ScrollView, StyleSheet, View } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { useSocial } from '@/lib/SocialContext'
+import { CommentsSection } from '@/components/video-player'
+
+type ShortsCommentsSheetProps = {
+  visible: boolean
+  onClose: () => void
+}
+
+export const ShortsCommentsSheet = memo(function ShortsCommentsSheet({ visible, onClose }: ShortsCommentsSheetProps) {
+  const insets = useSafeAreaInsets()
+  const {
+    commentText,
+    setCommentText,
+    replyToComment,
+    setReplyToComment,
+    commentsLoading,
+    postingComment,
+    hasMoreComments,
+    loadingMoreComments,
+    refreshingComments,
+    deletingCommentId,
+    refreshComments,
+    loadMoreComments,
+    postComment,
+    deleteComment,
+    displayComments,
+    organizedComments,
+  } = useSocial()
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <View style={styles.modalRoot}>
+        <Pressable style={styles.backdrop} onPress={onClose} accessibilityLabel="Close Shorts comments" />
+        <View style={[styles.sheet, { paddingBottom: Math.max(insets.bottom, 16) }]}>
+          <View style={styles.handle} />
+          <ScrollView
+            style={styles.scroll}
+            contentContainerStyle={styles.scrollContent}
+            keyboardShouldPersistTaps="handled"
+            showsVerticalScrollIndicator={false}
+          >
+            <CommentsSection
+              organizedComments={organizedComments}
+              displayCommentsCount={displayComments.length}
+              commentsLoading={commentsLoading}
+              hasMoreComments={hasMoreComments}
+              loadingMoreComments={loadingMoreComments}
+              refreshingComments={refreshingComments}
+              commentText={commentText}
+              replyToComment={replyToComment}
+              postingComment={postingComment}
+              deletingCommentId={deletingCommentId}
+              onChangeCommentText={setCommentText}
+              onSetReplyToComment={setReplyToComment}
+              onRefreshComments={refreshComments}
+              onLoadMoreComments={loadMoreComments}
+              onPostComment={postComment}
+              onDeleteComment={deleteComment}
+              isOwnComment={() => false}
+            />
+          </ScrollView>
+        </View>
+      </View>
+    </Modal>
+  )
+})
+
+const styles = StyleSheet.create({
+  modalRoot: {
+    flex: 1,
+    justifyContent: 'flex-end',
+  },
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0,0,0,0.55)',
+  },
+  sheet: {
+    maxHeight: '78%',
+    minHeight: '45%',
+    borderTopLeftRadius: 28,
+    borderTopRightRadius: 28,
+    backgroundColor: '#0b0d10',
+    borderTopWidth: 1,
+    borderLeftWidth: 1,
+    borderRightWidth: 1,
+    borderColor: 'rgba(255,255,255,0.1)',
+    overflow: 'hidden',
+  },
+  handle: {
+    width: 42,
+    height: 5,
+    borderRadius: 999,
+    backgroundColor: 'rgba(255,255,255,0.32)',
+    alignSelf: 'center',
+    marginTop: 10,
+    marginBottom: 2,
+  },
+  scroll: {
+    flexGrow: 0,
+  },
+  scrollContent: {
+    paddingHorizontal: 18,
+    paddingTop: 12,
+  },
+})

--- a/packages/app/components/discovery/VerticalShortsPlayer.tsx
+++ b/packages/app/components/discovery/VerticalShortsPlayer.tsx
@@ -16,6 +16,7 @@ type VerticalShortsPlayerProps = {
   isLoading?: boolean
   thumbnailUrl?: string | null
   controlsVisible?: boolean
+  progressBottomOffset?: number
   onControlsVisibleChange?: (visible: boolean) => void
   onReplay?: () => void
 }
@@ -39,6 +40,7 @@ export const VerticalShortsPlayer = memo(function VerticalShortsPlayer({
   isLoading = false,
   thumbnailUrl,
   controlsVisible = true,
+  progressBottomOffset = 150,
   onControlsVisibleChange,
   onReplay,
 }: VerticalShortsPlayerProps) {
@@ -190,7 +192,7 @@ export const VerticalShortsPlayer = memo(function VerticalShortsPlayer({
       ) : null}
 
       {showPlayer ? (
-        <View style={styles.progressDock} pointerEvents="box-none">
+        <View style={[styles.progressDock, { bottom: progressBottomOffset }]} pointerEvents="box-none">
           {controlsVisible ? (
             <View style={styles.controlButtons} pointerEvents="box-none">
               <Pressable
@@ -261,7 +263,6 @@ const styles = StyleSheet.create({
     position: 'absolute',
     left: 0,
     right: 0,
-    bottom: 0,
     paddingHorizontal: 18,
     paddingBottom: 18,
   },

--- a/packages/app/lib/VideoPlayerContext.tsx
+++ b/packages/app/lib/VideoPlayerContext.tsx
@@ -78,6 +78,7 @@ interface VideoPlayerContextType {
 
   // Actions
   loadAndPlayVideo: (video: VideoData, url: string) => void
+  setAmbientVideoContext: (video: VideoData | null, url?: string | null) => void
   pauseVideo: () => void
   resumeVideo: () => void
   closeVideo: () => void
@@ -846,6 +847,25 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
     startInActivityPlayback(video, url, 'direct-load')
   }, [startInActivityPlayback])
 
+  const setAmbientVideoContext = useCallback((video: VideoData | null, url: string | null = null) => {
+    const currentKey = currentVideoRef.current
+      ? `${currentVideoRef.current.channelKey || ''}:${currentVideoRef.current.id || currentVideoRef.current.path || ''}`
+      : null
+    const nextKey = video ? `${video.channelKey || ''}:${video.id || video.path || ''}` : null
+
+    currentVideoRef.current = video
+    videoUrlRef.current = url
+    dispatch({ type: 'SET_AMBIENT_VIDEO_CONTEXT', source: 'setAmbientVideoContext', video, url })
+
+    if (video && currentKey !== nextKey) {
+      setVideoStats(null)
+      setCurrentTime(0)
+      setDuration(0)
+      setVideoAspectRatio(null)
+      _videoLoadEventEmitter.emit(video)
+    }
+  }, [dispatch])
+
   // Pause video
   const pauseVideo = useCallback(() => {
     console.log('[VideoPlayerContext] Pausing video')
@@ -1226,6 +1246,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
     seekPosition,
     playerRef,
     loadAndPlayVideo,
+    setAmbientVideoContext,
     pauseVideo,
     resumeVideo,
     closeVideo,
@@ -1258,7 +1279,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
     // High-frequency dependencies (progress - NOTE: this still causes re-renders at 4Hz)
     currentTime, duration, progress,
     // Callbacks (stable references via useCallback)
-    loadAndPlayVideo, pauseVideo, resumeVideo,
+    loadAndPlayVideo, setAmbientVideoContext, pauseVideo, resumeVideo,
     closeVideo, enterBackgroundAudio, suppressForegroundRestoreOnce, suppressForegroundRestoreFor, clearLastClosedVideo, minimizePlayer, maximizePlayer, seekTo, seekBy, setPlaybackRate,
     setIsInPipMode,
     onProgress, onLoaded, onPlaying, onPaused, onBuffering,

--- a/packages/app/lib/playerStateMachine.ts
+++ b/packages/app/lib/playerStateMachine.ts
@@ -30,8 +30,8 @@ type PlaybackMemory = {
 
 type HiddenPlayerState = PlaybackMemory & {
   mode: 'hidden'
-  video: null
-  url: null
+  video: VideoData | null
+  url: string | null
 }
 
 type ActivePlayerState = PlaybackMemory & {
@@ -54,6 +54,7 @@ export type TransitionSource =
   | 'minimizePlayer'
   | 'maximizePlayer'
   | 'enterBackgroundAudio'
+  | 'setAmbientVideoContext'
 
 export type PlayerEvent =
   | {
@@ -61,6 +62,12 @@ export type PlayerEvent =
       source: 'loadAndPlayVideo'
       video: VideoData
       url: string
+    }
+  | {
+      type: 'SET_AMBIENT_VIDEO_CONTEXT'
+      source: 'setAmbientVideoContext'
+      video: VideoData | null
+      url?: string | null
     }
   | {
       type: 'RESTORE_FROM_LAST_CLOSED'
@@ -353,6 +360,13 @@ function playerReducerInternal(state: PlayerState, event: PlayerEvent): PlayerSt
       switch (event.type) {
         case 'LOAD_VIDEO':
           return toFullscreenState(state, event.video, event.url, true)
+        case 'SET_AMBIENT_VIDEO_CONTEXT':
+          return {
+            ...state,
+            mode: 'hidden',
+            video: event.video,
+            url: event.url || null,
+          }
         case 'RESTORE_FROM_LAST_CLOSED':
           return toFullscreenState(state, event.video, event.url, false)
         case 'FORCE_RELOAD_PLAYBACK':
@@ -398,6 +412,7 @@ function playerReducerInternal(state: PlayerState, event: PlayerEvent): PlayerSt
       switch (event.type) {
         case 'LOAD_VIDEO':
         case 'RESTORE_FROM_LAST_CLOSED':
+        case 'SET_AMBIENT_VIDEO_CONTEXT':
         case 'APP_BACKGROUND':
         case 'APP_FOREGROUND':
         case 'REMOTE_PLAY':
@@ -446,6 +461,12 @@ function playerReducerInternal(state: PlayerState, event: PlayerEvent): PlayerSt
         case 'LOAD_VIDEO':
           // Allow loading a new video while in fullscreen (e.g., tapping related video)
           return toFullscreenState(state, event.video, event.url, true)
+        case 'SET_AMBIENT_VIDEO_CONTEXT':
+          return {
+            ...state,
+            video: event.video,
+            url: event.url || null,
+          }
         case 'RESTORE_FROM_LAST_CLOSED':
           return invalidTransition(state, event)
         case 'CLOSE_VIDEO':
@@ -500,6 +521,12 @@ function playerReducerInternal(state: PlayerState, event: PlayerEvent): PlayerSt
           // Allow loading a new video from mini mode — transitions to fullscreen.
           // This happens when user taps a new video while mini player is active.
           return toFullscreenState(state, event.video, event.url, true)
+        case 'SET_AMBIENT_VIDEO_CONTEXT':
+          return {
+            ...state,
+            video: event.video,
+            url: event.url || null,
+          }
         case 'RESTORE_FROM_LAST_CLOSED':
           return invalidTransition(state, event)
         case 'PIP_ENTERED_ANDROID':
@@ -593,6 +620,7 @@ function playerReducerInternal(state: PlayerState, event: PlayerEvent): PlayerSt
       switch (event.type) {
         case 'LOAD_VIDEO':
         case 'RESTORE_FROM_LAST_CLOSED':
+        case 'SET_AMBIENT_VIDEO_CONTEXT':
         case 'FORCE_RELOAD_PLAYBACK':
         case 'MINIMIZE':
         case 'MAXIMIZE':
@@ -632,6 +660,7 @@ function playerReducerInternal(state: PlayerState, event: PlayerEvent): PlayerSt
       switch (event.type) {
         case 'LOAD_VIDEO':
         case 'RESTORE_FROM_LAST_CLOSED':
+        case 'SET_AMBIENT_VIDEO_CONTEXT':
         case 'FORCE_RELOAD_PLAYBACK':
         case 'MINIMIZE':
         case 'MAXIMIZE':
@@ -690,6 +719,7 @@ function playerReducerInternal(state: PlayerState, event: PlayerEvent): PlayerSt
       switch (event.type) {
         case 'LOAD_VIDEO':
         case 'RESTORE_FROM_LAST_CLOSED':
+        case 'SET_AMBIENT_VIDEO_CONTEXT':
         case 'FORCE_RELOAD_PLAYBACK':
         case 'MINIMIZE':
         case 'MAXIMIZE':


### PR DESCRIPTION
## Summary
- moves the Shorts progress bar higher above the bottom metadata/actions, closer to X/Twitter placement
- opens a reusable comments bottom sheet from the Shorts message action instead of routing to Details
- adds ambient video context wiring so the existing SocialContext/CommentsSection can load comments for the active Shorts video without launching the normal playback overlay

## Test Plan
- `node --test packages/app/tests/vertical-discovery-regression.test.mjs`
- `./node_modules/.bin/eslint --quiet 'packages/app/app/(tabs)/discover.tsx' packages/app/components/discovery/VerticalShortsPlayer.tsx packages/app/components/discovery/ShortsCommentsSheet.tsx packages/app/lib/VideoPlayerContext.tsx packages/app/lib/playerStateMachine.ts`
- `git diff --check`

## Notes
- `npm run lint:changed` reported `No changed JS/TS files to lint` before commit, so targeted ESLint was run directly against the changed files.
- Full local project typecheck is currently blocked by broad existing environment/dependency issues such as missing React declarations, missing Expo/router/safe-area packages, and existing unrelated app type errors.
