### PR TITLE
fix(app): align React Native with Expo SDK 55

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,6 @@
     "expo": "~55.0.4",
     "hrpc": "^4.3.0",
     "react": "^19.2.0",
-    "react-native": "0.85.3"
+    "react-native": "0.83.9"
   }
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -108,7 +108,7 @@
     "protomux-wakeup": "^2.9.0",
     "react": "19.2.6",
     "react-dom": "19.2.6",
-    "react-native": "0.85.3",
+    "react-native": "0.83.9",
     "react-native-b4a": "^0.1.0",
     "react-native-bare-kit": "^0.13.1",
     "react-native-css-interop": "^0.2.1",


### PR DESCRIPTION
## Summary
- Pin React Native to `0.83.9`, the supported React Native line for Expo SDK 55.
- Fix the Android release Kotlin break where `expo-modules-core` was compiling against React Native `0.85.3` and its nullable `Promise.reject(...)` signatures.

## Failure fixed
`v0.1.91` Android release failed in `:expo-modules-core:compileReleaseKotlin` with:

```text
Class '<anonymous>' is not abstract and does not implement abstract members:
fun reject(code: String?, message: String?): Unit
...
'reject' overrides nothing
```

Expo SDK 55 ships against React Native 0.83; SDK 56 is the line for React Native 0.85. Keeping SDK 55 on RN 0.85 made Expo's Kotlin bridge signatures incompatible during release APK builds.

## Test Plan
- `npm run lint:changed`
- `git diff --check`
- Checked package pins for root and app `react-native=0.83.9`
- Manually dispatched `Build Mobile` on this branch: https://github.com/ayooooo123/peartube/actions/runs/25712547179
  - `android-debug`: success
  - `android-release-artifacts`: success
  - `ios-build`: failed separately while bundling `bare-ffmpeg` on macOS; not part of the Android failure being fixed here

Local Gradle verification is blocked on this runner because Java is not installed (`JAVA_HOME is not set and no 'java' command could be found in your PATH`). GitHub Actions with JDK 17 validated both Android debug and Android release artifact builds.
