### PR TITLE
perf(backend): make channel metadata count lazy

### DIFF
--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -235,6 +235,21 @@ export function createApi({
     return 0
   }
 
+  function getFeedEntryVideoCount(driveKey, publicBeeKey = null) {
+    const entry = getPublicFeedEntry(driveKey)
+    if (!entry) return 0
+    const previews = Array.isArray(entry.previewVideos) ? entry.previewVideos : []
+    if (previews.length > 0) return previews.length
+    if (
+      publicBeeKey &&
+      entry.publicBeeKey &&
+      entry.publicBeeKey !== publicBeeKey
+    ) {
+      return 0
+    }
+    return Number.isFinite(entry.videoCount) ? entry.videoCount : 0
+  }
+
   function previewVideosFromFeedEntry(driveKey, publicBeeKey = null) {
     const entry = getPublicFeedEntry(driveKey)
     const previews = Array.isArray(entry?.previewVideos) ? entry.previewVideos : []
@@ -517,7 +532,9 @@ export function createApi({
     },
 
     /**
-     * Get channel metadata with video count (for public feed)
+     * Get channel metadata. Keep the default path metadata-only: videoCount is
+     * derived from public-feed snapshots/previews when available instead of
+     * calling listVideos(), which duplicates expensive PublicBee/channel reads.
      * @param {string} driveKey
      * @returns {Promise<ChannelMetadata>}
      */
@@ -529,14 +546,10 @@ export function createApi({
           return cloneObject(cached.value)
         }
         // Fast/public-feed path: if publicBeeKey is provided, don't load Autobase.
-        // Viewers should be able to list metadata/videos via the auto-replicating PublicBee.
+        // Viewers should be able to read metadata via the auto-replicating PublicBee.
         if (publicBeeKey) {
           const publicBee = await loadPublicBee(ctx, publicBeeKey)
           const meta = await withTimeout(publicBee.getMetadata().catch(() => null), 1000, `PublicBee getMetadata ${driveKey?.slice?.(0, 16) || ''}`).catch(() => null)
-          const previewVideos = previewVideosFromFeedEntry(driveKey, publicBeeKey)
-          const videos = previewVideos.length > 0
-            ? previewVideos
-            : await listPublicBeeVideosBounded({ publicBee, driveKey, publicBeeKey, timeoutMs: 1200 })
           const result = {
             driveKey,
             name: meta?.name || 'Channel',
@@ -544,7 +557,7 @@ export function createApi({
             avatar: meta?.avatar || null,
             createdAt: meta?.createdAt || Date.now(),
             publicKey: meta?.createdBy || null,
-            videoCount: videos?.length || 0
+            videoCount: getFeedEntryVideoCount(driveKey, publicBeeKey)
           }
           channelMetaCache.set(driveKey, { ts: Date.now(), value: result })
           return cloneObject(result)
@@ -553,7 +566,6 @@ export function createApi({
         const channel = await loadChannelBounded(driveKey)
         await markAsMultiWriterChannel(driveKey)
         const meta = await channel.getMetadata().catch(() => null)
-        const videos = await withTimeout(channel.listVideos().catch(() => []), 1200, `channel meta listVideos ${driveKey?.slice?.(0, 16) || ''}`).catch(() => [])
         const result = {
           driveKey,
           name: meta?.name || 'Channel',
@@ -561,7 +573,7 @@ export function createApi({
           avatar: meta?.avatar || null,
           createdAt: meta?.createdAt || Date.now(),
           publicKey: meta?.createdBy || null,
-          videoCount: videos?.length || 0
+          videoCount: getFeedEntryVideoCount(driveKey)
         }
         channelMetaCache.set(driveKey, { ts: Date.now(), value: result })
         return cloneObject(result)

--- a/packages/backend/test/channel-meta-api.test.mjs
+++ b/packages/backend/test/channel-meta-api.test.mjs
@@ -1,0 +1,94 @@
+import test from 'brittle'
+
+import { createApi } from '../src/api.js'
+
+test('getChannelMeta uses feed preview count without listing PublicBee videos', async (t) => {
+  const driveKey = 'aa'.repeat(32)
+  const publicBeeKey = 'bb'.repeat(32)
+  let publicBeeListCalls = 0
+
+  const api = createApi({
+    ctx: {},
+    publicFeed: {
+      getFeed() {
+        return [{
+          driveKey,
+          publicBeeKey,
+          channelName: 'Feed Channel',
+          videoCount: 99,
+          previewVideos: [{ id: 'one' }, { id: 'two' }],
+        }]
+      },
+    },
+    loadPublicBee: async () => ({
+      async getMetadata() {
+        return { name: 'PublicBee Channel', description: 'metadata only', createdAt: 123 }
+      },
+      async listVideos() {
+        publicBeeListCalls += 1
+        throw new Error('getChannelMeta must not list videos')
+      },
+    }),
+  })
+
+  const meta = await api.getChannelMeta(driveKey, publicBeeKey)
+
+  t.is(meta.name, 'PublicBee Channel')
+  t.is(meta.videoCount, 2)
+  t.is(publicBeeListCalls, 0)
+})
+
+test('getChannelMeta uses feed videoCount without listing local channel videos', async (t) => {
+  const driveKey = 'cc'.repeat(32)
+  let channelListCalls = 0
+
+  const api = createApi({
+    ctx: {},
+    publicFeed: {
+      getFeed() {
+        return [{
+          driveKey,
+          videoCount: 7,
+          previewVideos: [],
+        }]
+      },
+    },
+    loadChannel: async () => ({
+      async getMetadata() {
+        return { name: 'Local Channel', description: 'local metadata', createdAt: 456 }
+      },
+      async listVideos() {
+        channelListCalls += 1
+        throw new Error('getChannelMeta must not list videos')
+      },
+    }),
+  })
+
+  const meta = await api.getChannelMeta(driveKey)
+
+  t.is(meta.name, 'Local Channel')
+  t.is(meta.videoCount, 7)
+  t.is(channelListCalls, 0)
+})
+
+test('getChannelMeta returns zero count when no feed snapshot exists', async (t) => {
+  const driveKey = 'dd'.repeat(32)
+
+  const api = createApi({
+    ctx: {},
+    publicFeed: { getFeed() { return [] } },
+    loadChannel: async () => ({
+      async getMetadata() {
+        return { name: 'Unknown Count Channel', createdAt: 789 }
+      },
+      async listVideos() {
+        throw new Error('getChannelMeta must not list videos')
+      },
+    }),
+  })
+
+  const meta = await api.getChannelMeta(driveKey)
+
+  t.is(meta.name, 'Unknown Count Channel')
+  t.is(meta.videoCount, 0)
+})


### PR DESCRIPTION
## Summary
- Makes `getChannelMeta()` metadata-only by default by deriving `videoCount` from public-feed previews/snapshots.
- Removes fallback `listVideos()` calls from both PublicBee and local-channel metadata paths.
- Adds regression coverage proving metadata loads without invoking `listVideos()`.

Closes #210

## Test Plan
- `./packages/backend/node_modules/.bin/brittle packages/backend/test/channel-meta-api.test.mjs`
- `git diff --check`

## Notes
- `codex` is now on PATH as `/home/user/.local/opt/node-v22.21.1-linux-x64/bin/codex`, but the CLI auth is not configured: `codex exec` returned 401 Unauthorized from OpenAI Responses API.
