### PR TITLE
Prevent PublicBee comments admin key leakage

### DIFF
--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -3063,12 +3063,6 @@ export function createApi({
                 } catch (err) {
                   console.log('[API] _getCommentsAutobase: could not store admin key in channel metadata:', err?.message)
                 }
-                try {
-                  await localChannel.publicBee?.setMetadata({ commentsAdminKey: adminKeyHex })
-                  console.log('[API] _getCommentsAutobase: published commentsAdminKey to PublicBee')
-                } catch (err) {
-                  console.log('[API] _getCommentsAutobase: could not publish admin key:', err?.message)
-                }
               }
 
               return commentsBase
@@ -3170,26 +3164,6 @@ export function createApi({
             console.log('[API] _getCommentsAutobase: published commentsAutobaseKey to PublicBee')
           } catch (err) {
             console.log('[API] _getCommentsAutobase: could not publish key to PublicBee:', err?.message)
-          }
-        }
-
-        // Publishing device: publish admin key if missing or stale.
-        if (isPublishingDevice && pubBee?.writable && commentsBase.localWriterKeyHex) {
-          const adminKeyHex = commentsBase.localWriterKeyHex
-          if (!commentsAdminKey || commentsAdminKey !== adminKeyHex) {
-            try {
-              await pubBee.setMetadata({ commentsAdminKey: adminKeyHex })
-              console.log('[API] _getCommentsAutobase: published commentsAdminKey to PublicBee')
-            } catch (err) {
-              console.log('[API] _getCommentsAutobase: could not publish admin key:', err?.message)
-            }
-          }
-          if (localChannel) {
-            try {
-              await localChannel.updateMetadata({ commentsAdminKey: adminKeyHex })
-            } catch (err) {
-              console.log('[API] _getCommentsAutobase: could not store admin key in channel metadata:', err?.message)
-            }
           }
         }
 

--- a/packages/backend/src/channel/multi-writer-channel.js
+++ b/packages/backend/src/channel/multi-writer-channel.js
@@ -716,10 +716,6 @@ export class MultiWriterChannel extends ReadyResource {
             await this.publicBee.setMetadata({ commentsAutobaseKey: this.commentsAutobase.keyHex })
             console.log('[Channel] _initCommentsAutobase: synced commentsAutobaseKey to PublicBee')
           }
-          if (adminKeyHex && pubMeta?.commentsAdminKey !== adminKeyHex) {
-            await this.publicBee.setMetadata({ commentsAdminKey: adminKeyHex })
-            console.log('[Channel] _initCommentsAutobase: synced commentsAdminKey to PublicBee')
-          }
         } catch (err) {
           console.log('[Channel] _initCommentsAutobase: publish error (non-fatal):', err?.message)
         }

