### PR TITLE
Fix feed availability cache metadata

### DIFF
--- a/packages/app/lib/feed-hydration.js
+++ b/packages/app/lib/feed-hydration.js
@@ -130,7 +130,7 @@ export function shouldAutoLoadFeedVideos({ feedEntries, swarmStatus }) {
 export function shouldRenderFeedVideo({ video, identityDriveKey }) {
   const channelKey = video?.channelKey || video?.driveKey || null
   if (identityDriveKey && channelKey === identityDriveKey) return true
-  return video?.availability === 'playable' || video?.playbackSupport === 'unverified-container'
+  return (video?.byteAvailability || video?.availability) === 'playable'
 }
 
 export function isConfirmedFeedHydrationResult({ entry, resolved, videos = [] }) {

--- a/packages/app/tests/feed-hydration.test.mjs
+++ b/packages/app/tests/feed-hydration.test.mjs
@@ -213,13 +213,23 @@ test('shouldRenderFeedVideo only accepts proven-playable remote videos but keeps
   }), false)
 
   assert.equal(shouldRenderFeedVideo({
+    video: { channelKey: 'remote', availability: 'unknown', playbackSupport: 'unverified-container' },
+    identityDriveKey: 'local',
+  }), false)
+
+  assert.equal(shouldRenderFeedVideo({
+    video: { channelKey: 'remote', byteAvailability: 'playable', playbackSupport: 'unverified-container' },
+    identityDriveKey: 'local',
+  }), true)
+
+  assert.equal(shouldRenderFeedVideo({
     video: { channelKey: 'local', availability: 'unknown' },
     identityDriveKey: 'local',
   }), true)
 })
 
 
