### PR TITLE
fix(backend): use listVideos array in playback prefetch

### DIFF
--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -2164,9 +2164,9 @@ export function createApi({
       console.log('[API] prefetchNextVideos: channel:', channelKey?.slice(0, 16), 'current:', currentVideoId, 'count:', count)
 
       try {
-        // Get list of videos for this channel
-        const videosResult = await this.listVideos({ channelKey })
-        const videos = videosResult?.videos || []
+        // Get list of videos for this channel. listVideos returns the
+        // normalized video array directly.
+        const videos = await this.listVideos(channelKey)
 
         if (videos.length === 0) {
           console.log('[API] prefetchNextVideos: no videos found')

--- a/packages/backend/test/playback-api.test.mjs
+++ b/packages/backend/test/playback-api.test.mjs
@@ -67,6 +67,62 @@ test('preparePlayback returns a playable URL before warmup settles or fails', as
   ])
 })
 
+test('prefetchNextVideos lists channel videos with the correct signature', async (t) => {
+  const api = createApi({ ctx: {} })
+  const calls = []
+
+  api.listVideos = async (...args) => {
+    calls.push(['listVideos', args])
+    return [
+      { id: 'current', title: 'Current' },
+      { id: 'next-one', title: 'Next one' },
+      { videoId: 'next-two', title: 'Next two' },
+      { path: 'videos/next-three.mp4', title: 'Next three' },
+    ]
+  }
+
+  api.prefetchVideo = async (...args) => {
+    calls.push(['prefetchVideo', args])
+    return { success: true }
+  }
+
+  const result = await api.prefetchNextVideos('channel-key', 'current', 2)
+
+  t.alike(result, { success: true, prefetchedCount: 2 })
+  t.alike(calls, [
+    ['listVideos', ['channel-key']],
+    ['prefetchVideo', ['channel-key', 'next-one']],
+    ['prefetchVideo', ['channel-key', 'next-two']],
+  ])
+})
+
+test('prefetchNextVideos prefetches first videos when current video is absent', async (t) => {
+  const api = createApi({ ctx: {} })
+  const calls = []
+
+  api.listVideos = async (...args) => {
+    calls.push(['listVideos', args])
+    return [
+      { path: 'videos/first.mp4', title: 'First' },
+      { id: 'second', title: 'Second' },
+    ]
+  }
+
+  api.prefetchVideo = async (...args) => {
+    calls.push(['prefetchVideo', args])
+    return { success: true }
+  }
+
+  const result = await api.prefetchNextVideos('channel-key', 'missing', 2)
+
+  t.alike(result, { success: true, prefetchedCount: 2 })
+  t.alike(calls, [
+    ['listVideos', ['channel-key']],
+    ['prefetchVideo', ['channel-key', 'videos/first.mp4']],
+    ['prefetchVideo', ['channel-key', 'second']],
+  ])
+})
+
 test('getVideoStats keeps video peer count separate from global swarm connections', (t) => {
   const videoCore = { peers: [1, 2] }
   const api = createApi({


### PR DESCRIPTION
## Summary
- Calls `listVideos(channelKey)` from playback prefetch with the correct API signature
- Treats `listVideos` as the normalized video array it returns
- Adds regression coverage for next-video and missing-current fallback prefetch paths

## Verification
- `npm test --prefix packages/backend -- test/playback-api.test.mjs`
- `npm run lint:changed`
- `git diff --check`

Closes #207
