### PR TITLE
Fix non-destructive public channel sync

### DIFF
--- a/packages/backend/src/channel/multi-writer-channel.js
+++ b/packages/backend/src/channel/multi-writer-channel.js
@@ -96,6 +96,11 @@ export class MultiWriterChannel extends ReadyResource {
     /** @type {Map<string, {count: number, windowStartMs: number}>} */
     this._localRateLimits = new Map()
 
+    // Local monotonic clock for video mutations. This intentionally avoids
+    // scanning the full video index on every add/update; the view apply path is
+    // still deterministic because the chosen clock is persisted in the op.
+    this._lastVideoLogicalClock = 0
+
     // CRITICAL: Queue connections that arrive before base is ready
     // This prevents the race condition where connections arrive during _open()
     // but before we can call base.replicate()
@@ -372,6 +377,13 @@ export class MultiWriterChannel extends ReadyResource {
     // - view entries contain schemaVersion/logicalClock but not type
     const { type, schemaVersion, logicalClock, ...rest } = value
     return rest
+  }
+
+  _nextVideoLogicalClock() {
+    const now = Date.now()
+    const next = Math.max(this._lastVideoLogicalClock + 1, now)
+    this._lastVideoLogicalClock = next
+    return next
   }
 
   async _syncPublicBeeFromViewDiff(beforeSnapshot, afterSnapshot) {
@@ -1439,16 +1451,7 @@ export class MultiWriterChannel extends ReadyResource {
     if (!id) throw new Error('Video id required')
     console.log('[Channel] addVideo:', id, 'blobId:', meta.blobId, 'blobsCoreKey:', meta.blobsCoreKey?.slice(0, 16), 'keyLen:', meta.blobsCoreKey?.length)
 
-    // Get next logical clock. Use a timeout to avoid hanging when the
-    // Autobase view has blocks from remote writers that aren't available locally.
-    const videos = await Promise.race([
-      this.listVideos().catch(() => []),
-      new Promise(resolve => setTimeout(() => resolve(null), 5000))
-    ])
-    const maxClock = videos
-      ? Math.max(...videos.map(v => v.logicalClock || 0), 0)
-      : Date.now()
-    const nextClock = maxClock + 1
+    const nextClock = this._nextVideoLogicalClock()
 
     const videoMeta = {
       type: 'add-video',
@@ -1493,16 +1496,7 @@ export class MultiWriterChannel extends ReadyResource {
     const existing = await this.getVideo(id)
     if (!existing) throw new Error('Video not found: ' + id)
 
-    // Get next logical clock. Use a timeout to avoid hanging when the
-    // Autobase view has blocks from remote writers that aren't available locally.
-    const videos = await Promise.race([
-      this.listVideos().catch(() => []),
-      new Promise(resolve => setTimeout(() => resolve(null), 5000))
-    ])
-    const maxClock = videos
-      ? Math.max(...videos.map(v => v.logicalClock || 0), 0)
-      : Date.now()
-    const nextClock = maxClock + 1
+    const nextClock = this._nextVideoLogicalClock()
 
     const videoMeta = {
       type: 'update-video',

--- a/packages/backend/src/channel/public-channel-bee.js
+++ b/packages/backend/src/channel/public-channel-bee.js
@@ -236,38 +236,46 @@ export class PublicChannelBee extends ReadyResource {
    * Sync all videos from a source (e.g., Autobase channel)
    * @param {Array<Object>} videos - Video metadata array
    */
-  async syncVideos(videos) {
+  async syncVideos(videos, opts = {}) {
     if (!this.writable) throw new Error('Not writable')
 
+    const destructive = opts.destructive !== false
     const batch = this.bee.batch()
 
-    // Get existing video IDs
+    // Get existing video IDs only when this sync is allowed to delete missing
+    // entries. Non-destructive callers may be syncing from stale/partial views.
     const existing = new Set()
-    const existingVideos = await this.listVideos()
-    for (const v of existingVideos) {
-      existing.add(v.id)
+    if (destructive) {
+      const existingVideos = await this.listVideos()
+      for (const v of existingVideos) {
+        existing.add(v.id)
+      }
     }
 
     // Add/update videos from source
     const sourceIds = new Set()
+    const now = Date.now()
     for (const video of videos) {
       if (!video.id) continue
       sourceIds.add(video.id)
       await batch.put(`videos/${video.id}`, {
         ...video,
-        syncedAt: Date.now()
+        syncedAt: now
       })
     }
 
-    // Delete videos that no longer exist in source
-    for (const id of existing) {
-      if (!sourceIds.has(id)) {
-        await batch.del(`videos/${id}`)
+    // Delete videos that no longer exist in source only for explicitly complete
+    // source snapshots. syncFromChannel intentionally disables this path.
+    if (destructive) {
+      for (const id of existing) {
+        if (!sourceIds.has(id)) {
+          await batch.del(`videos/${id}`)
+        }
       }
     }
 
     await batch.flush()
-    console.log('[PublicBee] Synced', videos.length, 'videos')
+    console.log('[PublicBee] Synced', videos.length, 'videos', destructive ? '(destructive)' : '(non-destructive)')
   }
 
   /**
@@ -287,18 +295,11 @@ export class PublicChannelBee extends ReadyResource {
         await this.setMetadata(meta)
       }
 
-      // Sync videos
+      // Sync videos non-destructively. The Autobase view may be stale or
+      // partially materialized (especially after bounded replication waits), so
+      // absence from this read must not delete already-published public videos.
       const videos = await channel.listVideos()
-      if ((videos?.length || 0) === 0) {
-        const existingVideos = await this.listVideos()
-        if (existingVideos.length > 0) {
-          console.warn(
-            '[PublicBee] syncFromChannel: channel returned 0 videos while public bee still has content; skipping destructive sync'
-          )
-          return
-        }
-      }
-      await this.syncVideos(videos)
+      await this.syncVideos(videos || [], { destructive: false })
 
       console.log('[PublicBee] Synced from channel:', channel.keyHex?.slice(0, 16))
     } catch (err) {

--- a/packages/backend/test/public-channel-bee-sync.test.mjs
+++ b/packages/backend/test/public-channel-bee-sync.test.mjs
@@ -13,7 +13,11 @@ function makeTempDir(prefix) {
 
 async function closeSilently(resource) {
   if (!resource || typeof resource.close !== 'function') return
-  try { await resource.close() } catch {}
+  try {
+    await resource.close()
+  } catch {
+    // Best-effort cleanup for temporary Corestore resources.
+  }
 }
 
 async function withPublicBee(fn) {

--- a/packages/backend/test/public-channel-bee-sync.test.mjs
+++ b/packages/backend/test/public-channel-bee-sync.test.mjs
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 
 import Corestore from 'corestore'
 import { PublicChannelBee } from '../src/channel/public-channel-bee.js'
+import { MultiWriterChannel } from '../src/channel/multi-writer-channel.js'
 
 function makeTempDir(prefix) {
   return mkdtempSync(join(tmpdir(), prefix))
@@ -15,16 +16,25 @@ async function closeSilently(resource) {
   try { await resource.close() } catch {}
 }
 
-test('syncFromChannel keeps existing public videos when a channel unexpectedly reads empty', async (t) => {
+async function withPublicBee(fn) {
   const dir = makeTempDir('peartube-public-bee-sync-')
   const store = new Corestore(dir)
   let publicBee = null
 
   try {
     await store.ready()
-    publicBee = new PublicChannelBee(store, { name: 'public-sync-guard-test' })
+    publicBee = new PublicChannelBee(store, { name: `public-sync-${Date.now()}-${Math.random()}` })
     await publicBee.ready()
+    await fn(publicBee)
+  } finally {
+    await closeSilently(publicBee)
+    await closeSilently(store)
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
 
+test('syncFromChannel keeps existing public videos when a channel unexpectedly reads empty', async (t) => {
+  await withPublicBee(async (publicBee) => {
     await publicBee.putVideo('video-1', {
       title: 'Existing public video',
       uploadedAt: 1,
@@ -48,9 +58,91 @@ test('syncFromChannel keeps existing public videos when a channel unexpectedly r
     t.is(videos.length, 1)
     t.is(videos[0]?.id, 'video-1')
     t.is(videos[0]?.title, 'Existing public video')
-  } finally {
-    await closeSilently(publicBee)
-    await closeSilently(store)
-    rmSync(dir, { recursive: true, force: true })
+  })
+})
+
+test('syncFromChannel merges partial channel views without deleting missing public videos', async (t) => {
+  await withPublicBee(async (publicBee) => {
+    await publicBee.putVideo('video-1', {
+      title: 'Existing public video',
+      uploadedAt: 1,
+    })
+    await publicBee.putVideo('video-2', {
+      title: 'Second existing public video',
+      uploadedAt: 2,
+    })
+
+    await publicBee.syncFromChannel({
+      keyHex: 'bb'.repeat(32),
+      async getMetadata() {
+        return { name: 'Partial Channel' }
+      },
+      async listVideos() {
+        return [{
+          id: 'video-1',
+          title: 'Updated from partial view',
+          uploadedAt: 3,
+        }]
+      },
+    })
+
+    const videos = await publicBee.listVideos()
+    const byId = new Map(videos.map((video) => [video.id, video]))
+
+    t.is(videos.length, 2)
+    t.is(byId.get('video-1')?.title, 'Updated from partial view')
+    t.is(byId.get('video-2')?.title, 'Second existing public video')
+  })
+})
+
+test('syncVideos remains destructive by default for complete source snapshots', async (t) => {
+  await withPublicBee(async (publicBee) => {
+    await publicBee.putVideo('video-1', { title: 'Keep', uploadedAt: 1 })
+    await publicBee.putVideo('video-2', { title: 'Delete', uploadedAt: 2 })
+
+    await publicBee.syncVideos([{ id: 'video-1', title: 'Kept', uploadedAt: 3 }])
+
+    const videos = await publicBee.listVideos()
+    t.is(videos.length, 1)
+    t.is(videos[0]?.id, 'video-1')
+    t.is(videos[0]?.title, 'Kept')
+  })
+})
+
+test('MultiWriterChannel video mutations do not scan all videos for logical clocks', async (t) => {
+  const channel = Object.create(MultiWriterChannel.prototype)
+  channel._lastVideoLogicalClock = 0
+  channel.base = { local: { key: Buffer.from('cc'.repeat(32), 'hex') } }
+  channel.publicBee = null
+
+  let appendedAdd = null
+  let appendedUpdate = null
+  let safeUpdates = 0
+
+  channel.listVideos = async () => {
+    throw new Error('listVideos should not be called to compute logicalClock')
   }
+  channel.appendOp = async (op) => {
+    if (op.type === 'add-video') appendedAdd = op
+    if (op.type === 'update-video') appendedUpdate = op
+  }
+  channel._safeUpdate = async () => {
+    safeUpdates += 1
+  }
+  channel.getVideo = async (id) => ({
+    id,
+    title: 'Existing',
+    logicalClock: 100,
+  })
+
+  await channel.addVideo({ id: 'video-1', title: 'New video' })
+  await channel.updateVideo('video-1', { title: 'Updated video' })
+
+  t.is(appendedAdd?.type, 'add-video')
+  t.is(appendedAdd?.id, 'video-1')
+  t.ok(Number.isSafeInteger(appendedAdd?.logicalClock), 'addVideo assigns a logical clock')
+  t.is(appendedUpdate?.type, 'update-video')
+  t.is(appendedUpdate?.id, 'video-1')
+  t.ok(appendedUpdate?.logicalClock > appendedAdd?.logicalClock, 'updateVideo clock advances without scanning')
+  t.is(safeUpdates, 2)
 })


### PR DESCRIPTION
## Summary
- make `PublicChannelBee.syncFromChannel()` merge channel views without deleting public entries missing from stale/partial reads
- keep `syncVideos()` destructive by default for complete snapshots, with a non-destructive mode for channel sync
- remove O(n) `listVideos()` scans from `MultiWriterChannel.addVideo()` / `updateVideo()` logical-clock generation
- add regressions for partial-view sync and logical-clock mutation paths

Closes #235

## Test plan
- `npm exec -- brittle test/public-channel-bee-sync.test.mjs test/public-channel-bee-security.test.mjs`
- `git diff --check origin/main..HEAD`

## Notes
- Full backend suite currently has an unrelated existing failure in `packages/backend/test/public-feed-descriptor.test.mjs` (`Cannot read properties of undefined (reading 'signedDescriptor')`), which also reproduces standalone.
