### PR TITLE
fix(app): preserve direct refs for cast playback

### DIFF
--- a/packages/app/components/VideoPlayerOverlayImpl.tsx
+++ b/packages/app/components/VideoPlayerOverlayImpl.tsx
@@ -492,9 +492,14 @@ export function VideoPlayerOverlay() {
           const videoRef = (currentVideo.path && typeof currentVideo.path === 'string' && currentVideo.path.startsWith('/'))
             ? currentVideo.path
             : currentVideo.id
+          const currentVideoAny = currentVideo as any
           const result = await rpc.getVideoUrl({
             channelKey: currentVideo.channelKey,
             videoId: videoRef,
+            publicBeeKey: currentVideoAny.publicBeeKey,
+            blobId: currentVideoAny.blobId,
+            blobsCoreKey: currentVideoAny.blobsCoreKey,
+            mimeType: currentVideo.mimeType,
           })
           urlToCast = result?.url || null
         } catch (err: any) {
@@ -566,9 +571,14 @@ export function VideoPlayerOverlay() {
           const videoRef = (currentVideo.path && typeof currentVideo.path === 'string' && currentVideo.path.startsWith('/'))
             ? currentVideo.path
             : currentVideo.id
+          const currentVideoAny = currentVideo as any
           const result = await rpc.getVideoUrl({
             channelKey: currentVideo.channelKey,
             videoId: videoRef,
+            publicBeeKey: currentVideoAny.publicBeeKey,
+            blobId: currentVideoAny.blobId,
+            blobsCoreKey: currentVideoAny.blobsCoreKey,
+            mimeType: currentVideo.mimeType,
           })
           urlToCast = result?.url || null
         }

--- a/packages/app/tests/vertical-discovery-regression.test.mjs
+++ b/packages/app/tests/vertical-discovery-regression.test.mjs
@@ -220,6 +220,13 @@ test('vertical discovery updates feed entries when previews change without chann
   assert.match(source, /prevSignature === nextSignature \? prev : mergedEntries/, 'unchanged signatures may preserve state, changed previews must update entries')
 })
 
+test('global overlay cast URL resolution preserves direct blob refs', () => {
+  const source = readAppFile('components/VideoPlayerOverlayImpl.tsx')
+
+  const directRefCastCalls = source.match(/rpc\.getVideoUrl\(\{[\s\S]*?publicBeeKey: currentVideoAny\.publicBeeKey,[\s\S]*?blobId: currentVideoAny\.blobId,[\s\S]*?blobsCoreKey: currentVideoAny\.blobsCoreKey,[\s\S]*?mimeType: currentVideo\.mimeType,[\s\S]*?\}\)/g) || []
+  assert.equal(directRefCastCalls.length, 2, 'manual and auto cast URL resolution should pass direct playback refs')
+})
+
 test('vertical discovery keeps the global watch/mini overlay off the Shorts route', () => {
   const discoverSource = readAppFile('app/(tabs)/discover.tsx')
   const overlaySource = readAppFile('components/VideoPlayerOverlayImpl.tsx')


### PR DESCRIPTION
## Summary
- Threads direct playback refs through global player cast URL resolution
- Covers both manual cast-device selection and auto-cast while already connected
- Adds a source regression so cast URL lookup keeps `publicBeeKey`, `blobId`, `blobsCoreKey`, and `mimeType`

## Verification
- `node --test packages/app/tests/vertical-discovery-regression.test.mjs`
- `npm run lint:changed`
- `git diff --check`

Closes #208
