### PR TITLE
fix(app): honor HypercoreIOReader blob byte offset

### DIFF
--- a/packages/app/backend/hypercore-io-reader.mjs
+++ b/packages/app/backend/hypercore-io-reader.mjs
@@ -39,13 +39,8 @@ export class HypercoreIOReader {
     this.blockLength = blobInfo.blockLength
     this.byteLength = blobInfo.byteLength
 
-    // NOTE: blobInfo.byteOffset is the ABSOLUTE byte position in the hypercore,
-    // not the offset within the first block. For blob-backed videos, the blob
-    // typically starts at offset 0 of its first block.
-    // We calculate the actual offset within the first block if needed.
-    // For now, assume offset 0 since that's where the MKV header is found.
-    this.byteOffset = 0
-    console.log('[HypercoreIOReader] Using byteOffset=0 (blob starts at beginning of first block)')
+    this.byteOffset = Number(blobInfo.byteOffset) || 0
+    console.log('[HypercoreIOReader] Using byteOffset=' + this.byteOffset + ' from blobInfo')
 
     // Calculated values
     this.startBlock = this.blockOffset

--- a/packages/app/backend/hypercore-io-reader.mjs
+++ b/packages/app/backend/hypercore-io-reader.mjs
@@ -315,15 +315,13 @@ export class HypercoreIOReader {
       throw new Error('Must call preload() before createIOContext()')
     }
 
-    const self = this
-
     // Use 128KB buffer for IOContext
     const ioContext = new ffmpeg.IOContext(128 * 1024, {
       onread: (buffer) => {
-        return self.syncRead(buffer)
+        return this.syncRead(buffer)
       },
       onseek: (offset, whence) => {
-        return self.seek(offset, whence)
+        return this.seek(offset, whence)
       }
     })
 

--- a/packages/app/tests/hypercore-io-reader-byte-offset-regression.test.mjs
+++ b/packages/app/tests/hypercore-io-reader-byte-offset-regression.test.mjs
@@ -1,0 +1,53 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { HypercoreIOReader } from '../backend/hypercore-io-reader.mjs'
+
+function createReaderWithBlocks(blobInfo, blocks) {
+  const reader = new HypercoreIOReader({
+    contiguousLength: blobInfo.blockOffset + blobInfo.blockLength,
+    async has() {
+      return true
+    },
+    async get(index) {
+      const block = blocks[index]
+      return Buffer.isBuffer(block) ? block : Buffer.from(block)
+    },
+  }, blobInfo)
+
+  return reader
+}
+
+test('HypercoreIOReader starts reads at blobInfo.byteOffset inside the first block', async () => {
+  const reader = createReaderWithBlocks(
+    { blockOffset: 4, blockLength: 2, byteOffset: 3, byteLength: 7 },
+    {
+      4: Buffer.from('abcHEADER'),
+      5: Buffer.from('TAILzzz'),
+    },
+  )
+
+  await reader.preload()
+
+  const buffer = Buffer.alloc(7)
+  assert.equal(reader.syncRead(buffer), 7)
+  assert.equal(buffer.toString(), 'HEADERT')
+  assert.equal(reader.syncRead(Buffer.alloc(1)), 0, 'reader should stop at blob byteLength, not block length')
+})
+
+test('HypercoreIOReader seek positions are relative to blob data, not hypercore block data', async () => {
+  const reader = createReaderWithBlocks(
+    { blockOffset: 7, blockLength: 2, byteOffset: 5, byteLength: 8 },
+    {
+      7: Buffer.from('xxxxx01234'),
+      8: Buffer.from('56789'),
+    },
+  )
+
+  await reader.preload()
+  assert.equal(reader.seek(4, 0), 4)
+
+  const buffer = Buffer.alloc(4)
+  assert.equal(reader.syncRead(buffer), 4)
+  assert.equal(buffer.toString(), '4567')
+})


### PR DESCRIPTION
## Summary
- Honor `blobInfo.byteOffset` when HypercoreIOReader maps blob-relative reads into the first Hypercore block
- Add regression coverage for initial reads and seeks on non-zero-offset blobs

Closes #223

## Test Plan
- [x] `node --test packages/app/tests/hypercore-io-reader-byte-offset-regression.test.mjs`
- [x] `node --test packages/app/tests/hypercore-io-reader-byte-offset-regression.test.mjs packages/app/tests/vertical-discovery-regression.test.mjs`
- [x] `git diff --check`
