### PR TITLE
Fix canonical feed contract normalization

### DIFF
--- a/packages/app/backend/canonical-feed-contract-rpc.test.mjs
+++ b/packages/app/backend/canonical-feed-contract-rpc.test.mjs
@@ -1,0 +1,50 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { attachMobileHandlers } from './mobile-handlers.mjs'
+import { createCanonicalFeedVideo } from '../../backend/src/canonical-feed-contract.js'
+
+test('RPC integration scaffold preserves canonical feed video fields through the app boundary', async () => {
+  const backend = {}
+  const deps = {
+    api: {
+      async listVideos() {
+        return [createCanonicalFeedVideo({
+          id: 'video-1',
+          title: 'Canonical RPC video',
+          uploadedAt: 100,
+          channelKey: 'channel-key',
+          blobId: 'blob-id',
+          blobsCoreKey: '11'.repeat(32),
+          mimeType: 'video/mp4',
+          availability: 'playable',
+          byteAvailability: 'playable',
+          publicBeeKey: 'bee-key',
+          thumbnailBlobId: 'thumb-blob',
+          thumbnailBlobsCoreKey: '22'.repeat(32),
+          thumbnailMimeType: 'image/jpeg',
+        })]
+      },
+    },
+    identityManager: {},
+    uploadManager: {},
+    ctx: {},
+    initializeIdentityFromMnemonic: async () => ({ needsRestart: false }),
+    rpc: {},
+    fs: {},
+    path: {},
+    generateAndStoreThumbnail: async () => null,
+    transcoder: {},
+  }
+
+  attachMobileHandlers(backend, deps)
+
+  const result = await backend.listVideos({ channelKey: 'channel-key', publicBeeKey: 'bee-key' })
+  assert.equal(result.videos.length, 1)
+  assert.equal(result.videos[0].title, 'Canonical RPC video')
+  assert.equal(result.videos[0].blobId, 'blob-id')
+  assert.equal(result.videos[0].blobsCoreKey, '11'.repeat(32))
+  assert.equal(result.videos[0].publicBeeKey, 'bee-key')
+  assert.equal(result.videos[0].thumbnailBlobId, 'thumb-blob')
+  assert.equal(result.videos[0].availability, 'playable')
+})

--- a/packages/app/tests/feed-preview-restoration-red.test.mjs
+++ b/packages/app/tests/feed-preview-restoration-red.test.mjs
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { getFeedPreviewVideos } from '../lib/feed-hydration.js'
+
+test('getFeedPreviewVideos preserves canonical preview metadata after a restart-style restoration', () => {
+  const videos = getFeedPreviewVideos([
+    {
+      driveKey: 'remote-channel',
+      publicBeeKey: 'bb'.repeat(32),
+      peerCount: 0,
+      previewVideos: [{
+        id: 'preview-video',
+        title: 'Canonical preview title',
+        uploadedAt: 42,
+        byteAvailability: 'playable',
+        availability: 'unknown',
+        blobId: '0:1:0:32',
+        blobsCoreKey: 'cc'.repeat(32),
+        mimeType: 'video/mp4',
+      }],
+    },
+  ], {
+    'remote-channel': {
+      name: 'Remote channel',
+      avatar: '/avatars/remote.png',
+      icon: '/icons/remote.png',
+    },
+  }, 'local-channel', 10)
+
+  assert.equal(videos.length, 1)
+  assert.deepEqual({
+    id: videos[0].id,
+    title: videos[0].title,
+    byteAvailability: videos[0].byteAvailability,
+    blobId: videos[0].blobId,
+    blobsCoreKey: videos[0].blobsCoreKey,
+    mimeType: videos[0].mimeType,
+    channelKey: videos[0].channelKey,
+    driveKey: videos[0].driveKey,
+    publicBeeKey: videos[0].publicBeeKey,
+    channel: videos[0].channel,
+  }, {
+    id: 'preview-video',
+    title: 'Canonical preview title',
+    byteAvailability: 'playable',
+    blobId: '0:1:0:32',
+    blobsCoreKey: 'cc'.repeat(32),
+    mimeType: 'video/mp4',
+    channelKey: 'remote-channel',
+    driveKey: 'remote-channel',
+    publicBeeKey: 'bb'.repeat(32),
+    channel: {
+      name: 'Remote channel',
+      avatar: '/avatars/remote.png',
+      icon: '/icons/remote.png',
+    },
+  })
+})