--- a/packages/backend/src/channel/public-channel-bee.js
+++ b/packages/backend/src/channel/public-channel-bee.js
@@ -108,10 +108,19 @@ export class PublicChannelBee extends ReadyResource {
   // Channel Metadata
   // ============================================
 
+  _sanitizePublicMetadata(meta) {
+    if (!meta || typeof meta !== 'object') return null
+    const out = { ...meta }
+    // PublicBee is intentionally readable by anyone with the key. Never persist
+    // the comments admin writer key here; keep it in private channel metadata only.
+    delete out.commentsAdminKey
+    return out
+  }
+
   async getMetadata() {
     await this.waitForSync(1500)
     const node = await this.bee.get('meta')
-    return node?.value || null
+    return this._sanitizePublicMetadata(node?.value || null)
   }
 
   async setMetadata(meta) {
@@ -119,11 +128,12 @@ export class PublicChannelBee extends ReadyResource {
     // Merge with existing metadata so callers can perform partial updates without
     // accidentally dropping previously published fields (e.g. commentsAutobaseKey).
     const existing = await this.bee.get('meta').catch(() => null)
-    const prev = existing?.value && typeof existing.value === 'object' ? existing.value : {}
+    const prev = this._sanitizePublicMetadata(existing?.value || null) || {}
+    const patch = this._sanitizePublicMetadata(meta) || {}
 
     await this.bee.put('meta', {
       ...prev,
-      ...(meta && typeof meta === 'object' ? meta : {}),
+      ...patch,
       updatedAt: Date.now()
     })
     console.log('[PublicBee] Metadata updated')

--- a/packages/backend/src/channel/public-channel-bee.js
+++ b/packages/backend/src/channel/public-channel-bee.js
@@ -160,7 +160,11 @@ export class PublicChannelBee extends ReadyResource {
         }
       }
     } catch (error) {
-      try { stream.destroy?.(error) } catch {}
+      try {
+        stream.destroy?.(error)
+      } catch (destroyError) {
+        console.warn('[PublicBee] listVideos stream destroy failed:', destroyError?.message || destroyError)
+      }
       console.warn('[PublicBee] listVideos stream failed:', error?.message || error)
       return videos
     }

--- a/packages/backend/test/public-channel-bee-security.test.mjs
+++ b/packages/backend/test/public-channel-bee-security.test.mjs
@@ -1,0 +1,57 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { PublicChannelBee } from '../src/channel/public-channel-bee.js'
+import { PublicFeedManager } from '../src/public-feed.js'
+
+test('PublicChannelBee strips commentsAdminKey from public metadata writes', async () => {
+  let stored = {
+    name: 'Existing channel',
+    commentsAdminKey: 'aa'.repeat(32),
+    commentsAutobaseKey: 'bb'.repeat(32),
+  }
+
+  const bee = Object.create(PublicChannelBee.prototype)
+  bee.core = { writable: true }
+  bee.bee = {
+    async get(key) {
+      assert.equal(key, 'meta')
+      return { value: stored }
+    },
+    async put(key, value) {
+      assert.equal(key, 'meta')
+      stored = value
+    },
+  }
+
+  await bee.setMetadata({
+    description: 'Public description',
+    commentsAdminKey: 'cc'.repeat(32),
+  })
+
+  assert.equal(stored.name, 'Existing channel')
+  assert.equal(stored.description, 'Public description')
+  assert.equal(stored.commentsAutobaseKey, 'bb'.repeat(32))
+  assert.equal(stored.commentsAdminKey, undefined)
+})
+
+test('public feed gossip serialization does not forward sensitive metadata fields', () => {
+  const manager = new PublicFeedManager({ connections: new Set(), peers: new Set() }, null)
+  const serialized = manager._serializeEntry({
+    driveKey: '11'.repeat(32),
+    publicBeeKey: '22'.repeat(32),
+    channelName: 'Public channel',
+    commentsAdminKey: 'dd'.repeat(32),
+    previewVideos: [{
+      id: 'video-1',
+      title: 'Video',
+      blobId: '0:4:0:512',
+      blobsCoreKey: '33'.repeat(32),
+      commentsAdminKey: 'ee'.repeat(32),
+    }],
+  })
+
+  assert.equal(serialized.commentsAdminKey, undefined)
+  assert.equal(serialized.previewVideos[0].commentsAdminKey, undefined)
+  assert.deepEqual(Object.keys(serialized).filter((key) => key.includes('Admin')), [])
+})


### PR DESCRIPTION
## Summary
- Stop writing `commentsAdminKey` into publicly readable PublicBee metadata.
- Scrub stale `commentsAdminKey` values when PublicBee metadata is read or merged.
- Remove explicit PublicBee admin-key publishing paths from comments initialization.
- Add security regression coverage for PublicBee metadata and feed gossip payloads.

Closes #232

## Tests
- `node --test packages/backend/test/public-channel-bee-security.test.mjs packages/backend/test/public-feed-manager.test.mjs packages/backend/test/channel-meta-api.test.mjs`
- `npm run lint:changed`
- `git diff --check`

Note: `packages/backend/test/public-feed-api.test.mjs` currently has a pre-existing expectation mismatch on discovery-only fields in `getPublicFeed returns peer entries even when publicBeeKey is absent`; the targeted security/regression suites above pass.
