### PR TITLE
fix: propagate blob server readiness state

### DIFF
--- a/packages/app/app/_layout.web.tsx
+++ b/packages/app/app/_layout.web.tsx
@@ -43,6 +43,8 @@ const isPear = typeof window !== 'undefined' && (
 )
 const isBridgeDesktop = typeof window !== 'undefined' && !!(window as any).bridge
 const shouldUseStatsPollingFallback = !isBridgeDesktop
+const isValidBlobServerPort = (port: unknown): port is number =>
+  typeof port === 'number' && Number.isFinite(port) && port > 0
 
 // Types from shared package
 import type { Identity, Video } from '@peartube/core'
@@ -156,8 +158,6 @@ export default function RootLayout() {
     if (!platformRPC) return
 
     try {
-      setLoading(true)
-
       // Load identities
       const result = await platformRPC.rpc.getIdentities()
       const identities = result?.identities || []
@@ -190,8 +190,6 @@ export default function RootLayout() {
       }
     } catch (err) {
       console.error('[App] Failed to load initial data:', err)
-    } finally {
-      setLoading(false)
     }
   }, [])
 
@@ -209,8 +207,12 @@ export default function RootLayout() {
         // Subscribe to events only on first init
         platformRPC.events.onReady(async (data: any) => {
           console.log('[App] Backend ready, blobServerPort:', data?.blobServerPort)
-          setBlobServerPort(data?.blobServerPort || null)
-          await loadInitialData()
+          setBlobServerPort(isValidBlobServerPort(data?.blobServerPort) ? data.blobServerPort : null)
+          setReady(true)
+          setLoading(false)
+          loadInitialData().catch((err: any) => {
+            console.error('[App] Background initial data load failed:', err?.message || err)
+          })
         })
 
         platformRPC.events.onVideoStats((data: any) => {
@@ -228,7 +230,8 @@ export default function RootLayout() {
       } else {
         // Already initialized - restore from cache or load fresh
         console.log('[App] RPC already initialized, cached state:', cachedAppState ? 'yes' : 'no')
-        setBlobServerPort(platformRPC.getBlobServerPort())
+        const existingBlobServerPort = platformRPC.getBlobServerPort()
+        setBlobServerPort(isValidBlobServerPort(existingBlobServerPort) ? existingBlobServerPort : null)
 
         if (cachedAppState) {
           // State already restored from cache in useState initializers
@@ -241,16 +244,18 @@ export default function RootLayout() {
           loadInitialData().catch(() => {})
           return // Early return since we already set ready/loading
         } else {
-          // No cache, need to load
-          await loadInitialData()
+          // No cache, need to load in the background after unblocking the shell
+          setReady(true)
+          setLoading(false)
+          loadInitialData().catch((err: any) => {
+            console.error('[App] Background initial data load failed:', err?.message || err)
+          })
+          return
         }
       }
     } catch (err) {
       console.error('[App] Failed to initialize Pear backend:', err)
     }
-
-    setReady(true)
-    setLoading(false)
   }, [loadInitialData])
 
   useEffect(() => {

--- a/packages/app/app/_layout.web.tsx
+++ b/packages/app/app/_layout.web.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-empty, @typescript-eslint/no-require-imports */
 /**
  * Root Layout (Web/Pear) - Wraps app with providers
  *

--- a/packages/backend/src/runtime.js
+++ b/packages/backend/src/runtime.js
@@ -24,8 +24,19 @@ async function appendDebugLine(line) {
   }
 }
 
+function getBlobServerStatus(backend) {
+  const ctx = backend?.ctx
+  const port = Number(ctx?.blobServer?.port || ctx?.blobServerPort || 0) || 0
+  const error = ctx?.blobServer?._peartubeListenError || ctx?.blobServerError || null
+  return {
+    blobServerPort: port > 0 ? port : null,
+    blobServerReady: port > 0 && !error,
+    blobServerError: error ? (error?.message || String(error)) : null
+  }
+}
+
 function getBlobServerPort(backend) {
-  return backend?.ctx?.blobServer?.port || backend?.ctx?.blobServerPort || 0
+  return getBlobServerStatus(backend).blobServerPort || 0
 }
 
 function getIdentityCount(backend) {
@@ -42,7 +53,7 @@ function buildSharedSystemHandlers(backend) {
         state: { subscriptionChannelKeys: [], identityChannelKeys: [], activeIdentityName: '', activeIdentityChannelKey: '', activeChannelPublished: false }
       }
       return {
-        blobServerPort: getBlobServerPort(backend),
+        ...getBlobServerStatus(backend),
         protocolVersion: PROTOCOL_VERSION,
         storagePath: req?.storagePath || '',
         snapshot: emptySnapshot
@@ -69,7 +80,7 @@ function buildSharedSystemHandlers(backend) {
         status: {
           ready: true,
           hasIdentity: getIdentityCount(backend) > 0,
-          blobServerPort: getBlobServerPort(backend)
+          ...getBlobServerStatus(backend)
         }
       }
     },
@@ -241,8 +252,20 @@ export function createBackendRuntime(opts = {}) {
 
         registerSharedHandlers(rpc, backend)
 
-        const readyPayload = { blobServerPort: getBlobServerPort(backend), protocolVersion: PROTOCOL_VERSION }
+        const blobStatus = getBlobServerStatus(backend)
+        const readyPayload = { ...blobStatus, protocolVersion: PROTOCOL_VERSION }
         readyCallback(readyPayload)
+        if (blobStatus.blobServerError) {
+          try {
+            rpc.eventError?.({
+              code: 'BLOB_SERVER_UNAVAILABLE',
+              message: blobStatus.blobServerError,
+              retryable: true
+            })
+          } catch {
+            // Preserve backend readiness if degraded error emission fails.
+          }
+        }
         try {
           rpc.eventReady?.(readyPayload)
         } catch {

--- a/packages/backend/src/storage.js
+++ b/packages/backend/src/storage.js
@@ -858,6 +858,11 @@ export async function initializeStorage(config) {
   // Initialize blob server for video streaming only after metadata cores are open.
   let blobServer = null;
   let blobServerPort = 0;
+  let blobServerError = null;
+  let resolveBlobServerReady;
+  const blobServerReady = new Promise((resolve) => {
+    resolveBlobServerReady = resolve
+  })
   let blobServerHost = blobServerHostOverride || '127.0.0.1';
   let blobServerBindHost = blobServerBindHostOverride || blobServerHost;
 
@@ -963,28 +968,47 @@ export async function initializeStorage(config) {
     console.log('[Storage] Starting blob server listen...');
     await appendDebugLine('[storage] blob server listen start')
     globalBlobServer = blobServer;
+    const markBlobServerReady = (port, error = null) => {
+      blobServerPort = Number(port || 0) || 0
+      blobServerError = error || null
+      blobServer._peartubeListenResolved = true
+      blobServer._peartubeReady = blobServerPort > 0 && !blobServerError
+      blobServer._peartubeListenError = blobServerError
+      if (!blobServerError) {
+        console.log('[Storage] Blob server listening on port:', blobServerPort)
+        void appendDebugLine(`[storage] blob server listening port=${blobServerPort}`)
+      }
+      resolveBlobServerReady?.({ port: blobServerPort, error: blobServerError })
+    }
+
     blobServer._peartubeListenResolved = false
+    blobServer._peartubeReady = false
+    blobServer._peartubeListenError = null
     const blobServerListenPromise = blobServer.listen()
 
     if (blobServerListenPromise && typeof blobServerListenPromise.then === 'function') {
       blobServerListenPromise
         .then(() => {
-          blobServer._peartubeListenResolved = true
-          blobServerPort = blobServer.port || 0
-          console.log('[Storage] Blob server listening on port:', blobServerPort)
-          void appendDebugLine(`[storage] blob server listening port=${blobServerPort}`)
+          const resolvedPort = Number(blobServer.port || 0) || 0
+          if (!resolvedPort) {
+            markBlobServerReady(0, new Error('Blob server listen resolved without an assigned port'))
+            return
+          }
+          markBlobServerReady(resolvedPort)
         })
         .catch((err) => {
-          console.error('[Storage] Blob server listen failed:', err?.message)
-          void appendDebugLine(`[storage] blob server listen failed ${err?.message || String(err)}`)
+          markBlobServerReady(0, err)
         })
     } else {
-      blobServer._peartubeListenResolved = true
-      blobServerPort = blobServer.port || 0
-      console.log('[Storage] Blob server listening on port:', blobServerPort)
-      await appendDebugLine(`[storage] blob server listening port=${blobServerPort}`)
+      const resolvedPort = Number(blobServer.port || 0) || 0
+      markBlobServerReady(
+        resolvedPort,
+        resolvedPort ? null : new Error('Blob server listen returned before an assigned port was available')
+      )
     }
   } catch (err) {
+    blobServerError = err
+    resolveBlobServerReady?.({ port: 0, error: err })
     console.error('[Storage] Failed to initialize blob server:', err.message);
     await appendDebugLine(`[storage] blob server init failed ${err?.message || String(err)}`)
     // Continue without blob server - will need alternative video streaming
@@ -1238,6 +1262,8 @@ export async function initializeStorage(config) {
     swarm,
     blobServer,
     blobServerPort,
+    blobServerReady,
+    blobServerError,
     blobServerHost,
     blobServerBindHost,
     blobSessionToken, // Session token for URL authentication

--- a/packages/host/src/index.d.ts
+++ b/packages/host/src/index.d.ts
@@ -1,5 +1,7 @@
 export type HostReadyData = {
   blobServerPort: number | null
+  blobServerReady?: boolean
+  blobServerError?: string | null
   protocolVersion: 2
 }
 

--- a/packages/host/src/start-host.js
+++ b/packages/host/src/start-host.js
@@ -89,6 +89,15 @@ function normalizeHostError(error, fallbackCode = HOST_ERROR_CODES.HOST_START_FA
   return createHostError(fallbackCode, message, { cause: error })
 }
 
+function normalizeReadyPayload(payload = {}) {
+  return {
+    blobServerPort: payload?.blobServerPort ?? null,
+    blobServerReady: Boolean(payload?.blobServerReady),
+    blobServerError: payload?.blobServerError ?? null,
+    protocolVersion: payload?.protocolVersion ?? PROTOCOL_VERSION
+  }
+}
+
 export async function startHost(options = {}) {
   validateStartOptions(options)
 
@@ -140,10 +149,7 @@ export async function startHost(options = {}) {
       onFeedUpdate,
       onVideoStats,
       onReady(payload = {}) {
-        const readyData = {
-          blobServerPort: payload?.blobServerPort ?? null,
-          protocolVersion: payload?.protocolVersion ?? PROTOCOL_VERSION
-        }
+        const readyData = normalizeReadyPayload(payload)
 
         settleReady(readyData)
         emitLifecycle({ type: 'host.ready', data: readyData })

--- a/packages/host/src/start-host.js
+++ b/packages/host/src/start-host.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-empty, @typescript-eslint/no-require-imports */
 import { createHostError, HOST_ERROR_CODES, PROTOCOL_VERSION } from './contracts.js'
 
 function noop() {}

--- a/packages/host/test/start-host.test.mjs
+++ b/packages/host/test/start-host.test.mjs
@@ -39,14 +39,36 @@ test('startHost forwards ready payload with protocolVersion and lifecycle event'
     stream: createFakeStream(),
     onLifecycle: (event) => lifecycleEvents.push(event),
     createBackendImpl: async ({ onReady }) => {
-      onReady({ blobServerPort: 7777 })
+      onReady({ blobServerPort: 7777, blobServerReady: true, blobServerError: null })
       return { destroy: async () => {} }
     }
   })
 
   const ready = await session.waitUntilReady()
 
-  t.alike(ready, { blobServerPort: 7777, protocolVersion: 2 })
+  t.alike(ready, { blobServerPort: 7777, blobServerReady: true, blobServerError: null, protocolVersion: 2 })
+  t.alike(lifecycleEvents, [{ type: 'host.ready', data: ready }])
+})
+
+test('startHost forwards degraded blob server readiness details', async (t) => {
+  const lifecycleEvents = []
+
+  const session = await startHost({
+    platform: 'desktop',
+    storagePath: '/tmp/peartube-host',
+    entrypoint: 'sidecar-entry',
+    args: [],
+    stream: createFakeStream(),
+    onLifecycle: (event) => lifecycleEvents.push(event),
+    createBackendImpl: async ({ onReady }) => {
+      onReady({ blobServerPort: null, blobServerReady: false, blobServerError: 'address in use', protocolVersion: 2 })
+      return { destroy: async () => {} }
+    }
+  })
+
+  const ready = await session.waitUntilReady()
+
+  t.alike(ready, { blobServerPort: null, blobServerReady: false, blobServerError: 'address in use', protocolVersion: 2 })
   t.alike(lifecycleEvents, [{ type: 'host.ready', data: ready }])
 })
 