--- a/packages/backend/src/canonical-feed-contract.js
+++ b/packages/backend/src/canonical-feed-contract.js
@@ -1,0 +1,219 @@
+/**
+ * Canonical feed contract for Home, Discover, and Shorts.
+ *
+ * The universal core is the source of truth for this schema.
+ * App surfaces may adapt layout and controls, but they must not narrow the model.
+ */
+
+/**
+ * @typedef {Object} CanonicalFeedChannel
+ * @property {string} [channelKey]
+ * @property {string} [driveKey]
+ * @property {string | null} [name]
+ * @property {string | null} [description]
+ * @property {string | null} [avatar]
+ * @property {string | null} [icon]
+ * @property {string | null} [thumbnail]
+ * @property {number | null} [videoCount]
+ * @property {number | null} [lastSeen]
+ * @property {number | null} [manifestUpdatedAt]
+ */
+
+/**
+ * @typedef {Object} CanonicalFeedVideo
+ * @property {string} id
+ * @property {string | null} [path]
+ * @property {string} title
+ * @property {string | null} [description]
+ * @property {number} uploadedAt
+ * @property {number | null} [duration]
+ * @property {string | null} [thumbnail]
+ * @property {string | null} [thumbnailUrl]
+ * @property {string | null} [thumbnailBlobId]
+ * @property {string | null} [thumbnailBlobsCoreKey]
+ * @property {string | null} [thumbnailMimeType]
+ * @property {string | null} [blobId]
+ * @property {string | null} [blobsCoreKey]
+ * @property {string | null} [mimeType]
+ * @property {'playable' | 'unavailable' | 'unknown' | null} [availability]
+ * @property {'playable' | 'unavailable' | 'unknown' | null} [byteAvailability]
+ * @property {string} channelKey
+ * @property {string | null} [driveKey]
+ * @property {string | null} [publicBeeKey]
+ * @property {CanonicalFeedChannel} [channel]
+ */
+
+/**
+ * @typedef {Object} CanonicalFeedEntry
+ * @property {string} channelKey
+ * @property {string | null} [driveKey]
+ * @property {string | null} [publicBeeKey]
+ * @property {'peer' | 'local' | 'relay-cache' | string} source
+ * @property {string | null} [relayRole]
+ * @property {boolean} [relayServing]
+ * @property {number} [peerCount]
+ * @property {number} [videoCount]
+ * @property {number} [lastSeen]
+ * @property {number} [manifestUpdatedAt]
+ * @property {string | null} [previewVideosHash]
+ * @property {CanonicalFeedChannel} [channel]
+ * @property {CanonicalFeedVideo[]} [previewVideos]
+ */
+
+export const CANONICAL_FEED_CONTRACT_VERSION = 1
+
+export const CANONICAL_FEED_CHANNEL_FIELDS = Object.freeze([
+  'channelKey',
+  'driveKey',
+  'name',
+  'description',
+  'avatar',
+  'icon',
+  'thumbnail',
+  'videoCount',
+  'lastSeen',
+  'manifestUpdatedAt',
+])
+
+export const CANONICAL_FEED_VIDEO_FIELDS = Object.freeze([
+  'id',
+  'path',
+  'title',
+  'description',
+  'uploadedAt',
+  'duration',
+  'thumbnail',
+  'thumbnailUrl',
+  'thumbnailBlobId',
+  'thumbnailBlobsCoreKey',
+  'thumbnailMimeType',
+  'blobId',
+  'blobsCoreKey',
+  'mimeType',
+  'availability',
+  'byteAvailability',
+  'channelKey',
+  'driveKey',
+  'publicBeeKey',
+  'channel',
+])
+
+export const CANONICAL_FEED_ENTRY_FIELDS = Object.freeze([
+  'channelKey',
+  'driveKey',
+  'publicBeeKey',
+  'source',
+  'relayRole',
+  'relayServing',
+  'peerCount',
+  'videoCount',
+  'lastSeen',
+  'manifestUpdatedAt',
+  'previewVideosHash',
+  'channel',
+  'previewVideos',
+])
+
+function copyDefinedFields(source, fields) {
+  const out = {}
+  for (const field of fields) {
+    if (source?.[field] !== undefined) out[field] = source[field]
+  }
+  return out
+}
+
+function normalizeNumber(value, fallback = null) {
+  const num = Number(value)
+  return Number.isFinite(num) ? num : fallback
+}
+
+export function createCanonicalFeedChannel(channel = {}) {
+  const normalized = copyDefinedFields(channel, CANONICAL_FEED_CHANNEL_FIELDS)
+  normalized.channelKey = channel.channelKey || channel.driveKey || normalized.channelKey || ''
+  normalized.driveKey = channel.driveKey || channel.channelKey || normalized.driveKey || normalized.channelKey || ''
+  normalized.name = channel.name ?? normalized.name ?? null
+  normalized.description = channel.description ?? normalized.description ?? null
+  normalized.avatar = channel.avatar ?? normalized.avatar ?? null
+  normalized.icon = channel.icon ?? normalized.icon ?? null
+  normalized.thumbnail = channel.thumbnail ?? normalized.thumbnail ?? null
+  normalized.videoCount = normalizeNumber(channel.videoCount, normalized.videoCount ?? null)
+  normalized.lastSeen = normalizeNumber(channel.lastSeen, normalized.lastSeen ?? null)
+  normalized.manifestUpdatedAt = normalizeNumber(channel.manifestUpdatedAt, normalized.manifestUpdatedAt ?? null)
+  return normalized
+}
+
+export function createCanonicalFeedVideo(video = {}) {
+  const normalized = copyDefinedFields(video, CANONICAL_FEED_VIDEO_FIELDS)
+  normalized.id = video.id ? String(video.id) : normalized.id || ''
+  normalized.path = video.path ?? normalized.path ?? null
+  normalized.title = video.title ? String(video.title) : normalized.title || ''
+  normalized.description = video.description ?? normalized.description ?? null
+  normalized.uploadedAt = normalizeNumber(video.uploadedAt, normalized.uploadedAt ?? 0) || 0
+  normalized.duration = normalizeNumber(video.duration, normalized.duration ?? null)
+  normalized.thumbnail = video.thumbnail ?? normalized.thumbnail ?? null
+  normalized.thumbnailUrl = video.thumbnailUrl ?? normalized.thumbnailUrl ?? null
+  normalized.thumbnailBlobId = video.thumbnailBlobId ?? normalized.thumbnailBlobId ?? null
+  normalized.thumbnailBlobsCoreKey = video.thumbnailBlobsCoreKey ?? normalized.thumbnailBlobsCoreKey ?? null
+  normalized.thumbnailMimeType = video.thumbnailMimeType ?? normalized.thumbnailMimeType ?? null
+  normalized.blobId = video.blobId ?? normalized.blobId ?? null
+  normalized.blobsCoreKey = video.blobsCoreKey ?? normalized.blobsCoreKey ?? null
+  normalized.mimeType = video.mimeType ?? normalized.mimeType ?? null
+  normalized.availability = video.availability ?? normalized.availability ?? null
+  normalized.byteAvailability = video.byteAvailability ?? normalized.byteAvailability ?? normalized.availability ?? null
+  normalized.channelKey = video.channelKey || video.driveKey || normalized.channelKey || ''
+  normalized.driveKey = video.driveKey || video.channelKey || normalized.driveKey || normalized.channelKey || ''
+  normalized.publicBeeKey = video.publicBeeKey ?? normalized.publicBeeKey ?? null
+  normalized.channel = video.channel ? createCanonicalFeedChannel(video.channel) : normalized.channel ? createCanonicalFeedChannel(normalized.channel) : undefined
+  return normalized
+}
+
+export function createCanonicalFeedEntry(entry = {}) {
+  const normalized = copyDefinedFields(entry, CANONICAL_FEED_ENTRY_FIELDS)
+  normalized.channelKey = entry.channelKey || entry.driveKey || normalized.channelKey || ''
+  normalized.driveKey = entry.driveKey || entry.channelKey || normalized.driveKey || normalized.channelKey || ''
+  normalized.publicBeeKey = entry.publicBeeKey ?? normalized.publicBeeKey ?? null
+  normalized.source = entry.source || normalized.source || 'peer'
+  normalized.relayRole = entry.relayRole ?? normalized.relayRole ?? null
+  normalized.relayServing = Boolean(entry.relayServing ?? normalized.relayServing)
+  normalized.peerCount = normalizeNumber(entry.peerCount, normalized.peerCount ?? 0) || 0
+  normalized.videoCount = normalizeNumber(entry.videoCount, normalized.videoCount ?? 0) || 0
+  normalized.lastSeen = normalizeNumber(entry.lastSeen, normalized.lastSeen ?? 0) || 0
+  normalized.manifestUpdatedAt = normalizeNumber(entry.manifestUpdatedAt, normalized.manifestUpdatedAt ?? 0) || 0
+  normalized.previewVideosHash = entry.previewVideosHash ?? normalized.previewVideosHash ?? null
+  normalized.channel = entry.channel ? createCanonicalFeedChannel(entry.channel) : normalized.channel ? createCanonicalFeedChannel(normalized.channel) : undefined
+  normalized.previewVideos = Array.isArray(entry.previewVideos)
+    ? entry.previewVideos.map((video) => createCanonicalFeedVideo(video))
+    : Array.isArray(normalized.previewVideos)
+      ? normalized.previewVideos.map((video) => createCanonicalFeedVideo(video))
+      : []
+  return normalized
+}
+
+export function createCanonicalFeedEnvelope({
+  version = CANONICAL_FEED_CONTRACT_VERSION,
+  savedAt = Date.now(),
+  identityDriveKey = undefined,
+  entries = [],
+  videos = [],
+  channelMetaByKey = {},
+} = {}) {
+  const normalizedEntries = Array.isArray(entries) ? entries.map((entry) => createCanonicalFeedEntry(entry)) : []
+  const normalizedVideos = Array.isArray(videos) ? videos.map((video) => createCanonicalFeedVideo(video)) : []
+  const normalizedChannelMetaByKey = {}
+
+  for (const [key, value] of Object.entries(channelMetaByKey || {})) {
+    normalizedChannelMetaByKey[key] = createCanonicalFeedChannel({
+      channelKey: key,
+      ...(value || {}),
+    })
+  }
+
+  return {
+    version,
+    savedAt,
+    identityDriveKey,
+    entries: normalizedEntries,
+    videos: normalizedVideos,
+    channelMetaByKey: normalizedChannelMetaByKey,
+  }
+}

