### PR TITLE
fix: preserve vertical discover error states

### DIFF
--- a/packages/app/app/(tabs)/discover.tsx
+++ b/packages/app/app/(tabs)/discover.tsx
@@ -27,8 +27,10 @@ import { colors } from '@/lib/colors'
 import { fetchThumbnailUrlWithRetry } from '@/lib/thumbnail'
 import {
   getVerticalFeedPreviewVideos,
+  hasRichVerticalFeedSnapshot,
   mapHydratedVerticalFeedVideos,
   mergeUniqueFeedVideos,
+  mergeVerticalFeedEntries,
   warmNextPlaybackUrls,
   withFeedTimeout,
 } from '@/lib/discover-feed-controller'
@@ -129,6 +131,11 @@ export default function VerticalDiscoveryScreen() {
   const [feedEntries, setFeedEntries] = useState<FeedEntry[]>(() => (cachedDiscoverFeed?.feedEntries || []) as FeedEntry[])
   const [videos, setVideos] = useState<VideoData[]>(() => (cachedDiscoverFeed?.videos || []) as VideoData[])
   const [cacheRestoredOnly, setCacheRestoredOnly] = useState(() => Boolean(cachedDiscoverFeed?.videos?.length || cachedDiscoverFeed?.feedEntries?.length))
+  const [feedError, setFeedError] = useState<string | null>(null)
+  const [feedTimedOut, setFeedTimedOut] = useState(false)
+  const [lastSuccessfulFeedAt, setLastSuccessfulFeedAt] = useState<number | null>(null)
+  const [usingCachedSnapshot, setUsingCachedSnapshot] = useState(() => Boolean(cachedDiscoverFeed?.videos?.length || cachedDiscoverFeed?.feedEntries?.length))
+  const [hydrationErrors, setHydrationErrors] = useState<Record<string, { error: string; lastAttempt: number }>>({})
   const [thumbnailCache, setThumbnailCache] = useState<Record<string, string>>({})
   const thumbnailCacheRef = useRef<Record<string, string>>({})
   thumbnailCacheRef.current = thumbnailCache
@@ -213,6 +220,7 @@ export default function VerticalDiscoveryScreen() {
 
   useEffect(() => {
     if (cacheRestoredOnly || (videos.length === 0 && feedEntries.length === 0)) return
+    if (!hasRichVerticalFeedSnapshot(feedEntries, videos)) return
     writeDiscoverFeedCache({ feedEntries, videos })
   }, [cacheRestoredOnly, feedEntries, videos])
 
@@ -228,7 +236,14 @@ export default function VerticalDiscoveryScreen() {
         3500,
         timeoutToken as any,
       )
-      if (result === timeoutToken) return
+      if (result === timeoutToken) {
+        setHydrationErrors((prev) => ({ ...prev, [channelKey]: { error: 'Channel refresh timed out; showing cached previews.', lastAttempt: Date.now() } }))
+        return
+      }
+      if ((result as any)?.success === false || (result as any)?.error) {
+        setHydrationErrors((prev) => ({ ...prev, [channelKey]: { error: (result as any)?.error || 'Channel refresh failed; showing cached previews.', lastAttempt: Date.now() } }))
+        return
+      }
       hydratedChannelsRef.current.add(channelKey)
       const channelVideos = Array.isArray((result as any)?.videos) ? (result as any).videos : []
       const mapped = mapHydratedVerticalFeedVideos(entry, channelVideos, {
@@ -238,9 +253,16 @@ export default function VerticalDiscoveryScreen() {
       if (mapped.length > 0) {
         setVideos((prev) => mergeUniqueFeedVideos(prev, mapped, 80))
         if (mapped.length > 0) setCacheRestoredOnly(false)
+        setHydrationErrors((prev) => {
+          if (!prev[channelKey]) return prev
+          const next = { ...prev }
+          delete next[channelKey]
+          return next
+        })
         void fetchThumbnailsForVideos(mapped)
       }
     } catch (err) {
+      setHydrationErrors((prev) => ({ ...prev, [channelKey]: { error: (err as any)?.message || String(err), lastAttempt: Date.now() } }))
       console.log('[VerticalDiscovery] Channel hydration failed:', (err as any)?.message || err)
     }
   }, [fetchThumbnailsForVideos, identity?.driveKey, rpc])
@@ -252,25 +274,45 @@ export default function VerticalDiscoveryScreen() {
     try {
       const timeoutToken = Symbol('vertical-feed-timeout')
       const result = await withFeedTimeout(rpc.getPublicFeed({}), 4000, timeoutToken as any)
-      if (result === timeoutToken) return
+      if (result === timeoutToken) {
+        setFeedTimedOut(true)
+        setFeedError('Feed refresh timed out; showing cached snapshot.')
+        setUsingCachedSnapshot(hasRichVerticalFeedSnapshot(feedEntries, videos))
+        return
+      }
+      if ((result as any)?.success === false || (result as any)?.error) {
+        setFeedTimedOut(false)
+        setFeedError((result as any)?.error || 'Feed refresh failed; showing cached snapshot.')
+        setUsingCachedSnapshot(hasRichVerticalFeedSnapshot(feedEntries, videos))
+        return
+      }
       const entries = Array.isArray((result as any)?.entries) ? (result as any).entries : []
-      if (entries.length > 0) setCacheRestoredOnly(false)
+      setFeedTimedOut(false)
+      setFeedError(null)
+      setLastSuccessfulFeedAt(Date.now())
+      setUsingCachedSnapshot(false)
+      if (entries.length > 0 && hasRichVerticalFeedSnapshot(entries, [])) setCacheRestoredOnly(false)
+      let mergedEntries = entries
       setFeedEntries((prev) => {
+        mergedEntries = mergeVerticalFeedEntries(prev, entries) as FeedEntry[]
         const prevSignature = prev.map(getFeedEntrySignature).join('\n')
-        const nextSignature = entries.map(getFeedEntrySignature).join('\n')
-        return prevSignature === nextSignature ? prev : entries
+        const nextSignature = mergedEntries.map(getFeedEntrySignature).join('\n')
+        return prevSignature === nextSignature ? prev : mergedEntries
       })
-      seedFromFeedEntries(entries)
-      for (const entry of entries.slice(0, 24)) {
+      seedFromFeedEntries(mergedEntries)
+      for (const entry of mergedEntries.slice(0, 24)) {
         void hydrateChannelVideos(entry)
       }
     } catch (err) {
+      setFeedTimedOut(false)
+      setFeedError((err as any)?.message || String(err))
+      setUsingCachedSnapshot(hasRichVerticalFeedSnapshot(feedEntries, videos))
       console.log('[VerticalDiscovery] Feed load failed:', (err as any)?.message || err)
     } finally {
       feedLoadInFlightRef.current = false
       setFeedLoading(false)
     }
-  }, [hydrateChannelVideos, rpc, seedFromFeedEntries])
+  }, [feedEntries, hydrateChannelVideos, rpc, seedFromFeedEntries, videos])
 
   useEffect(() => {
     if (!ready || !rpc) return
@@ -431,6 +473,16 @@ export default function VerticalDiscoveryScreen() {
       thumbnailUrl: thumbnailCache[cacheKey] || video.thumbnailUrl || (video as any).thumbnail || null,
     }
   }), [thumbnailCache, videos])
