### PR TITLE
fix(app): suppress shorts overlay by route segment

### DIFF
--- a/packages/app/components/VideoPlayerOverlayImpl.tsx
+++ b/packages/app/components/VideoPlayerOverlayImpl.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useContext, useEffect, useState, useRef, useMemo } from 'react'
 import { View, Text, Pressable, StyleSheet, useWindowDimensions, Platform, ScrollView, ActivityIndicator, Alert, StatusBar, Dimensions, TextInput, AppState } from 'react-native'
-import { usePathname } from 'expo-router'
+import { usePathname, useSegments } from 'expo-router'
 import { rpc } from '@peartube/platform/rpc'
 import { SafeAreaInsetsContext } from 'react-native-safe-area-context'
 import { GestureDetector, Gesture } from 'react-native-gesture-handler'
@@ -99,6 +99,7 @@ const ZERO_EDGE_INSETS = Object.freeze({ top: 0, right: 0, bottom: 0, left: 0 })
 export function VideoPlayerOverlay() {
   const insets = useContext(SafeAreaInsetsContext) ?? ZERO_EDGE_INSETS
   const pathname = usePathname()
+  const segments = useSegments()
   const { width: windowWidth, height: windowHeight } = useWindowDimensions()
   const screenMetrics = Dimensions.get('screen')
   const { isDesktop, isPear } = usePlatform()
@@ -373,7 +374,10 @@ export function VideoPlayerOverlay() {
   // Mini player corner/drag state
   const [pendingLandscapeExit, setPendingLandscapeExit] = useState(false)
   const disableMiniLayoutOnAndroidSplit = Platform.OS === 'android' && androidSplitPlayerEnabled
-  const isDiscoverPathActive = pathname === '/discover' || pathname === '/(tabs)/discover'
+  const isDiscoverPathActive =
+    pathname === '/discover' ||
+    pathname === '/(tabs)/discover' ||
+    segments.includes('discover')
   const hideGlobalOverlayOnDiscover = !isDesktop && isDiscoverPathActive
   const showLegacyMiniUi =
     playerMode === 'mini' &&

--- a/packages/app/tests/vertical-discovery-regression.test.mjs
+++ b/packages/app/tests/vertical-discovery-regression.test.mjs
@@ -236,6 +236,8 @@ test('vertical discovery keeps the global watch/mini overlay off the Shorts rout
 
   assert.match(discoverSource, /closeVideo\(\)\n\s*setAmbientVideoContext\(null, null\)/, 'handoff should clear ambient player context after closing the global player')
   assert.match(overlaySource, /usePathname\(\)/, 'global overlay should know the active route')
+  assert.match(overlaySource, /useSegments\(\)/, 'global overlay should inspect active route segments when pathname is group-normalized')
+  assert.match(overlaySource, /segments\.includes\('discover'\)/, 'mobile Discover suppression should not depend on one exact Expo Router pathname string')
   assert.match(overlaySource, /const hideGlobalOverlayOnDiscover = !isDesktop && isDiscoverPathActive/, 'mobile Discover should suppress the global watch overlay')
   assert.match(overlaySource, /hideGlobalOverlayOnDiscover && playerMode !== 'hidden'\)/, 'Discover should not show stale mini/fullscreen/PiP overlays over Shorts')
   assert.doesNotMatch(overlaySource, /hideGlobalOverlayOnDiscover && playerMode !== 'hidden' && !isInPipMode/, 'Discover suppression must include stale PiP mode, not exempt it')


### PR DESCRIPTION
## Summary
- broadens Discover/Shorts global-overlay suppression to use Expo Router segments, not only exact pathname strings
- keeps the existing mobile-only suppression for all non-hidden global player modes
- adds regression coverage so Discover suppression does not depend on one normalized pathname shape

## Root cause
`v0.1.95` had the right overlay early-return, but it only recognized `/discover` and `/(tabs)/discover`. On-device Expo Router can normalize grouped tab routes differently while still exposing `discover` in route segments, so the global mini/PiP overlay could miss the guard and render over the Shorts feed.

## Test Plan
- `node --test packages/app/tests/vertical-discovery-regression.test.mjs`
- `git diff --check`
- `npm run lint:changed` (reported no changed JS/TS files to lint)
