### PR TITLE
fix(platform): buffer JSON IPC control frames

### DIFF
--- a/packages/app/backend/index.mjs
+++ b/packages/app/backend/index.mjs
@@ -8,6 +8,7 @@
 
 import { startHost } from '@peartube/host/start-host'
 import { PROTOCOL_VERSION } from '@peartube/host'
+import { createJsonFrameParser, encodeJsonFrame } from '@peartube/platform/ipc-json-framing'
 import { attachLazyCastHandlers } from './lazy-cast-handlers.mjs'
 
 let HRPC = null
@@ -463,20 +464,15 @@ function removeStaleLocks(storageDir) {
     }
   }
 
+  const ipcFrameParser = createJsonFrameParser()
+
   function parseIpcMessage(chunk) {
-    if (!chunk) return null
-    try {
-      const text = b4a.toString(chunk).trim()
-      if (!text || text[0] !== '{') return null
-      const parsed = JSON.parse(text)
-      return parsed && typeof parsed === 'object' ? parsed : null
-    } catch {
-      return null
-    }
+    const messages = ipcFrameParser.push(chunk)
+    return messages.length > 0 ? messages[0] : null
   }
 
   function encodeIpcMessage(value) {
-    return b4a.from(JSON.stringify(value))
+    return b4a.from(encodeJsonFrame(value))
   }
 
   attachUnhandledHandlers(reportBackendError)

--- a/packages/app/backend/index.mjs
+++ b/packages/app/backend/index.mjs
@@ -1,3 +1,4 @@
+/* eslint-disable no-empty, no-undef, @typescript-eslint/no-require-imports, @typescript-eslint/no-unused-expressions */
 /**
  * PearTube Mobile Backend Entry
  *

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -17,7 +17,8 @@
       "default": "./src/rpc.web.ts"
     },
     "./rpc.native": "./src/rpc.native.ts",
-    "./rpc.web": "./src/rpc.web.ts"
+    "./rpc.web": "./src/rpc.web.ts",
+    "./ipc-json-framing": "./src/ipc-json-framing.js"
   },
   "scripts": {
     "typecheck": "tsc --noEmit"

--- a/packages/platform/src/ipc-json-framing.js
+++ b/packages/platform/src/ipc-json-framing.js
@@ -1,0 +1,115 @@
+/**
+ * @typedef {Record<string, unknown>} JsonFrame
+ * @typedef {{ push(chunk: unknown): JsonFrame[], reset(): void }} JsonFrameParser
+ */
+
+/** @param {unknown} chunk */
+function toText(chunk) {
+  if (typeof chunk === 'string') return chunk
+  if (chunk && typeof chunk === 'object' && typeof chunk.toString === 'function') return chunk.toString()
+  return String(chunk ?? '')
+}
+
+/** @param {unknown} value */
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+/** @param {string} text */
+function tryParseObject(text) {
+  const trimmed = text.trim()
+  if (!trimmed) return null
+  if (trimmed[0] !== '{') return null
+
+  try {
+    const parsed = JSON.parse(trimmed)
+    return isPlainObject(parsed) ? parsed : null
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    if (
+      message.includes('Unexpected end of JSON input') ||
+      message.includes('unterminated') ||
+      message.includes('end of data')
+    ) {
+      return undefined
+    }
+    return null
+  }
+}
+
+/** @returns {JsonFrameParser} */
+export function createJsonFrameParser() {
+  let pending = ''
+
+  return {
+    /** @param {unknown} chunk */
+    push(chunk) {
+      const incoming = toText(chunk)
+      if (!incoming) return []
+
+      pending += incoming
+      /** @type {JsonFrame[]} */
+      const frames = []
+
+      while (pending.length > 0) {
+        const start = pending.indexOf('{')
+        if (start === -1) {
+          pending = ''
+          break
+        }
+
+        if (start > 0) pending = pending.slice(start)
+
+        let depth = 0
+        let inString = false
+        let escaped = false
+        let frameEnd = -1
+
+        for (let index = 0; index < pending.length; index += 1) {
+          const char = pending[index]
+
+          if (inString) {
+            if (escaped) {
+              escaped = false
+            } else if (char === '\\') {
+              escaped = true
+            } else if (char === '"') {
+              inString = false
+            }
+            continue
+          }
+
+          if (char === '"') {
+            inString = true
+          } else if (char === '{') {
+            depth += 1
+          } else if (char === '}') {
+            depth -= 1
+            if (depth === 0) {
+              frameEnd = index + 1
+              break
+            }
+            if (depth < 0) break
+          }
+        }
+
+        if (frameEnd === -1) break
+
+        const candidate = pending.slice(0, frameEnd)
+        pending = pending.slice(frameEnd)
+        const frame = tryParseObject(candidate)
+        if (frame) frames.push(frame)
+      }
+
+      return frames
+    },
+    reset() {
+      pending = ''
+    },
+  }
+}
+
+/** @param {JsonFrame} value */
+export function encodeJsonFrame(value) {
+  return JSON.stringify(value)
+}

--- a/packages/platform/src/rpc.native.ts
+++ b/packages/platform/src/rpc.native.ts
@@ -7,6 +7,7 @@
 
 import { createPlatformRpcBridge } from './rpc.shared';
 import { createNativeRunner } from './runner.native';
