### PR TITLE
fix(app): polish Android playback social UX

### DIFF
--- a/packages/app/app/(tabs)/index.tsx
+++ b/packages/app/app/(tabs)/index.tsx
@@ -120,6 +120,7 @@ export default function HomeScreen() {
   const { width: screenWidth } = useWindowDimensions()
   const tabBarMetrics = useTabBarMetrics()
   const bottomPadding = Math.max(tabBarMetrics.height + 16, insets.bottom + 16)
+  const feedBottomPadding = Math.max(bottomPadding, tabBarMetrics.height + 40, insets.bottom + 40)
 
   const gridColumns = getDesktopVideoGridColumns(isDesktop, screenWidth)
 
@@ -998,6 +999,9 @@ export default function HomeScreen() {
               onPress={refreshFeed}
               className="p-2 active:opacity-60"
               disabled={feedLoading || backendConnecting || !rpc}
+              accessibilityRole="button"
+              accessibilityLabel="Refresh discover feed"
+              accessibilityState={{ disabled: feedLoading || backendConnecting || !rpc, busy: feedLoading }}
             >
               <Feather
                 name="refresh-cw"
@@ -1095,6 +1099,9 @@ export default function HomeScreen() {
               <Pressable
                 key={cat}
                 onPress={() => setActiveCategory(cat)}
+                accessibilityRole="button"
+                accessibilityLabel={`Filter by ${cat}`}
+                accessibilityState={{ selected: activeCategory === cat }}
                 style={{
                   paddingHorizontal: 16,
                   paddingVertical: 8,
@@ -1266,7 +1273,7 @@ export default function HomeScreen() {
               : item.type
           )}
           renderItem={renderHomeFeedItem}
-          contentContainerStyle={{ paddingBottom: bottomPadding, flexGrow: 1 }}
+          contentContainerStyle={{ paddingBottom: feedBottomPadding, flexGrow: 1 }}
           refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={colors.primary} />}
           showsVerticalScrollIndicator={false}
           removeClippedSubviews={true}

--- a/packages/app/components/PillTabBar.tsx
+++ b/packages/app/components/PillTabBar.tsx
@@ -209,6 +209,9 @@ function TabButton({ tab, isActive, onPress }: TabButtonProps) {
       onPress={onPress}
       onPressIn={handlePressIn}
       onPressOut={handlePressOut}
+      accessibilityRole="tab"
+      accessibilityLabel={tab.label}
+      accessibilityState={{ selected: isActive }}
     >
       {tab.emphasized ? (
         <View style={[styles.emphasizedIconBg, isActive && styles.emphasizedIconBgActive]}>

--- a/packages/app/components/VideoPlayerOverlayImpl.tsx
+++ b/packages/app/components/VideoPlayerOverlayImpl.tsx
@@ -3034,6 +3034,9 @@ export function VideoPlayerOverlay() {
                   onPress={refreshComments}
                   disabled={refreshingComments}
                   style={[styles.refreshButton, refreshingComments && { opacity: 0.5 }]}
+                  accessibilityRole="button"
+                  accessibilityLabel="Refresh comments"
+                  accessibilityState={{ disabled: refreshingComments, busy: refreshingComments }}
                 >
                   {refreshingComments ? (
                     <ActivityIndicator size="small" color={colors.primary} />
@@ -3063,11 +3066,15 @@ export function VideoPlayerOverlay() {
                   placeholderTextColor={colors.textMuted}
                   style={styles.commentInput}
                   multiline
+                  accessibilityLabel={replyToComment ? 'Write a reply' : 'Add a comment'}
                 />
                 <Pressable
                   onPress={postComment}
                   disabled={postingComment || !commentText.trim()}
                   style={[styles.commentButton, (postingComment || !commentText.trim()) && { opacity: 0.5 }]}
+                  accessibilityRole="button"
+                  accessibilityLabel={postingComment ? 'Posting comment' : 'Post comment'}
+                  accessibilityState={{ disabled: postingComment || !commentText.trim(), busy: postingComment }}
                 >
                   <Text style={styles.commentButtonText}>{postingComment ? 'Posting…' : 'Post'}</Text>
                 </Pressable>
@@ -3097,7 +3104,12 @@ export function VideoPlayerOverlay() {
                             </Text>
                           )}
                           <View style={styles.commentActions}>
-                            <Pressable onPress={() => setReplyToComment(c)} style={styles.commentActionButton}>
+                            <Pressable
+                              onPress={() => setReplyToComment(c)}
+                              style={styles.commentActionButton}
+                              accessibilityRole="button"
+                              accessibilityLabel="Reply to comment"
+                            >
                               <Feather name="corner-up-left" color={colors.textMuted} size={14} />
                             </Pressable>
                             {(isOwnComment(c) || c.pendingState) && (
@@ -3105,6 +3117,9 @@ export function VideoPlayerOverlay() {
                                 onPress={() => deleteComment(c.commentId)}
                                 disabled={deletingCommentId === c.commentId}
                                 style={styles.commentActionButton}
+                                accessibilityRole="button"
+                                accessibilityLabel="Delete comment"
+                                accessibilityState={{ disabled: deletingCommentId === c.commentId, busy: deletingCommentId === c.commentId }}
                               >
                                 {deletingCommentId === c.commentId ? (
                                   <ActivityIndicator size="small" color={colors.textMuted} />
@@ -3139,6 +3154,9 @@ export function VideoPlayerOverlay() {
                                     onPress={() => deleteComment(reply.commentId)}
                                     disabled={deletingCommentId === reply.commentId}
                                     style={styles.commentActionButton}
+                                    accessibilityRole="button"
+                                    accessibilityLabel="Delete comment"
+                                    accessibilityState={{ disabled: deletingCommentId === reply.commentId, busy: deletingCommentId === reply.commentId }}
                                   >
                                     {deletingCommentId === reply.commentId ? (
                                       <ActivityIndicator size="small" color={colors.textMuted} />
@@ -3161,6 +3179,9 @@ export function VideoPlayerOverlay() {
                       onPress={loadMoreComments}
                       disabled={loadingMoreComments}
                       style={styles.loadMoreButton}
+                      accessibilityRole="button"
+                      accessibilityLabel="Load more comments"
+                      accessibilityState={{ disabled: loadingMoreComments, busy: loadingMoreComments }}
                     >
                       {loadingMoreComments ? (
                         <ActivityIndicator size="small" color={colors.primary} />

--- a/packages/app/components/video-player/ActionButton.tsx
+++ b/packages/app/components/video-player/ActionButton.tsx
@@ -16,6 +16,7 @@ interface ActionButtonProps {
   onPress?: () => void
   active?: boolean
   loading?: boolean
+  accessibilityLabel?: string
 }
 
 export const ActionButton = memo(function ActionButton({
@@ -24,9 +25,16 @@ export const ActionButton = memo(function ActionButton({
   onPress,
   active,
   loading,
+  accessibilityLabel,
 }: ActionButtonProps) {
   return (
-    <Pressable style={styles.actionButton} onPress={onPress}>
+    <Pressable
+      style={styles.actionButton}
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel || label}
+      accessibilityState={{ disabled: !onPress || loading, selected: Boolean(active), busy: Boolean(loading) }}
+    >
       {loading ? (
         <ActivityIndicator size={20} color={colors.primary} />
       ) : (

--- a/packages/app/components/video-player/CommentItem.tsx
+++ b/packages/app/components/video-player/CommentItem.tsx
@@ -52,7 +52,12 @@ export const CommentItem = memo(function CommentItem({
           </Text>
         )}
         <View style={styles.commentActions}>
-          <Pressable onPress={onReply} style={styles.commentActionButton}>
+          <Pressable
+            onPress={onReply}
+            style={styles.commentActionButton}
+            accessibilityRole="button"
+            accessibilityLabel="Reply to comment"
+          >
             <Feather name="corner-up-left" color={colors.textMuted} size={14} />
           </Pressable>
           {(isOwnComment || comment.pendingState) && (
@@ -60,6 +65,9 @@ export const CommentItem = memo(function CommentItem({
               onPress={onDelete}
               disabled={isDeleting}
               style={styles.commentActionButton}
+              accessibilityRole="button"
+              accessibilityLabel="Delete comment"
+              accessibilityState={{ disabled: isDeleting, busy: isDeleting }}
             >
               {isDeleting ? (
                 <ActivityIndicator size="small" color={colors.textMuted} />

--- a/packages/app/components/video-player/CommentsSection.tsx
+++ b/packages/app/components/video-player/CommentsSection.tsx
@@ -80,6 +80,9 @@ export const CommentsSection = memo(function CommentsSection({
           onPress={onRefreshComments}
           disabled={refreshingComments}
           style={[styles.refreshButton, refreshingComments && { opacity: 0.5 }]}
+          accessibilityRole="button"
+          accessibilityLabel="Refresh comments"
+          accessibilityState={{ disabled: refreshingComments, busy: refreshingComments }}
         >
           {refreshingComments ? (
             <ActivityIndicator size="small" color={colors.primary} />

--- a/packages/app/components/video-player/P2PStatsBar.tsx
+++ b/packages/app/components/video-player/P2PStatsBar.tsx
@@ -19,15 +19,23 @@ export const P2PStatsBar = memo(function P2PStatsBar({ stats }: P2PStatsBarProps
   const peerCount = stats?.peerCount ?? 0
   const downloadSpeed = Number(stats?.speedMBps ?? 0)
   const uploadSpeed = Number(stats?.uploadSpeedMBps ?? 0)
+  const downloadedBytes = Number(stats?.downloadedBytes ?? 0)
+  const totalBytes = Number(stats?.totalBytes ?? 0)
+  const downloadedBlocks = Number(stats?.downloadedBlocks ?? 0)
+  const totalBlocks = Number(stats?.totalBlocks ?? 0)
+  const hasBytes = totalBytes > 0
+  const hasBlocks = totalBlocks > 0
+  const hasProgressDetails = hasBytes || hasBlocks || Boolean(stats?.isComplete)
 
   const getStatusInfo = () => {
-    if (!stats) {
-      return { color: '#6b7280', label: 'Connecting' }
-    }
+    if (!stats) return { color: '#6b7280', label: 'Starting player' }
     if (stats.isComplete) return { color: '#4ade80', label: 'Cached' }
     if (stats.status === 'downloading') return { color: '#fbbf24', label: 'Downloading' }
-    if (stats.status === 'connecting' || stats.status === 'resolving') return { color: '#60a5fa', label: 'Connecting' }
-    return { color: '#6b7280', label: 'Waiting' }
+    if (stats.status === 'connecting') return { color: '#60a5fa', label: 'Finding video peers' }
+    if (stats.status === 'resolving') return { color: '#a78bfa', label: 'Resolving video' }
+    if (stats.status === 'error') return { color: '#f87171', label: 'Playback error' }
+    if (peerCount === 0 && !hasProgressDetails) return { color: '#6b7280', label: 'Waiting for video peers' }
+    return { color: '#6b7280', label: 'Preparing video' }
   }
 
   const { color, label } = getStatusInfo()
@@ -53,21 +61,25 @@ export const P2PStatsBar = memo(function P2PStatsBar({ stats }: P2PStatsBarProps
       </View>
 
       {/* Progress bar */}
-      {stats && !stats.isComplete && (
+      {stats && !stats.isComplete && hasProgressDetails && (
         <View style={styles.progressBarBg}>
           <View style={[styles.progressBarFill, { width: `${stats.progress || 0}%` }]} />
         </View>
       )}
 
       {/* Details row */}
-      {stats && (
+      {stats && hasProgressDetails && (
         <View style={styles.statsRowSecondary}>
-          <Text style={styles.statDetail}>
-            {formatSizeCompact(stats.downloadedBytes || 0)} / {formatSizeCompact(stats.totalBytes || 0)}
-          </Text>
-          <Text style={styles.statDetail}>
-            {stats.downloadedBlocks || 0} / {stats.totalBlocks || 0} blocks
-          </Text>
+          {hasBytes && (
+            <Text style={styles.statDetail}>
+              {formatSizeCompact(downloadedBytes)} / {formatSizeCompact(totalBytes)}
+            </Text>
+          )}
+          {hasBlocks && (
+            <Text style={styles.statDetail}>
+              {downloadedBlocks} / {totalBlocks} blocks
+            </Text>
+          )}
           <Text style={[styles.statProgress, stats.isComplete && styles.statProgressComplete]}>
             {stats.progress || 0}%
           </Text>

--- a/packages/app/components/video/VideoCard.tsx
+++ b/packages/app/components/video/VideoCard.tsx
@@ -101,7 +101,13 @@ function VideoCardComponent({ video, onPress, onChannelPress, showChannelInfo = 
   }))
 
   return (
-    <Pressable onPress={handlePress} style={getPressedStyle} testID={testID}>
+    <Pressable
+      onPress={handlePress}
+      style={getPressedStyle}
+      testID={testID}
+      accessibilityRole="button"
+      accessibilityLabel={`Play ${video.title}`}
+    >
       <View style={styles.surface}>
         <View style={styles.thumbnailFrame}>
           <ThumbnailImage
@@ -119,6 +125,8 @@ function VideoCardComponent({ video, onPress, onChannelPress, showChannelInfo = 
               onPressOut={channelPressOut}
               style={[styles.avatarContainer, channelAnimStyle]}
               hitSlop={6}
+              accessibilityRole="button"
+              accessibilityLabel={`Open ${channelName}`}
             >
               <View style={styles.avatar}>
                 <Text style={styles.avatarText}>{channelInitial}</Text>
@@ -145,6 +153,8 @@ function VideoCardComponent({ video, onPress, onChannelPress, showChannelInfo = 
                     onPressOut={channelPressOut}
                     style={channelAnimStyle}
                     hitSlop={6}
+                    accessibilityRole="button"
+                    accessibilityLabel={`Open ${channelName}`}
                   >
                     <Text style={styles.channelNameLink} numberOfLines={1}>
                       {channelName}

--- a/packages/app/lib/SocialContext.tsx
+++ b/packages/app/lib/SocialContext.tsx
@@ -5,6 +5,20 @@ import { useApp } from '@/lib/AppContext'
 import { useVideoPlayerContext } from '@/lib/VideoPlayerContext'
 import { COMMENTS_PER_PAGE } from '@/components/video-player'
 
+const SOCIAL_RPC_TIMEOUT_MS = 8000
+
+function withTimeout<T>(promise: Promise<T>, ms: number, fallback: T): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  return Promise.race([
+    promise.finally(() => {
+      if (timeout) clearTimeout(timeout)
+    }),
+    new Promise<T>((resolve) => {
+      timeout = setTimeout(() => resolve(fallback), ms)
+    }),
+  ])
+}
+
 interface SocialContextType {
   comments: any[]
   pendingComments: any[]
@@ -117,8 +131,16 @@ export function SocialProvider({ children }: { children: React.ReactNode }) {
 
     try {
       const [commentsRes, reactionsRes] = await Promise.all([
-        rpc.listComments?.({ channelKey: ch, videoId: canonicalVid, publicBeeKey: pubBee, page, limit: COMMENTS_PER_PAGE }).catch(() => null),
-        !append ? rpc.getReactions?.({ channelKey: ch, videoId: canonicalVid, publicBeeKey: pubBee }).catch(() => null) : Promise.resolve(null),
+        withTimeout(
+          rpc.listComments?.({ channelKey: ch, videoId: canonicalVid, publicBeeKey: pubBee, page, limit: COMMENTS_PER_PAGE }).catch(() => null) ?? Promise.resolve(null),
+          SOCIAL_RPC_TIMEOUT_MS,
+          null
+        ),
+        !append ? withTimeout(
+          rpc.getReactions?.({ channelKey: ch, videoId: canonicalVid, publicBeeKey: pubBee }).catch(() => null) ?? Promise.resolve(null),
+          SOCIAL_RPC_TIMEOUT_MS,
+          null
+        ) : Promise.resolve(null),
       ])
 
       const primaryOk = Boolean(commentsRes?.success && Array.isArray(commentsRes.comments))


### PR DESCRIPTION
## Summary
- make P2P playback status less stale/confusing by hiding zero progress details and using clearer waiting/resolving labels
- add timeouts around comments/reactions RPC calls so social UI does not spin forever on slow P2P responses
- add bottom feed padding and accessibility labels/states for feed controls, video cards, tab bar, and comment actions

## Verification
- Rebased on origin/main
- npx eslint targeted changed files --quiet --rule '@typescript-eslint/no-require-imports: off'
- git diff --check
- npx tsc --noEmit --pretty false (fails on existing unrelated project errors: gluestack/html-elements deps, known app/web/player type errors)
- Built release APK locally after setting JAVA_HOME=/home/user/.local/opt/jdk-21; first full npm build hit packageRelease splitter failure, reran :app:packageRelease --stacktrace successfully
- Installed app-x86_64-release.apk on emulator-5554 and launched com.peartube.app
- Verified app stays focused/no fatal AndroidRuntime crash in logcat
- Verified UIAutomator exposes Refresh discover feed, Filter category buttons, video Play labels, tab labels, Refresh comments, Add a comment, Post comment
- Opened a feed video and verified P2P stats show real Cached/peer/block data without bogus 0 / 0 blocks