### PR TITLE
Fix persistent Shorts PiP teardown

### DIFF
--- a/packages/app/app/(tabs)/discover.tsx
+++ b/packages/app/app/(tabs)/discover.tsx
@@ -330,14 +330,17 @@ export default function VerticalDiscoveryScreen() {
   }, [loadFeed, platformEvents, ready, rpc])
 
   const stopShortsPlayback = useCallback(() => {
+    void shortsPlayerRef.current?.exitPictureInPicture?.()
     void shortsPlayerRef.current?.stop?.()
     void shortsPlayerRef.current?.pause?.()
+    void shortsPlayerRef.current?.destroy?.()
     pendingPlayKeyRef.current = null
     playbackRequestSeqRef.current += 1
+    setAmbientVideoContext(null, null)
     setShortsVideoUrl(null)
     setCommentsSheetVisible(false)
     setShortsLoading(false)
-  }, [])
+  }, [setAmbientVideoContext])
 
   useFocusEffect(
     useCallback(() => {

--- a/packages/app/components/video-player/PearInlineVideoView.tsx
+++ b/packages/app/components/video-player/PearInlineVideoView.tsx
@@ -183,6 +183,7 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
           videoRef.current?.seek(0)
         },
         destroy: async () => {
+          videoRef.current?.dismissFullscreenPlayer?.()
           videoRef.current?.pause?.()
           videoRef.current?.seek(0)
         },
@@ -198,6 +199,10 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
         },
         enterPip: () => {
           void videoRef.current?.enterPictureInPicture?.()
+        },
+        exitPictureInPicture: () => {
+          videoRef.current?.dismissFullscreenPlayer?.()
+          void videoRef.current?.exitPictureInPicture?.()
         },
       },
       {

--- a/packages/app/tests/vertical-discovery-regression.test.mjs
+++ b/packages/app/tests/vertical-discovery-regression.test.mjs
@@ -267,9 +267,21 @@ test('vertical discovery stops inline Shorts playback when the route unmounts or
 
   assert.match(source, /useFocusEffect/, 'Discover should subscribe to route focus lifecycle')
   assert.match(source, /stopShortsPlayback/, 'Discover should centralize Shorts playback teardown')
+  assert.match(source, /shortsPlayerRef\.current\?\.exitPictureInPicture\?\.\(\)/, 'teardown should force-exit any stale native PiP window before detaching Shorts')
   assert.match(source, /shortsPlayerRef\.current\?\.stop\?\.\(\)/, 'teardown should stop the native inline player instead of merely hiding React chrome')
+  assert.match(source, /shortsPlayerRef\.current\?\.destroy\?\.\(\)/, 'teardown should destroy the route-local native surface so it cannot keep PiP alive')
+  assert.match(source, /setAmbientVideoContext\(null, null\)/, 'teardown should clear hidden ambient Shorts metadata from the global player context')
   assert.match(source, /setShortsVideoUrl\(null\)/, 'teardown should detach the playback URL so the inline surface unmounts')
   assert.match(source, /return stopShortsPlayback/, 'Discover should run teardown when tab navigation leaves the Shorts route')
+})
+
+test('native inline player exposes explicit PiP exit and tears down its surface on destroy', () => {
+  const source = readAppFile('components/video-player/PearInlineVideoView.tsx')
+  const portSource = readAppFile('lib/video-player/playerPort.ts')
+
+  assert.match(portSource, /exitPictureInPicture\?: \(\) => void \| Promise<void>/, 'PlayerPort should expose explicit PiP exit for route-local teardown')
+  assert.match(source, /exitPictureInPicture:\s*\(\) => \{[\s\S]*dismissFullscreenPlayer\?\.\(\)[\s\S]*exitPictureInPicture\?\.\(\)/, 'native inline player should bridge explicit PiP exit to react-native-video')
+  assert.match(source, /destroy: async \(\) => \{[\s\S]*dismissFullscreenPlayer\?\.\(\)[\s\S]*pause\?\.\(\)[\s\S]*seek\(0\)/, 'destroy should leave no fullscreen/PiP surface playing behind the route')
 })
 
 test('bottom tab screens pad scrollable content by the measured pill tab bar height', () => {


### PR DESCRIPTION
## Summary
- Force the route-local Shorts player to exit native PiP before route teardown.
- Destroy the inline native player surface and clear ambient Shorts metadata on focus loss/unmount.
- Expose explicit PiP exit through `PearInlineVideoView`'s player port.

Closes #243

## Tests
- `node --test packages/app/tests/vertical-discovery-regression.test.mjs`
- `npm run lint:changed`
- `git diff --check`
- `NODE_PATH=/home/user/peartube-work/node_modules /home/user/peartube-work/node_modules/.bin/eslint --resolve-plugins-relative-to /home/user/peartube-work --quiet packages/app/app/'(tabs)'/discover.tsx packages/app/components/video-player/PearInlineVideoView.tsx packages/app/tests/vertical-discovery-regression.test.mjs`

Note: this worktree has no local `node_modules`; direct ESLint used the already-installed `/home/user/peartube-work/node_modules` plugin set to match repo lint config.