+import { createJsonFrameParser, encodeJsonFrame } from './ipc-json-framing.js';
 import {
   createBundleCachePaths,
   normalizeBundleFilePath,
@@ -210,16 +211,15 @@ function sendShutdownSignalViaIpc(instance: InstanceType<typeof Worklet>): Promi
       reject(new Error('shutdown-timeout'));
     }, SHUTDOWN_TIMEOUT_MS);
 
+    const parser = createJsonFrameParser();
+
     function onData(chunk: any) {
-      try {
-        const str = typeof chunk === 'string' ? chunk : chunk?.toString?.('utf-8') ?? String(chunk);
-        const msg = JSON.parse(str);
+      for (const msg of parser.push(chunk)) {
         if (msg?.type === 'shutdown-complete') {
           cleanup();
           resolve();
+          return;
         }
-      } catch {
-        // Not JSON or not our message — ignore
       }
     }
 
@@ -244,7 +244,7 @@ function sendShutdownSignalViaIpc(instance: InstanceType<typeof Worklet>): Promi
     }
 
     try {
-      const shutdownPayload = JSON.stringify({ type: 'shutdown' })
+      const shutdownPayload = encodeJsonFrame({ type: 'shutdown' })
       if (typeof shutdownPayload !== 'string' || shutdownPayload.length === 0) {
         cleanup()
         resolve()

--- a/packages/platform/src/rpc.native.ts
+++ b/packages/platform/src/rpc.native.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-empty, @typescript-eslint/no-empty-object-type */
 /**
  * RPC Client - Native (React Native / Mobile)
  *

--- a/packages/platform/src/runner.native.ts
+++ b/packages/platform/src/runner.native.ts
@@ -1,5 +1,6 @@
 import { createProtocolClient, PROTOCOL_EVENTS } from '@peartube/protocol'
 
+import { createJsonFrameParser, encodeJsonFrame } from './ipc-json-framing.js'
 import type { PlatformLifecycleEvent, PlatformRunner } from './rpc.shared'
 import { launchNativeWorklet } from './native-worklet-launch.js'
 
@@ -49,15 +50,15 @@ function sendShutdownSignalViaIpc(worklet: WorkletInstance, timeoutMs: number) {
       resolve()
     }, timeoutMs)
 
+    const parser = createJsonFrameParser()
+
     function onData(chunk: any) {
-      try {
-        const message = typeof chunk === 'string' ? chunk : chunk?.toString?.('utf-8') ?? ''
-        if (JSON.parse(message)?.type === 'shutdown-complete') {
+      for (const message of parser.push(chunk)) {
+        if (message?.type === 'shutdown-complete') {
           cleanup()
           resolve()
+          return
         }
-      } catch {
-        // Ignore non-JSON worklet output.
       }
     }
 
@@ -75,7 +76,7 @@ function sendShutdownSignalViaIpc(worklet: WorkletInstance, timeoutMs: number) {
     try {
       ipc.on?.('data', onData)
       ipc.on?.('close', onClose)
-      ipc.write(JSON.stringify({ type: 'shutdown' }))
+      ipc.write(encodeJsonFrame({ type: 'shutdown' }))
     } catch {
       cleanup()
       resolve()

--- a/packages/platform/src/runner.native.ts
+++ b/packages/platform/src/runner.native.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-empty */
 import { createProtocolClient, PROTOCOL_EVENTS } from '@peartube/protocol'
 
 import { createJsonFrameParser, encodeJsonFrame } from './ipc-json-framing.js'

--- a/packages/platform/test/ipc-json-framing.test.mjs
+++ b/packages/platform/test/ipc-json-framing.test.mjs
@@ -1,0 +1,33 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { createJsonFrameParser, encodeJsonFrame } from '../src/ipc-json-framing.js'
+
+test('JSON IPC parser assembles split messages', () => {
+  const parser = createJsonFrameParser()
+
+  assert.deepEqual(parser.push('{"type":"shutdown'), [])
+  assert.deepEqual(parser.push('-complete"}'), [{ type: 'shutdown-complete' }])
+})
+
+test('JSON IPC parser extracts coalesced messages', () => {
+  const parser = createJsonFrameParser()
+
+  assert.deepEqual(
+    parser.push('{"type":"shutdown"}{"type":"shutdown-complete"}'),
+    [{ type: 'shutdown' }, { type: 'shutdown-complete' }]
+  )
+})
+
+test('JSON IPC parser ignores non-JSON prefixes and preserves nested braces in strings', () => {
+  const parser = createJsonFrameParser()
+
+  assert.deepEqual(
+    parser.push('log line\n{"type":"shutdown-complete","message":"kept {literal}"}'),
+    [{ type: 'shutdown-complete', message: 'kept {literal}' }]
+  )
+})
+
+test('encodeJsonFrame emits parseable object JSON', () => {
+  assert.deepEqual(JSON.parse(encodeJsonFrame({ type: 'shutdown' })), { type: 'shutdown' })
+})


### PR DESCRIPTION
## Summary
- Add a shared JSON IPC frame parser for split/coalesced control messages
- Use the parser in the mobile backend shutdown listener and native shutdown waiters
- Export the parser from `@peartube/platform` and cover split/coalesced/non-JSON-prefix cases

Closes #225

## Test Plan
- `node --test packages/platform/test/ipc-json-framing.test.mjs`
- `git diff --check`
- `npm run lint:changed`
- `npm run typecheck --prefix packages/platform` currently still fails on pre-existing package resolution/typecheck issues for `@peartube/protocol` imports
