### PR TITLE
fix(app): add Android discovery diagnostics

### DIFF
--- a/packages/app/android/app/src/main/java/com/peartube/app/MainApplication.kt
+++ b/packages/app/android/app/src/main/java/com/peartube/app/MainApplication.kt
@@ -21,8 +21,7 @@ class MainApplication : Application(), ReactApplication {
       context = applicationContext,
       packageList =
         PackageList(this).packages.apply {
-          // Packages that cannot be autolinked yet can be added manually here, for example:
-          // add(MyReactNativePackage())
+          add(PeartubeNetworkDiscoveryPackage())
         }
     )
   }

--- a/packages/app/android/app/src/main/java/com/peartube/app/PeartubeNetworkDiscoveryModule.kt
+++ b/packages/app/android/app/src/main/java/com/peartube/app/PeartubeNetworkDiscoveryModule.kt
@@ -1,0 +1,84 @@
+package com.peartube.app
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.net.wifi.WifiManager
+import android.os.Build
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.WritableMap
+import androidx.core.content.ContextCompat
+
+class PeartubeNetworkDiscoveryModule(
+  private val reactContext: ReactApplicationContext
+) : ReactContextBaseJavaModule(reactContext) {
+  private var multicastLock: WifiManager.MulticastLock? = null
+  private var lastError: String? = null
+
+  override fun getName(): String = "PeartubeNetworkDiscovery"
+
+  @ReactMethod
+  fun acquireMulticastLock(promise: Promise) {
+    try {
+      val appContext = reactContext.applicationContext
+      val wifiManager = appContext.getSystemService(Context.WIFI_SERVICE) as? WifiManager
+        ?: throw IllegalStateException("WifiManager unavailable")
+      val lock = multicastLock ?: wifiManager.createMulticastLock("peartube-network-discovery").apply {
+        setReferenceCounted(false)
+        multicastLock = this
+      }
+      if (!lock.isHeld) lock.acquire()
+      lastError = null
+      promise.resolve(getDiscoveryNetworkStatusMap())
+    } catch (err: Throwable) {
+      lastError = err.message ?: err.toString()
+      promise.reject("ERR_MULTICAST_LOCK", lastError, err)
+    }
+  }
+
+  @ReactMethod
+  fun releaseMulticastLock(promise: Promise) {
+    try {
+      multicastLock?.let { lock ->
+        if (lock.isHeld) lock.release()
+      }
+      lastError = null
+      promise.resolve(getDiscoveryNetworkStatusMap())
+    } catch (err: Throwable) {
+      lastError = err.message ?: err.toString()
+      promise.reject("ERR_MULTICAST_UNLOCK", lastError, err)
+    }
+  }
+
+  @ReactMethod
+  fun getDiscoveryNetworkStatus(promise: Promise) {
+    promise.resolve(getDiscoveryNetworkStatusMap())
+  }
+
+  private fun getDiscoveryNetworkStatusMap(): WritableMap {
+    val appContext = reactContext.applicationContext
+    val wifiManager = appContext.getSystemService(Context.WIFI_SERVICE) as? WifiManager
+    val map = Arguments.createMap()
+    map.putBoolean("multicastLockHeld", multicastLock?.isHeld == true)
+    map.putBoolean("wifiEnabled", wifiManager?.isWifiEnabled == true)
+    map.putInt("sdkVersion", Build.VERSION.SDK_INT)
+    map.putBoolean("nearbyWifiPermissionGranted", hasNearbyWifiPermission())
+    map.putString("lastError", lastError)
+    return map
+  }
+
+  private fun hasNearbyWifiPermission(): Boolean {
+    return if (Build.VERSION.SDK_INT >= 33) {
+      ContextCompat.checkSelfPermission(
+        reactContext,
+        Manifest.permission.NEARBY_WIFI_DEVICES,
+      ) == PackageManager.PERMISSION_GRANTED
+    } else {
+      true
+    }
+  }
+}

--- a/packages/app/android/app/src/main/java/com/peartube/app/PeartubeNetworkDiscoveryPackage.kt
+++ b/packages/app/android/app/src/main/java/com/peartube/app/PeartubeNetworkDiscoveryPackage.kt
@@ -1,0 +1,16 @@
+package com.peartube.app
+
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ViewManager
+
+class PeartubeNetworkDiscoveryPackage : ReactPackage {
+  override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
+    return listOf(PeartubeNetworkDiscoveryModule(reactContext))
+  }
+
+  override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> {
+    return emptyList()
+  }
+}