--- a/packages/platform/src/rpc.shared.ts
+++ b/packages/platform/src/rpc.shared.ts
@@ -124,7 +124,8 @@ function createCallbackStore(): PlatformCallbacks {
 function safeDispatch<T>(callbacks: T[], value: Parameters<Extract<T, (...args: any[]) => unknown>>[0]) {
   for (const callback of callbacks) {
     try {
-      ;(callback as (data: typeof value) => void)(value)
+      const typedCallback = callback as (data: typeof value) => void
+      typedCallback(value)
     } catch (error) {
       console.error('[Platform RPC] Event callback failed:', error)
     }

--- a/packages/platform/src/rpc.shared.ts
+++ b/packages/platform/src/rpc.shared.ts
@@ -1,7 +1,12 @@
 import { PROTOCOL_EVENTS } from '@peartube/protocol/events'
 
-export type HostReadyData = {
+type BlobServerStatus = {
   blobServerPort: number | null
+  blobServerReady?: boolean
+  blobServerError?: string | null
+}
+
+export type HostReadyData = BlobServerStatus & {
   protocolVersion: 2
 }
 
@@ -143,6 +148,8 @@ export function createPlatformRpcBridge(options: PlatformRpcBridgeOptions) {
     if (
       lastReady &&
       lastReady.blobServerPort === data.blobServerPort &&
+      lastReady.blobServerReady === data.blobServerReady &&
+      lastReady.blobServerError === data.blobServerError &&
       lastReady.protocolVersion === data.protocolVersion
     ) {
       return

--- a/packages/protocol/src/create-client.js
+++ b/packages/protocol/src/create-client.js
@@ -147,6 +147,8 @@ function normalizeReadyPayload(payload = {}) {
 
   return {
     blobServerPort: status?.blobServerPort ?? null,
+    blobServerReady: Boolean(status?.blobServerReady),
+    blobServerError: status?.blobServerError ?? null,
     protocolVersion: status?.protocolVersion ?? PROTOCOL_VERSION
   }
 }
@@ -246,6 +248,8 @@ export function createProtocolClient({ stream, HRPCImpl } = {}) {
     if (
       lastReady &&
       lastReady.blobServerPort === normalized.blobServerPort &&
+      lastReady.blobServerReady === normalized.blobServerReady &&
+      lastReady.blobServerError === normalized.blobServerError &&
       lastReady.protocolVersion === normalized.protocolVersion
     ) {
       return normalized

--- a/packages/protocol/src/create-client.js
+++ b/packages/protocol/src/create-client.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-empty, @typescript-eslint/no-require-imports */
 import { createHostError, HOST_ERROR_CODES, PROTOCOL_VERSION } from '@peartube/host'
 import DefaultHRPC from '@peartube/spec'
 

--- a/packages/protocol/test/create-client.test.mjs
+++ b/packages/protocol/test/create-client.test.mjs
@@ -15,6 +15,8 @@ class FakeHRPC {
     return Promise.resolve({
         status: {
           blobServerPort: 9999,
+          blobServerReady: true,
+          blobServerError: null,
           protocolVersion: 2
         }
       })
@@ -53,12 +55,66 @@ test('createProtocolClient remaps feed update events', async (t) => {
 
   const ready = await client.ready()
 
-  t.alike(ready, { blobServerPort: 9999, protocolVersion: 2 })
+  t.alike(ready, { blobServerPort: 9999, blobServerReady: true, blobServerError: null, protocolVersion: 2 })
   t.alike(readyEvents[0], ready)
 
   FakeHRPC.instances[0].handlers.feedUpdate({ action: 'update', channelKey: 'abc' })
 
   t.alike(events[0], { action: 'update', channelKey: 'abc' })
+})
+
+test('createProtocolClient propagates degraded blob server readiness and does not dedupe status changes', async (t) => {
+  FakeHRPC.instances.length = 0
+  const readyEvents = []
+
+  class DegradedHRPC extends FakeHRPC {
+    getStatus() {
+      return Promise.resolve({
+        status: {
+          blobServerPort: null,
+          blobServerReady: false,
+          blobServerError: 'listen failed',
+          protocolVersion: 2
+        }
+      })
+    }
+
+    onEventReady(handler) {
+      this.handlers.ready = handler
+    }
+  }
+
+  const client = createProtocolClient({
+    stream: {},
+    HRPCImpl: DegradedHRPC
+  })
+
+  client.events.on(PROTOCOL_EVENTS.HOST_READY, (payload) => {
+    readyEvents.push(payload)
+  })
+
+  const ready = await client.ready()
+
+  t.alike(ready, { blobServerPort: null, blobServerReady: false, blobServerError: 'listen failed', protocolVersion: 2 })
+  t.alike(readyEvents, [ready])
+
+  FakeHRPC.instances[0].handlers.ready({
+    blobServerPort: null,
+    blobServerReady: false,
+    blobServerError: 'listen failed',
+    protocolVersion: 2
+  })
+  FakeHRPC.instances[0].handlers.ready({
+    blobServerPort: 4545,
+    blobServerReady: true,
+    blobServerError: null,
+    protocolVersion: 2
+  })
+
+  t.alike(readyEvents, [
+    ready,
+    { blobServerPort: 4545, blobServerReady: true, blobServerError: null, protocolVersion: 2 }
+  ])
 })
 
 test('createProtocolClient forwards log events through the shared event map', async (t) => {

--- a/packages/spec/schema.cjs
+++ b/packages/spec/schema.cjs
@@ -1000,6 +1000,8 @@ ns.register({
   name: 'desktop-bootstrap-response',
   fields: [
     { name: 'blobServerPort', type: 'uint', required: false },
+    { name: 'blobServerReady', type: 'bool', required: false },
+    { name: 'blobServerError', type: 'string', required: false },
     { name: 'protocolVersion', type: 'uint', required: false },
     { name: 'storagePath', type: 'string', required: false },
     { name: 'snapshot', type: '@peartube/desktop-browse-snapshot', required: true }
@@ -1220,7 +1222,9 @@ ns.register({
   fields: [
     { name: 'ready', type: 'bool', required: true },
     { name: 'hasIdentity', type: 'bool', required: false },
-    { name: 'blobServerPort', type: 'uint', required: false }
+    { name: 'blobServerPort', type: 'uint', required: false },
+    { name: 'blobServerReady', type: 'bool', required: false },
+    { name: 'blobServerError', type: 'string', required: false }
   ]
 })
 

--- a/packages/spec/schema.cjs
+++ b/packages/spec/schema.cjs
@@ -1,3 +1,4 @@
+/* eslint-disable no-empty, @typescript-eslint/no-require-imports */
 /**
  * PearTube HRPC Schema Definition
  *


### PR DESCRIPTION
## Summary
- Render the Pear/web shell as soon as backend-ready arrives instead of waiting on identity/listVideos hydration
- Track blob server readiness explicitly and propagate `blobServerReady` / `blobServerError` through runtime, host, protocol, and RPC types
- Surface degraded blob-server readiness without pretending port `0` is a healthy local blob server

Closes #190
Closes #191

## Test Plan
- `node packages/protocol/test/create-client.test.mjs`
- `node packages/host/test/start-host.test.mjs`
- `npm test --prefix packages/spec`
- `npm run lint:changed`
- `git diff --check`
