### PR TITLE
Harden Android manifest and networking lifecycle

### DIFF
--- a/packages/app/android/app/src/main/AndroidManifest.xml
+++ b/packages/app/android/app/src/main/AndroidManifest.xml
@@ -6,7 +6,8 @@
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"/>
   <uses-permission android:name="android.permission.INTERNET"/>
-  <uses-permission android:name="android.permission.NEARBY_WIFI_DEVICES"/>
+  <uses-permission android:name="android.permission.NEARBY_WIFI_DEVICES" android:usesPermissionFlags="neverForLocation"/>
+  <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" tools:replace="android:maxSdkVersion"/>
   <uses-permission android:name="android.permission.READ_MEDIA_AUDIO"/>
   <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
@@ -23,7 +24,7 @@
       <data android:scheme="https"/>
     </intent>
   </queries>
-  <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="true" android:theme="@style/AppTheme" android:supportsRtl="true" android:enableOnBackInvokedCallback="false" android:requestLegacyExternalStorage="true" android:usesCleartextTraffic="true">
+  <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="false" android:theme="@style/AppTheme" android:supportsRtl="true" android:enableOnBackInvokedCallback="false" android:requestLegacyExternalStorage="false" android:usesCleartextTraffic="false" android:networkSecurityConfig="@xml/network_security_config">
     <meta-data android:name="expo.modules.updates.ENABLED" android:value="false"/>
     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH" android:value="ALWAYS"/>
     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS" android:value="0"/>

--- a/packages/app/android/app/src/main/res/xml/network_security_config.xml
+++ b/packages/app/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+  <base-config cleartextTrafficPermitted="false" />
+  <domain-config cleartextTrafficPermitted="true">
+    <domain includeSubdomains="false">localhost</domain>
+    <domain includeSubdomains="false">127.0.0.1</domain>
+    <domain includeSubdomains="false">10.0.2.2</domain>
+  </domain-config>
+</network-security-config>

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -39,7 +39,8 @@
         "android.permission.ACCESS_NETWORK_STATE",
         "android.permission.ACCESS_WIFI_STATE",
         "android.permission.CHANGE_WIFI_MULTICAST_STATE",
-        "android.permission.NEARBY_WIFI_DEVICES"
+        "android.permission.NEARBY_WIFI_DEVICES",
+        "android.permission.POST_NOTIFICATIONS"
       ]
     },
     "web": {
@@ -63,7 +64,7 @@
         {
           "android": {
             "minSdkVersion": 29,
-            "usesCleartextTraffic": true
+            "usesCleartextTraffic": false
           }
         }
       ],

--- a/packages/app/tests/android-manifest-network-lifecycle-regression.test.mjs
+++ b/packages/app/tests/android-manifest-network-lifecycle-regression.test.mjs
@@ -1,0 +1,54 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const appRoot = path.resolve(__dirname, '..')
+
+function readAppFile(relativePath) {
+  return fs.readFileSync(path.join(appRoot, relativePath), 'utf8')
+}
+
+test('Android release manifest disables legacy storage, backup, and blanket cleartext traffic', () => {
+  const manifest = readAppFile('android/app/src/main/AndroidManifest.xml')
+  const appJson = JSON.parse(readAppFile('app.json'))
+  const buildPropertiesPlugin = appJson.expo.plugins.find((plugin) => Array.isArray(plugin) && plugin[0] === 'expo-build-properties')
+
+  assert.match(manifest, /android:allowBackup="false"/)
+  assert.match(manifest, /android:requestLegacyExternalStorage="false"/)
+  assert.match(manifest, /android:usesCleartextTraffic="false"/)
+  assert.match(manifest, /android:networkSecurityConfig="@xml\/network_security_config"/)
+  assert.match(manifest, /android:name="android\.permission\.NEARBY_WIFI_DEVICES" android:usesPermissionFlags="neverForLocation"/)
+  assert.match(manifest, /android:name="android\.permission\.POST_NOTIFICATIONS"/)
+  assert.equal(buildPropertiesPlugin?.[1]?.android?.usesCleartextTraffic, false)
+  assert.ok(appJson.expo.android.permissions.includes('android.permission.POST_NOTIFICATIONS'))
+})
+
+test('Android network security config blocks cleartext except local development loopbacks', () => {
+  const config = readAppFile('android/app/src/main/res/xml/network_security_config.xml')
+
+  assert.match(config, /<base-config cleartextTrafficPermitted="false"\s*\/>/)
+  assert.match(config, /<domain-config cleartextTrafficPermitted="true">/)
+  assert.match(config, /<domain includeSubdomains="false">localhost<\/domain>/)
+  assert.match(config, /<domain includeSubdomains="false">127\.0\.0\.1<\/domain>/)
+  assert.match(config, /<domain includeSubdomains="false">10\.0\.2\.2<\/domain>/)
+})
+
+test('root layout suspends native networking on background and resumes it on foreground', () => {
+  const source = readAppFile('app/_layout.tsx')
+  const handlerStart = source.indexOf('const handleAppStateChange = useCallback((nextState: AppStateStatus) => {')
+  const handlerEnd = source.indexOf('  useEffect(() => {', handlerStart)
+  const handlerBody = handlerStart >= 0 && handlerEnd > handlerStart ? source.slice(handlerStart, handlerEnd) : ''
+
+  assert.ok(handlerBody, 'handleAppStateChange callback should exist')
+  assert.match(source, /AppState\.addEventListener\('change', handleAppStateChange\)/)
+  assert.match(handlerBody, /nextState === 'background'/)
+  assert.match(handlerBody, /nextState === 'inactive' && Platform\.OS !== 'android'/)
+  assert.match(handlerBody, /playbackActiveEmitter\.isActive/)
+  assert.match(handlerBody, /platformRPC\.rpc\?\.suspendNetwork\?\.\(\)/)
+  assert.match(handlerBody, /nextState === 'active'/)
+  assert.match(handlerBody, /platformRPC\.rpc\?\.resumeNetwork\?\.\(\)/)
+})


### PR DESCRIPTION
## Summary
- disable release cleartext traffic and legacy external storage in Android manifest/config
- disable Android backup and add network security config with only loopback cleartext exceptions
- mark nearby Wi-Fi permission as not location-derived and request Android 13 notification permission
- add source regressions covering manifest hardening and native lifecycle suspend/resume wiring

Closes #236

## Test plan
- `node --test packages/app/tests/android-manifest-network-lifecycle-regression.test.mjs`
- `git diff --cached --check`

## Notes
- Local `npm run lint:changed` reported no changed JS/TS files before commit in this checkout; root `./node_modules/.bin/eslint` is not installed locally, so CI will validate lint with workspace dependencies.
