### PR TITLE
perf(backend): warm-dial known peers on startup

### DIFF
--- a/packages/backend/src/known-peers.js
+++ b/packages/backend/src/known-peers.js
@@ -1,0 +1,123 @@
+/**
+ * Known-Peer Cache
+ *
+ * Persists noise public keys of peers we've connected to so subsequent cold
+ * starts can call `swarm.joinPeer(pk)` directly. This short-circuits the
+ * topic-based DHT lookup that would otherwise have to complete before any
+ * peer connection can occur.
+ *
+ * Pattern follows Hyperswarm's documented `joinPeer` semantics (direct
+ * reconnect with auto-reconnect on failure). Storage is a single Hyperbee
+ * row keyed by `known-peers-v1`.
+ */
+
+import b4a from 'b4a'
+
+const KNOWN_PEERS_KEY = 'known-peers-v1'
+const MAX_KNOWN_PEERS = 64
+const FLUSH_DEBOUNCE_MS = 5000
+
+function toKeyHex(publicKey) {
+  if (!publicKey) return null
+  if (typeof publicKey === 'string') {
+    return /^[0-9a-f]{64}$/i.test(publicKey) ? publicKey.toLowerCase() : null
+  }
+  if (b4a.isBuffer(publicKey) || publicKey instanceof Uint8Array) {
+    if (publicKey.length !== 32) return null
+    return b4a.toString(publicKey, 'hex')
+  }
+  return null
+}
+
+export function createKnownPeerCache(metaDb, { selfKeyHex = null } = {}) {
+  const peers = new Map()
+  let dirty = false
+  let flushTimer = null
+  let closed = false
+
+  function evictOldest() {
+    if (peers.size <= MAX_KNOWN_PEERS) return
+    const sorted = [...peers.entries()].sort((a, b) => a[1] - b[1])
+    while (peers.size > MAX_KNOWN_PEERS) {
+      const [k] = sorted.shift()
+      peers.delete(k)
+    }
+  }
+
+  function scheduleFlush() {
+    if (flushTimer || closed) return
+    flushTimer = setTimeout(() => {
+      flushTimer = null
+      void flush()
+    }, FLUSH_DEBOUNCE_MS)
+  }
+
+  async function flush() {
+    if (!dirty || !metaDb || closed) return
+    dirty = false
+    const list = [...peers.entries()].map(([key, lastSeen]) => ({ key, lastSeen }))
+    try {
+      await metaDb.put(KNOWN_PEERS_KEY, list)
+    } catch (err) {
+      console.log('[KnownPeers] flush failed:', err?.message)
+      dirty = true
+    }
+  }
+
+  function record(publicKey) {
+    if (closed || !metaDb) return
+    const keyHex = toKeyHex(publicKey)
+    if (!keyHex) return
+    if (selfKeyHex && keyHex === selfKeyHex) return
+    peers.set(keyHex, Date.now())
+    evictOldest()
+    dirty = true
+    scheduleFlush()
+  }
+
+  async function close() {
+    closed = true
+    if (flushTimer) {
+      clearTimeout(flushTimer)
+      flushTimer = null
+    }
+    await flush()
+  }
+
+  return {
+    record,
+    flush,
+    close,
+    get size() { return peers.size }
+  }
+}
+
+export async function loadKnownPeers(metaDb) {
+  if (!metaDb) return []
+  try {
+    const entry = await metaDb.get(KNOWN_PEERS_KEY).catch(() => null)
+    const list = Array.isArray(entry?.value) ? entry.value : []
+    return list
+      .filter((p) => p && typeof p.key === 'string' && /^[0-9a-f]{64}$/i.test(p.key))
+      .sort((a, b) => (b.lastSeen || 0) - (a.lastSeen || 0))
+  } catch (err) {
+    console.log('[KnownPeers] load failed:', err?.message)
+    return []
+  }
+}
+
+export function dialKnownPeers(swarm, knownList, { limit = MAX_KNOWN_PEERS, selfKeyHex = null } = {}) {
+  if (!swarm || typeof swarm.joinPeer !== 'function') return 0
+  if (swarm._peartubeOffline) return 0
+  let dialed = 0
+  for (const entry of knownList.slice(0, limit)) {
+    if (selfKeyHex && entry.key === selfKeyHex) continue
+    try {
+      const pk = b4a.from(entry.key, 'hex')
+      if (pk.length !== 32) continue
+      swarm.joinPeer(pk)
+      dialed++
+    } catch { /* best effort */ }
+  }
+  return dialed
+}

