### PR TITLE
Fix UI data truth hydration fallbacks

### DIFF
--- a/packages/app/app/channel/[key].tsx
+++ b/packages/app/app/channel/[key].tsx
@@ -23,6 +23,26 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { ThumbnailImage } from '@/components/video/ThumbnailImage'
 import { colors } from '@/lib/colors'
 
+const CHANNEL_PAGE_RPC_TIMEOUT_MS = 4500
+
+type ChannelPageTimeoutResult = { timedOut: true }
+
+function withChannelPageTimeout<T>(promise: Promise<T>, ms = CHANNEL_PAGE_RPC_TIMEOUT_MS): Promise<T | ChannelPageTimeoutResult> {
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  return Promise.race([
+    promise.finally(() => {
+      if (timeout) clearTimeout(timeout)
+    }),
+    new Promise<ChannelPageTimeoutResult>((resolve) => {
+      timeout = setTimeout(() => resolve({ timedOut: true }), ms)
+    }),
+  ])
+}
+
+function isTimedOutResult(result: unknown): result is { timedOut: true } {
+  return Boolean(result && typeof result === 'object' && (result as any).timedOut === true)
+}
+
 type ChannelMeta = {
   name?: string
   description?: string
@@ -156,6 +176,7 @@ export default function ChannelScreen() {
   const [identityDriveKey, setIdentityDriveKey] = useState('')
   const [isLoading, setIsLoading] = useState(true)
   const [screenError, setScreenError] = useState('')
+  const [videosDegradedMessage, setVideosDegradedMessage] = useState('')
 
   const [isEditModalVisible, setIsEditModalVisible] = useState(false)
   const [editName, setEditName] = useState('')
@@ -204,14 +225,33 @@ export default function ChannelScreen() {
     try {
       setScreenError('')
       setIsLoading(true)
-      const [channelMetaResponse, channelVideosResponse] = await Promise.all([
-        rpc.getChannelMeta({ channelKey, publicBeeKey: channelPublicBeeKey || undefined } as any),
-        rpc.listVideos({ channelKey, publicBeeKey: channelPublicBeeKey || undefined } as any),
+      setVideosDegradedMessage('')
+      const [channelMetaSettled, channelVideosSettled] = await Promise.allSettled([
+        withChannelPageTimeout(rpc.getChannelMeta({ channelKey, publicBeeKey: channelPublicBeeKey || undefined } as any)),
+        withChannelPageTimeout(rpc.listVideos({ channelKey, publicBeeKey: channelPublicBeeKey || undefined } as any)),
       ])
-      const loadedVideos = Array.isArray(channelVideosResponse?.videos) ? channelVideosResponse.videos : []
-      setChannelMeta(channelMetaResponse || null)
-      setChannelVideos(loadedVideos)
-      resolveChannelThumbnails(loadedVideos)
+
+      const metaResult = channelMetaSettled.status === 'fulfilled' ? channelMetaSettled.value : null
+      if (!isTimedOutResult(metaResult) && metaResult) {
+        setChannelMeta(metaResult)
+      }
+
+      const videosResult = channelVideosSettled.status === 'fulfilled' ? channelVideosSettled.value : null
+      if (isTimedOutResult(videosResult)) {
+        setVideosDegradedMessage('Video list is taking longer than expected. Showing any cached channel details; retry to refresh videos.')
+      } else if (channelVideosSettled.status === 'rejected') {
+        setVideosDegradedMessage(channelVideosSettled.reason?.message || 'Failed to load videos. Retry to refresh this channel.')
+      } else if ((videosResult as any)?.success === false) {
+        setVideosDegradedMessage((videosResult as any)?.error || 'Failed to load videos. Retry to refresh this channel.')
+      } else {
+        const loadedVideos = Array.isArray((videosResult as any)?.videos) ? (videosResult as any).videos : []
+        setChannelVideos(loadedVideos)
+        resolveChannelThumbnails(loadedVideos)
+      }
+
+      if (channelMetaSettled.status === 'rejected' && channelVideosSettled.status === 'rejected') {
+        setScreenError(channelMetaSettled.reason?.message || channelVideosSettled.reason?.message || 'Failed to load channel page.')
+      }
     } catch (channelFetchError: any) {
       setScreenError(channelFetchError?.message || 'Failed to load channel page.')
     } finally {
@@ -390,7 +430,19 @@ export default function ChannelScreen() {
               </View>
 
               <View style={styles.videoListSection}>
-            {channelVideos.length === 0 ? (
+            {videosDegradedMessage ? (
+              <View className="mb-4 rounded-xl bg-pear-bg-card border border-pear-border px-4 py-3">
+                <Text className="text-body text-pear-text-secondary" selectable>{videosDegradedMessage}</Text>
+                <PressableFeedback
+                  onPress={fetchChannelPage}
+                  className="mt-3 self-start bg-pear-primary rounded-lg px-4 py-2"
+                  accessibilityRole="button"
+                >
+                  <Text className="text-white text-label">Retry</Text>
+                </PressableFeedback>
+              </View>
+            ) : null}
+            {channelVideos.length === 0 && !videosDegradedMessage ? (
               <View className="py-16 items-center justify-center rounded-xl bg-pear-bg-card border border-pear-border">
                 <Feather name="video-off" size={30} color={colors.textMuted} />
                 <Text className="text-body text-pear-text-secondary mt-3">No videos yet</Text>

--- a/packages/app/app/channel/[key].web.tsx
+++ b/packages/app/app/channel/[key].web.tsx
@@ -38,6 +38,26 @@ type ChannelPageProps = {
   }
 }
 
+const CHANNEL_PAGE_RPC_TIMEOUT_MS = 4500
+
+type ChannelPageTimeoutResult = { timedOut: true }
+
+function withChannelPageTimeout<T>(promise: Promise<T>, ms = CHANNEL_PAGE_RPC_TIMEOUT_MS): Promise<T | ChannelPageTimeoutResult> {
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  return Promise.race([
+    promise.finally(() => {
+      if (timeout) clearTimeout(timeout)
+    }),
+    new Promise<ChannelPageTimeoutResult>((resolve) => {
+      timeout = setTimeout(() => resolve({ timedOut: true }), ms)
+    }),
+  ])
+}
+
+function isTimedOutResult(result: unknown): result is ChannelPageTimeoutResult {
+  return Boolean(result && typeof result === 'object' && (result as any).timedOut === true)
+}
+
 function parseChannelKeyFromHash(hash: string): ChannelRouteParams {
   const normalized = hash.replace(/^#\/?/, '')
   const [pathPart = '', queryPart = ''] = normalized.split('?')
@@ -111,13 +131,30 @@ export default function ChannelPageWeb(props: ChannelPageProps) {
     setLoading(true)
     setError(null)
     try {
-      const [metaResult, videosResult] = await Promise.all([
-        rpc.getChannelMeta({ channelKey: resolvedChannelKey, publicBeeKey: resolvedPublicBeeKey || undefined }),
-        rpc.listVideos({ channelKey: resolvedChannelKey, publicBeeKey: resolvedPublicBeeKey || undefined }),
+      const [metaSettled, videosSettled] = await Promise.allSettled([
+        withChannelPageTimeout(rpc.getChannelMeta({ channelKey: resolvedChannelKey, publicBeeKey: resolvedPublicBeeKey || undefined })),
+        withChannelPageTimeout(rpc.listVideos({ channelKey: resolvedChannelKey, publicBeeKey: resolvedPublicBeeKey || undefined })),
       ])
 
-      setChannelMeta(metaResult || null)
-      setVideos(Array.isArray(videosResult?.videos) ? videosResult.videos : [])
+      const metaResult = metaSettled.status === 'fulfilled' ? metaSettled.value : null
+      if (!isTimedOutResult(metaResult) && metaResult) {
+        setChannelMeta(metaResult || null)
+      }
+
+      const videosResult = videosSettled.status === 'fulfilled' ? videosSettled.value : null
+      if (isTimedOutResult(videosResult)) {
+        setError('Video list is taking longer than expected. Showing cached channel details; retry to refresh videos.')
+      } else if (videosSettled.status === 'rejected') {
+        setError(videosSettled.reason?.message || 'Failed to load videos')
+      } else if ((videosResult as any)?.success === false) {
+        setError((videosResult as any)?.error || 'Failed to load videos')
+      } else {
+        setVideos(Array.isArray((videosResult as any)?.videos) ? (videosResult as any).videos : [])
+      }
+
+      if (metaSettled.status === 'rejected' && videosSettled.status === 'rejected') {
+        setError(metaSettled.reason?.message || videosSettled.reason?.message || 'Failed to load channel')
+      }
     } catch (err: any) {
       setError(err?.message || 'Failed to load channel')
     } finally {

--- a/packages/app/app/video/[id].tsx
+++ b/packages/app/app/video/[id].tsx
@@ -93,9 +93,9 @@ function P2PStatsOverlay({ stats, showDetails, onPress }: {
 // P2P Stats Bar Component - Enhanced with more details
 function P2PStatsBar({ stats }: { stats: VideoStats | null }) {
   const { rpc: appRpc } = useApp()
-  const [globalPeers, setGlobalPeers] = useState(0)
+  const [globalConnections, setGlobalConnections] = useState(0)
 
-  // Fetch global peer count as fallback when video stats are not available yet.
+  // Fetch global connection count as network diagnostics when video stats are not available yet.
   useEffect(() => {
     let mounted = true
     let intervalId: NodeJS.Timeout | null = null
@@ -103,12 +103,9 @@ function P2PStatsBar({ stats }: { stats: VideoStats | null }) {
     const fetchGlobalStatus = async () => {
       try {
         const swarmStatus = await appRpc?.getSwarmStatus?.()
-        const peerCount =
-          swarmStatus?.peerCount ??
-          swarmStatus?.swarmConnections ??
-          swarmStatus?.swarmPeers
-        if (mounted && peerCount !== undefined) {
-          setGlobalPeers(peerCount)
+        const connectionCount = swarmStatus?.swarmConnections ?? swarmStatus?.feedConnections ?? 0
+        if (mounted) {
+          setGlobalConnections(connectionCount)
         }
       } catch {
         // Ignore errors - backend might be unavailable
@@ -126,7 +123,7 @@ function P2PStatsBar({ stats }: { stats: VideoStats | null }) {
     }
   }, [stats, appRpc])
 
-  console.log('[P2PStatsBar] Rendering, stats:', stats ? 'present' : 'null', 'globalPeers:', globalPeers)
+  console.log('[P2PStatsBar] Rendering, stats:', stats ? 'present' : 'null', 'globalConnections:', globalConnections)
 
   // Format bytes to human readable
   const formatBytes = (bytes: number): string => {
@@ -137,8 +134,7 @@ function P2PStatsBar({ stats }: { stats: VideoStats | null }) {
     return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`
   }
 
-  // Get peer count - prefer video stats, fallback to global
-  const peerCount = stats?.peerCount ?? globalPeers
+  const videoPeerCount = stats?.peerCount ?? 0
   const downloadSpeedValue = Number(stats?.speedMBps ?? 0)
   const uploadSpeedValue = Number(stats?.uploadSpeedMBps ?? 0)
   const downloadSpeedText = Number.isFinite(downloadSpeedValue) ? downloadSpeedValue.toFixed(2) : '0.00'
@@ -147,8 +143,7 @@ function P2PStatsBar({ stats }: { stats: VideoStats | null }) {
   // Status color and label
   const getStatusInfo = () => {
     if (!stats) {
-      if (globalPeers > 0) return { color: '#60a5fa', label: 'Connected' }
-      return { color: '#6b7280', label: 'Connecting...' }
+      return { color: '#6b7280', label: 'Waiting for video peers' }
     }
     if (stats.isComplete) return { color: '#4ade80', label: 'Cached' }
     if (stats.status === 'downloading') return { color: '#fbbf24', label: 'Downloading' }
@@ -170,7 +165,7 @@ function P2PStatsBar({ stats }: { stats: VideoStats | null }) {
         </View>
         <View style={styles.statsBarCenter}>
           <Feather name="users" color={colors.textMuted} size={12} />
-          <Text style={styles.statsBarText}>{peerCount} peers</Text>
+          <Text style={styles.statsBarText}>{videoPeerCount} video peer{videoPeerCount !== 1 ? 's' : ''}</Text>
         </View>
         {stats && (
           <View style={styles.statsBarSpeeds}>
@@ -184,6 +179,12 @@ function P2PStatsBar({ stats }: { stats: VideoStats | null }) {
       {stats && !stats.isComplete && (
         <View style={styles.progressBarBg}>
           <View style={[styles.progressBarFill, { width: `${stats.progress || 0}%` }]} />
+        </View>
+      )}
+
+      {!stats && globalConnections > 0 && (
+        <View style={styles.statsBarRow2}>
+          <Text style={styles.statsBarDetail}>Network online: {globalConnections} connection{globalConnections !== 1 ? 's' : ''}</Text>
         </View>
       )}
 

--- a/packages/app/tests/channel-page-hydration-timeout-regression.test.mjs
+++ b/packages/app/tests/channel-page-hydration-timeout-regression.test.mjs
@@ -1,0 +1,37 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const appRoot = path.resolve(__dirname, '..')
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(appRoot, relativePath), 'utf8')
+}
+
+for (const [label, relativePath] of [
+  ['native', 'app/channel/[key].tsx'],
+  ['web', 'app/channel/[key].web.tsx'],
+]) {
+  test(`${label} channel page bounds independent metadata/video hydration`, () => {
+    const source = read(relativePath)
+
+    assert.match(source, /CHANNEL_PAGE_RPC_TIMEOUT_MS = 4500/, `${label} channel page should define a bounded RPC timeout`)
+    assert.match(source, /withChannelPageTimeout/, `${label} channel page should wrap RPC hydration in a timeout`)
+    assert.match(source, /Promise\.allSettled/, `${label} channel page should hydrate metadata and videos independently`)
+    assert.doesNotMatch(
+      source,
+      /await Promise\.all\(\[\s*\n\s*rpc\.getChannelMeta[\s\S]*?rpc\.listVideos/s,
+      `${label} channel page must not block the whole skeleton on one Promise.all`,
+    )
+    assert.match(
+      source,
+      /success\) === false|success === false/,
+      `${label} channel page should treat unsuccessful video-list responses as degraded, not empty`,
+    )
+    assert.match(source, /Retry/, `${label} channel page should leave a retry path in degraded state`)
+  })
+}

--- a/packages/app/tests/p2p-stats-bar-data-truth-regression.test.mjs
+++ b/packages/app/tests/p2p-stats-bar-data-truth-regression.test.mjs
@@ -1,0 +1,43 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const appRoot = path.resolve(__dirname, '..')
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(appRoot, relativePath), 'utf8')
+}
+
+test('P2PStatsBar does not report video connected from global swarm fallback', () => {
+  const source = read('app/video/[id].tsx')
+
+  assert.doesNotMatch(
+    source,
+    /swarmStatus\?\.swarmPeers/,
+    'global discovered swarm peers must not be used as a connected/video peer fallback',
+  )
+  assert.doesNotMatch(
+    source,
+    /if \(global(?:Peers|Connections) > 0\) return \{ color: '#60a5fa', label: 'Connected' \}/,
+    'missing video stats must not label the video as Connected from global network state',
+  )
+  assert.match(
+    source,
+    /label: 'Waiting for video peers'/,
+    'missing video stats should keep the video-specific status waiting for video peers',
+  )
+  assert.match(
+    source,
+    /Network online: \{globalConnections\} connection/,
+    'global network state may be shown only as a separate diagnostic',
+  )
+  assert.match(
+    source,
+    /const connectionCount = swarmStatus\?\.swarmConnections \?\? swarmStatus\?\.feedConnections \?\? 0/,
+    'network diagnostics should use explicit connection counts, not discovered peer candidates',
+  )
+})

--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -212,6 +212,29 @@ export function createApi({
     }
   }
 
+  function getVideoCorePeerCount(driveKey, videoPath) {
+    try {
+      const channel = ctx.channels?.get?.(driveKey)
+      const normalizedId = normalizeVideoId(videoPath)
+      const candidates = [
+        videoPath,
+        normalizedId,
+        normalizedId ? `/videos/${normalizedId}.mp4` : null,
+        normalizedId ? `videos/${normalizedId}.mp4` : null,
+      ].filter(Boolean)
+
+      for (const candidate of candidates) {
+        const core = channel?.videoCores?.get?.(candidate) || channel?.cores?.get?.(candidate)
+        const peers = core?.peers
+        if (Array.isArray(peers)) return peers.length
+        if (typeof peers?.length === 'number') return peers.length
+        if (typeof peers?.size === 'number') return peers.size
+      }
+    } catch { /* best effort */ }
+
+    return 0
+  }
+
   function previewVideosFromFeedEntry(driveKey, publicBeeKey = null) {
     const entry = getPublicFeedEntry(driveKey)
     const previews = Array.isArray(entry?.previewVideos) ? entry.previewVideos : []
@@ -2192,10 +2215,12 @@ export function createApi({
      * @returns {Object}
      */
     getVideoStats(driveKey, videoPath) {
+      const videoPeerCount = getVideoCorePeerCount(driveKey, videoPath);
       if (videoStats) {
         const stats = videoStats.getStats(driveKey, videoPath);
         if (stats) {
           stats.swarmConnections = ctx.swarm?.connections?.size || 0;
+          stats.peerCount = videoPeerCount || stats.peerCount || 0;
           return stats;
         }
       }
@@ -2207,7 +2232,7 @@ export function createApi({
         downloadedBlocks: 0,
         totalBytes: 0,
         downloadedBytes: 0,
-        peerCount: ctx.swarm?.connections?.size || 0,
+        peerCount: videoPeerCount,
         swarmConnections: ctx.swarm?.connections?.size || 0,
         speedMBps: '0',
         elapsed: 0,

--- a/packages/backend/test/playback-api.test.mjs
+++ b/packages/backend/test/playback-api.test.mjs
@@ -66,3 +66,34 @@ test('preparePlayback returns a playable URL before warmup settles or fails', as
     ['getVideoStats', ['channel-key', 'videos/demo.mp4']],
   ])
 })
+
+test('getVideoStats keeps video peer count separate from global swarm connections', (t) => {
+  const videoCore = { peers: [1, 2] }
+  const api = createApi({
+    ctx: {
+      swarm: { connections: new Set([1, 2, 3, 4]) },
+      channels: new Map([
+        ['channel-key', { videoCores: new Map([['videos/demo.mp4', videoCore]]) }],
+      ]),
+    },
+  })
+
+  const stats = api.getVideoStats('channel-key', 'videos/demo.mp4')
+
+  t.is(stats.peerCount, 2)
+  t.is(stats.swarmConnections, 4)
+})
+
+test('getVideoStats does not fall back to global swarm connections as video peers', (t) => {
+  const api = createApi({
+    ctx: {
+      swarm: { connections: new Set([1, 2, 3]) },
+      channels: new Map(),
+    },
+  })
+
+  const stats = api.getVideoStats('channel-key', 'missing-video')
+
+  t.is(stats.peerCount, 0)
+  t.is(stats.swarmConnections, 3)
+})


### PR DESCRIPTION
## Summary
- keep video-specific P2P stats separate from global swarm/network diagnostics
- bound native/web channel metadata and video hydration so loading skeletons clear on hangs
- show degraded channel video-load states with retry instead of silently rendering a clean empty channel

Closes #187
Closes #193

## Tests
- ./packages/backend/node_modules/.bin/brittle packages/backend/test/playback-api.test.mjs
- node --test packages/app/tests/p2p-stats-bar-data-truth-regression.test.mjs packages/app/tests/channel-page-hydration-timeout-regression.test.mjs
- git diff --check
- npm run lint:changed