-test('feed preview videos keep unverified mirrored media visible while marked playable', () => {
+test('feed preview videos keep unverified mirrored media visible when byte availability is marked playable', () => {
   const videos = getFeedPreviewVideos([{
     driveKey: 'remote-a',
     publicBeeKey: 'bb'.repeat(32),

--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -1462,6 +1462,9 @@ export function createApi({
               const id = extractVideoId(video)
               if (!id) return null
               const hint = hintById.get(id)
+              const availability = hint?.availability === 'playable' ? 'playable'
+                : (hint?.availability || 'unknown') !== 'unknown' ? (hint?.availability || 'unknown')
+                : 'unknown'
               return {
                 id,
                 title: video?.title ? String(video.title) : 'Untitled',
@@ -1472,20 +1475,20 @@ export function createApi({
                 blobsCoreKey: video?.blobsCoreKey ? String(video.blobsCoreKey) : null,
                 mimeType: video?.mimeType ? String(video.mimeType) : null,
                 playbackSupport: video?.playbackSupport ? String(video.playbackSupport) : null,
+                containerSupport: video?.containerSupport ? String(video.containerSupport) : (video?.playbackSupport ? String(video.playbackSupport) : null),
                 // Trust the per-video availability hint if present. Previously
                 // this fell back to "playable" whenever the swarm had any peer
                 // connection, which surfaced truly-unavailable videos. Now we
                 // only surface 'playable' if the hint system actually confirmed
                 // it — matching the stricter listVideos path.
-                availability: hint?.availability === 'playable' ? 'playable'
-                  : (hint?.availability || 'unknown') !== 'unknown' ? (hint?.availability || 'unknown')
-                  : 'unknown',
+                availability,
+                byteAvailability: availability,
                 thumbnailBlobId: video?.thumbnailBlobId ? String(video.thumbnailBlobId) : null,
                 thumbnailBlobsCoreKey: video?.thumbnailBlobsCoreKey ? String(video.thumbnailBlobsCoreKey) : null,
                 thumbnailMimeType: video?.thumbnailMimeType ? String(video.thumbnailMimeType) : null,
               }
             })
-            .filter((video) => video && (video.availability === 'playable' || video.playbackSupport === 'unverified-container'))
+            .filter((video) => video && video.byteAvailability === 'playable')
             .slice(0, limitPerChannel)
 
           return {
@@ -1531,6 +1534,10 @@ export function createApi({
             channelName: entry?.channelName || null,
             videoCount: entry?.videoCount || 0,
             peerCount: entry?.peerCount || 0,
+            discoveryOnly: Boolean(entry?.discoveryOnly),
+            restoredFromCache: Boolean(entry?.restoredFromCache),
+            restoredFrom: entry?.restoredFrom || null,
+            requiresAvailabilityProbe: Boolean(entry?.requiresAvailabilityProbe),
             lastSeen: entry?.lastSeen || entry?.lastSeenAt || entry?.addedAt || 0,
             manifestUpdatedAt: entry?.manifestUpdatedAt || 0,
             previewVideos: Array.isArray(entry?.previewVideos) ? entry.previewVideos : [],

--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -176,21 +176,52 @@ export class PublicFeedManager {
     return videos
       .filter((video) => video && typeof video === 'object' && typeof video.id === 'string' && video.id.length > 0)
       .slice(0, 3)
-      .map((video) => ({
-        id: String(video.id),
-        title: video?.title ? String(video.title) : 'Untitled',
-        uploadedAt: Number(video?.uploadedAt || 0) || 0,
-        duration: Number(video?.duration || 0) || 0,
-        thumbnail: video?.thumbnail ? String(video.thumbnail) : null,
-        blobId: video?.blobId ? String(video.blobId) : null,
-        blobsCoreKey: video?.blobsCoreKey ? String(video.blobsCoreKey) : null,
-        mimeType: video?.mimeType ? String(video.mimeType) : null,
-        availability: video?.availability === 'playable' ? 'playable' : (video?.availability === 'unknown' ? 'unknown' : 'unavailable'),
-        playbackSupport: video?.playbackSupport ? String(video.playbackSupport) : null,
-        thumbnailBlobId: video?.thumbnailBlobId ? String(video.thumbnailBlobId) : null,
-        thumbnailBlobsCoreKey: video?.thumbnailBlobsCoreKey ? String(video.thumbnailBlobsCoreKey) : null,
-        thumbnailMimeType: video?.thumbnailMimeType ? String(video.thumbnailMimeType) : null,
+      .map((video) => {
+        const availability = video?.byteAvailability || video?.availability
+        const containerSupport = video?.containerSupport || video?.playbackSupport
+        return {
+          id: String(video.id),
+          title: video?.title ? String(video.title) : 'Untitled',
+          uploadedAt: Number(video?.uploadedAt || 0) || 0,
+          duration: Number(video?.duration || 0) || 0,
+          thumbnail: video?.thumbnail ? String(video.thumbnail) : null,
+          blobId: video?.blobId ? String(video.blobId) : null,
+          blobsCoreKey: video?.blobsCoreKey ? String(video.blobsCoreKey) : null,
+          mimeType: video?.mimeType ? String(video.mimeType) : null,
+          availability: availability === 'playable' ? 'playable' : (availability === 'unknown' ? 'unknown' : 'unavailable'),
+          byteAvailability: availability === 'playable' ? 'playable' : (availability === 'unknown' ? 'unknown' : 'unavailable'),
+          playbackSupport: video?.playbackSupport ? String(video.playbackSupport) : null,
+          containerSupport: containerSupport ? String(containerSupport) : null,
+          thumbnailBlobId: video?.thumbnailBlobId ? String(video.thumbnailBlobId) : null,
+          thumbnailBlobsCoreKey: video?.thumbnailBlobsCoreKey ? String(video.thumbnailBlobsCoreKey) : null,
+          thumbnailMimeType: video?.thumbnailMimeType ? String(video.thumbnailMimeType) : null,
+          discoveryOnly: Boolean(video?.discoveryOnly),
+          restoredFromCache: Boolean(video?.restoredFromCache),
+          requiresAvailabilityProbe: Boolean(video?.requiresAvailabilityProbe),
+        }
+      })
+  }
+
+  _markRestoredDiscoveryOnly(entry, restoredFrom) {
+    if (!entry || typeof entry !== 'object') return entry
+    const marked = {
+      ...entry,
+      discoveryOnly: true,
+      restoredFromCache: true,
+      restoredFrom,
+      requiresAvailabilityProbe: true,
+    }
+    if (Array.isArray(marked.previewVideos)) {
+      marked.previewVideos = marked.previewVideos.map((video) => ({
+        ...video,
+        availability: video?.availability === 'playable' ? 'unknown' : (video?.availability || 'unknown'),
+        byteAvailability: video?.byteAvailability === 'playable' ? 'unknown' : (video?.byteAvailability || 'unknown'),
+        discoveryOnly: true,
+        restoredFromCache: true,
+        requiresAvailabilityProbe: true,
       }))
+    }
+    return marked
   }
 
   _normalizeSignedDescriptor(signed) {
@@ -236,6 +267,10 @@ export class PublicFeedManager {
       publicBeeKey: entry.publicBeeKey || null,
       relayRole: entry.relayRole || (entry.source === 'relay-cache' ? 'cache' : 'publisher'),
       relayServing: Boolean(entry.relayServing || entry.source === 'relay-cache' || entry.source === 'local'),
+      discoveryOnly: Boolean(entry.discoveryOnly),
+      restoredFromCache: Boolean(entry.restoredFromCache),
+      restoredFrom: entry.restoredFrom || null,
+      requiresAvailabilityProbe: Boolean(entry.requiresAvailabilityProbe),
       lastSeenAt: entry.lastSeenAt || entry.addedAt || Date.now(),
       version: Number(entry.version || 0) || 0,
     }
@@ -279,6 +314,16 @@ export class PublicFeedManager {
     }
     if (Number(snapshot.lastSeenAt || 0) > Number(entry.lastSeenAt || 0)) {
       entry.lastSeenAt = Number(snapshot.lastSeenAt)
+      changed = true
+    }
+    for (const flag of ['discoveryOnly', 'restoredFromCache', 'requiresAvailabilityProbe']) {
+      if (typeof snapshot[flag] !== 'undefined' && Boolean(snapshot[flag]) !== Boolean(entry[flag])) {
+        entry[flag] = Boolean(snapshot[flag])
+        changed = true
+      }
+    }
+    if (typeof snapshot.restoredFrom === 'string' && snapshot.restoredFrom !== entry.restoredFrom) {
+      entry.restoredFrom = snapshot.restoredFrom
       changed = true
     }
     if (Number.isFinite(snapshot.videoCount) && Number(snapshot.videoCount) !== Number(entry.videoCount || 0)) {
@@ -728,7 +773,8 @@ export class PublicFeedManager {
         const cachedV2 = await this.metaDb.get('discovered-channels-v2').catch(() => null)
         if (cachedV2?.value && Array.isArray(cachedV2.value) && cachedV2.value.length) {
           for (const entry of cachedV2.value) {
-            if (entry.driveKey && this.addEntry(entry.driveKey, 'peer', entry.publicBeeKey, entry)) {
+            const restoredEntry = this._markRestoredDiscoveryOnly(entry, 'discovered-channels-v2')
+            if (entry.driveKey && this.addEntry(entry.driveKey, 'peer', entry.publicBeeKey, restoredEntry)) {
               restored++
             }
           }
@@ -743,7 +789,7 @@ export class PublicFeedManager {
           const keys = cached?.value || []
           if (Array.isArray(keys) && keys.length) {
             for (const key of keys) {
-              if (this.addEntry(key, 'peer')) restored++
+              if (this.addEntry(key, 'peer', null, this._markRestoredDiscoveryOnly({ driveKey: key }, 'legacy-discovered-channels'))) restored++
             }
             if (restored > 0) {
               console.log('[PublicFeed] Restored', restored, 'cached discovered channels (legacy format)')
@@ -763,9 +809,10 @@ export class PublicFeedManager {
         const entries = Array.isArray(catalog?.value?.entries) ? catalog.value.entries : []
         let restoredCatalog = 0
         for (const entry of entries) {
-          if (entry?.driveKey && this.addEntry(entry.driveKey, entry.source || 'relay-cache', entry.publicBeeKey, entry)) {
+          const restoredEntry = this._markRestoredDiscoveryOnly(entry, PUBLIC_FEED_RELAY_CATALOG_KEY)
+          if (entry?.driveKey && this.addEntry(entry.driveKey, entry.source || 'relay-cache', entry.publicBeeKey, restoredEntry)) {
             restoredCatalog++
-          } else if (entry?.driveKey && this._applyEntrySnapshot(entry.driveKey, entry)) {
+          } else if (entry?.driveKey && this._applyEntrySnapshot(entry.driveKey, restoredEntry)) {
             restoredCatalog++
           }
         }
@@ -914,6 +961,10 @@ export class PublicFeedManager {
           catalogVersion: Number(e.catalogVersion || PUBLIC_FEED_CATALOG_VERSION) || PUBLIC_FEED_CATALOG_VERSION,
           relayRole: e.relayRole || null,
           relayServing: Boolean(e.relayServing),
+          discoveryOnly: Boolean(e.discoveryOnly),
+          restoredFromCache: Boolean(e.restoredFromCache),
+          restoredFrom: e.restoredFrom || null,
+          requiresAvailabilityProbe: Boolean(e.requiresAvailabilityProbe),
           lastSeenAt: e.lastSeenAt || e.addedAt || Date.now(),
           channelName: e.channelName || null,
           videoCount: Number(e.videoCount || 0) || 0,
@@ -1353,6 +1404,10 @@ export class PublicFeedManager {
       catalogVersion: Number(snapshot?.catalogVersion || PUBLIC_FEED_CATALOG_VERSION) || PUBLIC_FEED_CATALOG_VERSION,
       relayRole: snapshot?.relayRole || (source === 'relay-cache' ? 'cache' : source === 'local' ? 'publisher' : null),
       relayServing: Boolean(snapshot?.relayServing || source === 'relay-cache' || source === 'local'),
+      discoveryOnly: Boolean(snapshot?.discoveryOnly),
+      restoredFromCache: Boolean(snapshot?.restoredFromCache),
+      restoredFrom: typeof snapshot?.restoredFrom === 'string' ? snapshot.restoredFrom : null,
+      requiresAvailabilityProbe: Boolean(snapshot?.requiresAvailabilityProbe),
       lastSeenAt: Number(snapshot?.lastSeenAt || Date.now()) || Date.now(),
       channelName: snapshot?.channelName || null,
       videoCount: Number(snapshot?.videoCount || 0) || 0,
@@ -1529,6 +1584,10 @@ export class PublicFeedManager {
       source: snapshot?.source || null,
       relayRole: snapshot?.relayRole || null,
       relayServing: Boolean(snapshot?.relayServing),
+      discoveryOnly: Boolean(snapshot?.discoveryOnly),
+      restoredFromCache: Boolean(snapshot?.restoredFromCache),
+      restoredFrom: snapshot?.restoredFrom || null,
+      requiresAvailabilityProbe: Boolean(snapshot?.requiresAvailabilityProbe),
       lastSeenAt: snapshot?.lastSeenAt || Date.now(),
       channelName: snapshot?.channelName || null,
       videoCount: Number(snapshot?.videoCount || 0) || 0,

--- a/packages/backend/test/public-feed-manager.test.mjs
+++ b/packages/backend/test/public-feed-manager.test.mjs
@@ -735,6 +735,79 @@ test('keyed peer entries survive persistence and restart even when peerCount is 
   }
 })
 
+
+test('restored discovered entries are marked discovery-only and previews require availability probes', async () => {
+  const metaDb = createPersistedMetaDb({
+    'discovered-channels-v2': [{
+      driveKey: DRIVE_KEY,
+      publicBeeKey: PUBLIC_BEE_KEY,
+      channelName: 'Cached Channel',
+      previewVideos: [{
+        id: 'cached-mkv',
+        title: 'Cached MKV',
+        availability: 'playable',
+        playbackSupport: 'unverified-container',
+        blobId: '0:8:0:1024',
+        blobsCoreKey: '44'.repeat(32),
+      }],
+    }],
+  })
+  const manager = new PublicFeedManager(createSwarm(), metaDb)
+
+  try {
+    await manager.start()
+    const feed = manager.getFeed()
+    assert.equal(feed.length, 1)
+    assert.equal(feed[0].discoveryOnly, true)
+    assert.equal(feed[0].restoredFromCache, true)
+    assert.equal(feed[0].requiresAvailabilityProbe, true)
+    assert.equal(feed[0].restoredFrom, 'discovered-channels-v2')
+    assert.equal(feed[0].previewVideos[0].availability, 'unknown')
+    assert.equal(feed[0].previewVideos[0].byteAvailability, 'unknown')
+    assert.equal(feed[0].previewVideos[0].playbackSupport, 'unverified-container')
+    assert.equal(feed[0].previewVideos[0].containerSupport, 'unverified-container')
+    assert.equal(feed[0].previewVideos[0].requiresAvailabilityProbe, true)
+  } finally {
+    manager.stop()
+  }
+})
+
+test('restored relay catalog entries are visible but discovery-only until re-probed', async () => {
+  const metaDb = createPersistedMetaDb({
+    'public-feed-relay-catalog-v1': {
+      entries: [{
+        driveKey: 'aa'.repeat(32),
+        publicBeeKey: 'bb'.repeat(32),
+        source: 'relay-cache',
+        relayServing: true,
+        relayRole: 'cache',
+        previewVideos: [{
+          id: 'relay-cached-video',
+          availability: 'playable',
+          blobId: '0:4:0:512',
+          blobsCoreKey: 'cc'.repeat(32),
+        }],
+      }],
+    },
+  })
+  const manager = new PublicFeedManager(createSwarm(), metaDb)
+
+  try {
+    await manager.start()
+    const feed = manager.getFeed()
+    assert.equal(feed.length, 1)
+    assert.equal(feed[0].source, 'relay-cache')
+    assert.equal(feed[0].relayServing, true)
+    assert.equal(feed[0].discoveryOnly, true)
+    assert.equal(feed[0].restoredFromCache, true)
+    assert.equal(feed[0].requiresAvailabilityProbe, true)
+    assert.equal(feed[0].previewVideos[0].availability, 'unknown')
+    assert.equal(feed[0].previewVideos[0].byteAvailability, 'unknown')
+  } finally {
+    manager.stop()
+  }
+})
+
 test('addEntry accepts legacy peer entries without publicBeeKey', () => {
   const swarm = createSwarm()
   const manager = new PublicFeedManager(swarm, createMetaDb())


### PR DESCRIPTION
Closes #188
Closes #189

## Summary
- Preserve discovery/cache metadata on restored public feed entries and preview videos.
- Downgrade restored cached preview byte availability to unknown so cached playable snapshots require a fresh availability probe.
- Split byte availability from container support so unverified containers are not treated as playable without proven bytes.

## Tests
- node --test packages/backend/test/public-feed-manager.test.mjs --test-name-pattern "restored discovered entries|restored relay catalog|keyed peer entries"
- node --test packages/app/tests/feed-hydration.test.mjs
- git diff --check
- npm run lint:changed