+  const hydrationErrorCount = Object.keys(hydrationErrors).length
+  const degradedCopy = feedTimedOut
+    ? 'Feed refresh timed out — showing cached previews.'
+    : feedError
+      ? feedError
+      : hydrationErrorCount > 0
+        ? `${hydrationErrorCount} channel${hydrationErrorCount === 1 ? '' : 's'} could not refresh; cached previews remain visible.`
+        : usingCachedSnapshot && verticalVideos.length > 0
+          ? 'Showing cached Discover snapshot while peers refresh.'
+          : null
 
   if (isDesktop) {
     return (
@@ -455,6 +507,12 @@ export default function VerticalDiscoveryScreen() {
               <Text style={styles.feedPillText}>{feedEntries.length}</Text>
             </View>
           ) : null}
+          {degradedCopy ? (
+            <View style={styles.feedPill}>
+              <Feather name="alert-circle" color={colors.primary} size={12} />
+              <Text style={styles.feedPillText}>Cached</Text>
+            </View>
+          ) : null}
           <Pressable onPress={onRefresh} style={styles.roundButton} disabled={refreshing || feedLoading}>
             <Feather name="refresh-cw" color={colors.text} size={18} />
           </Pressable>
@@ -469,10 +527,10 @@ export default function VerticalDiscoveryScreen() {
         <View style={styles.centerState}>
           {feedLoading || !ready ? <ActivityIndicator color={colors.primary} size="large" /> : null}
           <Text style={styles.centerTitle}>
-            {backendError ? 'Backend error' : ready ? 'No videos discovered yet' : (startupStatus || 'Connecting to P2P network…')}
+            {backendError ? 'Backend error' : ready ? (feedTimedOut || feedError || usingCachedSnapshot ? 'Showing cached Discover' : 'No videos discovered yet') : (startupStatus || 'Connecting to P2P network…')}
           </Text>
           <Text style={styles.centerBody}>
-            {backendError || 'Pull down to refresh, or wait for peers to announce channels.'}
+            {backendError || degradedCopy || 'Pull down to refresh, or wait for peers to announce channels.'}
           </Text>
         </View>
       ) : (

--- a/packages/app/lib/discover-feed-controller.d.ts
+++ b/packages/app/lib/discover-feed-controller.d.ts
@@ -6,6 +6,13 @@ export function mergeUniqueFeedVideos<T extends { channelKey?: string; driveKey?
   limit?: number,
 ): T[]
 
+export function mergeVerticalFeedEntries<T extends { channelKey?: string; driveKey?: string }>(
+  previousEntries?: T[],
+  incomingEntries?: T[],
+): T[]
+
+export function hasRichVerticalFeedSnapshot(entries?: any[], videos?: any[]): boolean
+
 export function getVerticalFeedPreviewVideos<T = any>(
   entries: any[],
   options?: {

--- a/packages/app/lib/discover-feed-controller.js
+++ b/packages/app/lib/discover-feed-controller.js
@@ -25,6 +25,75 @@ export function mergeUniqueFeedVideos(previousVideos = [], incomingVideos = [], 
   return Array.from(byKey.values()).slice(0, limit)
 }
 
+function hasNonEmpty(value) {
+  if (Array.isArray(value)) return value.length > 0
+  return value !== undefined && value !== null && value !== ''
+}
+
+function getEntryKey(entry) {
+  return entry?.channelKey || entry?.driveKey || ''
+}
+
+function getEntryFreshness(entry) {
+  return Number(entry?.manifestUpdatedAt || entry?.lastSeen || 0) || 0
+}
+
+function mergeFeedEntry(previous, incoming) {
+  if (!previous) return incoming
+  if (!incoming) return previous
+
+  const previousFreshness = getEntryFreshness(previous)
+  const incomingFreshness = getEntryFreshness(incoming)
+  const incomingIsNewer = incomingFreshness >= previousFreshness
+  const merged = { ...previous, ...incoming }
+
+  if (!hasNonEmpty(incoming.previewVideos) || !incomingIsNewer) {
+    merged.previewVideos = previous.previewVideos || []
+  }
+
+  if (!hasNonEmpty(incoming.channelName) || !incomingIsNewer) {
+    merged.channelName = previous.channelName || incoming.channelName || null
+  }
+
+  if (!hasNonEmpty(incoming.manifestUpdatedAt) || !incomingIsNewer) {
+    merged.manifestUpdatedAt = previous.manifestUpdatedAt || incoming.manifestUpdatedAt || 0
+  }
+
+  if (!hasNonEmpty(incoming.publicBeeKey)) {
+    merged.publicBeeKey = previous.publicBeeKey || incoming.publicBeeKey || null
+  }
+
+  return merged
+}
+
+export function mergeVerticalFeedEntries(previousEntries = [], incomingEntries = []) {
+  const byKey = new Map()
+  const order = []
+
+  for (const entry of previousEntries || []) {
+    const key = getEntryKey(entry)
+    if (!key) continue
+    byKey.set(key, entry)
+    order.push(key)
+  }
+
+  for (const entry of incomingEntries || []) {
+    const key = getEntryKey(entry)
+    if (!key) continue
+    if (!byKey.has(key)) order.push(key)
+    byKey.set(key, mergeFeedEntry(byKey.get(key), entry))
+  }
+
+  return order.map((key) => byKey.get(key)).filter(Boolean)
+}
+
+export function hasRichVerticalFeedSnapshot(entries = [], videos = []) {
+  return Boolean(
+    (videos || []).length > 0 ||
+    (entries || []).some((entry) => Array.isArray(entry?.previewVideos) && entry.previewVideos.length > 0)
+  )
+}
+
 export function getVerticalFeedPreviewVideos(entries, { identityDriveKey, channelMeta = {}, limit = 40 } = {}) {
   const visibleEntries = getVisibleSeededFeedEntries(entries || [], Infinity)
   const previewVideos = getFeedPreviewVideos(

--- a/packages/app/tests/discover-feed-controller.test.mjs
+++ b/packages/app/tests/discover-feed-controller.test.mjs
@@ -4,8 +4,10 @@ import test from 'node:test'
 import {
   clearHydratedFeedChannels,
   getVerticalFeedPreviewVideos,
+  hasRichVerticalFeedSnapshot,
   mapHydratedVerticalFeedVideos,
   mergeUniqueFeedVideos,
+  mergeVerticalFeedEntries,
   warmNextPlaybackUrls,
   withFeedTimeout,
 } from '../lib/discover-feed-controller.js'
@@ -31,6 +33,50 @@ test('vertical feed controller dedupes preview and hydrated videos by channel/vi
     ['one', 'b', 'keep'],
     ['two', 'c', 'add'],
   ])
+})
+
+test('vertical feed controller preserves rich cached entries during partial feed hydration', () => {
+  const cached = [{
+    channelKey: 'one',
+    driveKey: 'one',
+    publicBeeKey: 'bee-one',
+    channelName: 'Cached Channel',
+    manifestUpdatedAt: 20,
+    previewVideos: [{ id: 'cached-video', blobId: '0:1:0:10', blobsCoreKey: 'abc' }],
+  }]
+  const partial = [{
+    channelKey: 'one',
+    driveKey: 'one',
+    channelName: null,
+    manifestUpdatedAt: 10,
+    previewVideos: [],
+  }]
+
+  const merged = mergeVerticalFeedEntries(cached, partial)
+
+  assert.equal(merged.length, 1)
+  assert.equal(merged[0].channelName, 'Cached Channel')
+  assert.equal(merged[0].publicBeeKey, 'bee-one')
+  assert.equal(merged[0].manifestUpdatedAt, 20)
+  assert.deepEqual(merged[0].previewVideos, cached[0].previewVideos)
+  assert.equal(hasRichVerticalFeedSnapshot(merged, []), true)
+})
+
+test('vertical feed controller accepts newer rich feed fields over restored cache', () => {
+  const merged = mergeVerticalFeedEntries([{
+    channelKey: 'one',
+    channelName: 'Old',
+    manifestUpdatedAt: 20,
+    previewVideos: [{ id: 'old' }],
+  }], [{
+    channelKey: 'one',
+    channelName: 'New',
+    manifestUpdatedAt: 30,
+    previewVideos: [{ id: 'new' }],
+  }])
+
+  assert.equal(merged[0].channelName, 'New')
+  assert.deepEqual(merged[0].previewVideos, [{ id: 'new' }])
 })
 
 test('vertical feed controller filters preview videos through renderability policy', () => {

--- a/packages/app/tests/vertical-discovery-regression.test.mjs
+++ b/packages/app/tests/vertical-discovery-regression.test.mjs
@@ -79,10 +79,10 @@ test('vertical discovery preserves a last-known-good cache across remounts and f
   assert.match(source, /useState<VideoData\[\]>\(\(\) => \(cachedDiscoverFeed\?\.videos \|\| \[\]\) as VideoData\[\]\)/, 'cached videos should seed the vertical deck on remount')
   assert.match(source, /writeDiscoverFeedCache\(\{ feedEntries, videos \}\)/, 'known-good vertical cards should be cached while mounted')
   assert.match(source, /const timeoutToken = Symbol\('vertical-feed-timeout'\)/, 'public-feed timeouts should be non-authoritative')
-  assert.match(source, /if \(result === timeoutToken\) return[\s\S]*const entries = Array\.isArray/, 'timed-out feed refreshes must not overwrite cached entries with empty lists')
+  assert.match(source, /if \(result === timeoutToken\) \{[\s\S]*return[\s\S]*const entries = Array\.isArray/, 'timed-out feed refreshes must not overwrite cached entries with empty lists')
   assert.match(source, /const \[cacheRestoredOnly, setCacheRestoredOnly\] = useState\(\(\) => Boolean\(cachedDiscoverFeed\?\.videos\?\.length \|\| cachedDiscoverFeed\?\.feedEntries\?\.length\)\)/, 'Discover should track restored-only cache state')
   assert.match(source, /if \(cacheRestoredOnly \|\| \(videos\.length === 0 && feedEntries\.length === 0\)\) return/, 'restored-only cache state should not be immediately re-saved as fresh')
-  assert.match(source, /if \(entries\.length > 0\) setCacheRestoredOnly\(false\)/, 'fresh public-feed entries should clear restored-only state')
+  assert.match(source, /if \(entries\.length > 0 && hasRichVerticalFeedSnapshot\(entries, \[\]\)\) setCacheRestoredOnly\(false\)/, 'fresh rich public-feed entries should clear restored-only state')
   assert.match(source, /if \(renderable\.length > 0\) setCacheRestoredOnly\(false\)/, 'fresh preview videos should clear restored-only state')
   assert.match(source, /if \(mapped\.length > 0\) setCacheRestoredOnly\(false\)/, 'fresh hydrated videos should clear restored-only state')
   assert.match(cacheSource, /const MAX_CACHE_AGE_MS = 30 \* 60 \* 1000/, 'vertical cache should be short-lived and route-local')
@@ -94,10 +94,12 @@ test('vertical discovery hydrates beyond sparse previews without permanently poi
   const hydrateBlock = source.slice(source.indexOf('const hydrateChannelVideos'), source.indexOf('const loadFeed'))
 
   assert.doesNotMatch(source, /entries\.slice\(0, 8\)/, 'shorts should not cap channel hydration to the first few feed entries')
-  assert.match(source, /entries\.slice\(0, 24\)/, 'shorts should fan out across enough feed channels to expose more than preview videos')
+  assert.match(source, /for \(const entry of mergedEntries\.slice\(0, 24\)\)/, 'shorts should fan out across enough feed channels to expose more than preview videos')
   assert.doesNotMatch(hydrateBlock, /hydratedChannelsRef\.current\.add\(channelKey\)[\s\S]*?const result = await withTimeout/, 'timed-out channel list calls must remain retryable')
   assert.match(hydrateBlock, /const timeoutToken = Symbol\('vertical-channel-timeout'\)/, 'channel hydration should distinguish timeout from an authoritative empty video list')
-  assert.match(hydrateBlock, /if \(result === timeoutToken\) return[\s\S]*hydratedChannelsRef\.current\.add\(channelKey\)/, 'channel hydration should only mark the channel hydrated after a real response')
+  assert.match(source, /if \(result === timeoutToken\) \{[\s\S]*setHydrationErrors[\s\S]*return[\s\S]*hydratedChannelsRef\.current\.add\(channelKey\)/, 'channel hydration should only mark the channel hydrated after a real response')
+  assert.match(source, /\(result as any\)\?\.success === false \|\| \(result as any\)\?\.error/, 'failed channel list responses must not be treated as authoritative empty hydration')
+  assert.match(source, /setHydrationErrors/, 'channel hydration failures should be represented in degraded UI state')
 })
 
 test('vertical discovery preloads the next few videos into the playback URL cache', () => {
@@ -201,9 +203,11 @@ test('vertical discovery stabilizes card order across feed refreshes', () => {
   assert.match(source, /mergeUniqueFeedVideos\(prev, renderable, 80\)/, 'preview feed merges should preserve existing card order through the controller')
   assert.match(source, /mergeUniqueFeedVideos\(prev, mapped, 80\)/, 'hydrated feed merges should preserve existing card order through the controller')
   assert.match(controllerSource, /for \(const video of \[\.\.\.\(previousVideos \|\| \[\]\), \.\.\.\(incomingVideos \|\| \[\]\)\]\)/, 'controller merge should consider existing videos before incoming videos')
-  assert.match(source, /getFeedEntrySignature/, 'Discover should compare feed-entry content, not only channel order')
-  assert.doesNotMatch(source, /prevKeys === nextKeys \? prev : entries/, 'same-channel feed updates must not discard changed previews or blob refs')
-  assert.match(source, /thumbnailCacheRef/, 'thumbnail cache reads should not recreate feed merge callbacks on every thumbnail resolution')
+  assert.match(source, /mergeVerticalFeedEntries\(prev, entries\)/, 'feed refreshes should merge by channel and preserve richer cached snapshots')
+  assert.match(source, /hasRichVerticalFeedSnapshot\(feedEntries, videos\)/, 'cache writes and degraded state should be gated on rich snapshots')
+  assert.match(source, /feedError/, 'Discover should track feed errors separately from empty results')
+  assert.match(source, /feedTimedOut/, 'Discover should expose feed timeout state')
+  assert.match(source, /usingCachedSnapshot/, 'Discover should distinguish cached/degraded display from genuine empty feed')
 })
 
 test('vertical discovery updates feed entries when previews change without channel order changing', () => {
@@ -213,7 +217,7 @@ test('vertical discovery updates feed entries when previews change without chann
   assert.match(source, /previewVideos/, 'signature should include preview video state')
   assert.match(source, /blobId/, 'signature should include direct blob ids')
   assert.match(source, /blobsCoreKey/, 'signature should include direct blob core keys')
-  assert.match(source, /prevSignature === nextSignature \? prev : entries/, 'unchanged signatures may preserve state, changed previews must update entries')
+  assert.match(source, /prevSignature === nextSignature \? prev : mergedEntries/, 'unchanged signatures may preserve state, changed previews must update entries')
 })
 
 test('vertical discovery keeps the global watch/mini overlay off the Shorts route', () => {

--- a/packages/app/workers/desktop/index.ts
+++ b/packages/app/workers/desktop/index.ts
@@ -450,9 +450,9 @@ B.updateChannel = async (r: any) => { const a = identityManager.getActiveIdentit
 B.updateVideoMetadata = async (r: any) => { const a = identityManager.getActiveIdentity(); if (!a?.driveKey) return { success: false, error: 'No active channel' }; return api.updateVideoMetadata(r.channelKey || a.driveKey, r.videoId, { title: r.title, description: r.description, category: r.category }) }
 B.updateChannelAvatar = async (r: any) => { const a = identityManager.getActiveIdentity(); if (!a?.driveKey) return { success: false, error: 'No active channel' }; const buf = fs.readFileSync(r.filePath); return api.updateChannelAvatar(a.driveKey, buf, r.mimeType || 'image/jpeg') }
 B.listVideos = async (r: any) => {
-  const ck = r?.channelKey || ''; if (!ck) return { videos: [] }
-  let raw: any[] = []; try { raw = await api.listVideos(ck, r.publicBeeKey) } catch (err: any) { return { success: false, error: err?.message || String(err), stale: true, videos: [] } }
-  return { videos: (raw || []).map((v: any) => {
+  const ck = r?.channelKey || ''; if (!ck) return { success: false, error: 'Missing channelKey', videos: [] }
+  let raw: any[] = []; try { raw = await api.listVideos(ck, r.publicBeeKey) } catch (err: any) { return { success: false, error: err?.message || String(err), stale: true, retryable: true, videos: [] } }
+  return { success: true, videos: (raw || []).map((v: any) => {
     const id = v?.id ? String(v.id) : ''; if (!id) return null
     return {
       id,
@@ -516,9 +516,11 @@ B.unsubscribeChannel = async (r: any) => { await api.unsubscribeChannel(r.channe
 B.getSubscriptions = async () => { const s = await api.getSubscriptions(); return { subscriptions: s.map((i: any) => ({ channelKey: i.driveKey, channelName: i.name })) } }
 B.joinChannel = async (r: any) => { await api.subscribeChannel(r.channelKey); return { success: true } }
 B.getPublicFeed = async () => {
-  const r = api.getPublicFeed()
-  return {
-    entries: (r.entries || [])
+  try {
+    const r = api.getPublicFeed()
+    return {
+      success: true,
+      entries: (r.entries || [])
       .map((e: any) => ({
         channelKey: e.channelKey || e.driveKey || '',
         driveKey: e.driveKey || e.channelKey || '',
@@ -532,7 +534,10 @@ B.getPublicFeed = async () => {
         previewVideos: Array.isArray(e.previewVideos) ? e.previewVideos : [],
       }))
       .filter((e: any) => typeof e.channelKey === 'string' && e.channelKey.length > 0),
-    stats: r.stats || { totalEntries: 0, hiddenCount: 0, peerCount: 0 },
+      stats: r.stats || { totalEntries: 0, hiddenCount: 0, peerCount: 0 },
+    }
+  } catch (err: any) {
+    return { success: false, error: err?.message || String(err), stale: true, retryable: true, entries: [], stats: { totalEntries: 0, hiddenCount: 0, peerCount: 0 } }
   }
 }
 B.refreshFeed = async () => { api.refreshFeed(); return { success: true } }
@@ -580,7 +585,7 @@ B.getVideoThumbnail = async (r: any) => {
     const parts = thumbnailBlobId.split(':').map(Number)
     const url = ctx.blobServer.getLink(blobsCore.key, { blob: { blockOffset: parts[0], blockLength: parts[1], byteOffset: parts[2], byteLength: parts[3] }, type: 'image/jpeg', host: ctx.blobServerHost || '127.0.0.1', port: ctx.blobServer?.port || ctx.blobServerPort })
     return { url, exists: true }
-  } catch { return { url: null, exists: false } }
+  } catch (err: any) { return { success: false, error: err?.message || String(err), stale: true, retryable: true, url: null, exists: false } }
 }
 B.setVideoThumbnail = async (r: any) => { const a = identityManager.getActiveIdentity(); if (!a?.driveKey) return { success: false }; const ch = await identityManager.getActiveChannel?.(); if (!ch?.blobs) return { success: false }; const blob = await ch.putBlob(Buffer.from(r.imageData, 'base64')); await ch.updateVideo(r.videoId, { thumbnailBlobId: blob.id, thumbnailBlobsCoreKey: ch.blobsKeyHex }); return { success: true, thumbnailBlobId: blob.id } }
 B.setVideoThumbnailFromFile = async (r: any) => { const a = identityManager.getActiveIdentity(); if (!a?.driveKey) return { success: false }; const ch = await identityManager.getActiveChannel?.(); if (!ch?.blobs) return { success: false }; const blob = await ch.putBlob(fs.readFileSync(r.filePath)); await ch.updateVideo(r.videoId, { thumbnailBlobId: blob.id, thumbnailBlobsCoreKey: ch.blobsKeyHex }); return { success: true, thumbnailBlobId: blob.id } }
@@ -608,7 +613,7 @@ B.getBlobServerPort = async () => ({ port: getBlobPort() })
 B.createDeviceInvite = async (r: any) => { const res = await api.createDeviceInvite(r.channelKey); return { inviteCode: res.inviteCode } }
 B.pairDevice = async (r: any) => { const res = await api.pairDevice(r.inviteCode, r.deviceName || ''); try { const ex = identityManager.getIdentities?.() || []; if (ex.length === 0 && res?.channelKey) await identityManager.addPairedChannelIdentity?.(res.channelKey, 'Paired Channel') } catch {} return { success: Boolean(res.success), channelKey: res.channelKey } }
 B.listDevices = async (r: any) => { const res = await api.listDevices(r.channelKey); return { devices: res.devices || [] } }
-B.globalSearchVideos = async (r: any) => { try { const raw = await api.globalSearchVideos(r.query, { topK: r.topK || 20 }); return { results: raw.map((i: any) => ({ id: String(i.id || ''), score: i.score != null ? String(i.score) : null, metadata: i.metadata ? JSON.stringify(i.metadata) : null })) } } catch { return { results: [] } } }
+B.globalSearchVideos = async (r: any) => { try { const raw = await api.globalSearchVideos(r.query, { topK: r.topK || 20 }); return { success: true, results: raw.map((i: any) => ({ id: String(i.id || ''), score: i.score != null ? String(i.score) : null, metadata: i.metadata ? JSON.stringify(i.metadata) : null })) } } catch (err: any) { return { success: false, error: err?.message || String(err), retryable: true, results: [] } } }
 B.searchVideos = async (r: any) => {
   try {
     const raw = await api.searchVideos(r.channelKey, r.query, { topK: r.topK || 10, federated: Boolean(r.federated) })


### PR DESCRIPTION
## Summary
- Preserve rich vertical Discover snapshots when feed refreshes return partial data or time out
- Keep failed/timed-out channel hydration retryable instead of marking channels hydrated from error responses
- Return explicit `success:false` error contracts from desktop feed/search handlers instead of clean empty arrays

Closes #194
Closes #195
Closes #196

## Test Plan
- `node --test packages/app/tests/discover-feed-controller.test.mjs packages/app/tests/vertical-discovery-regression.test.mjs`
- `npm run lint:changed`
- `git diff --check`
