### PR TITLE
fix: declutter shorts playback chrome

### DIFF
--- a/packages/app/app/(tabs)/discover.tsx
+++ b/packages/app/app/(tabs)/discover.tsx
@@ -120,6 +120,8 @@ export default function VerticalDiscoveryScreen() {
   } = useVideoPlayerContext()
 
   const bottomChromePadding = Math.max(insets.bottom + 86, 104)
+  const metaBottomPadding = bottomChromePadding + 56
+  const progressBottomOffset = bottomChromePadding + 16
   const pageHeight = Math.max(1, screenHeight - insets.top)
   const cachedDiscoverFeed = useMemo(() => readDiscoverFeedCache(), [])
   const [refreshing, setRefreshing] = useState(false)
@@ -459,6 +461,10 @@ export default function VerticalDiscoveryScreen() {
         </View>
       </View>
 
+      {shortsChromeVisible ? (
+        <View pointerEvents="none" style={[styles.topChromeFade, { height: Math.max(insets.top + 112, 136) }]} />
+      ) : null}
+
       {verticalVideos.length === 0 ? (
         <View style={styles.centerState}>
           {feedLoading || !ready ? <ActivityIndicator color={colors.primary} size="large" /> : null}
@@ -501,20 +507,20 @@ export default function VerticalDiscoveryScreen() {
                     isLoading={shortsLoading && activeVideoKey === `${video.channelKey}:${video.id}`}
                     thumbnailUrl={video.thumbnailUrl || null}
                     controlsVisible={shortsChromeVisible}
-                    progressBottomOffset={bottomChromePadding}
+                    progressBottomOffset={progressBottomOffset}
                     onControlsVisibleChange={setShortsChromeVisible}
                     onReplay={() => playVideo(video)}
                   />
                 </View>
                 {shortsChromeVisible ? (
-                  <View style={[styles.bottomMeta, { paddingBottom: bottomChromePadding + 22 }]}>
+                  <View style={[styles.bottomMeta, { paddingBottom: metaBottomPadding }]}>
                     <Pressable onPress={() => openDetails(video)} style={styles.metaTextBlock}>
                       <Text style={styles.videoTitle} numberOfLines={2}>{video.title || 'Untitled'}</Text>
                       <Text style={styles.videoMeta} numberOfLines={1}>
                         {video.channel?.name || 'Channel'} · {formatTimeAgo(video.uploadedAt || Date.now())}
                       </Text>
                       {video.description ? (
-                        <Text style={styles.videoDescription} numberOfLines={2}>{video.description}</Text>
+                        <Text style={styles.videoDescription} numberOfLines={1}>{video.description}</Text>
                       ) : null}
                     </Pressable>
                     <View style={styles.sideRail}>
@@ -607,6 +613,14 @@ const styles = StyleSheet.create({
   page: {
     backgroundColor: '#050607',
   },
+  topChromeFade: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    zIndex: 9,
+    backgroundColor: 'rgba(0,0,0,0.36)',
+  },
   backdrop: {
     flex: 1,
     justifyContent: 'center',
@@ -626,19 +640,21 @@ const styles = StyleSheet.create({
   bottomMeta: {
     position: 'absolute',
     left: 18,
-    right: 16,
+    right: 14,
     bottom: 0,
     flexDirection: 'row',
     alignItems: 'flex-end',
-    gap: 14,
+    gap: 10,
   },
   metaTextBlock: {
     flex: 1,
-    paddingRight: 4,
+    minWidth: 0,
+    paddingRight: 2,
   },
   videoTitle: {
     color: '#fff',
-    fontSize: 22,
+    fontSize: 20,
+    lineHeight: 24,
     fontWeight: '800',
     letterSpacing: -0.5,
     textShadowColor: 'rgba(0,0,0,0.45)',
@@ -647,28 +663,29 @@ const styles = StyleSheet.create({
   },
   videoMeta: {
     color: 'rgba(255,255,255,0.78)',
-    fontSize: 13,
+    fontSize: 12,
     fontWeight: '600',
-    marginTop: 8,
+    marginTop: 6,
   },
   videoDescription: {
-    color: 'rgba(255,255,255,0.72)',
-    fontSize: 14,
-    lineHeight: 19,
-    marginTop: 8,
+    color: 'rgba(255,255,255,0.68)',
+    fontSize: 12,
+    lineHeight: 16,
+    marginTop: 5,
   },
   sideRail: {
-    width: 72,
+    width: 58,
     alignItems: 'center',
-    gap: 20,
+    gap: 14,
   },
   sideButton: {
     alignItems: 'center',
-    gap: 6,
+    gap: 4,
   },
   sideLabel: {
     color: 'rgba(255,255,255,0.82)',
-    fontSize: 11,
+    fontSize: 10,
+    lineHeight: 12,
     fontWeight: '700',
   },
   centerState: {

--- a/packages/app/tests/vertical-discovery-regression.test.mjs
+++ b/packages/app/tests/vertical-discovery-regression.test.mjs
@@ -226,12 +226,18 @@ test('vertical discovery keeps the global watch/mini overlay off the Shorts rout
   assert.match(overlaySource, /hideGlobalOverlayOnDiscover && playerMode !== 'hidden' && !isInPipMode/, 'Discover should not show stale mini/fullscreen overlays over Shorts')
 })
 
-test('vertical discovery positions progress above bottom chrome without colliding with metadata', () => {
+test('vertical discovery positions progress and chrome without clumping metadata/actions', () => {
   const source = readAppFile('app/(tabs)/discover.tsx')
 
   assert.match(source, /const bottomChromePadding = Math\.max\(insets\.bottom \+ 86, 104\)/, 'Discover should compute a tab-safe bottom chrome inset')
-  assert.match(source, /progressBottomOffset=\{bottomChromePadding\}/, 'Shorts progress should sit just above the tab bar, not under metadata')
-  assert.match(source, /paddingBottom: bottomChromePadding \+ 22/, 'metadata should reserve extra space above the progress bar')
+  assert.match(source, /const metaBottomPadding = bottomChromePadding \+ 56/, 'metadata should sit well above progress and nav chrome')
+  assert.match(source, /const progressBottomOffset = bottomChromePadding \+ 16/, 'progress should sit between metadata and bottom chrome')
+  assert.match(source, /progressBottomOffset=\{progressBottomOffset\}/, 'Shorts progress should use the separated progress offset')
+  assert.match(source, /paddingBottom: metaBottomPadding/, 'metadata should reserve its own larger bottom offset')
+  assert.match(source, /numberOfLines=\{1\}>\{video\.description\}/, 'description/source copy should not grow into controls while playing')
+  assert.match(source, /styles\.topChromeFade/, 'header should have a subtle backing fade over active video')
+  assert.match(source, /sideRail:\s*\{[\s\S]*width: 58[\s\S]*gap: 14/, 'side action rail should stay compact enough to avoid title overlap')
+  assert.match(source, /metaTextBlock:\s*\{[\s\S]*minWidth: 0/, 'metadata text should shrink instead of pushing into action controls')
   assert.doesNotMatch(source, /progressBottomOffset=\{Math\.max\(insets\.bottom \+ 140, 158\)\}/, 'old low progress offset caused title/source overlap')
 })
 


### PR DESCRIPTION
## Summary
- Separate bottom offsets for metadata and playback progress so the title/source/action rail do not stack on top of each other
- Compact the Shorts action rail and metadata typography while keeping the tap targets available
- Limit description/source copy to one line during playback to prevent it growing into controls
- Add a subtle header fade behind the Discover chrome over active video
- Extend vertical discovery regressions for anti-clumping layout contracts

## Test Plan
- `node --test packages/app/tests/vertical-discovery-regression.test.mjs`
- `./node_modules/.bin/eslint --quiet packages/app/app/'(tabs)'/discover.tsx packages/app/tests/vertical-discovery-regression.test.mjs`
- `git diff --check`
- `npm run lint:changed` reported `No changed JS/TS files to lint`, so direct ESLint was used for changed files.
