### PR TITLE
fix(app): keep Shorts playback out of mini player

### DIFF
--- a/packages/app/app/(tabs)/discover.tsx
+++ b/packages/app/app/(tabs)/discover.tsx
@@ -367,7 +367,7 @@ export default function VerticalDiscoveryScreen() {
       if (cachedUrl) {
         void rpc.preparePlayback(playbackRequest).catch(() => undefined)
         if (isStalePlaybackRequest()) return
-        setAmbientVideoContext(video, cachedUrl)
+        setAmbientVideoContext(video, cachedUrl, { keepHidden: true })
         setShortsVideoUrl(cachedUrl)
         setShortsPlaybackSession((prev) => prev + 1)
         setShortsLoading(false)
@@ -378,7 +378,7 @@ export default function VerticalDiscoveryScreen() {
       if (isStalePlaybackRequest()) return
       if (result?.url) {
         if (cacheKey) setCachedVideoUrl(cacheKey, result.url)
-        setAmbientVideoContext(video, result.url)
+        setAmbientVideoContext(video, result.url, { keepHidden: true })
         setShortsVideoUrl(result.url)
         setShortsPlaybackSession((prev) => prev + 1)
       }
@@ -461,7 +461,7 @@ export default function VerticalDiscoveryScreen() {
   }, [router])
 
   const openComments = useCallback((video: VideoData) => {
-    setAmbientVideoContext(video, activeVideoKey === `${video.channelKey}:${video.id}` ? shortsVideoUrl : null)
+    setAmbientVideoContext(video, activeVideoKey === `${video.channelKey}:${video.id}` ? shortsVideoUrl : null, { keepHidden: true })
     setShortsChromeVisible(true)
     setCommentsSheetVisible(true)
   }, [activeVideoKey, setAmbientVideoContext, shortsVideoUrl])

--- a/packages/app/lib/VideoPlayerContext.tsx
+++ b/packages/app/lib/VideoPlayerContext.tsx
@@ -78,7 +78,7 @@ interface VideoPlayerContextType {
 
   // Actions
   loadAndPlayVideo: (video: VideoData, url: string) => void
-  setAmbientVideoContext: (video: VideoData | null, url?: string | null) => void
+  setAmbientVideoContext: (video: VideoData | null, url?: string | null, options?: { keepHidden?: boolean }) => void
   pauseVideo: () => void
   resumeVideo: () => void
   closeVideo: () => void
@@ -847,7 +847,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
     startInActivityPlayback(video, url, 'direct-load')
   }, [startInActivityPlayback])
 
-  const setAmbientVideoContext = useCallback((video: VideoData | null, url: string | null = null) => {
+  const setAmbientVideoContext = useCallback((video: VideoData | null, url: string | null = null, options: { keepHidden?: boolean } = {}) => {
     const currentKey = currentVideoRef.current
       ? `${currentVideoRef.current.channelKey || ''}:${currentVideoRef.current.id || currentVideoRef.current.path || ''}`
       : null
@@ -855,7 +855,13 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
 
     currentVideoRef.current = video
     videoUrlRef.current = url
-    dispatch({ type: 'SET_AMBIENT_VIDEO_CONTEXT', source: 'setAmbientVideoContext', video, url })
+    dispatch({
+      type: 'SET_AMBIENT_VIDEO_CONTEXT',
+      source: 'setAmbientVideoContext',
+      video,
+      url,
+      keepHidden: options.keepHidden,
+    })
 
     if (video && currentKey !== nextKey) {
       setVideoStats(null)

--- a/packages/app/lib/playerStateMachine.ts
+++ b/packages/app/lib/playerStateMachine.ts
@@ -68,6 +68,7 @@ export type PlayerEvent =
       source: 'setAmbientVideoContext'
       video: VideoData | null
       url?: string | null
+      keepHidden?: boolean
     }
   | {
       type: 'RESTORE_FROM_LAST_CLOSED'
@@ -462,6 +463,14 @@ function playerReducerInternal(state: PlayerState, event: PlayerEvent): PlayerSt
           // Allow loading a new video while in fullscreen (e.g., tapping related video)
           return toFullscreenState(state, event.video, event.url, true)
         case 'SET_AMBIENT_VIDEO_CONTEXT':
+          if (event.keepHidden) {
+            return {
+              ...state,
+              mode: 'hidden',
+              video: event.video,
+              url: event.url || null,
+            }
+          }
           return {
             ...state,
             video: event.video,
@@ -522,6 +531,14 @@ function playerReducerInternal(state: PlayerState, event: PlayerEvent): PlayerSt
           // This happens when user taps a new video while mini player is active.
           return toFullscreenState(state, event.video, event.url, true)
         case 'SET_AMBIENT_VIDEO_CONTEXT':
+          if (event.keepHidden) {
+            return {
+              ...state,
+              mode: 'hidden',
+              video: event.video,
+              url: event.url || null,
+            }
+          }
           return {
             ...state,
             video: event.video,

--- a/packages/app/tests/vertical-discovery-regression.test.mjs
+++ b/packages/app/tests/vertical-discovery-regression.test.mjs
@@ -36,6 +36,9 @@ test('vertical discovery uses paged full-screen feed and plays inline in the sho
   assert.match(source, /handoffToShorts\(\)/, 'vertical discovery should pause and close the global player before Shorts starts')
   assert.match(source, /preparePlayback\(playbackRequest\)/, 'vertical player should resolve playback through backend preparePlayback')
   assert.match(source, /getCachedVideoUrl\(cacheKey\)/, 'vertical player should use the short playback URL cache')
+  assert.match(source, /setAmbientVideoContext\(video, cachedUrl, \{ keepHidden: true \}\)/, 'cached Shorts playback should update social context without showing the global mini player')
+  assert.match(source, /setAmbientVideoContext\(video, result\.url, \{ keepHidden: true \}\)/, 'prepared Shorts playback should update social context without showing the global mini player')
+  assert.match(source, /setAmbientVideoContext\(video, activeVideoKey === `\$\{video\.channelKey\}:\$\{video\.id\}` \? shortsVideoUrl : null, \{ keepHidden: true \}\)/, 'comments should receive active Shorts context without launching the global player')
   assert.match(source, /setShortsVideoUrl\(/, 'vertical player should keep playback URL in local shorts-player state')
   assert.match(source, /handoffToShorts\(\)[\s\S]*const cachedUrl = cacheKey \? getCachedVideoUrl\(cacheKey\) : null/, 'handoff should happen before cached Shorts playback attaches')
   assert.match(source, /handoffToShorts\(\)[\s\S]*const result = await rpc\.preparePlayback\(playbackRequest\)/, 'handoff should happen before prepared Shorts playback attaches')
@@ -235,6 +238,9 @@ test('vertical discovery keeps the global watch/mini overlay off the Shorts rout
   assert.match(overlaySource, /usePathname\(\)/, 'global overlay should know the active route')
   assert.match(overlaySource, /const hideGlobalOverlayOnDiscover = !isDesktop && isDiscoverPathActive/, 'mobile Discover should suppress the global watch overlay')
   assert.match(overlaySource, /hideGlobalOverlayOnDiscover && playerMode !== 'hidden' && !isInPipMode/, 'Discover should not show stale mini/fullscreen overlays over Shorts')
+  const stateMachineSource = readAppFile('lib/playerStateMachine.ts')
+  assert.match(stateMachineSource, /keepHidden\?: boolean/, 'ambient Shorts context should be able to update video metadata without activating the global player')
+  assert.match(stateMachineSource, /case 'SET_AMBIENT_VIDEO_CONTEXT':[\s\S]*if \(event\.keepHidden\) \{[\s\S]*mode: 'hidden'/, 'ambient context updates should force hidden mode when requested')
 })
 
 test('vertical discovery positions progress and chrome without clumping metadata/actions', () => {


### PR DESCRIPTION
## Summary
- Adds a `keepHidden` ambient video-context path for Shorts/social state
- Uses that hidden ambient path when Shorts attaches cached/prepared playback URLs and opens comments
- Keeps actual Shorts playback owned by `VerticalShortsPlayer` instead of waking the global mini-player overlay for every active card

## Verification
- `node --test packages/app/tests/vertical-discovery-regression.test.mjs`
- `npm run lint:changed`
- `git diff --check`

