### PR TITLE
perf(backend): start public feed discovery earlier

### DIFF
--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -2600,6 +2600,10 @@ export function createApi({
       const topicHex = b4a.toString(crypto.data(b4a.from(NETWORK_TOPIC_STRING, 'utf-8')), 'hex')
       const networkDebug = getNetworkStats()
       const feedStats = publicFeed?.getStats?.() || {}
+      const startupTiming = {
+        storage: networkDebug?.startupTiming || null,
+        publicFeed: feedStats.startupTiming || null,
+      }
       const doctor = {
         dht: {
           bootstrapped: ctx.swarm?.dht?.bootstrapped ?? null,
@@ -2639,6 +2643,7 @@ export function createApi({
         feedEntries: publicFeed?.entries?.size || 0,
         feedTopicHex: topicHex,
         network: networkDebug,
+        startupTiming,
         doctor,
         swarmOffline: Boolean(ctx.swarm?._peartubeOffline),
         swarmOfflineReason: ctx.swarm?._peartubeOfflineReason || null,

--- a/packages/backend/src/orchestrator.js
+++ b/packages/backend/src/orchestrator.js
@@ -334,6 +334,14 @@ export async function createBackendContext(config) {
       console.error('[Orchestrator] publicFeed.handleDiscoveredPeer failed:', err?.message)
     }
   })
+  // Start public feed discovery before slower local managers/API wiring so DHT
+  // lookup, socket setup, and Protomux feed opening overlap backend warm-up.
+  ipcLog('[orchestrator] publicFeed.start starting early')
+  await appendDebugLine('[orchestrator] publicFeed.start starting early')
+  const publicFeedStartPromise = publicFeed.start().catch((e) => {
+    console.error('[Orchestrator] Public feed start failed:', e?.message);
+  })
+
   ipcLog('[orchestrator] seedingManager.init starting')
   await appendDebugLine('[orchestrator] seedingManager.init starting')
 
@@ -388,14 +396,9 @@ export async function createBackendContext(config) {
     publicFeed.setFeedSnapshotProvider((entries) => api.getFeedSnapshotEntries(entries, { limitPerChannel: 3 }))
   }
 
-  // Phase 6.5: Start public feed discovery immediately so UIs can get updates without waiting
-  ipcLog('[orchestrator] publicFeed.start starting')
-  await appendDebugLine('[orchestrator] publicFeed.start starting')
-  try {
-    await publicFeed.start();
-  } catch (e) {
-    console.error('[Orchestrator] Public feed start failed:', e?.message);
-  }
+  // The early start may still be restoring cached feed entries. Await it before
+  // exposing backend-ready so initial feed/status snapshots are consistent.
+  await publicFeedStartPromise
   await appendDebugLine('[orchestrator] publicFeed.start done')
   ipcLog('[orchestrator] publicFeed.start done')
 

--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -111,6 +111,12 @@ export class PublicFeedManager {
     this._gossipInterval = null;
     /** @type {number} */
     this._gossipIntervalMs = 30000;
+    /** @type {Array<{name: string, at: number, sinceStartMs: number, [key: string]: any}>} */
+    this._startupEvents = [];
+    /** @type {number} */
+    this._startupStartedAt = this._now();
+    this._recordStartupEvent('manager-created');
+
     /** @type {(() => void) | null} */
     this.onFeedUpdate = null;
     /** @type {((conn: any) => void) | null} */
@@ -127,6 +133,27 @@ export class PublicFeedManager {
     this._persistMaxEntries = 500
 
     log.info('Initialized')
+  }
+
+  _recordStartupEvent(name, details = {}) {
+    const at = this._now()
+    const event = {
+      name,
+      at,
+      sinceStartMs: Math.max(0, at - this._startupStartedAt),
+      ...details
+    }
+    this._startupEvents.push(event)
+    while (this._startupEvents.length > 80) this._startupEvents.shift()
+    return event
+  }
+
+  getStartupTiming() {
+    return {
+      startedAt: this._startupStartedAt,
+      elapsedMs: Math.max(0, this._now() - this._startupStartedAt),
+      events: this._startupEvents.slice(-40)
+    }
   }
 
   /**
@@ -617,6 +644,9 @@ export class PublicFeedManager {
     if (!this.swarm) return false
     const publicKey = this._peerEntryPublicKey(peer)
     const remembered = this._rememberPeerPublicKey(publicKey, peer, topic)
+    if (remembered) {
+      this._recordStartupEvent('feed-peer-discovered', { key: remembered.keyHex.slice(0, 16), topic: topic ? (this._isNetworkTopic(topic) ? 'peartube-network' : 'other') : 'unknown', relayAddresses: Array.isArray(peer?.relayAddresses) ? peer.relayAddresses.length : 0 })
+    }
     if (!remembered) {
       this._directPeerDialStats.skipped++
       this._directPeerDialStats.lastReason = 'self-or-missing-key'
@@ -727,6 +757,7 @@ export class PublicFeedManager {
   async start() {
     if (this.started) return;
     this.started = true;
+    this._recordStartupEvent('public-feed-start-called')
     console.log('[PublicFeed] ===== STARTING PUBLIC FEED =====');
 
     // Load persisted published channels from database
@@ -830,7 +861,9 @@ export class PublicFeedManager {
 
     try {
       this.feedDiscovery = this.swarm.join(NETWORK_TOPIC, { server: true, client: true })
+      this._recordStartupEvent('public-feed-topic-join-called', { topicHex: NETWORK_TOPIC_HEX })
       this.feedDiscovery?.flushed?.().then(() => {
+        this._recordStartupEvent('public-feed-topic-flushed', { peers: this.swarm.peers?.size || 0, connections: this.swarm.connections?.size || 0 })
         console.log('[PublicFeed] Shared network feed discovery flushed, connections:', this.swarm.connections?.size || 0)
       }).catch(() => {})
       console.log('[PublicFeed] Joined shared network feed topic:', NETWORK_TOPIC_HEX.slice(0, 16))
@@ -1015,6 +1048,7 @@ export class PublicFeedManager {
     const remoteKey = info?.publicKey || conn.remotePublicKey || conn.publicKey
     this._markPeerConnected(remoteKey)
     console.log('[PublicFeed] handleConnection:', label, 'setting up feed protocol on new connection');
+    this._recordStartupEvent('feed-socket-connected', { connection: label })
     this.wiredConnections.add(conn);
 
     let mux;
@@ -1083,6 +1117,7 @@ export class PublicFeedManager {
       }],
       onopen: () => {
         console.log('[PublicFeed] Feed channel opened:', label, 'Total feed connections:', this.feedConnections.size + 1, 'ageMs=', this._connectionAgeMs(conn));
+        this._recordStartupEvent('protomux-feed-open', { connection: label, ageMs: this._connectionAgeMs(conn), feedConnections: this.feedConnections.size + 1 })
         this.feedConnections.add(conn);
         try {
           this.onFeedConnectionOpen?.(conn);
@@ -1281,6 +1316,9 @@ export class PublicFeedManager {
       }
 
       const peerSetChanged = this._setPeerFeedKeys(conn, announcedKeys)
+      if (!this._startupEvents.some((event) => event.name === 'first-have-feed-received')) {
+        this._recordStartupEvent('first-have-feed-received', { keys: announcedKeys.length, entries: receivedCount })
+      }
       try {
         this.onFeedSync?.({ type: 'HAVE_FEED', added, received: receivedCount });
       } catch {}
@@ -1701,6 +1739,7 @@ export class PublicFeedManager {
       candidateConnections: feed.candidateConnections,
       rememberedPeerCandidates: feed.rememberedPeerCandidates,
       directPeerDial: this.getDirectPeerDialStats(),
+      startupTiming: this.getStartupTiming(),
     };
   }
 }

--- a/packages/backend/src/storage.js
+++ b/packages/backend/src/storage.js
@@ -87,6 +87,42 @@ let hyperswarmModuleReady = null
 // Global network stats instance (set after swarm is created)
 let networkStats = null;
 
+function createNetworkStartupTiming() {
+  const startedAt = Date.now()
+  const events = []
+  const seen = new Set()
+  const record = (name, details = {}) => {
+    const at = Date.now()
+    const event = {
+      name,
+      at,
+      sinceStartMs: Math.max(0, at - startedAt),
+      ...details
+    }
+    events.push(event)
+    while (events.length > 80) events.shift()
+    seen.add(name)
+    void appendDebugLine(`[startup-timing] ${name} t=${event.sinceStartMs}ms ${JSON.stringify(details)}`)
+    return event
+  }
+  record('storage-entry')
+  return {
+    startedAt,
+    record,
+    markOnce(name, details = {}) {
+      if (seen.has(name)) return null
+      return record(name, details)
+    },
+    snapshot() {
+      return {
+        startedAt,
+        elapsedMs: Math.max(0, Date.now() - startedAt),
+        events: events.slice(-40)
+      }
+    }
+  }
+}
+
 // Global references for suspend/resume (set in initializeStorage)
 let globalSwarm = null;
 let globalBlobServer = null;
@@ -94,6 +130,7 @@ let globalChannels = null;
 let globalPeerPoolDiscovery = null;
 let globalPeerPoolTopicHex = null;
 let globalSwarmDiagnostics = null;
+let globalNetworkStartupTiming = null;
 
 // Cast active flag — set by API handlers to prevent network suspension during active cast
 let globalCastActive = false
@@ -790,6 +827,7 @@ export async function retainPublicBeeContentDiscovery(ctx, publicBeeKeyHex, opti
  * @returns {Promise<import('./types.js').StorageContext>}
  */
 export async function initializeStorage(config) {
+  globalNetworkStartupTiming = createNetworkStartupTiming()
   await appendDebugLine('[storage] initializeStorage entry')
   warmOptionalStorageDeps()
   warmHyperswarmModule()
@@ -1093,6 +1131,7 @@ export async function initializeStorage(config) {
     }
   }
   console.log('[Storage] Swarm created, publicKey:', b4a.toString(swarm.keyPair.publicKey, 'hex').slice(0, 16));
+  globalNetworkStartupTiming?.record('swarm-created', { offline: Boolean(swarm._peartubeOffline) })
   const initialDhtState = describeDhtState(swarm.dht)
   if (initialDhtState) {
     console.log('[Storage] Initial DHT bind state:', JSON.stringify(initialDhtState))
@@ -1122,11 +1161,13 @@ export async function initializeStorage(config) {
   if (!swarm._peartubeOffline) {
     try {
       const poolDiscovery = swarm.join(PEARTUBE_NETWORK_TOPIC, { server: true, client: true });
+      globalNetworkStartupTiming?.record('topic-join-called', { topic: 'peer-pool', topicHex: globalPeerPoolTopicHex })
       globalPeerPoolDiscovery = poolDiscovery;
       console.log('[Storage] Joined peartube-network topic for peer pool building');
       // Don't await flushed() - it can hang on mobile
       poolDiscovery.flushed().then(() => {
         console.log('[Storage] Peer pool topic discovery flushed, connections:', swarm.connections?.size || 0);
+        globalNetworkStartupTiming?.record('topic-flushed', { topic: 'peer-pool', connections: swarm.connections?.size || 0, bootstrapped: swarm.dht?.bootstrapped })
         void appendDebugLine(
           `[storage] peer-pool discovery flushed connections=${swarm.connections?.size || 0} bootstrapped=${swarm.dht?.bootstrapped}`
         )
@@ -1146,6 +1187,7 @@ export async function initializeStorage(config) {
   console.log('[Storage] Starting swarm.listen() (non-blocking)...');
   await appendDebugLine('[storage] swarm.listen start')
   const listenPromise = swarm.listen()
+  globalNetworkStartupTiming?.record('swarm-listen-called')
 
   // Track listen state for debugging
   swarm._peartubeListenResolved = false
@@ -1153,12 +1195,14 @@ export async function initializeStorage(config) {
     listenPromise
       .then(() => {
         swarm._peartubeListenResolved = true
+        globalNetworkStartupTiming?.record('swarm-listen-resolved', { firewalled: swarm.dht?.firewalled, bootstrapped: swarm.dht?.bootstrapped })
         console.log('[Storage] listen() resolved, dht.firewalled:', swarm.dht?.firewalled, 'dht.bootstrapped:', swarm.dht?.bootstrapped)
         void appendDebugLine(
           `[storage] swarm.listen resolved firewalled=${swarm.dht?.firewalled} bootstrapped=${swarm.dht?.bootstrapped}`
         )
       })
       .catch((e) => {
+        globalNetworkStartupTiming?.record('swarm-listen-failed', { error: e?.message || String(e) })
         console.log('[Storage] listen() failed:', e?.message)
         void appendDebugLine(`[storage] swarm.listen failed ${e?.message || String(e)}`)
       })
@@ -1190,6 +1234,7 @@ export async function initializeStorage(config) {
   swarm.on('peer', (peer, topic) => {
     globalSwarmDiagnostics?.recordPeer?.(peer, topic)
     const peerKey = peer?.publicKey ? b4a.toString(peer.publicKey, 'hex').slice(0, 16) : 'unknown'
+    globalNetworkStartupTiming?.record('peer-discovered', { key: peerKey, relayAddresses: Array.isArray(peer?.relayAddresses) ? peer.relayAddresses.length : 0, connections: swarm.connections?.size || 0, connecting: swarm.connecting || 0 })
     const relayAddresses = Array.isArray(peer?.relayAddresses) ? peer.relayAddresses.length : 0
     console.log('[Storage] PEER DISCOVERED:', peerKey, 'total peers:', swarm.peers?.size || 0, 'relayAddresses:', relayAddresses, 'connecting:', swarm.connecting || 0)
     void appendDebugLine(`[storage] peer discovered ${peerKey} totalPeers=${swarm.peers?.size || 0} relayAddresses=${relayAddresses} connecting=${swarm.connecting || 0}`)
@@ -1202,6 +1247,7 @@ export async function initializeStorage(config) {
     try {
       if (!conn || conn.destroyed) return
       const remoteKey = info?.publicKey ? b4a.toString(info.publicKey, 'hex').slice(0, 16) : 'unknown';
+      globalNetworkStartupTiming?.record('socket-connected', { key: remoteKey, connections: swarm.connections?.size || 0, connecting: swarm.connecting || 0 })
       globalSwarmDiagnostics?.recordConnection?.(conn, info)
       console.log('[Storage] Peer connected:', remoteKey, 'connections:', swarm.connections?.size || 0, 'connecting:', swarm.connecting || 0);
       void appendDebugLine(`[storage] peer connected ${remoteKey} connections=${swarm.connections?.size || 0} connecting=${swarm.connecting || 0}`)
@@ -2320,6 +2366,7 @@ export async function resumeNetworking() {
  */
 export function getNetworkStats() {
   const diagnostics = globalSwarmDiagnostics?.snapshot?.() || null
+  const startupTiming = globalNetworkStartupTiming?.snapshot?.() || null
   if (!networkStats) {
     // Fallback: return basic stats from swarm
     if (globalSwarm) {
@@ -2337,7 +2384,8 @@ export function getNetworkStats() {
           ephemeral: globalSwarm.dht?.ephemeral ?? null,
           online: globalSwarm.dht?.online ?? null
         },
-        hyperswarm: diagnostics
+        hyperswarm: diagnostics,
+        startupTiming
       };
     }
     return null;
@@ -2345,10 +2393,10 @@ export function getNetworkStats() {
 
   try {
     const stats = networkStats.toJson();
-    return diagnostics ? { ...stats, hyperswarm: diagnostics } : stats
+    return { ...stats, hyperswarm: diagnostics, startupTiming }
   } catch (err) {
     console.log('[Network] Stats toJson error:', err?.message);
-    return diagnostics ? { hyperswarm: diagnostics } : null;
+    return diagnostics || startupTiming ? { hyperswarm: diagnostics, startupTiming } : null;
   }
 }
 

--- a/packages/backend/test/public-feed-manager.test.mjs
+++ b/packages/backend/test/public-feed-manager.test.mjs
@@ -410,6 +410,46 @@ test('PublicFeedManager.start joins shared PearTube network topic for feed-peer 
   }
 })
 
+test('PublicFeedManager exposes startup timing boundaries for discovery and feed open', async () => {
+  const swarm = createSwarm()
+  const manager = new PublicFeedManager(swarm, createMetaDb())
+  const publicKey = b4a.alloc(32, 21)
+  const conn = createConnection()
+  conn.remotePublicKey = publicKey
+  const originalFrom = Protomux.from
+
+  Protomux.from = () => ({
+    pair() {},
+    createChannel(opts) {
+      return {
+        messages: [{ send() {} }],
+        open() {
+          opts.onopen()
+        }
+      }
+    }
+  })
+
+  try {
+    await manager.start()
+    manager.handleDiscoveredPeer({ publicKey }, NETWORK_TOPIC)
+    manager.handleConnection(conn, { publicKey })
+    manager.handleMessage({ type: 'HAVE_FEED', keys: [] }, conn)
+
+    const events = manager.getStats().startupTiming.events.map((event) => event.name)
+    assert.equal(events.includes('manager-created'), true)
+    assert.equal(events.includes('public-feed-start-called'), true)
+    assert.equal(events.includes('public-feed-topic-join-called'), true)
+    assert.equal(events.includes('feed-peer-discovered'), true)
+    assert.equal(events.includes('feed-socket-connected'), true)
+    assert.equal(events.includes('protomux-feed-open'), true)
+    assert.equal(events.includes('first-have-feed-received'), true)
+  } finally {
+    Protomux.from = originalFrom
+    manager.stop()
+  }
+})
+
 test('discovered peer diagnostics become connected when the Hyperswarm socket arrives', () => {
   const publicKey = b4a.alloc(32, 14)
   const swarm = createSwarm()


### PR DESCRIPTION
## Summary
- start `PublicFeedManager.start()` immediately after swarm event wiring so topic join / DHT lookup / socket handling overlap later backend warm-up
- expose startup timing boundaries in storage/public-feed diagnostics: swarm creation/listen, topic join/flush, peer discovery, socket connection, Protomux feed open, first `HAVE_FEED`
- surface the timing snapshot through `getSwarmStatus()` for mobile/desktop/relay doctor output

## Test Plan
- `node --test packages/backend/test/public-feed-manager.test.mjs`
- `git diff --check`
- `npm run lint:changed` *(reports no changed JS/TS files in this local checkout; direct targeted test above covers changed backend file)*

## Notes
This intentionally does not add app-level redial loops or static/manual DHT ports. The change starts the feed protocol earlier and makes the slow boundary explicit before any further transport tuning.
