### PR TITLE
fix: keep shorts discover chrome clear

### DIFF
--- a/packages/app/app/(tabs)/discover.tsx
+++ b/packages/app/app/(tabs)/discover.tsx
@@ -119,6 +119,7 @@ export default function VerticalDiscoveryScreen() {
     setAmbientVideoContext,
   } = useVideoPlayerContext()
 
+  const bottomChromePadding = Math.max(insets.bottom + 86, 104)
   const pageHeight = Math.max(1, screenHeight - insets.top)
   const cachedDiscoverFeed = useMemo(() => readDiscoverFeedCache(), [])
   const [refreshing, setRefreshing] = useState(false)
@@ -304,7 +305,8 @@ export default function VerticalDiscoveryScreen() {
     if (!currentVideo || playerMode === 'hidden') return
     pauseVideo()
     closeVideo()
-  }, [closeVideo, currentVideo, pauseVideo, playerMode])
+    setAmbientVideoContext(null, null)
+  }, [closeVideo, currentVideo, pauseVideo, playerMode, setAmbientVideoContext])
 
   const playVideo = useCallback(async (video: VideoData) => {
     if (!rpc) return
@@ -499,13 +501,13 @@ export default function VerticalDiscoveryScreen() {
                     isLoading={shortsLoading && activeVideoKey === `${video.channelKey}:${video.id}`}
                     thumbnailUrl={video.thumbnailUrl || null}
                     controlsVisible={shortsChromeVisible}
-                    progressBottomOffset={Math.max(insets.bottom + 140, 158)}
+                    progressBottomOffset={bottomChromePadding}
                     onControlsVisibleChange={setShortsChromeVisible}
                     onReplay={() => playVideo(video)}
                   />
                 </View>
                 {shortsChromeVisible ? (
-                  <View style={[styles.bottomMeta, { paddingBottom: Math.max(insets.bottom + 116, 134) }]}>
+                  <View style={[styles.bottomMeta, { paddingBottom: bottomChromePadding + 22 }]}>
                     <Pressable onPress={() => openDetails(video)} style={styles.metaTextBlock}>
                       <Text style={styles.videoTitle} numberOfLines={2}>{video.title || 'Untitled'}</Text>
                       <Text style={styles.videoMeta} numberOfLines={1}>

--- a/packages/app/components/VideoPlayerOverlayImpl.tsx
+++ b/packages/app/components/VideoPlayerOverlayImpl.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useContext, useEffect, useState, useRef, useMemo } from 'react'
 import { View, Text, Pressable, StyleSheet, useWindowDimensions, Platform, ScrollView, ActivityIndicator, Alert, StatusBar, Dimensions, TextInput, AppState } from 'react-native'
+import { usePathname } from 'expo-router'
 import { rpc } from '@peartube/platform/rpc'
 import { SafeAreaInsetsContext } from 'react-native-safe-area-context'
 import { GestureDetector, Gesture } from 'react-native-gesture-handler'
@@ -97,6 +98,7 @@ const ZERO_EDGE_INSETS = Object.freeze({ top: 0, right: 0, bottom: 0, left: 0 })
 
 export function VideoPlayerOverlay() {
   const insets = useContext(SafeAreaInsetsContext) ?? ZERO_EDGE_INSETS
+  const pathname = usePathname()
   const { width: windowWidth, height: windowHeight } = useWindowDimensions()
   const screenMetrics = Dimensions.get('screen')
   const { isDesktop, isPear } = usePlatform()
@@ -371,10 +373,13 @@ export function VideoPlayerOverlay() {
   // Mini player corner/drag state
   const [pendingLandscapeExit, setPendingLandscapeExit] = useState(false)
   const disableMiniLayoutOnAndroidSplit = Platform.OS === 'android' && androidSplitPlayerEnabled
+  const isDiscoverPathActive = pathname === '/discover' || pathname === '/(tabs)/discover'
+  const hideGlobalOverlayOnDiscover = !isDesktop && isDiscoverPathActive
   const showLegacyMiniUi =
     playerMode === 'mini' &&
     !isLandscapeFullscreen &&
     !isInPipMode &&
+    !hideGlobalOverlayOnDiscover &&
     !disableMiniLayoutOnAndroidSplit
   const isLandscapeFullscreenShared = useSharedValue(false)
   const [channelMetaName, setChannelMetaName] = useState<string | null>(null)
@@ -2050,6 +2055,10 @@ export function VideoPlayerOverlay() {
   }, [currentVideo, playerMode, videoUrl, isPear, isDesktop])
 
   if (!currentVideo) {
+    return null
+  }
+
+  if (hideGlobalOverlayOnDiscover && playerMode !== 'hidden' && !isInPipMode) {
     return null
   }
 

--- a/packages/app/tests/vertical-discovery-regression.test.mjs
+++ b/packages/app/tests/vertical-discovery-regression.test.mjs
@@ -215,6 +215,25 @@ test('vertical discovery updates feed entries when previews change without chann
   assert.match(source, /prevSignature === nextSignature \? prev : entries/, 'unchanged signatures may preserve state, changed previews must update entries')
 })
 
+test('vertical discovery keeps the global watch/mini overlay off the Shorts route', () => {
+  const discoverSource = readAppFile('app/(tabs)/discover.tsx')
+  const overlaySource = readAppFile('components/VideoPlayerOverlayImpl.tsx')
+
+  assert.match(discoverSource, /closeVideo\(\)\n\s*setAmbientVideoContext\(null, null\)/, 'handoff should clear ambient player context after closing the global player')
+  assert.match(overlaySource, /usePathname\(\)/, 'global overlay should know the active route')
+  assert.match(overlaySource, /const hideGlobalOverlayOnDiscover = !isDesktop && isDiscoverPathActive/, 'mobile Discover should suppress the global watch overlay')
+  assert.match(overlaySource, /hideGlobalOverlayOnDiscover && playerMode !== 'hidden' && !isInPipMode/, 'Discover should not show stale mini/fullscreen overlays over Shorts')
+})
+
+test('vertical discovery positions progress above bottom chrome without colliding with metadata', () => {
+  const source = readAppFile('app/(tabs)/discover.tsx')
+
+  assert.match(source, /const bottomChromePadding = Math\.max\(insets\.bottom \+ 86, 104\)/, 'Discover should compute a tab-safe bottom chrome inset')
+  assert.match(source, /progressBottomOffset=\{bottomChromePadding\}/, 'Shorts progress should sit just above the tab bar, not under metadata')
+  assert.match(source, /paddingBottom: bottomChromePadding \+ 22/, 'metadata should reserve extra space above the progress bar')
+  assert.doesNotMatch(source, /progressBottomOffset=\{Math\.max\(insets\.bottom \+ 140, 158\)\}/, 'old low progress offset caused title/source overlap')
+})
+
 test('vertical discovery stops inline Shorts playback when the route unmounts or loses focus', () => {
   const source = readAppFile('app/(tabs)/discover.tsx')
 


### PR DESCRIPTION
## Summary
- Hide the stale global watch/mini overlay on the mobile Discover Shorts route
- Clear ambient global player context during Shorts handoff so the old mini-player cannot cover the feed
- Move the Shorts progress bar above bottom chrome and reserve metadata padding so title/source/actions do not collide
- Add source-level regressions for the overlay suppression and progress/metadata spacing contracts

## Test Plan
- `node --test packages/app/tests/vertical-discovery-regression.test.mjs`
- `./node_modules/.bin/eslint --quiet packages/app/app/'(tabs)'/discover.tsx packages/app/components/VideoPlayerOverlayImpl.tsx packages/app/tests/vertical-discovery-regression.test.mjs`
- `git diff --check`

## Notes
- `npm run lint:changed` reported `No changed JS/TS files to lint`, so I ran ESLint directly on the changed files.