--- a/packages/backend/src/canonical-feed.js
+++ b/packages/backend/src/canonical-feed.js
@@ -11,6 +11,12 @@ function firstString(...values) {
   return ''
 }
 
+function coerceString(value) {
+  if (value === null || value === undefined) return ''
+  const stringValue = String(value)
+  return stringValue.length > 0 ? stringValue : ''
+}
+
 function firstStringOrNull(...values) {
   const value = firstString(...values)
   return value.length > 0 ? value : null
@@ -28,9 +34,9 @@ function toNumberOrNull(value) {
 }
 
 function normalizeAvailability(value) {
-  if (typeof value !== 'string') return 'unknown'
+  if (typeof value !== 'string') return null
   const normalized = value.trim().toLowerCase()
-  return CANONICAL_AVAILABILITY.has(normalized) ? normalized : 'unknown'
+  return CANONICAL_AVAILABILITY.has(normalized) ? normalized : null
 }
 
 function reconcileAvailability(rawAvailability, rawByteAvailability, rawPlaybackSupport) {
@@ -41,10 +47,10 @@ function reconcileAvailability(rawAvailability, rawByteAvailability, rawPlayback
       ? 'unavailable'
       : null
 
-  const availabilityCandidates = [rawAvailability, rawByteAvailability, fromPlaybackHint].map(normalizeAvailability)
-  if (availabilityCandidates.includes('playable')) return 'playable'
-  if (availabilityCandidates.includes('unavailable')) return 'unavailable'
-  return 'unknown'
+  const availability = normalizeAvailability(rawAvailability) ?? fromPlaybackHint ?? normalizeAvailability(rawByteAvailability) ?? 'unknown'
+  const byteAvailability = normalizeAvailability(rawByteAvailability) ?? fromPlaybackHint ?? normalizeAvailability(rawAvailability) ?? 'unknown'
+
+  return { availability, byteAvailability }
 }
 
 /**
@@ -152,23 +158,23 @@ export function normalizeCanonicalFeedVideo(rawVideo = {}, options = {}) {
   ) || channelKey
   const directRefs = normalizeDirectPlaybackRefs(rawVideo)
   const thumbnailRefs = normalizeThumbnailRefs(rawVideo)
-  const resolvedAvailability = reconcileAvailability(
+  const { availability, byteAvailability } = reconcileAvailability(
     rawVideo.availability,
     rawVideo.byteAvailability,
     rawVideo.playbackSupport,
   )
 
   return {
-    id: firstString(rawVideo.id, rawVideo.videoId, rawVideo.path, rawVideo.slug),
+    id: firstString(rawVideo.id, rawVideo.videoId, rawVideo.path, rawVideo.slug) || coerceString(rawVideo.id ?? rawVideo.videoId ?? rawVideo.path ?? rawVideo.slug),
     path: firstStringOrNull(rawVideo.path, rawVideo.videoPath, rawVideo.legacyPath),
-    title: firstString(rawVideo.title, rawVideo.name, rawVideo.videoTitle, rawVideo.displayName, rawVideo.filename) || 'Untitled',
+    title: firstString(rawVideo.title, rawVideo.name, rawVideo.videoTitle, rawVideo.displayName, rawVideo.filename) || coerceString(rawVideo.title ?? rawVideo.name ?? rawVideo.videoTitle ?? rawVideo.displayName ?? rawVideo.filename) || 'Untitled',
     description: rawVideo.description ?? rawVideo.videoDescription ?? null,
     uploadedAt: toNumber(rawVideo.uploadedAt ?? rawVideo.createdAt ?? rawVideo.addedAt ?? rawVideo.lastSeen ?? 0),
     duration: toNumberOrNull(rawVideo.duration ?? rawVideo.length ?? rawVideo.seconds),
     ...thumbnailRefs,
     ...directRefs,
-    availability: resolvedAvailability,
-    byteAvailability: resolvedAvailability,
+    availability,
+    byteAvailability,
     channelKey,
     driveKey,
     publicBeeKey: firstStringOrNull(rawVideo.publicBeeKey, options.publicBeeKey),

--- a/packages/backend/src/canonical-feed.js
+++ b/packages/backend/src/canonical-feed.js
@@ -1,0 +1,242 @@
+import {
+  CANONICAL_FEED_CONTRACT_VERSION,
+} from './canonical-feed-contract.js'
+
+const CANONICAL_AVAILABILITY = new Set(['playable', 'unavailable', 'unknown'])
+
+function firstString(...values) {
+  for (const value of values) {
+    if (typeof value === 'string' && value.length > 0) return value
+  }
+  return ''
+}
+
+function firstStringOrNull(...values) {
+  const value = firstString(...values)
+  return value.length > 0 ? value : null
+}
+
+function toNumber(value, fallback = 0) {
+  const num = Number(value)
+  return Number.isFinite(num) ? num : fallback
+}
+
+function toNumberOrNull(value) {
+  if (value === null || value === undefined || value === '') return null
+  const num = Number(value)
+  return Number.isFinite(num) ? num : null
+}
+
+function normalizeAvailability(value) {
+  if (typeof value !== 'string') return 'unknown'
+  const normalized = value.trim().toLowerCase()
+  return CANONICAL_AVAILABILITY.has(normalized) ? normalized : 'unknown'
+}
+
+function reconcileAvailability(rawAvailability, rawByteAvailability, rawPlaybackSupport) {
+  const playbackHint = typeof rawPlaybackSupport === 'string' ? rawPlaybackSupport.trim().toLowerCase() : ''
+  const fromPlaybackHint = playbackHint === 'playable' || playbackHint === 'verified' || playbackHint === 'ready'
+    ? 'playable'
+    : playbackHint === 'unavailable' || playbackHint === 'blocked' || playbackHint === 'unsupported'
+      ? 'unavailable'
+      : null
+
+  const availabilityCandidates = [rawAvailability, rawByteAvailability, fromPlaybackHint].map(normalizeAvailability)
+  if (availabilityCandidates.includes('playable')) return 'playable'
+  if (availabilityCandidates.includes('unavailable')) return 'unavailable'
+  return 'unknown'
+}
+
+function normalizeChannelObject(rawChannel = {}, fallback = {}) {
+  const channelKey = firstStringOrNull(
+    rawChannel.channelKey,
+    rawChannel.driveKey,
+    fallback.channelKey,
+    fallback.driveKey,
+    fallback.channel,
+    rawChannel.key,
+  )
+  const driveKey = firstStringOrNull(
+    rawChannel.driveKey,
+    rawChannel.channelKey,
+    fallback.driveKey,
+    fallback.channelKey,
+    channelKey,
+  )
+
+  return {
+    channelKey,
+    driveKey,
+    name: rawChannel.name ?? fallback.name ?? null,
+    description: rawChannel.description ?? fallback.description ?? null,
+    avatar: rawChannel.avatar ?? rawChannel.avatarUrl ?? fallback.avatar ?? null,
+    icon: rawChannel.icon ?? fallback.icon ?? null,
+    thumbnail: rawChannel.thumbnail ?? fallback.thumbnail ?? null,
+    videoCount: toNumberOrNull(rawChannel.videoCount ?? fallback.videoCount),
+    lastSeen: toNumberOrNull(rawChannel.lastSeen ?? fallback.lastSeen),
+    manifestUpdatedAt: toNumberOrNull(rawChannel.manifestUpdatedAt ?? fallback.manifestUpdatedAt),
+  }
+}
+
+function normalizeDirectPlaybackRefs(raw = {}) {
+  return {
+    blobId: firstStringOrNull(raw.blobId, raw.videoBlobId, raw.sourceBlobId, raw.refBlobId),
+    blobsCoreKey: firstStringOrNull(raw.blobsCoreKey, raw.blobCoreKey, raw.contentKey, raw.refCoreKey),
+    mimeType: firstStringOrNull(raw.mimeType, raw.mediaType, raw.type),
+  }
+}
+
+function normalizeThumbnailRefs(raw = {}) {
+  return {
+    thumbnail: raw.thumbnail ?? raw.thumbnailUrl ?? null,
+    thumbnailUrl: raw.thumbnailUrl ?? raw.thumbnail ?? null,
+    thumbnailBlobId: firstStringOrNull(raw.thumbnailBlobId, raw.previewBlobId),
+    thumbnailBlobsCoreKey: firstStringOrNull(raw.thumbnailBlobsCoreKey, raw.previewBlobsCoreKey),
+    thumbnailMimeType: firstStringOrNull(raw.thumbnailMimeType, raw.previewMimeType),
+  }
+}
+
+/**
+ * Normalize a raw video record into the canonical feed video shape.
+ *
+ * This is the shared normalization layer for local uploads, public feed entries,
+ * and restart-style preview restoration.
+ *
+ * @param {Object} rawVideo
+ * @param {Object} [options]
+ * @param {'local-upload'|'public-feed'|'preview-hydration'|string} [options.source]
+ * @param {Object} [options.channel]
+ * @param {Object} [options.channelMeta]
+ * @param {string} [options.channelKey]
+ * @param {string} [options.driveKey]
+ * @param {string} [options.publicBeeKey]
+ * @returns {import('./canonical-feed-contract.js').CanonicalFeedVideo}
+ */
+export function normalizeCanonicalFeedVideo(rawVideo = {}, options = {}) {
+  const source = options.source || rawVideo.source || 'public-feed'
+  const rawChannel = rawVideo.channel || options.channel || rawVideo.channelMeta || options.channelMeta || {}
+  const channel = normalizeChannelObject(rawChannel, {
+    channelKey: options.channelKey || rawVideo.channelKey || rawVideo.driveKey,
+    driveKey: options.driveKey || rawVideo.driveKey || rawVideo.channelKey,
+    name: rawVideo.channelName,
+    description: rawVideo.channelDescription,
+    avatar: rawVideo.channelAvatar,
+    icon: rawVideo.channelIcon,
+    thumbnail: rawVideo.channelThumbnail,
+    videoCount: rawVideo.channelVideoCount,
+    lastSeen: rawVideo.channelLastSeen,
+    manifestUpdatedAt: rawVideo.channelManifestUpdatedAt || rawVideo.manifestUpdatedAt,
+  })
+
+  const channelKey = firstStringOrNull(
+    rawVideo.channelKey,
+    rawVideo.driveKey,
+    options.channelKey,
+    options.driveKey,
+    channel.channelKey,
+    channel.driveKey,
+  ) || ''
+  const driveKey = firstStringOrNull(
+    rawVideo.driveKey,
+    rawVideo.channelKey,
+    options.driveKey,
+    options.channelKey,
+    channel.driveKey,
+    channel.channelKey,
+    channelKey,
+  ) || channelKey
+  const directRefs = normalizeDirectPlaybackRefs(rawVideo)
+  const thumbnailRefs = normalizeThumbnailRefs(rawVideo)
+  const resolvedAvailability = reconcileAvailability(
+    rawVideo.availability,
+    rawVideo.byteAvailability,
+    rawVideo.playbackSupport,
+  )
+
+  return {
+    id: firstString(rawVideo.id, rawVideo.videoId, rawVideo.path, rawVideo.slug),
+    path: firstStringOrNull(rawVideo.path, rawVideo.videoPath, rawVideo.legacyPath),
+    title: firstString(rawVideo.title, rawVideo.name, rawVideo.videoTitle, rawVideo.displayName, rawVideo.filename) || 'Untitled',
+    description: rawVideo.description ?? rawVideo.videoDescription ?? null,
+    uploadedAt: toNumber(rawVideo.uploadedAt ?? rawVideo.createdAt ?? rawVideo.addedAt ?? rawVideo.lastSeen ?? 0),
+    duration: toNumberOrNull(rawVideo.duration ?? rawVideo.length ?? rawVideo.seconds),
+    ...thumbnailRefs,
+    ...directRefs,
+    availability: resolvedAvailability,
+    byteAvailability: resolvedAvailability,
+    channelKey,
+    driveKey,
+    publicBeeKey: firstStringOrNull(rawVideo.publicBeeKey, options.publicBeeKey),
+    channel,
+    source,
+  }
+}
+
+/**
+ * Normalize a local upload payload into the canonical feed video shape.
+ *
+ * @param {Object} rawVideo
+ * @param {Object} [channel]
+ * @returns {import('./canonical-feed-contract.js').CanonicalFeedVideo}
+ */
+export function normalizeCanonicalFeedVideoFromLocalUpload(rawVideo = {}, channel = {}) {
+  return normalizeCanonicalFeedVideo(rawVideo, {
+    source: 'local-upload',
+    channel,
+    channelKey: rawVideo.channelKey || rawVideo.driveKey,
+    driveKey: rawVideo.driveKey || rawVideo.channelKey,
+    publicBeeKey: rawVideo.publicBeeKey || null,
+  })
+}
+
+/**
+ * Normalize a public feed entry or preview manifest item into the canonical feed video shape.
+ *
+ * @param {Object} rawVideo
+ * @param {Object} [feedEntry]
+ * @returns {import('./canonical-feed-contract.js').CanonicalFeedVideo}
+ */
+export function normalizeCanonicalFeedVideoFromPublicFeed(rawVideo = {}, feedEntry = {}) {
+  return normalizeCanonicalFeedVideo(rawVideo, {
+    source: 'public-feed',
+    channel: feedEntry.channel || rawVideo.channel,
+    channelMeta: feedEntry.channelMeta || rawVideo.channelMeta,
+    channelKey: feedEntry.channelKey || feedEntry.driveKey || rawVideo.channelKey || rawVideo.driveKey,
+    driveKey: feedEntry.driveKey || feedEntry.channelKey || rawVideo.driveKey || rawVideo.channelKey,
+    publicBeeKey: feedEntry.publicBeeKey || rawVideo.publicBeeKey || null,
+  })
+}
+
+/**
+ * Normalize preview-hydrated feed video metadata after restart.
+ * This keeps the direct blob refs and the full channel object intact so
+ * restored previews can survive a refresh without losing renderable metadata.
+ *
+ * @param {Object} rawVideo
+ * @param {Object} [feedEntry]
+ * @returns {import('./canonical-feed-contract.js').CanonicalFeedVideo}
+ */
+export function normalizeCanonicalFeedVideoFromPreviewHydration(rawVideo = {}, feedEntry = {}) {
+  return normalizeCanonicalFeedVideo(rawVideo, {
+    source: 'preview-hydration',
+    channel: feedEntry.channel || rawVideo.channel,
+    channelMeta: feedEntry.channelMeta || rawVideo.channelMeta,
+    channelKey: feedEntry.channelKey || feedEntry.driveKey || rawVideo.channelKey || rawVideo.driveKey,
+    driveKey: feedEntry.driveKey || feedEntry.channelKey || rawVideo.driveKey || rawVideo.channelKey,
+    publicBeeKey: feedEntry.publicBeeKey || rawVideo.publicBeeKey || null,
+  })
+}
+
+/**
+ * Normalize a list of raw videos into canonical feed videos.
+ *
+ * @param {Object[]} videos
+ * @param {Object} [options]
+ * @returns {import('./canonical-feed-contract.js').CanonicalFeedVideo[]}
+ */
+export function normalizeCanonicalFeedVideos(videos = [], options = {}) {
+  if (!Array.isArray(videos)) return []
+  return videos.map((video) => normalizeCanonicalFeedVideo(video, options))
+}
+
+export const CANONICAL_FEED_VERSION = CANONICAL_FEED_CONTRACT_VERSION

--- a/packages/backend/src/canonical-feed.js
+++ b/packages/backend/src/canonical-feed.js
@@ -47,13 +47,19 @@ function reconcileAvailability(rawAvailability, rawByteAvailability, rawPlayback
   return 'unknown'
 }
 
-function normalizeChannelObject(rawChannel = {}, fallback = {}) {
+/**
+ * Normalize a raw channel snapshot into the canonical channel object.
+ *
+ * @param {Object} rawChannel
+ * @param {Object} [fallback]
+ * @returns {import('./canonical-feed-contract.js').CanonicalFeedVideo['channel']}
+ */
+export function normalizeCanonicalFeedChannel(rawChannel = {}, fallback = {}) {
   const channelKey = firstStringOrNull(
     rawChannel.channelKey,
     rawChannel.driveKey,
     fallback.channelKey,
     fallback.driveKey,
-    fallback.channel,
     rawChannel.key,
   )
   const driveKey = firstStringOrNull(
@@ -113,9 +119,8 @@ function normalizeThumbnailRefs(raw = {}) {
  * @returns {import('./canonical-feed-contract.js').CanonicalFeedVideo}
  */
 export function normalizeCanonicalFeedVideo(rawVideo = {}, options = {}) {
-  const source = options.source || rawVideo.source || 'public-feed'
   const rawChannel = rawVideo.channel || options.channel || rawVideo.channelMeta || options.channelMeta || {}
-  const channel = normalizeChannelObject(rawChannel, {
+  const channel = normalizeCanonicalFeedChannel(rawChannel, {
     channelKey: options.channelKey || rawVideo.channelKey || rawVideo.driveKey,
     driveKey: options.driveKey || rawVideo.driveKey || rawVideo.channelKey,
     name: rawVideo.channelName,
@@ -168,7 +173,6 @@ export function normalizeCanonicalFeedVideo(rawVideo = {}, options = {}) {
     driveKey,
     publicBeeKey: firstStringOrNull(rawVideo.publicBeeKey, options.publicBeeKey),
     channel,
-    source,
   }
 }
 

--- a/packages/backend/test/canonical-feed-contract.test.mjs
+++ b/packages/backend/test/canonical-feed-contract.test.mjs
@@ -5,7 +5,6 @@ import {
   CANONICAL_FEED_CONTRACT_VERSION,
   CANONICAL_FEED_ENTRY_FIELDS,
   CANONICAL_FEED_VIDEO_FIELDS,
-  createCanonicalFeedEntry,
   createCanonicalFeedEnvelope,
   createCanonicalFeedVideo,
 } from '../src/canonical-feed-contract.js'
@@ -177,6 +176,34 @@ test('normalizeCanonicalFeedVideo preserves mixed raw inputs and channel fallbac
   t.is(video.availability, 'unknown')
   t.is(video.byteAvailability, 'playable')
   t.is(video.publicBeeKey, '44'.repeat(32))
+})
+
+test('normalizeCanonicalFeedVideoFromLocalUpload keeps local upload channel metadata intact', (t) => {
+  const video = normalizeCanonicalFeedVideoFromLocalUpload({
+    id: 100,
+    title: 'Local upload',
+    uploadedAt: 9,
+    availability: 'playable',
+    byteAvailability: 'playable',
+    blobId: 'local-blob',
+    blobsCoreKey: '88'.repeat(32),
+    mimeType: 'video/mp4',
+    channelKey: 'local-channel',
+    driveKey: 'local-channel',
+  }, {
+    channelKey: 'local-channel',
+    driveKey: 'local-channel',
+    name: 'Local channel',
+    avatar: '/local-avatar.png',
+    icon: '/local-icon.png',
+  })
+
+  t.is(video.id, '100')
+  t.is(video.channelKey, 'local-channel')
+  t.is(video.channel?.name, 'Local channel')
+  t.is(video.channel?.avatar, '/local-avatar.png')
+  t.is(video.channel?.icon, '/local-icon.png')
+  t.is(video.blobId, 'local-blob')
 })
 
 test('normalizeCanonicalFeedVideoFromPublicFeed falls back to feed channel metadata before channelMeta snapshots', (t) => {

--- a/packages/backend/test/canonical-feed-contract.test.mjs
+++ b/packages/backend/test/canonical-feed-contract.test.mjs
@@ -9,6 +9,12 @@ import {
   createCanonicalFeedEnvelope,
   createCanonicalFeedVideo,
 } from '../src/canonical-feed-contract.js'
+import {
+  normalizeCanonicalFeedVideo,
+  normalizeCanonicalFeedVideoFromLocalUpload,
+  normalizeCanonicalFeedVideoFromPreviewHydration,
+  normalizeCanonicalFeedVideoFromPublicFeed,
+} from '../src/canonical-feed.js'
 
 test('canonical feed contract exposes the canonical surface fields', (t) => {
   t.is(CANONICAL_FEED_CONTRACT_VERSION, 1)
@@ -103,6 +109,145 @@ test('createCanonicalFeedVideo preserves titles, icons, and blob references', (t
   t.is(video.blobId, 'video-blob')
   t.is(video.blobsCoreKey, '22'.repeat(32))
   t.is(video.publicBeeKey, '44'.repeat(32))
+})
+
+test('normalizeCanonicalFeedVideo preserves mixed raw inputs and channel fallback precedence', (t) => {
+  const video = normalizeCanonicalFeedVideo({
+    id: 7,
+    title: null,
+    name: 'Mixed input title',
+    description: 'Raw description',
+    uploadedAt: '123',
+    duration: '456',
+    thumbnailUrl: 'http://localhost/thumbs/raw.jpg',
+    blobId: 'video-blob',
+    blobsCoreKey: '22'.repeat(32),
+    mimeType: 'video/mp4',
+    availability: 'unknown',
+    byteAvailability: 'playable',
+    playbackSupport: 'blocked',
+    channel: {
+      channelKey: 'raw-channel',
+      driveKey: 'raw-drive',
+      name: 'Raw channel',
+      description: 'Raw channel description',
+      avatar: '/raw-avatar.png',
+      icon: '/raw-icon.png',
+      thumbnail: '/raw-thumbnail.png',
+      videoCount: '11',
+      lastSeen: '789',
+      manifestUpdatedAt: '987',
+    },
+    channelName: 'Ignored scalar channel name',
+    channelAvatar: '/ignored-avatar.png',
+    channelIcon: '/ignored-icon.png',
+    publicBeeKey: '44'.repeat(32),
+  }, {
+    source: 'preview-hydration',
+    channel: {
+      channelKey: 'option-channel',
+      driveKey: 'option-drive',
+      name: 'Option channel',
+      avatar: '/option-avatar.png',
+      icon: '/option-icon.png',
+    },
+    channelMeta: {
+      channelKey: 'meta-channel',
+      driveKey: 'meta-drive',
+      name: 'Meta channel',
+      avatar: '/meta-avatar.png',
+      icon: '/meta-icon.png',
+    },
+    channelKey: 'option-channel',
+    driveKey: 'option-drive',
+    publicBeeKey: '55'.repeat(32),
+  })
+
+  t.is(video.id, '7')
+  t.is(video.title, 'Mixed input title')
+  t.is(video.channelKey, 'raw-channel')
+  t.is(video.driveKey, 'raw-drive')
+  t.is(video.channel?.name, 'Raw channel')
+  t.is(video.channel?.avatar, '/raw-avatar.png')
+  t.is(video.channel?.icon, '/raw-icon.png')
+  t.is(video.channel?.thumbnail, '/raw-thumbnail.png')
+  t.is(video.channel?.videoCount, 11)
+  t.is(video.channel?.lastSeen, 789)
+  t.is(video.channel?.manifestUpdatedAt, 987)
+  t.is(video.availability, 'unknown')
+  t.is(video.byteAvailability, 'playable')
+  t.is(video.publicBeeKey, '44'.repeat(32))
+})
+
+test('normalizeCanonicalFeedVideoFromPublicFeed falls back to feed channel metadata before channelMeta snapshots', (t) => {
+  const video = normalizeCanonicalFeedVideoFromPublicFeed({
+    id: 'preview-1',
+    title: 'Preview',
+    uploadedAt: 1,
+    blobId: 'preview-blob',
+    blobsCoreKey: '11'.repeat(32),
+    mimeType: 'video/mp4',
+    availability: 'playable',
+    byteAvailability: 'playable',
+    channelName: 'Ignored video channel',
+    channelAvatar: '/ignored-video-avatar.png',
+    channelIcon: '/ignored-video-icon.png',
+  }, {
+    channelKey: 'feed-channel',
+    driveKey: 'feed-drive',
+    publicBeeKey: '66'.repeat(32),
+    channel: {
+      channelKey: 'feed-channel',
+      driveKey: 'feed-drive',
+      name: 'Feed channel',
+      avatar: '/feed-avatar.png',
+      icon: '/feed-icon.png',
+      videoCount: 2,
+    },
+    channelMeta: {
+      name: 'Meta channel',
+      avatar: '/meta-avatar.png',
+      icon: '/meta-icon.png',
+      videoCount: 11,
+    },
+  })
+
+  t.is(video.channelKey, 'feed-channel')
+  t.is(video.driveKey, 'feed-drive')
+  t.is(video.channel?.name, 'Feed channel')
+  t.is(video.channel?.avatar, '/feed-avatar.png')
+  t.is(video.channel?.icon, '/feed-icon.png')
+  t.is(video.channel?.videoCount, 2)
+  t.is(video.publicBeeKey, '66'.repeat(32))
+  t.is(video.blobId, 'preview-blob')
+})
+
+test('normalizeCanonicalFeedVideoFromPreviewHydration preserves distinct availability and byte availability after restart', (t) => {
+  const video = normalizeCanonicalFeedVideoFromPreviewHydration({
+    id: 'restored-1',
+    title: 'Restored preview',
+    uploadedAt: 42,
+    availability: 'unknown',
+    byteAvailability: 'playable',
+    blobId: 'restored-blob',
+    blobsCoreKey: '77'.repeat(32),
+    mimeType: 'video/mp4',
+  }, {
+    channelKey: 'restored-channel',
+    driveKey: 'restored-channel',
+    channel: {
+      channelKey: 'restored-channel',
+      driveKey: 'restored-channel',
+      name: 'Restored channel',
+      avatar: '/restored-avatar.png',
+      icon: '/restored-icon.png',
+    },
+  })
+
+  t.is(video.availability, 'unknown')
+  t.is(video.byteAvailability, 'playable')
+  t.is(video.channel?.avatar, '/restored-avatar.png')
+  t.is(video.channel?.icon, '/restored-icon.png')
 })
 
 test('createCanonicalFeedEnvelope normalizes nested entries and videos', (t) => {

--- a/packages/backend/test/canonical-feed-contract.test.mjs
+++ b/packages/backend/test/canonical-feed-contract.test.mjs
@@ -1,0 +1,130 @@
+import test from 'brittle'
+
+import {
+  CANONICAL_FEED_CHANNEL_FIELDS,
+  CANONICAL_FEED_CONTRACT_VERSION,
+  CANONICAL_FEED_ENTRY_FIELDS,
+  CANONICAL_FEED_VIDEO_FIELDS,
+  createCanonicalFeedEntry,
+  createCanonicalFeedEnvelope,
+  createCanonicalFeedVideo,
+} from '../src/canonical-feed-contract.js'
+
+test('canonical feed contract exposes the canonical surface fields', (t) => {
+  t.is(CANONICAL_FEED_CONTRACT_VERSION, 1)
+  t.alike(CANONICAL_FEED_CHANNEL_FIELDS, [
+    'channelKey',
+    'driveKey',
+    'name',
+    'description',
+    'avatar',
+    'icon',
+    'thumbnail',
+    'videoCount',
+    'lastSeen',
+    'manifestUpdatedAt',
+  ])
+  t.alike(CANONICAL_FEED_VIDEO_FIELDS, [
+    'id',
+    'path',
+    'title',
+    'description',
+    'uploadedAt',
+    'duration',
+    'thumbnail',
+    'thumbnailUrl',
+    'thumbnailBlobId',
+    'thumbnailBlobsCoreKey',
+    'thumbnailMimeType',
+    'blobId',
+    'blobsCoreKey',
+    'mimeType',
+    'availability',
+    'byteAvailability',
+    'channelKey',
+    'driveKey',
+    'publicBeeKey',
+    'channel',
+  ])
+  t.alike(CANONICAL_FEED_ENTRY_FIELDS, [
+    'channelKey',
+    'driveKey',
+    'publicBeeKey',
+    'source',
+    'relayRole',
+    'relayServing',
+    'peerCount',
+    'videoCount',
+    'lastSeen',
+    'manifestUpdatedAt',
+    'previewVideosHash',
+    'channel',
+    'previewVideos',
+  ])
+})
+
+test('createCanonicalFeedVideo preserves titles, icons, and blob references', (t) => {
+  const video = createCanonicalFeedVideo({
+    id: 'video-1',
+    path: '/videos/demo.mp4',
+    title: 'Canonical title',
+    description: 'Canonical description',
+    uploadedAt: 123,
+    duration: 456,
+    thumbnail: '/thumbs/demo.jpg',
+    thumbnailUrl: 'http://localhost/thumbs/demo.jpg',
+    thumbnailBlobId: 'thumb-blob',
+    thumbnailBlobsCoreKey: '11'.repeat(32),
+    thumbnailMimeType: 'image/jpeg',
+    blobId: 'video-blob',
+    blobsCoreKey: '22'.repeat(32),
+    mimeType: 'video/mp4',
+    availability: 'playable',
+    byteAvailability: 'playable',
+    channelKey: '33'.repeat(32),
+    publicBeeKey: '44'.repeat(32),
+    channel: {
+      channelKey: '33'.repeat(32),
+      driveKey: '33'.repeat(32),
+      name: 'Channel name',
+      description: 'Channel description',
+      avatar: '/avatars/channel.jpg',
+      icon: '/icons/channel.png',
+      thumbnail: '/thumbnails/channel.jpg',
+      videoCount: 12,
+      lastSeen: 789,
+      manifestUpdatedAt: 987,
+    },
+  })
+
+  t.is(video.title, 'Canonical title')
+  t.is(video.channel?.avatar, '/avatars/channel.jpg')
+  t.is(video.channel?.icon, '/icons/channel.png')
+  t.is(video.blobId, 'video-blob')
+  t.is(video.blobsCoreKey, '22'.repeat(32))
+  t.is(video.publicBeeKey, '44'.repeat(32))
+})
+
+test('createCanonicalFeedEnvelope normalizes nested entries and videos', (t) => {
+  const envelope = createCanonicalFeedEnvelope({
+    savedAt: 1234,
+    identityDriveKey: '55'.repeat(32),
+    entries: [{
+      channelKey: '66'.repeat(32),
+      source: 'peer',
+      channel: { name: 'Channel', avatar: '/avatar.jpg', icon: '/icon.png' },
+      previewVideos: [{ id: 'preview-1', title: 'Preview', uploadedAt: 1, channelKey: '66'.repeat(32) }],
+    }],
+    videos: [{ id: 'video-2', title: 'Video', uploadedAt: 2, channelKey: '66'.repeat(32) }],
+    channelMetaByKey: {
+      ['66'.repeat(32)]: { name: 'Channel', avatar: '/avatar.jpg', icon: '/icon.png' },
+    },
+  })
+
+  t.is(envelope.version, 1)
+  t.is(envelope.savedAt, 1234)
+  t.is(envelope.identityDriveKey, '55'.repeat(32))
+  t.is(envelope.entries[0].previewVideos[0].title, 'Preview')
+  t.is(envelope.videos[0].title, 'Video')
+  t.is(envelope.channelMetaByKey['66'.repeat(32)].icon, '/icon.png')
+})


### PR DESCRIPTION
Harden canonical feed normalization and preserve distinct availability fields plus full channel metadata across raw inputs, public feeds, and preview hydration.