--- a/packages/app/app/(tabs)/discover.tsx
+++ b/packages/app/app/(tabs)/discover.tsx
@@ -36,6 +36,7 @@ import {
 } from '@/lib/discover-feed-controller'
 import { getCachedVideoUrl, makeVideoUrlCacheKey, setCachedVideoUrl } from '@/lib/video-url-cache'
 import { readDiscoverFeedCache, writeDiscoverFeedCache } from '@/lib/discover-feed-cache'
+import { classifyFeedDiscoveryState } from '@/lib/android-discovery-diagnostics'
 import { formatTimeAgo } from '@/lib/formatters'
 import { useTabBarMetrics } from '@/lib/tabBarHeight'
 import { VerticalShortsPlayer } from '@/components/discovery/VerticalShortsPlayer'
@@ -60,6 +61,13 @@ interface FeedEntry {
     thumbnailBlobsCoreKey?: string | null
     thumbnailMimeType?: string | null
   }>
+}
+
+type SwarmStatus = {
+  peers: number
+  feedConnections?: number
+  channels?: number
+  doctor?: { recommendedBoundary?: string | null }
 }
 function getFeedEntrySignature(entry: FeedEntry) {
   const previewSignature = (entry.previewVideos || []).map((video) => [
@@ -114,7 +122,7 @@ export default function VerticalDiscoveryScreen() {
   const insets = useSafeAreaInsets()
   const { height: screenHeight, width: screenWidth } = useWindowDimensions()
   const { isDesktop } = usePlatform()
-  const { ready, identity, rpc, blobServerPort, backendError, startupStatus, platformEvents } = useApp()
+  const { ready, identity, rpc, blobServerPort, backendError, startupStatus, platformEvents, androidDiscoveryPermissionStatus } = useApp()
   const tabBarMetrics = useTabBarMetrics()
   const bottomChromePadding = Math.max(tabBarMetrics.height + 18, insets.bottom + 110, 126)
   const metaBottomPadding = bottomChromePadding
@@ -123,6 +131,8 @@ export default function VerticalDiscoveryScreen() {
   const cachedDiscoverFeed = useMemo(() => readDiscoverFeedCache(), [])
   const [refreshing, setRefreshing] = useState(false)
   const [feedLoading, setFeedLoading] = useState(false)
+  const [peerCount, setPeerCount] = useState(0)
+  const [swarmStatus, setSwarmStatus] = useState<SwarmStatus | null>(null)
   const [feedEntries, setFeedEntries] = useState<FeedEntry[]>(() => (cachedDiscoverFeed?.feedEntries || []) as FeedEntry[])
   const [videos, setVideos] = useState<VideoData[]>(() => (cachedDiscoverFeed?.videos || []) as VideoData[])
   const [cacheRestoredOnly, setCacheRestoredOnly] = useState(() => Boolean(cachedDiscoverFeed?.videos?.length || cachedDiscoverFeed?.feedEntries?.length))
@@ -282,11 +292,15 @@ export default function VerticalDiscoveryScreen() {
         return
       }
       const entries = Array.isArray((result as any)?.entries) ? (result as any).entries : []
+      const stats = (result as any)?.stats
       const channelMetaByKey = (result as any)?.channelMetaByKey || {}
       setFeedTimedOut(false)
       setFeedError(null)
       setLastSuccessfulFeedAt(Date.now())
       setUsingCachedSnapshot(false)
+      if (stats) {
+        setPeerCount(stats.peerCount || 0)
+      }
       if (entries.length > 0 && hasRichVerticalFeedSnapshot(entries, [])) setCacheRestoredOnly(false)
       let mergedEntries = entries
       setFeedEntries((prev) => {
@@ -296,6 +310,20 @@ export default function VerticalDiscoveryScreen() {
         return prevSignature === nextSignature ? prev : mergedEntries
       })
       seedFromFeedEntries(mergedEntries, channelMetaByKey)
+      try {
+        const statusPromise = rpc.getSwarmStatus()
+        const status = await Promise.race([statusPromise, new Promise((resolve) => setTimeout(() => resolve(null), 3000))])
+        if (status) {
+          setSwarmStatus({
+            peers: (status as any).peerCount || (status as any).swarmConnections || 0,
+            feedConnections: (status as any).feedConnections,
+            channels: (status as any).channelsLoaded,
+            doctor: (status as any).doctor || undefined,
+          })
+        }
+      } catch (err) {
+        console.log('[VerticalDiscovery] Failed to load swarm status:', (err as any)?.message || err)
+      }
       for (const entry of mergedEntries.slice(0, 24)) {
         void hydrateChannelVideos(entry)
       }
@@ -462,6 +490,39 @@ export default function VerticalDiscoveryScreen() {
       thumbnailUrl: thumbnailCache[cacheKey] || video.thumbnailUrl || (video as any).thumbnail || null,
     }
   }), [thumbnailCache, videos])
+  const feedDiscoveryState = useMemo(() => classifyFeedDiscoveryState({
+    ready,
+    entries: feedEntries,
+    videos: verticalVideos,
+    peerCount,
+    swarmStatus,
+    permissionStatus: androidDiscoveryPermissionStatus,
+    hasCachedSnapshot: Boolean(cachedDiscoverFeed?.videos?.length || cachedDiscoverFeed?.feedEntries?.length) || usingCachedSnapshot,
+  }), [androidDiscoveryPermissionStatus, cachedDiscoverFeed?.feedEntries?.length, cachedDiscoverFeed?.videos?.length, feedEntries, peerCount, ready, swarmStatus, usingCachedSnapshot, verticalVideos])
+  const discoveryState = feedDiscoveryState?.state || 'discovery-waiting'
+  const discoveryReason = feedDiscoveryState?.reason
+  const discoveryTitle = discoveryState === 'backend-starting'
+    ? (startupStatus || 'Connecting to P2P network…')
+    : discoveryState === 'permission-degraded'
+      ? 'Local peer discovery needs Nearby Wi-Fi'
+      : discoveryState === 'network-degraded'
+        ? 'Peer discovery is degraded'
+        : discoveryState === 'cached-fallback'
+          ? 'Using cached Discover data'
+          : discoveryState === 'hydrating'
+            ? 'Hydrating Discover feed'
+            : 'Looking for peers'
+  const discoveryDetail = discoveryState === 'backend-starting'
+    ? 'Waiting for the backend to report discovery status.'
+    : discoveryState === 'permission-degraded'
+      ? 'Grant Nearby Wi-Fi permission, then pull to refresh.'
+      : discoveryState === 'network-degraded'
+        ? `Network boundary: ${discoveryReason || 'unknown'}. Pull to retry the feed path.`
+        : discoveryState === 'cached-fallback'
+          ? 'No live peers are connected yet; cached videos will stay visible when available.'
+          : discoveryState === 'hydrating'
+            ? `peerCount: ${peerCount}. Waiting for channel hydration.`
+            : `peerCount: ${peerCount}. Keep the app open or pull to refresh.`
   const hydrationErrorCount = Object.keys(hydrationErrors).length
   const degradedCopy = feedTimedOut
     ? 'Feed refresh timed out — showing cached previews.'
@@ -518,10 +579,10 @@ export default function VerticalDiscoveryScreen() {
         <View style={styles.centerState}>
           {feedLoading || !ready ? <ActivityIndicator color={colors.primary} size="large" /> : null}
           <Text style={styles.centerTitle}>
-            {backendError ? 'Backend error' : ready ? (feedTimedOut || feedError || usingCachedSnapshot ? 'Showing cached Discover' : 'No videos discovered yet') : (startupStatus || 'Connecting to P2P network…')}
+            {backendError ? 'Backend error' : discoveryTitle}
           </Text>
           <Text style={styles.centerBody}>
-            {backendError || degradedCopy || 'Pull down to refresh, or wait for peers to announce channels.'}
+            {backendError || discoveryDetail || degradedCopy || 'Pull down to refresh, or wait for peers to announce channels.'}
           </Text>
         </View>
       ) : (

--- a/packages/app/app/(tabs)/index.tsx
+++ b/packages/app/app/(tabs)/index.tsx
@@ -39,6 +39,7 @@ import {
   readFeedSnapshotFromDisk,
   writeFeedSnapshotToDisk,
 } from '@/lib/feed-snapshot-storage'
+import { classifyFeedDiscoveryState } from '@/lib/android-discovery-diagnostics'
 // Public feed types
 interface FeedEntry {
   driveKey: string
@@ -114,7 +115,7 @@ const isPear = Platform.OS === 'web' && typeof window !== 'undefined' && (!!(win
 export default function HomeScreen() {
   const insets = useSafeAreaInsets()
   const router = useRouter()
-  const { ready, identity, videos, loading, loadVideos, rpc, backendError, startupStatus, retryBackend, platformEvents, blobServerPort } = useApp()
+  const { ready, identity, videos, loading, loadVideos, rpc, backendError, startupStatus, retryBackend, platformEvents, blobServerPort, androidDiscoveryPermissionStatus } = useApp()
   const { loadAndPlayVideo } = useVideoPlayerContext()
   const { isDesktop } = usePlatform()
   const { width: screenWidth } = useWindowDimensions()
@@ -889,6 +890,22 @@ export default function HomeScreen() {
 
   const backendConnecting = !ready
   const backendLoading = Boolean(loading)
+  const feedDiscoveryState = useMemo(() => classifyFeedDiscoveryState({
+    ready,
+    entries: feedEntries,
+    videos: feedVideosWithThumbs,
+    peerCount,
+    permissionStatus: androidDiscoveryPermissionStatus,
+    hasCachedSnapshot: snapshotRestoredOnly || snapshotChannelKeys.size > 0,
+  }), [
+    androidDiscoveryPermissionStatus,
+    feedEntries,
+    feedVideosWithThumbs,
+    peerCount,
+    ready,
+    snapshotChannelKeys,
+    snapshotRestoredOnly,
+  ])
   const videoGridItemStyle = useMemo(() => isDesktop ? {
     width: `calc(${100 / gridColumns}% - ${(gridColumns - 1) * 24 / gridColumns}px)`,
   } as any : undefined, [isDesktop, gridColumns])
@@ -1136,12 +1153,38 @@ export default function HomeScreen() {
     }
 
     if (item.type === 'discover-empty') {
+      const state = feedDiscoveryState?.state || 'discovery-waiting'
+      const reason = feedDiscoveryState?.reason
+      const title = state === 'permission-degraded'
+        ? 'Local peer discovery needs Nearby Wi-Fi'
+        : state === 'network-degraded'
+          ? 'Peer discovery is degraded'
+          : state === 'cached-fallback'
+            ? 'Using cached discovery data'
+            : 'Looking for PearTube peers'
+      const detail = state === 'permission-degraded'
+        ? 'Grant Nearby devices/Wi-Fi permission, then refresh discovery.'
+        : state === 'network-degraded'
+          ? `Network boundary: ${reason || 'unknown'}. Refresh will retry the feed path.`
+          : state === 'cached-fallback'
+            ? 'No live peers are connected yet; cached videos will stay visible when available.'
+            : 'No live peers have announced channels yet. Keep the app open or tap refresh.'
+
       return (
         <View style={{ paddingHorizontal: isDesktop ? 24 : 20 }}>
           <View className="py-8 items-center bg-pear-bg-elevated rounded-xl">
-            <Feather name="globe" color={colors.textMuted} size={32} />
-            <Text className="text-label text-pear-text mt-2">No seeded videos discovered yet</Text>
-            <Text className="text-caption text-pear-text-muted mt-1">Click refresh or wait for peers that are actively announcing channels</Text>
+            <Feather name="radio" color={colors.textMuted} size={32} />
+            <Text className="text-label text-pear-text mt-2 text-center">{title}</Text>
+            <Text className="text-caption text-pear-text-muted mt-1 text-center px-6">{detail}</Text>
+            <Pressable
+              onPress={refreshFeed}
+              disabled={feedLoading || backendConnecting || !rpc}
+              className="mt-4 px-4 py-2 rounded-lg bg-pear-primary active:opacity-70"
+              accessibilityRole="button"
+              accessibilityLabel="Retry peer discovery"
+            >
+              <Text className="text-label text-white">Retry discovery</Text>
+            </Pressable>
           </View>
         </View>
       )
@@ -1197,6 +1240,7 @@ export default function HomeScreen() {
     backendError,
     backendLoading,
     categories,
+    feedDiscoveryState,
     feedEntries.length,
     feedLoading,
     identity?.driveKey,

--- a/packages/app/app/(tabs)/index.tsx
+++ b/packages/app/app/(tabs)/index.tsx
@@ -135,7 +135,7 @@ export default function HomeScreen() {
   const [feedLoading, setFeedLoading] = useState(false)
   const [peerCount, setPeerCount] = useState(0)
   const [lastFeedRefresh, setLastFeedRefresh] = useState<number | null>(null)
-  const [swarmStatus, setSwarmStatus] = useState<{ peers: number; feedConnections?: number; channels?: number } | null>(null)
+  const [swarmStatus, setSwarmStatus] = useState<{ peers: number; feedConnections?: number; channels?: number; doctor?: { recommendedBoundary?: string | null } } | null>(null)
   const channelMetaRef = useRef(channelMeta)
   channelMetaRef.current = channelMeta
   const inflightChannelMetaLoads = useRef<Set<string>>(new Set())
@@ -305,6 +305,7 @@ export default function HomeScreen() {
             peers: (status as any).peerCount || (status as any).swarmConnections || 0,
             feedConnections: (status as any).feedConnections,
             channels: (status as any).channelsLoaded,
+            doctor: (status as any).doctor || undefined,
           })
         }
       } catch (err) {

--- a/packages/app/app/_layout.tsx
+++ b/packages/app/app/_layout.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-require-imports, no-empty, no-extra-semi */
 /**
  * Root Layout - Wraps app with providers
  *
@@ -6,7 +7,7 @@
 import '../global.css'
 import { useEffect, useState, useCallback, useRef } from 'react'
 import { Stack } from 'expo-router'
-import { StatusBar, View, Platform, AppState, AppStateStatus, PermissionsAndroid } from 'react-native'
+import { StatusBar, View, Platform, AppState, AppStateStatus, PermissionsAndroid, NativeModules } from 'react-native'
 import { GluestackUIProvider } from '@/components/ui/gluestack-ui-provider'
 import { PlatformProvider } from '@/lib/PlatformProvider'
 import { VideoPlayerProvider, videoStatsEventEmitter, videoLoadEventEmitter, VideoData, playbackActiveEmitter } from '@/lib/VideoPlayerContext'
@@ -75,6 +76,14 @@ let platformRPC: any = null
 const BACKEND_SOURCE_CACHE_KEY = '__PEARTUBE_BACKEND_SOURCE__'
 const DOWNLOADER_SOURCE_CACHE_KEY = '__PEARTUBE_DOWNLOADER_WORKER_SOURCE__'
 const CAST_ACTIVE_GLOBAL_KEY = '__PEARTUBE_CAST_ACTIVE__'
+const PeartubeNetworkDiscovery = (NativeModules as any).PeartubeNetworkDiscovery
+
+type AndroidDiscoveryPermissionStatus = {
+  postNotifications?: string
+  nearbyWifi?: string
+  multicastLockHeld?: boolean
+  lastError?: string | null
+}
 
 function coerceBundleSource(mod: any): string | null {
   if (typeof mod === 'string') return mod
@@ -176,6 +185,7 @@ export default function RootLayout() {
   const [blobServerPort, setBlobServerPort] = useState<number | null>(() => cachedAppState?.blobServerPort ?? null)
   const [backendError, setBackendError] = useState<string | null>(null)
   const [startupStatus, setStartupStatus] = useState<string | null>(null)
+  const [androidDiscoveryPermissionStatus, setAndroidDiscoveryPermissionStatus] = useState<AndroidDiscoveryPermissionStatus | null>(null)
   const statsPollersRef = useRef<Map<string, NodeJS.Timeout>>(new Map())
 const castKeepaliveIntervalRef = useRef<NodeJS.Timeout | null>(null)
 const castSuspendGraceTimerRef = useRef<NodeJS.Timeout | null>(null)
@@ -779,20 +789,62 @@ const BACKEND_STARTUP_TIMEOUT_MS = 30000
     stopCastKeepalive,
   ])
 
-  useEffect(() => {
-    if (isNative) {
-      if (Platform.OS === 'android' && Platform.Version >= 33) {
-        PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS).catch(() => {})
-        if (PermissionsAndroid.PERMISSIONS.NEARBY_WIFI_DEVICES) {
-          PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.NEARBY_WIFI_DEVICES).catch(() => {})
+  const requestAndroidDiscoveryPermissions = useCallback(async (): Promise<AndroidDiscoveryPermissionStatus> => {
+    const status: AndroidDiscoveryPermissionStatus = {}
+
+    if (Platform.OS !== 'android') return status
+
+    if (Platform.Version >= 33) {
+      try {
+        status.postNotifications = await PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS)
+      } catch (err: any) {
+        status.postNotifications = 'error'
+        status.lastError = err?.message || String(err)
+      }
+
+      if (PermissionsAndroid.PERMISSIONS.NEARBY_WIFI_DEVICES) {
+        try {
+          status.nearbyWifi = await PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.NEARBY_WIFI_DEVICES)
+        } catch (err: any) {
+          status.nearbyWifi = 'error'
+          status.lastError = err?.message || String(err)
         }
       }
-      initNativeBackend()
+    }
+
+    try {
+      const discoveryStatus = await PeartubeNetworkDiscovery?.acquireMulticastLock?.()
+      status.multicastLockHeld = discoveryStatus?.multicastLockHeld === true
+      status.lastError = discoveryStatus?.lastError ?? status.lastError ?? null
+    } catch (err: any) {
+      status.multicastLockHeld = false
+      status.lastError = err?.message || String(err)
+      console.warn('[App] Android network discovery setup failed:', status.lastError)
+    }
+
+    console.log('[App] Android discovery permission status:', JSON.stringify(status))
+    setAndroidDiscoveryPermissionStatus(status)
+    return status
+  }, [])
+
+  useEffect(() => {
+    if (isNative) {
+      let cancelled = false
+      ;(async () => {
+        await requestAndroidDiscoveryPermissions()
+        if (!cancelled) initNativeBackend()
+      })()
 
       const subscription = AppState.addEventListener('change', handleAppStateChange)
       return () => {
+        cancelled = true
         subscription.remove()
         castPlaybackStateUnsubRef.current?.()
+        if (Platform.OS === 'android') {
+          PeartubeNetworkDiscovery?.releaseMulticastLock?.().catch((err: any) => {
+            console.log('[App] Android discovery multicast release failed:', err?.message)
+          })
+        }
         clearCastSuspendGraceTimer()
         if (startupTimerRef.current) {
           clearTimeout(startupTimerRef.current)
@@ -821,6 +873,7 @@ const BACKEND_STARTUP_TIMEOUT_MS = 30000
     handleAppStateChange,
     initNativeBackend,
     initPearBackend,
+    requestAndroidDiscoveryPermissions,
     stopCastKeepalive,
   ])
 
@@ -1034,6 +1087,7 @@ const BACKEND_STARTUP_TIMEOUT_MS = 30000
     platformEvents: platformRPC?.events,
     backendError,
     startupStatus,
+    androidDiscoveryPermissionStatus,
     retryBackend,
     uploadVideo: uploadVideoHandler,
     pickVideoFile: pickVideoFileHandler,

--- a/packages/app/lib/AppContext.tsx
+++ b/packages/app/lib/AppContext.tsx
@@ -11,6 +11,7 @@ export interface AppContextType {
   platformEvents?: any
   backendError?: string | null
   startupStatus?: string | null
+  androidDiscoveryPermissionStatus?: any
   retryBackend?: () => void
   uploadVideo: (
     filePath: string,

--- a/packages/app/lib/android-discovery-diagnostics.js
+++ b/packages/app/lib/android-discovery-diagnostics.js
@@ -1,0 +1,41 @@
+export function getAndroidDiscoveryPermissionRequests({ platformOS, platformVersion, permissions = {} } = {}) {
+  if (platformOS !== 'android') return []
+  const requests = []
+  if (Number(platformVersion || 0) >= 33) {
+    if (permissions.POST_NOTIFICATIONS) requests.push(permissions.POST_NOTIFICATIONS)
+    if (permissions.NEARBY_WIFI_DEVICES) requests.push(permissions.NEARBY_WIFI_DEVICES)
+  }
+  return requests
+}
+
+export function classifyFeedDiscoveryState({
+  ready = false,
+  entries = [],
+  videos = [],
+  peerCount = 0,
+  swarmStatus = null,
+  permissionStatus = null,
+  hasCachedSnapshot = false,
+} = {}) {
+  if (!ready) return { state: 'backend-starting', recoverable: true }
+  if (permissionStatus?.nearbyWifi === 'denied' || permissionStatus?.nearbyWifi === 'never_ask_again') {
+    return { state: 'permission-degraded', recoverable: true, reason: 'nearby-wifi-denied' }
+  }
+  if (Array.isArray(videos) && videos.length > 0) {
+    return { state: 'content-ready', recoverable: false }
+  }
+  if (Array.isArray(entries) && entries.length > 0) {
+    if (Number(peerCount || 0) > 0 || Number(swarmStatus?.peers || 0) > 0 || Number(swarmStatus?.feedConnections || 0) > 0) {
+      return { state: 'hydrating', recoverable: true }
+    }
+    return hasCachedSnapshot
+      ? { state: 'cached-fallback', recoverable: true, reason: 'zero-peers-with-entries' }
+      : { state: 'discovery-waiting', recoverable: true, reason: 'zero-peers-with-entries' }
+  }
+  const boundary = swarmStatus?.doctor?.recommendedBoundary || null
+  if (boundary && boundary !== 'content-playback-or-ui') {
+    return { state: 'network-degraded', recoverable: true, reason: boundary }
+  }
+  if (hasCachedSnapshot) return { state: 'cached-fallback', recoverable: true, reason: 'zero-peers-no-entries' }
+  return { state: 'discovery-waiting', recoverable: true, reason: 'zero-peers-no-entries' }
+}

--- a/packages/app/tests/android-physical-discovery-regression.test.mjs
+++ b/packages/app/tests/android-physical-discovery-regression.test.mjs
@@ -1,0 +1,113 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import {
+  classifyFeedDiscoveryState,
+  getAndroidDiscoveryPermissionRequests,
+} from '../lib/android-discovery-diagnostics.js'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const appRoot = path.resolve(__dirname, '..')
+
+function readAppFile(relativePath) {
+  return fs.readFileSync(path.join(appRoot, relativePath), 'utf8')
+}
+
+test('Android native discovery module owns MulticastLock lifecycle and status diagnostics', () => {
+  const moduleSource = readAppFile('android/app/src/main/java/com/peartube/app/PeartubeNetworkDiscoveryModule.kt')
+  const packageSource = readAppFile('android/app/src/main/java/com/peartube/app/PeartubeNetworkDiscoveryPackage.kt')
+  const applicationSource = readAppFile('android/app/src/main/java/com/peartube/app/MainApplication.kt')
+
+  assert.match(moduleSource, /WifiManager\.MulticastLock/)
+  assert.match(moduleSource, /createMulticastLock\("peartube-network-discovery"\)/)
+  assert.match(moduleSource, /setReferenceCounted\(false\)/)
+  assert.match(moduleSource, /fun acquireMulticastLock\(/)
+  assert.match(moduleSource, /fun releaseMulticastLock\(/)
+  assert.match(moduleSource, /fun getDiscoveryNetworkStatus\(/)
+  assert.match(packageSource, /PeartubeNetworkDiscoveryModule\(reactContext\)/)
+  assert.match(applicationSource, /add\(PeartubeNetworkDiscoveryPackage\(\)\)/)
+})
+
+test('root layout requests Android discovery permissions, records results, and acquires MulticastLock before backend startup', () => {
+  const source = readAppFile('app/_layout.tsx')
+
+  assert.match(source, /NativeModules/)
+  assert.match(source, /PeartubeNetworkDiscovery/)
+  assert.match(source, /requestAndroidDiscoveryPermissions/)
+  assert.match(source, /PermissionsAndroid\.request\(PermissionsAndroid\.PERMISSIONS\.NEARBY_WIFI_DEVICES\)/)
+  assert.match(source, /setAndroidDiscoveryPermissionStatus/)
+  assert.match(source, /acquireMulticastLock\?\.\(\)/)
+  assert.match(source, /initNativeBackend\(\)/)
+  const helperIndex = source.indexOf('const requestAndroidDiscoveryPermissions = useCallback')
+  const effectCallIndex = source.indexOf('await requestAndroidDiscoveryPermissions()')
+  assert.ok(
+    helperIndex >= 0 && effectCallIndex > helperIndex,
+    'permissions helper should be defined before the native backend boot effect uses it',
+  )
+})
+
+test('Android discovery permission helper requests Nearby Wi-Fi only on Android 33+', () => {
+  const permissions = {
+    POST_NOTIFICATIONS: 'android.permission.POST_NOTIFICATIONS',
+    NEARBY_WIFI_DEVICES: 'android.permission.NEARBY_WIFI_DEVICES',
+  }
+
+  assert.deepEqual(getAndroidDiscoveryPermissionRequests({ platformOS: 'ios', platformVersion: 17, permissions }), [])
+  assert.deepEqual(getAndroidDiscoveryPermissionRequests({ platformOS: 'android', platformVersion: 32, permissions }), [])
+  assert.deepEqual(getAndroidDiscoveryPermissionRequests({ platformOS: 'android', platformVersion: 33, permissions }), [
+    'android.permission.POST_NOTIFICATIONS',
+    'android.permission.NEARBY_WIFI_DEVICES',
+  ])
+})
+
+test('feed discovery state distinguishes permission, transport, cached fallback, and empty discovery states', () => {
+  assert.deepEqual(classifyFeedDiscoveryState({ ready: false }), {
+    state: 'backend-starting',
+    recoverable: true,
+  })
+
+  assert.deepEqual(classifyFeedDiscoveryState({
+    ready: true,
+    permissionStatus: { nearbyWifi: 'denied' },
+  }), {
+    state: 'permission-degraded',
+    recoverable: true,
+    reason: 'nearby-wifi-denied',
+  })
+
+  assert.deepEqual(classifyFeedDiscoveryState({
+    ready: true,
+    entries: [],
+    videos: [],
+    swarmStatus: { doctor: { recommendedBoundary: 'transport-socket' } },
+  }), {
+    state: 'network-degraded',
+    recoverable: true,
+    reason: 'transport-socket',
+  })
+
+  assert.deepEqual(classifyFeedDiscoveryState({
+    ready: true,
+    entries: [],
+    videos: [],
+    hasCachedSnapshot: true,
+  }), {
+    state: 'cached-fallback',
+    recoverable: true,
+    reason: 'zero-peers-no-entries',
+  })
+
+  assert.deepEqual(classifyFeedDiscoveryState({
+    ready: true,
+    entries: [],
+    videos: [],
+  }), {
+    state: 'discovery-waiting',
+    recoverable: true,
+    reason: 'zero-peers-no-entries',
+  })
+})

--- a/packages/app/tests/android-physical-discovery-regression.test.mjs
+++ b/packages/app/tests/android-physical-discovery-regression.test.mjs
@@ -42,6 +42,7 @@ test('root layout requests Android discovery permissions, records results, and a
   assert.match(source, /setAndroidDiscoveryPermissionStatus/)
   assert.match(source, /acquireMulticastLock\?\.\(\)/)
   assert.match(source, /initNativeBackend\(\)/)
+  assert.match(source, /doctor: (status as any).doctor || undefined/)
   const helperIndex = source.indexOf('const requestAndroidDiscoveryPermissions = useCallback')
   const effectCallIndex = source.indexOf('await requestAndroidDiscoveryPermissions()')
   assert.ok(
@@ -110,4 +111,10 @@ test('feed discovery state distinguishes permission, transport, cached fallback,
     recoverable: true,
     reason: 'zero-peers-no-entries',
   })
+
+  const discoverSource = readAppFile('app/(tabs)/discover.tsx')
+  assert.match(discoverSource, /classifyFeedDiscoveryState/)
+  assert.match(discoverSource, /Looking for peers/)
+  assert.match(discoverSource, /peerCount: \${peerCount}. Keep the app open or pull to refresh./)
+  assert.match(discoverSource, /Network boundary: \${discoveryReason \|\| 'unknown'}. Pull to retry the feed path./)
 })

--- a/packages/app/tests/android-physical-discovery-regression.test.mjs
+++ b/packages/app/tests/android-physical-discovery-regression.test.mjs
@@ -42,7 +42,7 @@ test('root layout requests Android discovery permissions, records results, and a
   assert.match(source, /setAndroidDiscoveryPermissionStatus/)
   assert.match(source, /acquireMulticastLock\?\.\(\)/)
   assert.match(source, /initNativeBackend\(\)/)
-  assert.match(source, /doctor: (status as any).doctor || undefined/)
+  assert.match(source, /doctor: \(status as any\)\.doctor \|\| undefined/)
   const helperIndex = source.indexOf('const requestAndroidDiscoveryPermissions = useCallback')
   const effectCallIndex = source.indexOf('await requestAndroidDiscoveryPermissions()')
   assert.ok(


### PR DESCRIPTION
## Summary
- Adds an Android native `PeartubeNetworkDiscovery` module that acquires/releases a `WifiManager.MulticastLock` and reports discovery capability status.
- Changes native startup to request/log Nearby Wi-Fi + notification permission results before booting the Bare backend.
- Adds a feed discovery classifier and Home empty-state messaging so zero-peer/no-entry states are explicit and recoverable instead of silent.
- Adds regression coverage for the native module wiring, runtime permission handling, multicast lock ownership, and zero-peer discovery states.

Closes #255.

## Test Plan
- [x] `node --test packages/app/tests/android-physical-discovery-regression.test.mjs`
- [x] `node --test packages/app/tests/android-physical-discovery-regression.test.mjs packages/app/tests/android-manifest-network-lifecycle-regression.test.mjs packages/app/tests/feed-hydration.test.mjs packages/app/tests/discover-feed-controller.test.mjs packages/app/tests/mobile-ui-redesign-regression.test.mjs`
- [x] `git diff --check`
- [x] `./node_modules/.bin/eslint --quiet 'packages/app/app/_layout.tsx' 'packages/app/app/(tabs)/index.tsx' packages/app/lib/AppContext.tsx packages/app/lib/android-discovery-diagnostics.js packages/app/tests/android-physical-discovery-regression.test.mjs`
- [x] `npm run lint:changed` (reports no changed JS/TS files to lint in this local branch comparison)

## Notes
- This closes the source/runtime wiring gap for Android discovery capability, but final proof still needs a physical Android device because emulator networking does not validate the original failure mode.