--- a/packages/backend/src/known-peers.js
+++ b/packages/backend/src/known-peers.js
@@ -5,10 +5,6 @@
  * starts can call `swarm.joinPeer(pk)` directly. This short-circuits the
  * topic-based DHT lookup that would otherwise have to complete before any
  * peer connection can occur.
- *
- * Pattern follows Hyperswarm's documented `joinPeer` semantics (direct
- * reconnect with auto-reconnect on failure). Storage is a single Hyperbee
- * row keyed by `known-peers-v1`.
  */
 
 import b4a from 'b4a'
@@ -33,7 +29,6 @@ export function createKnownPeerCache(metaDb, { selfKeyHex = null } = {}) {
   const peers = new Map()
   let dirty = false
   let flushTimer = null
-  let closed = false
 
   function evictOldest() {
     if (peers.size <= MAX_KNOWN_PEERS) return
@@ -45,7 +40,7 @@ export function createKnownPeerCache(metaDb, { selfKeyHex = null } = {}) {
   }
 
   function scheduleFlush() {
-    if (flushTimer || closed) return
+    if (flushTimer) return
     flushTimer = setTimeout(() => {
       flushTimer = null
       void flush()
@@ -53,7 +48,7 @@ export function createKnownPeerCache(metaDb, { selfKeyHex = null } = {}) {
   }
 
   async function flush() {
-    if (!dirty || !metaDb || closed) return
+    if (!dirty || !metaDb) return
     dirty = false
     const list = [...peers.entries()].map(([key, lastSeen]) => ({ key, lastSeen }))
     try {
@@ -65,31 +60,16 @@ export function createKnownPeerCache(metaDb, { selfKeyHex = null } = {}) {
   }
 
   function record(publicKey) {
-    if (closed || !metaDb) return
+    if (!metaDb) return
     const keyHex = toKeyHex(publicKey)
-    if (!keyHex) return
-    if (selfKeyHex && keyHex === selfKeyHex) return
+    if (!keyHex || keyHex === selfKeyHex) return
     peers.set(keyHex, Date.now())
     evictOldest()
     dirty = true
     scheduleFlush()
   }
 
-  async function close() {
-    closed = true
-    if (flushTimer) {
-      clearTimeout(flushTimer)
-      flushTimer = null
-    }
-    await flush()
-  }
-
-  return {
-    record,
-    flush,
-    close,
-    get size() { return peers.size }
-  }
+  return { record, flush }
 }
 
 export async function loadKnownPeers(metaDb) {
@@ -106,12 +86,10 @@ export async function loadKnownPeers(metaDb) {
   }
 }
 
-export function dialKnownPeers(swarm, knownList, { limit = MAX_KNOWN_PEERS, selfKeyHex = null } = {}) {
-  if (!swarm || typeof swarm.joinPeer !== 'function') return 0
-  if (swarm._peartubeOffline) return 0
+export function dialKnownPeers(swarm, knownList) {
+  if (!swarm || typeof swarm.joinPeer !== 'function' || swarm._peartubeOffline) return 0
   let dialed = 0
-  for (const entry of knownList.slice(0, limit)) {
-    if (selfKeyHex && entry.key === selfKeyHex) continue
+  for (const entry of knownList) {
     try {
       const pk = b4a.from(entry.key, 'hex')
       if (pk.length !== 32) continue

--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -760,6 +760,23 @@ export class PublicFeedManager {
     this._recordStartupEvent('public-feed-start-called')
     console.log('[PublicFeed] ===== STARTING PUBLIC FEED =====');
 
+    // Issue the topic join up front so DHT announce/lookup overlaps with the
+    // metaDb cache restoration below. (Matches the hyperdrive README pattern:
+    // attach handlers → join → do other work; never await flush() on the
+    // hot path.)
+    try {
+      this.feedDiscovery = this.swarm.join(NETWORK_TOPIC, { server: true, client: true })
+      this._recordStartupEvent('public-feed-topic-join-called', { topicHex: NETWORK_TOPIC_HEX })
+      this.feedDiscovery?.flushed?.().then(() => {
+        this._recordStartupEvent('public-feed-topic-flushed', { peers: this.swarm.peers?.size || 0, connections: this.swarm.connections?.size || 0 })
+        console.log('[PublicFeed] Shared network feed discovery flushed, connections:', this.swarm.connections?.size || 0)
+      }).catch(() => {})
+      console.log('[PublicFeed] Joined shared network feed topic:', NETWORK_TOPIC_HEX.slice(0, 16))
+    } catch (err) {
+      console.log('[PublicFeed] Shared network feed topic join failed:', err?.message)
+      this.feedDiscovery = null
+    }
+
     // Load persisted published channels from database
     // Try new format first (with publicBeeKey), fall back to legacy format
     if (this.metaDb) {
@@ -857,19 +874,6 @@ export class PublicFeedManager {
     if (this.entries.size > 0) {
       console.log('[PublicFeed] Notifying listeners of', this.entries.size, 'restored entries');
       try { this.onFeedUpdate?.(); } catch {}
-    }
-
-    try {
-      this.feedDiscovery = this.swarm.join(NETWORK_TOPIC, { server: true, client: true })
-      this._recordStartupEvent('public-feed-topic-join-called', { topicHex: NETWORK_TOPIC_HEX })
-      this.feedDiscovery?.flushed?.().then(() => {
-        this._recordStartupEvent('public-feed-topic-flushed', { peers: this.swarm.peers?.size || 0, connections: this.swarm.connections?.size || 0 })
-        console.log('[PublicFeed] Shared network feed discovery flushed, connections:', this.swarm.connections?.size || 0)
-      }).catch(() => {})
-      console.log('[PublicFeed] Joined shared network feed topic:', NETWORK_TOPIC_HEX.slice(0, 16))
-    } catch (err) {
-      console.log('[PublicFeed] Shared network feed topic join failed:', err?.message)
-      this.feedDiscovery = null
     }
 
     // Set up feed protocol on any existing connections.

--- a/packages/backend/src/storage.js
+++ b/packages/backend/src/storage.js
@@ -25,6 +25,7 @@ import {
 } from './runtime-modules.js'
 import { NETWORK_TOPIC_STRING } from './types.js'
 import { normalizeBlobRefInput } from './blob-ref.js'
+import { createKnownPeerCache, loadKnownPeers, dialKnownPeers } from './known-peers.js'
 
 function resolveDebugLogPath() {
   return globalThis?.process?.env?.PEARTUBE_NATIVE_WORKLET_DEBUG_LOG || null
@@ -131,6 +132,7 @@ let globalPeerPoolDiscovery = null;
 let globalPeerPoolTopicHex = null;
 let globalSwarmDiagnostics = null;
 let globalNetworkStartupTiming = null;
+let globalKnownPeerCache = null;
 
 // Cast active flag — set by API handlers to prevent network suspension during active cast
 let globalCastActive = false
@@ -1242,6 +1244,12 @@ export async function initializeStorage(config) {
 
   const channels = new Map();
 
+  // Known-peer cache: persist remote pubkeys so the next cold start can
+  // `swarm.joinPeer(pk)` them directly without waiting for a topic DHT lookup.
+  const selfKeyHex = swarm.keyPair?.publicKey ? b4a.toString(swarm.keyPair.publicKey, 'hex') : null
+  const knownPeerCache = createKnownPeerCache(metaDb, { selfKeyHex })
+  globalKnownPeerCache = knownPeerCache
+
   // Set up replication for all connections
   swarm.on('connection', (conn, info) => {
     try {
@@ -1251,6 +1259,7 @@ export async function initializeStorage(config) {
       globalSwarmDiagnostics?.recordConnection?.(conn, info)
       console.log('[Storage] Peer connected:', remoteKey, 'connections:', swarm.connections?.size || 0, 'connecting:', swarm.connecting || 0);
       void appendDebugLine(`[storage] peer connected ${remoteKey} connections=${swarm.connections?.size || 0} connecting=${swarm.connecting || 0}`)
+      if (info?.publicKey) knownPeerCache.record(info.publicKey)
 
       // Register stream with wakeup protocol for content announcements
       if (wakeup) {
@@ -1299,6 +1308,23 @@ export async function initializeStorage(config) {
     }
   });
 
+  // Warm dial: re-connect to recently-seen peers via swarm.joinPeer(pk). This
+  // runs in the background — joinPeer is non-blocking and idempotent against
+  // the topic-based discovery that's already in flight.
+  if (!swarm._peartubeOffline) {
+    loadKnownPeers(metaDb).then((known) => {
+      if (!known.length) return
+      const dialed = dialKnownPeers(swarm, known, { selfKeyHex })
+      if (dialed > 0) {
+        console.log('[Storage] Warm-dialed', dialed, 'known peer(s) of', known.length, 'cached')
+        globalNetworkStartupTiming?.record('warm-dial-issued', { dialed, cached: known.length })
+        void appendDebugLine(`[storage] warm-dial issued dialed=${dialed} cached=${known.length}`)
+      }
+    }).catch((err) => {
+      console.log('[Storage] Warm-dial skipped:', err?.message)
+    })
+  }
+
   // Initialize blind peering for mobile connectivity
   // Desktop (non-firewalled): runs as blind peer server to keep data available
   // Mobile (firewalled): connects to mirrors to sync when direct P2P fails
@@ -1341,7 +1367,8 @@ export async function initializeStorage(config) {
     blobSessionToken, // Session token for URL authentication
     channels,
     wakeup,
-    peerPoolDiscovery: globalPeerPoolDiscovery
+    peerPoolDiscovery: globalPeerPoolDiscovery,
+    knownPeerCache
   };
 }
 
@@ -2140,6 +2167,9 @@ export async function suspendNetworking() {
     if (globalSwarm) {
       await globalSwarm.suspend();
       console.log('[Network] Swarm suspended');
+    }
+    if (globalKnownPeerCache) {
+      try { await globalKnownPeerCache.flush() } catch { /* best effort */ }
     }
     if (globalBlobServer) {
       console.log('[CastDiag] suspendNetworking: suspending BlobServer (cast not active)');

--- a/packages/backend/src/storage.js
+++ b/packages/backend/src/storage.js
@@ -1156,6 +1156,112 @@ export async function initializeStorage(config) {
     }
   }
 
+  const channels = new Map();
+
+  // Initialize protomux-wakeup for content announcements
+  let wakeup = null;
+  if (Wakeup) {
+    try {
+      wakeup = new Wakeup();
+      console.log('[Storage] Wakeup protocol initialized');
+    } catch (err) {
+      console.log('[Storage] Wakeup init failed (non-fatal):', err?.message);
+    }
+  }
+
+  // Known-peer cache: persist remote pubkeys so the next cold start can
+  // `swarm.joinPeer(pk)` them directly without waiting for a topic DHT lookup.
+  const selfKeyHex = swarm.keyPair?.publicKey ? b4a.toString(swarm.keyPair.publicKey, 'hex') : null
+  const knownPeerCache = createKnownPeerCache(metaDb, { selfKeyHex })
+  globalKnownPeerCache = knownPeerCache
+
+  // Register handlers BEFORE swarm.join so any incoming connection is replicated
+  // immediately (canonical Hyperswarm/Hyperdrive pattern).
+  swarm.on('connection', (conn, info) => {
+    try {
+      if (!conn || conn.destroyed) return
+      const remoteKey = info?.publicKey ? b4a.toString(info.publicKey, 'hex').slice(0, 16) : 'unknown';
+      globalNetworkStartupTiming?.record('socket-connected', { key: remoteKey, connections: swarm.connections?.size || 0, connecting: swarm.connecting || 0 })
+      globalSwarmDiagnostics?.recordConnection?.(conn, info)
+      console.log('[Storage] Peer connected:', remoteKey, 'connections:', swarm.connections?.size || 0, 'connecting:', swarm.connecting || 0);
+      void appendDebugLine(`[storage] peer connected ${remoteKey} connections=${swarm.connections?.size || 0} connecting=${swarm.connecting || 0}`)
+      if (info?.publicKey) knownPeerCache.record(info.publicKey)
+
+      // Register stream with wakeup protocol for content announcements
+      if (wakeup) {
+        try {
+          wakeup.addStream(conn);
+        } catch (err) {
+          console.log('[Storage] Wakeup addStream error (non-fatal):', err?.message);
+        }
+      }
+
+      // Replicate all Hypercore data in the Corestore:
+      // - Autobase cores (channel metadata, videos, comments, etc.)
+      // - Hyperblobs cores (video bytes, thumbnails)
+      try {
+        if (conn.destroyed) return
+        store.replicate(conn);
+      } catch (err) {
+        console.log('[Storage] store.replicate failed (non-fatal):', err?.message);
+      }
+
+      // Also replicate all loaded Autobase channels. Each channel's setupPairing
+      // registers its own handler, but only for connections established AFTER the
+      // channel is loaded. This covers channels that were loaded BEFORE this peer
+      // connected.
+      if (channels.size > 0) {
+        console.log('[Storage] Replicating', channels.size, 'Autobase channel(s) on new connection');
+        for (const [keyHex, channel] of channels) {
+          if (conn.destroyed) break
+          if (channel?.base && channel._replicatedConns && !channel._replicatedConns.has(conn)) {
+            try {
+              channel._replicatedConns.add(conn)
+              if (conn.destroyed) {
+                channel._replicatedConns.delete(conn)
+                continue
+              }
+              channel.base.replicate(conn)
+              console.log('[Storage] Replicated Autobase for channel:', keyHex.slice(0, 16))
+            } catch (err) {
+              console.log('[Storage] Error replicating channel', keyHex.slice(0, 16), ':', err?.message)
+            }
+          }
+        }
+      }
+    } catch (err) {
+      console.log('[Storage] connection handler error (non-fatal):', err?.message)
+    }
+  });
+
+  // Log swarm events for debugging mobile connectivity
+  swarm.on('update', () => {
+    globalSwarmDiagnostics?.recordUpdate?.()
+    log.debug('Swarm update event', { connections: swarm.connections?.size || 0, peers: swarm.peers?.size || 0 })
+  });
+
+  // Log peer discovery events (DHT found a peer)
+  swarm.on('peer', (peer, topic) => {
+    globalSwarmDiagnostics?.recordPeer?.(peer, topic)
+    const peerKey = peer?.publicKey ? b4a.toString(peer.publicKey, 'hex').slice(0, 16) : 'unknown'
+    globalNetworkStartupTiming?.record('peer-discovered', { key: peerKey, relayAddresses: Array.isArray(peer?.relayAddresses) ? peer.relayAddresses.length : 0, connections: swarm.connections?.size || 0, connecting: swarm.connecting || 0 })
+    const relayAddresses = Array.isArray(peer?.relayAddresses) ? peer.relayAddresses.length : 0
+    console.log('[Storage] PEER DISCOVERED:', peerKey, 'total peers:', swarm.peers?.size || 0, 'relayAddresses:', relayAddresses, 'connecting:', swarm.connecting || 0)
+    void appendDebugLine(`[storage] peer discovered ${peerKey} totalPeers=${swarm.peers?.size || 0} relayAddresses=${relayAddresses} connecting=${swarm.connecting || 0}`)
+  })
+
+  // Warm dial: re-connect to recently-seen peers. swarm.joinPeer is idempotent
+  // against any topic-based discovery that follows.
+  if (!swarm._peartubeOffline) {
+    loadKnownPeers(metaDb).then((known) => {
+      if (!known.length) return
+      const dialed = dialKnownPeers(swarm, known)
+      if (dialed > 0) console.log('[Storage] Warm-dialed', dialed, 'of', known.length, 'known peers')
+    }).catch((err) => {
+      console.log('[Storage] Warm-dial skipped:', err?.message)
+    })
+  }
+
   // Join the PearTube network topic for peer pool building
   // More connected peers = better relay options for symmetric NAT holepunching
   const PEARTUBE_NETWORK_TOPIC = crypto.data(b4a.from(NETWORK_TOPIC_STRING, 'utf-8'));
@@ -1226,122 +1332,6 @@ export async function initializeStorage(config) {
   setTimeout(logDhtState, 2000)
   setTimeout(logDhtState, 5000)
 
-  // Log swarm events for debugging mobile connectivity
-  swarm.on('update', () => {
-    globalSwarmDiagnostics?.recordUpdate?.()
-    log.debug('Swarm update event', { connections: swarm.connections?.size || 0, peers: swarm.peers?.size || 0 })
-  });
-
-  // Log peer discovery events (DHT found a peer)
-  swarm.on('peer', (peer, topic) => {
-    globalSwarmDiagnostics?.recordPeer?.(peer, topic)
-    const peerKey = peer?.publicKey ? b4a.toString(peer.publicKey, 'hex').slice(0, 16) : 'unknown'
-    globalNetworkStartupTiming?.record('peer-discovered', { key: peerKey, relayAddresses: Array.isArray(peer?.relayAddresses) ? peer.relayAddresses.length : 0, connections: swarm.connections?.size || 0, connecting: swarm.connecting || 0 })
-    const relayAddresses = Array.isArray(peer?.relayAddresses) ? peer.relayAddresses.length : 0
-    console.log('[Storage] PEER DISCOVERED:', peerKey, 'total peers:', swarm.peers?.size || 0, 'relayAddresses:', relayAddresses, 'connecting:', swarm.connecting || 0)
-    void appendDebugLine(`[storage] peer discovered ${peerKey} totalPeers=${swarm.peers?.size || 0} relayAddresses=${relayAddresses} connecting=${swarm.connecting || 0}`)
-  })
-
-  const channels = new Map();
-
-  // Known-peer cache: persist remote pubkeys so the next cold start can
-  // `swarm.joinPeer(pk)` them directly without waiting for a topic DHT lookup.
-  const selfKeyHex = swarm.keyPair?.publicKey ? b4a.toString(swarm.keyPair.publicKey, 'hex') : null
-  const knownPeerCache = createKnownPeerCache(metaDb, { selfKeyHex })
-  globalKnownPeerCache = knownPeerCache
-
-  // Set up replication for all connections
-  swarm.on('connection', (conn, info) => {
-    try {
-      if (!conn || conn.destroyed) return
-      const remoteKey = info?.publicKey ? b4a.toString(info.publicKey, 'hex').slice(0, 16) : 'unknown';
-      globalNetworkStartupTiming?.record('socket-connected', { key: remoteKey, connections: swarm.connections?.size || 0, connecting: swarm.connecting || 0 })
-      globalSwarmDiagnostics?.recordConnection?.(conn, info)
-      console.log('[Storage] Peer connected:', remoteKey, 'connections:', swarm.connections?.size || 0, 'connecting:', swarm.connecting || 0);
-      void appendDebugLine(`[storage] peer connected ${remoteKey} connections=${swarm.connections?.size || 0} connecting=${swarm.connecting || 0}`)
-      if (info?.publicKey) knownPeerCache.record(info.publicKey)
-
-      // Register stream with wakeup protocol for content announcements
-      if (wakeup) {
-        try {
-          wakeup.addStream(conn);
-        } catch (err) {
-          console.log('[Storage] Wakeup addStream error (non-fatal):', err?.message);
-        }
-      }
-
-      // Replicate all Hypercore data in the Corestore:
-      // - Autobase cores (channel metadata, videos, comments, etc.)
-      // - Hyperblobs cores (video bytes, thumbnails)
-      try {
-        if (conn.destroyed) return
-        store.replicate(conn);
-      } catch (err) {
-        console.log('[Storage] store.replicate failed (non-fatal):', err?.message);
-      }
-
-      // CRITICAL: Also replicate all loaded Autobase channels
-      // Each channel's setupPairing registers its own handler, but that only fires for
-      // connections established AFTER the channel is loaded. This ensures channels loaded
-      // BEFORE this peer connected also get replicated.
-      if (channels.size > 0) {
-        console.log('[Storage] Replicating', channels.size, 'Autobase channel(s) on new connection');
-        for (const [keyHex, channel] of channels) {
-          if (conn.destroyed) break
-          if (channel?.base && channel._replicatedConns && !channel._replicatedConns.has(conn)) {
-            try {
-              channel._replicatedConns.add(conn)
-              if (conn.destroyed) {
-                channel._replicatedConns.delete(conn)
-                continue
-              }
-              channel.base.replicate(conn)
-              console.log('[Storage] Replicated Autobase for channel:', keyHex.slice(0, 16))
-            } catch (err) {
-              console.log('[Storage] Error replicating channel', keyHex.slice(0, 16), ':', err?.message)
-            }
-          }
-        }
-      }
-    } catch (err) {
-      console.log('[Storage] connection handler error (non-fatal):', err?.message)
-    }
-  });
-
-  // Warm dial: re-connect to recently-seen peers via swarm.joinPeer(pk). This
-  // runs in the background — joinPeer is non-blocking and idempotent against
-  // the topic-based discovery that's already in flight.
-  if (!swarm._peartubeOffline) {
-    loadKnownPeers(metaDb).then((known) => {
-      if (!known.length) return
-      const dialed = dialKnownPeers(swarm, known, { selfKeyHex })
-      if (dialed > 0) {
-        console.log('[Storage] Warm-dialed', dialed, 'known peer(s) of', known.length, 'cached')
-        globalNetworkStartupTiming?.record('warm-dial-issued', { dialed, cached: known.length })
-        void appendDebugLine(`[storage] warm-dial issued dialed=${dialed} cached=${known.length}`)
-      }
-    }).catch((err) => {
-      console.log('[Storage] Warm-dial skipped:', err?.message)
-    })
-  }
-
-  // Initialize blind peering for mobile connectivity
-  // Desktop (non-firewalled): runs as blind peer server to keep data available
-  // Mobile (firewalled): connects to mirrors to sync when direct P2P fails
-  // DISABLED: Testing if this affects playback
-  let wakeup = null;
-
-  // Initialize protomux-wakeup for content announcements
-  // This enables faster sync by announcing new content to peers immediately
-  if (Wakeup) {
-    try {
-      wakeup = new Wakeup();
-      console.log('[Storage] Wakeup protocol initialized');
-    } catch (err) {
-      console.log('[Storage] Wakeup init failed (non-fatal):', err?.message);
-    }
-  }
-
 
   // Set global reference for suspend/resume lifecycle management
   globalChannels = channels;
@@ -1367,8 +1357,7 @@ export async function initializeStorage(config) {
     blobSessionToken, // Session token for URL authentication
     channels,
     wakeup,
-    peerPoolDiscovery: globalPeerPoolDiscovery,
-    knownPeerCache
+    peerPoolDiscovery: globalPeerPoolDiscovery
   };
 }
 


### PR DESCRIPTION
Persist remote noise public keys of peers we've connected to and call
swarm.joinPeer(pk) for the most-recent ones on the next cold start. This
short-circuits the topic-based DHT lookup that would otherwise have to
complete before the first peer connection can occur. Idempotent against
the topic discovery that runs in parallel.

Also moves the public-feed swarm.join(NETWORK_TOPIC) to the top of
start() so DHT announce/lookup overlaps with metaDb cache restoration
(matches the hyperdrive README pattern).

https://claude.ai/code/session_013SzTdQqMVjRpT7sAR1PMLn