### PR TITLE
Fix canonical feed contract surfaces

### DIFF
--- a/packages/app/app/(tabs)/discover.tsx
+++ b/packages/app/app/(tabs)/discover.tsx
@@ -193,10 +193,10 @@ export default function VerticalDiscoveryScreen() {
     }
   }, [blobServerPort, rpc])
 
-  const seedFromFeedEntries = useCallback((entries: FeedEntry[]) => {
+  const seedFromFeedEntries = useCallback((entries: FeedEntry[], channelMeta: Record<string, any> = {}) => {
     const renderable = getVerticalFeedPreviewVideos(entries as any, {
       identityDriveKey: identity?.driveKey || undefined,
-      channelMeta: {},
+      channelMeta,
       limit: 40,
     }) as VideoData[]
 
@@ -268,7 +268,7 @@ export default function VerticalDiscoveryScreen() {
     setFeedLoading(true)
     try {
       const timeoutToken = Symbol('vertical-feed-timeout')
-      const result = await withFeedTimeout(rpc.getPublicFeed({}), 4000, timeoutToken as any)
+      const result = await withFeedTimeout(rpc.getCanonicalFeed({}), 4000, timeoutToken as any)
       if (result === timeoutToken) {
         setFeedTimedOut(true)
         setFeedError('Feed refresh timed out; showing cached snapshot.')
@@ -282,6 +282,7 @@ export default function VerticalDiscoveryScreen() {
         return
       }
       const entries = Array.isArray((result as any)?.entries) ? (result as any).entries : []
+      const channelMetaByKey = (result as any)?.channelMetaByKey || {}
       setFeedTimedOut(false)
       setFeedError(null)
       setLastSuccessfulFeedAt(Date.now())
@@ -294,7 +295,7 @@ export default function VerticalDiscoveryScreen() {
         const nextSignature = mergedEntries.map(getFeedEntrySignature).join('\n')
         return prevSignature === nextSignature ? prev : mergedEntries
       })
-      seedFromFeedEntries(mergedEntries)
+      seedFromFeedEntries(mergedEntries, channelMetaByKey)
       for (const entry of mergedEntries.slice(0, 24)) {
         void hydrateChannelVideos(entry)
       }

--- a/packages/app/app/(tabs)/discover.tsx
+++ b/packages/app/app/(tabs)/discover.tsx
@@ -193,10 +193,10 @@ export default function VerticalDiscoveryScreen() {
     }
   }, [blobServerPort, rpc])
 
-  const seedFromFeedEntries = useCallback((entries: FeedEntry[], channelMeta: Record<string, any> = {}) => {
+  const seedFromFeedEntries = useCallback((entries: FeedEntry[], channelMetaByKey: Record<string, any> = {}) => {
     const renderable = getVerticalFeedPreviewVideos(entries as any, {
       identityDriveKey: identity?.driveKey || undefined,
-      channelMeta,
+      channelMeta: channelMetaByKey,
       limit: 40,
     }) as VideoData[]
 

--- a/packages/app/app/(tabs)/index.tsx
+++ b/packages/app/app/(tabs)/index.tsx
@@ -263,7 +263,7 @@ export default function HomeScreen() {
     try {
       setFeedLoading(true)
       // Add timeout to prevent infinite spinner if RPC hangs
-      const feedPromise = rpc.getPublicFeed({})
+      const feedPromise = rpc.getCanonicalFeed({})
       const timeoutPromise = new Promise<null>((resolve) => setTimeout(() => resolve(null), 10000))
       const result = await Promise.race([feedPromise, timeoutPromise])
 
@@ -272,13 +272,16 @@ export default function HomeScreen() {
           const key = entry?.channelKey || entry?.driveKey
           return key && all.findIndex((candidate) => (candidate?.channelKey || candidate?.driveKey) === key) === index
         }) as FeedEntry[]
-        console.log('[Home] getPublicFeed entries:', mergedEntries.map((e: any) => ({
+        console.log('[Home] getCanonicalFeed entries:', mergedEntries.map((e: any) => ({
           channelKey: e.channelKey || e.driveKey,
           source: e.source,
           peerCount: e.peerCount,
           hasBee: !!e.publicBeeKey,
         })))
         setFeedEntries(mergedEntries)
+        if (result?.channelMetaByKey) {
+          setChannelMeta((prev) => ({ ...result.channelMetaByKey, ...prev }))
+        }
         const CONCURRENT_META_LOADS = 3
         const metaRequests = getMissingChannelMetaRequests(mergedEntries, channelMetaRef.current, 6)
         for (const request of metaRequests.slice(0, CONCURRENT_META_LOADS)) {
@@ -288,7 +291,7 @@ export default function HomeScreen() {
       if (result?.stats) {
         setPeerCount(result.stats.peerCount || 0)
       }
-      logTiming('publicFeed', startedAt, {
+      logTiming('canonicalFeed', startedAt, {
         entries: result?.entries?.length || 0,
         timedOut: !result,
       })

--- a/packages/app/backend/mobile-handlers.mjs
+++ b/packages/app/backend/mobile-handlers.mjs
@@ -129,24 +129,10 @@ export function attachMobileHandlers(B, deps) {
   B.joinChannel = async (r) => { await api.subscribeChannel(r.channelKey); return { success: true } }
 
   // --- Public Feed handlers ---
-  B.getPublicFeed = async () => {
-    const r = await api.getPublicFeed()
-    return {
-      entries: r.entries.map(e => ({
-        channelKey: e.driveKey || e.channelKey,
-        driveKey: e.driveKey || e.channelKey,
-        source: e.source || 'peer',
-        publicBeeKey: e.publicBeeKey || null,
-        channelName: e.channelName || e.name || null,
-        videoCount: e.videoCount || 0,
-        peerCount: e.peerCount || 0,
-        lastSeen: e.lastSeen || 0,
-        manifestUpdatedAt: e.manifestUpdatedAt || 0,
-        previewVideos: Array.isArray(e.previewVideos) ? e.previewVideos : [],
-      })),
-      stats: r.stats || { totalEntries: 0, hiddenCount: 0, peerCount: 0 },
-    }
+  B.getCanonicalFeed = async () => {
+    return api.getCanonicalFeed()
   }
+  B.getPublicFeed = async () => B.getCanonicalFeed()
   B.refreshFeed = async () => { await api.refreshFeed(); return { success: true } }
   B.submitToFeed = async () => {
     const a = identityManager.getActiveIdentity();

--- a/packages/app/lib/discover-feed-controller.js
+++ b/packages/app/lib/discover-feed-controller.js
@@ -121,7 +121,7 @@ export function mapHydratedVerticalFeedVideos(entry, videoList, { identityDriveK
       ...video,
       channelKey,
       publicBeeKey: entry.publicBeeKey || undefined,
-      channel: { name: entry.channelName || 'Channel' },
+      channel: entry.channel || { name: entry.channelName || 'Channel' },
     }))
 }
 

--- a/packages/app/lib/feed-hydration.js
+++ b/packages/app/lib/feed-hydration.js
@@ -88,12 +88,13 @@ export function getFeedPreviewVideos(feedEntries, channelMeta, identityDriveKey,
       })) continue
 
       seen.add(videoKey)
+      const resolvedChannel = channelMeta?.[channelKey] || entry?.channel || { name: channelName }
       videos.push({
         ...preview,
         channelKey,
         driveKey: channelKey,
         publicBeeKey,
-        channel: { name: channelName },
+        channel: resolvedChannel,
       })
     }
   }

--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -1590,20 +1590,12 @@ export function createApi({
         const channelKey = entry?.channelKey || entry?.driveKey || ''
         if (!channelKey) continue
 
-        const channel = entry?.channel || (entry?.channelName ? { name: entry.channelName } : null)
-        const channelMeta = channel || {}
-        if (!channelMetaByKey[channelKey]) {
+        const channel = entry?.channel && typeof entry.channel === 'object' ? entry.channel : null
+        if (channel && Object.keys(channel).length > 0 && !channelMetaByKey[channelKey]) {
           channelMetaByKey[channelKey] = {
+            ...channel,
             channelKey,
             driveKey: entry?.driveKey || channelKey,
-            name: channelMeta.name || entry?.channelName || null,
-            description: channelMeta.description || null,
-            avatar: channelMeta.avatar || null,
-            icon: channelMeta.icon || null,
-            thumbnail: channelMeta.thumbnail || null,
-            videoCount: Number.isFinite(entry?.videoCount) ? entry.videoCount : null,
-            lastSeen: Number(entry?.lastSeen || 0) || 0,
-            manifestUpdatedAt: Number(entry?.manifestUpdatedAt || 0) || 0,
           }
         }
 
@@ -1614,7 +1606,7 @@ export function createApi({
             channelKey,
             driveKey: entry?.driveKey || channelKey,
             publicBeeKey: entry?.publicBeeKey || null,
-            channel: channelMetaByKey[channelKey],
+            channel: channelMetaByKey[channelKey] || channel || undefined,
           })
         }
       }

--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -18,6 +18,7 @@ import { Recommender } from './recommendations/recommender.js';
 import { getVideoToolboxDecodeSettings, setVideoToolboxDecodeEnabled, setVideoToolboxHwMapEnabled } from './transcode/videotoolbox-settings.mjs';
 import { buildBlobRefCacheKey, normalizeBlobsCoreKey, normalizeBlobRefInput, parseBlobRef, stringifyBlobId } from './blob-ref.js';
 import { NETWORK_TOPIC_STRING } from './types.js'
+import { createCanonicalFeedEnvelope } from './canonical-feed-contract.js'
 
 /**
  * @typedef {import('./types.js').StorageContext} StorageContext
@@ -1574,6 +1575,60 @@ export function createApi({
           unkeyedEntries,
         },
       };
+    },
+
+    /**
+     * Get the canonical feed envelope for app surfaces.
+     * @returns {{version: number, savedAt: number, identityDriveKey: string | null, entries: Array, videos: Array, channelMetaByKey: Object, stats: Object}}
+     */
+    getCanonicalFeed() {
+      const feed = this.getPublicFeed()
+      const channelMetaByKey = {}
+      const videos = []
+
+      for (const entry of feed.entries || []) {
+        const channelKey = entry?.channelKey || entry?.driveKey || ''
+        if (!channelKey) continue
+
+        const channel = entry?.channel || (entry?.channelName ? { name: entry.channelName } : null)
+        const channelMeta = channel || {}
+        if (!channelMetaByKey[channelKey]) {
+          channelMetaByKey[channelKey] = {
+            channelKey,
+            driveKey: entry?.driveKey || channelKey,
+            name: channelMeta.name || entry?.channelName || null,
+            description: channelMeta.description || null,
+            avatar: channelMeta.avatar || null,
+            icon: channelMeta.icon || null,
+            thumbnail: channelMeta.thumbnail || null,
+            videoCount: Number.isFinite(entry?.videoCount) ? entry.videoCount : null,
+            lastSeen: Number(entry?.lastSeen || 0) || 0,
+            manifestUpdatedAt: Number(entry?.manifestUpdatedAt || 0) || 0,
+          }
+        }
+
+        for (const preview of Array.isArray(entry?.previewVideos) ? entry.previewVideos : []) {
+          if (!preview) continue
+          videos.push({
+            ...preview,
+            channelKey,
+            driveKey: entry?.driveKey || channelKey,
+            publicBeeKey: entry?.publicBeeKey || null,
+            channel: channelMetaByKey[channelKey],
+          })
+        }
+      }
+
+      return {
+        ...createCanonicalFeedEnvelope({
+          savedAt: Date.now(),
+          identityDriveKey: ctx?.identityManager?.getActiveIdentity?.()?.driveKey || null,
+          entries: feed.entries || [],
+          videos,
+          channelMetaByKey,
+        }),
+        stats: feed.stats || { totalEntries: 0, hiddenCount: 0, peerCount: 0 },
+      }
     },
 
     /**

--- a/packages/backend/src/canonical-feed.js
+++ b/packages/backend/src/canonical-feed.js
@@ -127,8 +127,8 @@ function normalizeThumbnailRefs(raw = {}) {
 export function normalizeCanonicalFeedVideo(rawVideo = {}, options = {}) {
   const rawChannel = rawVideo.channel || options.channel || rawVideo.channelMeta || options.channelMeta || {}
   const channel = normalizeCanonicalFeedChannel(rawChannel, {
-    channelKey: options.channelKey || rawVideo.channelKey || rawVideo.driveKey,
-    driveKey: options.driveKey || rawVideo.driveKey || rawVideo.channelKey,
+    channelKey: rawVideo.channelKey || rawVideo.driveKey || options.channelKey,
+    driveKey: rawVideo.driveKey || rawVideo.channelKey || options.driveKey,
     name: rawVideo.channelName,
     description: rawVideo.channelDescription,
     avatar: rawVideo.channelAvatar,
@@ -142,6 +142,8 @@ export function normalizeCanonicalFeedVideo(rawVideo = {}, options = {}) {
   const channelKey = firstStringOrNull(
     rawVideo.channelKey,
     rawVideo.driveKey,
+    rawChannel.channelKey,
+    rawChannel.driveKey,
     options.channelKey,
     options.driveKey,
     channel.channelKey,
@@ -150,6 +152,8 @@ export function normalizeCanonicalFeedVideo(rawVideo = {}, options = {}) {
   const driveKey = firstStringOrNull(
     rawVideo.driveKey,
     rawVideo.channelKey,
+    rawChannel.driveKey,
+    rawChannel.channelKey,
     options.driveKey,
     options.channelKey,
     channel.driveKey,

--- a/packages/backend/src/hrpc-handlers.js
+++ b/packages/backend/src/hrpc-handlers.js
@@ -68,6 +68,7 @@ export const SHARED_HANDLER_NAMES = [
   'GetBlobServerPort',
   'GetChannel',
   'GetChannelMeta',
+  'GetCanonicalFeed',
   'GetIdentities',
   'GetIdentity',
   'GetPinnedChannels',

--- a/packages/platform/src/rpc.web.ts
+++ b/packages/platform/src/rpc.web.ts
@@ -419,6 +419,10 @@ export const rpc = {
   },
 
   // Public Feed
+  async getCanonicalFeed() {
+    return ensureRPC().getCanonicalFeed({});
+  },
+
   async getPublicFeed() {
     return ensureRPC().getPublicFeed({});
   },


### PR DESCRIPTION
## Summary
- Adds and wires the canonical feed contract for Home, Discover, and Shorts.
- Exposes `getCanonicalFeed` across backend, mobile handlers, HRPC handler names, and platform web RPC.
- Preserves titles, direct blob refs, byte availability, and channel metadata (`name`, `avatar`, `icon`, `thumbnail`) across preview extraction, snapshots, and app surfaces.
- Fixes fallback precedence so raw video/channel fields win over weaker option fallbacks.
- Keeps Discover/Shorts using the shared preview extraction path with canonical `channelMetaByKey`.

## Test Plan
- [x] `node --test packages/app/backend/mobile-handlers-canonical-feed.test.mjs packages/app/tests/feed-preview-restoration-red.test.mjs packages/app/tests/feed-snapshot-canonical-red.test.mjs packages/app/tests/canonical-feed-surface-regression.test.mjs packages/app/tests/vertical-discovery-regression.test.mjs packages/backend/test/canonical-feed-contract.test.mjs`
- [x] `npm run lint:changed`
- [x] `npm run typecheck`
- [x] `git diff --check`

## Local APK validation
Previously on this branch lineage I also built the local x86_64 release APK and verified signing/font/native ABI contents:
- APK: `packages/app/android/app/build/outputs/apk/release/app-x86_64-release.apk`
- `apksigner verify --print-certs` passed
- APK contained `lib/x86_64/libreactnative.so`, `assets/fonts/Feather.ttf`, and `assets/fonts/MaterialIcons.ttf`

Closes #241
