### PR TITLE
fix(backend): preserve video byte availability

### DIFF
--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -765,14 +765,18 @@ export function createApi({
 
           return videos.map((video) => {
             const id = extractVideoId(video)
+            const localHint = id ? localHintsById.get(id) : null
+            const peerHint = id ? peerHintsById.get(id) : null
+            const availability = id
+              ? resolveExplicitVideoAvailability({ localHint, peerHint })
+              : 'unavailable'
+
             return {
               ...video,
-              availability: id
-                ? resolveExplicitVideoAvailability({
-                    localHint: localHintsById.get(id),
-                    peerHint: peerHintsById.get(id),
-                  })
-                : 'unavailable',
+              availability,
+              byteAvailability: availability,
+              contiguousBlocks: Number(localHint?.contiguousBlocks || peerHint?.contiguousBlocks || 0) || 0,
+              hasHeadBlock: Boolean(localHint?.hasHeadBlock || peerHint?.hasHeadBlock),
             }
           })
         }

--- a/packages/backend/test/public-feed-api.test.mjs
+++ b/packages/backend/test/public-feed-api.test.mjs
@@ -356,6 +356,7 @@ test('listVideos marks videos unavailable when neither local cache nor peer hint
   t.is(requestCalls.length, 1)
   t.is(videos.length, 1)
   t.is(videos[0]?.availability, 'unavailable')
+  t.is(videos[0]?.byteAvailability, 'unavailable')
 })
 
 test('listVideos does not mark remote videos playable from unrelated swarm peers alone', async (t) => {
@@ -479,6 +480,9 @@ test('listVideos keeps the local head-block fast path explicitly playable', asyn
 
   t.is(videos.length, 1)
   t.is(videos[0]?.availability, 'playable')
+  t.is(videos[0]?.byteAvailability, 'playable')
+  t.is(videos[0]?.contiguousBlocks, 8)
+  t.is(videos[0]?.hasHeadBlock, true)
 })
 
 test('listVideos respects authoritative unavailable hints even when peers are connected', async (t) => {
@@ -548,6 +552,7 @@ test('listVideos respects authoritative unavailable hints even when peers are co
 
   t.is(videos.length, 1)
   t.is(videos[0]?.availability, 'unavailable')
+  t.is(videos[0]?.byteAvailability, 'unavailable')
 })
 
 test('listVideos revalidates cached remote availability on each read', async (t) => {
@@ -619,7 +624,11 @@ test('listVideos revalidates cached remote availability on each read', async (t)
   const second = await api.listVideos(driveKey, publicBeeKey)
 
   t.is(first[0]?.availability, 'playable')
+  t.is(first[0]?.byteAvailability, 'playable')
+  t.is(first[0]?.contiguousBlocks, 8)
+  t.is(first[0]?.hasHeadBlock, true)
   t.is(second[0]?.availability, 'unavailable')
+  t.is(second[0]?.byteAvailability, 'unavailable')
   t.is(requestCount, 2)
 })
 


### PR DESCRIPTION
## Summary
- Keeps hydrated `listVideos()` results aligned with feed-preview availability contracts
- Adds `byteAvailability` alongside `availability`
- Preserves availability probe details (`contiguousBlocks`, `hasHeadBlock`) when available

## Verification
- `npm test --prefix packages/backend -- test/public-feed-api.test.mjs`
- `npm run lint:changed`
- `git diff --check`

Closes #206
