### PR TITLE
fix(backend): avoid blocking startup on optional P2P imports

### DIFF
--- a/packages/backend/src/storage.js
+++ b/packages/backend/src/storage.js
@@ -82,6 +82,7 @@ const log = logger('Storage')
 // Network stats for debugging connection issues
 let HyperswarmStats = null
 let optionalStorageDepsReady = null
+let hyperswarmModuleReady = null
 
 // Global network stats instance (set after swarm is created)
 let networkStats = null;
@@ -480,7 +481,7 @@ async function ensureHttpModule() {
   return http
 }
 
-async function initOptionalStorageDeps() {
+function initOptionalStorageDeps() {
   if (optionalStorageDepsReady) return optionalStorageDepsReady
 
   optionalStorageDepsReady = (async () => {
@@ -517,8 +518,7 @@ async function initOptionalStorageDeps() {
 }
 
 async function initStorageModules() {
-  await initOptionalStorageDeps()
-  if (fs && path && Hyperswarm) return;
+  if (fs && path) return;
   fs = resolveBareOrNodeFsModuleSync()
   path = resolveBareOrNodePathModuleSync()
   if (!fs) {
@@ -527,9 +527,29 @@ async function initStorageModules() {
   if (!path) {
     try { path = await loadBareOrNodePathModule(); } catch { /* best effort */ }
   }
-  if (!Hyperswarm) {
-    try { Hyperswarm = await loadHyperswarmModule(); } catch { /* best effort */ }
+}
+
+function warmOptionalStorageDeps() {
+  void initOptionalStorageDeps()
+    .catch((error) => {
+      log.debug('optional storage dependency warm-up failed', { error: error?.message || String(error) })
+    })
+}
+
+function warmHyperswarmModule() {
+  if (Hyperswarm) return hyperswarmModuleReady || Promise.resolve(Hyperswarm)
+  if (!hyperswarmModuleReady) {
+    hyperswarmModuleReady = loadHyperswarmModule()
+      .then((LoadedHyperswarm) => {
+        if (!Hyperswarm) Hyperswarm = LoadedHyperswarm
+        return Hyperswarm
+      })
+      .catch(async (error) => {
+        await appendDebugLine(`[storage] hyperswarm module unavailable during background warm-up ${error?.message || String(error)}`)
+        return null
+      })
   }
+  return hyperswarmModuleReady
 }
 
 async function migrateLegacyCorestoreLayout(storagePath) {
@@ -771,6 +791,8 @@ export async function retainPublicBeeContentDiscovery(ctx, publicBeeKeyHex, opti
  */
 export async function initializeStorage(config) {
   await appendDebugLine('[storage] initializeStorage entry')
+  warmOptionalStorageDeps()
+  warmHyperswarmModule()
   await initStorageModules();
   await appendDebugLine('[storage] initStorageModules complete')
 
@@ -1052,14 +1074,18 @@ export async function initializeStorage(config) {
 
   console.log('[Storage] Creating Hyperswarm...');
   await appendDebugLine('[storage] creating hyperswarm')
+  const LoadedHyperswarm = Hyperswarm || (hyperswarmModuleReady ? await Promise.race([
+    hyperswarmModuleReady,
+    new Promise((resolve) => setTimeout(() => resolve(null), 100))
+  ]) : null)
   let swarm
-  if (typeof Hyperswarm !== 'function') {
+  if (typeof LoadedHyperswarm !== 'function') {
     console.warn('[Storage] Hyperswarm unavailable; continuing with offline P2P networking')
     await appendDebugLine('[storage] hyperswarm unavailable; using offline swarm')
     swarm = createOfflineSwarm(keyPair, 'module-unavailable')
   } else {
     try {
-      swarm = new Hyperswarm({ keyPair });
+      swarm = new LoadedHyperswarm({ keyPair });
     } catch (err) {
       console.warn('[Storage] Hyperswarm creation failed; continuing with offline P2P networking:', err?.message)
       await appendDebugLine(`[storage] hyperswarm create failed; using offline swarm ${err?.message || String(err)}`)

--- a/packages/backend/test/storage-startup-regression.test.mjs
+++ b/packages/backend/test/storage-startup-regression.test.mjs
@@ -16,6 +16,19 @@ test('storage startup does not eagerly load HTTP before backend ready', () => {
   assert.doesNotMatch(initStorageModulesBody, /loadBareOrNodeHttpModule\(\)/)
 })
 
+test('storage startup does not await optional network dependencies before local readiness', () => {
+  const initStorageModulesBody =
+    storageSource.match(/async function initStorageModules\(\) \{([\s\S]*?)\n\}/)?.[1] ?? ''
+
+  assert.ok(initStorageModulesBody, 'initStorageModules should exist')
+  assert.doesNotMatch(initStorageModulesBody, /await initOptionalStorageDeps\(\)/)
+  assert.doesNotMatch(initStorageModulesBody, /await loadHyperswarmModule\(\)/)
+  assert.match(storageSource, /function warmOptionalStorageDeps\(\)/)
+  assert.match(storageSource, /function warmHyperswarmModule\(\)/)
+  assert.match(storageSource, /warmOptionalStorageDeps\(\)[\s\S]*?warmHyperswarmModule\(\)[\s\S]*?await initStorageModules\(\)/)
+  assert.match(storageSource, /Promise\.race\(\[[\s\S]*?hyperswarmModuleReady[\s\S]*?setTimeout\(\(\) => resolve\(null\), 100\)/)
+})
+
 test('blob server watchdog lazily loads HTTP only when cast probing is needed', () => {
   const watchdogBody =
     storageSource.match(/export function startBlobServerWatchdog\(\) \{([\s\S]*?)\n\}/)?.[1] ?? ''
@@ -44,7 +57,7 @@ test('storage creates an offline swarm fallback when Hyperswarm is unavailable',
   )
   assert.match(
     storageSource,
-    /typeof Hyperswarm !== 'function'[\s\S]*?createOfflineSwarm\(keyPair, 'module-unavailable'\)/,
+    /typeof LoadedHyperswarm !== 'function'[\s\S]*?createOfflineSwarm\(keyPair, 'module-unavailable'\)/,
     'storage init should continue with offline swarm when Hyperswarm module did not load'
   )
   assert.match(


### PR DESCRIPTION
## Summary
- Makes storage startup stop awaiting optional network dependency imports before local storage readiness
- Starts optional `hyperswarm-stats` / `protomux-wakeup` and Hyperswarm module loading as background warm-ups
- Uses a short bounded wait for an already-warming Hyperswarm module, then falls back to the offline swarm instead of blocking local backend boot

## Why
Issue #192: a slow/hung native P2P import should degrade networking, not prevent local/offline backend APIs from coming up.

## Verification
- `node --test packages/backend/test/storage-startup-regression.test.mjs`
- `npm run lint:changed`
- `git diff --check`
- `npm test --prefix packages/backend`

Closes #192
