### PR TITLE
[codex] Align universal backend architecture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,586 +1,145 @@
 # PearTube Development Guide
 
-This document provides everything needed to understand and develop the PearTube project - a decentralized P2P video streaming platform built on Pear Runtime and Hypercore Protocol.
+PearTube is a decentralized P2P video platform built on the Hypercore stack. The current architecture is centered on a **universal backend**: every client boots or connects to the same backend contract instead of maintaining separate desktop and mobile backend implementations.
 
 ## Agent Instructions
 
 Builds, installs, and deploy commands may be run when explicitly requested.
 
-## Table of Contents
-
-- [Project Overview](#project-overview)
-- [Monorepo Structure](#monorepo-structure)
-- [Packages](#packages)
-- [App Package (Mobile + Desktop)](#app-package)
-- [Backend Package](#backend-package)
-- [Platform Package](#platform-package)
-- [Hypercore Protocol Stack](#hypercore-protocol-stack)
-- [Build System](#build-system)
-- [Development Workflow](#development-workflow)
-- [Design System](#design-system)
-- [Troubleshooting](#troubleshooting)
-- [Helpful Links](#helpful-links)
-
----
-
-## Project Overview
-
-**PearTube** is a decentralized P2P video streaming platform that enables users to create channels, upload videos, and watch content in a serverless, censorship-resistant environment.
-
-**Key Technologies:**
-- **Pear Runtime** - Desktop app platform (Electron-based with Bare JS runtime)
-- **Hypercore Protocol** - P2P data replication and storage
-- **Expo + React Native** - Cross-platform mobile app
-- **React 19** - UI framework
-- **TypeScript** - Type-safe development
-
----
-
-## Monorepo Structure
+## Current Architecture
 
 ```
-peartube/
-├── packages/
-│   ├── app/              # Main app (Expo mobile + Pear desktop)
-│   ├── backend/          # P2P backend logic (Hypercore, Hyperdrive, etc.)
-│   ├── core/             # Shared UI components, hooks, types, stores
-│   ├── platform/         # Platform abstraction (RPC, detection, storage)
-│   └── spec/             # HRPC schema and generated code
-├── package.json          # Root scripts
-└── pnpm-workspace.yaml   # Workspace configuration
+Client shell
+  -> platform runner
+  -> @peartube/protocol
+  -> @peartube/host
+  -> @peartube/backend
+  -> Hypercore / Hyperdrive / Hyperbee / Hyperswarm
 ```
 
-### Package Dependencies
+The client shell is platform-specific. The backend logic is not.
+
+| Client | UI shell | Backend runner | RPC |
+| --- | --- | --- | --- |
+| iOS / Android | Expo + React Native | BareKit worklet | HRPC over BareKit IPC |
+| Electrobun desktop | Expo web export | desktop worker | HRPC over worker pipe |
+| `desktop-native` | SwiftUI macOS app | bare-native sidecar or embedded BareKit | HRPC over native bridge |
+
+## Monorepo Layout
 
 ```
-@peartube/app
-  └── @peartube/core
-      └── @peartube/platform
-          └── @peartube/spec
-  └── @peartube/backend (via bundle)
+packages/
+├── app/                # Expo app for mobile and Electrobun desktop
+├── backend/            # Universal P2P backend logic
+├── core/               # Shared app components, hooks, stores, and types
+├── desktop-native/     # Native macOS SwiftUI client
+├── host/               # Universal backend host lifecycle and protocol version
+├── platform/           # Platform runners and app-facing RPC facade
+├── protocol/           # Shared protocol client, event map, readiness handling
+├── spec/               # HRPC schema and code generation
+└── bare-*/             # Vendored/native Bare addons used by backend runtimes
 ```
 
----
+## Package Responsibilities
 
-## Packages
+`@peartube/backend` owns P2P behavior: storage layout, Corestore/Hyperdrive setup, Hyperbee metadata, Hyperswarm networking, public feed gossip, uploads, seeding, playback URLs, and diagnostics.
 
-### `@peartube/app` - Main Application
+`@peartube/host` owns backend lifecycle. It validates startup options, starts the backend runtime, reports host readiness/errors, and defines the shared `PROTOCOL_VERSION`.
 
-**Location:** `packages/app/`
+`@peartube/protocol` owns the universal client contract. It wraps generated HRPC, normalizes host readiness, surfaces protocol events, and exposes grouped namespaces such as `system`, `feed`, `video`, `transfer`, and `shell`.
 
-The unified app package that builds for both mobile (iOS/Android via Expo) and desktop (Pear Runtime).
+`@peartube/platform` owns app-side runner selection. Mobile uses the native runner, Electrobun uses the web runner, and both expose the same app-facing RPC facade.
 
-```
-packages/app/
-├── app/                        # Expo Router (file-based routing)
-│   ├── _layout.tsx             # Root layout + backend init
-│   └── (tabs)/                 # Tab navigation
-│       ├── index.tsx           # Home
-│       ├── subscriptions.tsx   # Subscriptions
-│       ├── studio.tsx          # Studio/Upload
-│       └── settings.tsx        # Settings
-├── backend/
-│   └── index.mjs               # P2P backend entry (bundled for mobile)
-├── components/
-│   ├── VideoPlayerOverlay.tsx  # Global video player overlay
-│   ├── video/                  # Video components
-│   ├── ui/                     # Gluestack UI components
-│   └── desktop/                # Desktop-specific components
-├── lib/
-│   ├── VideoPlayerContext.tsx  # Global video state
-│   ├── PlatformProvider.tsx    # Platform detection
-│   └── colors.ts               # Design tokens
-├── pear/                       # Built Pear desktop app
-├── pear-src/                   # Pear desktop source
-│   ├── package.json            # Pear app manifest
-│   ├── index.js                # Pear entry point
-│   ├── worker-client.js        # Worker IPC client
-│   └── workers/core/index.ts   # Pear backend worker
-├── Frameworks/                 # iOS XCFrameworks (native addons)
-├── backend.bundle.js           # Compiled Bare backend for mobile
-├── ios/                        # iOS native project
-├── android/                    # Android native project
-└── package.json
-```
+`@peartube/spec` is the schema source of truth. Update `packages/spec/schema.cjs`, then regenerate schema outputs before relying on new fields from JS or Swift.
 
-### `@peartube/backend` - P2P Backend
+`packages/desktop-native` is a native macOS client, not a second backend. Its Swift service uses generated HRPC types, validates the universal protocol version, and displays backend network diagnostics from `getSwarmStatus`.
 
-**Location:** `packages/backend/`
+## Important Files
 
-Core P2P logic shared between mobile and desktop.
+| File | Purpose |
+| --- | --- |
+| `packages/host/src/contracts.js` | Shared protocol version and host error codes |
+| `packages/host/src/start-host.js` | Universal host startup wrapper |
+| `packages/backend/src/runtime.js` | Backend runtime used by native/mobile hosts |
+| `packages/backend/src/api.js` | Backend API surface and swarm diagnostics |
+| `packages/protocol/src/create-client.js` | Universal protocol client |
+| `packages/protocol/src/event-map.js` | Shared protocol event names |
+| `packages/platform/src/rpc.shared.ts` | Common app-facing RPC bridge |
+| `packages/spec/schema.cjs` | HRPC schema source |
+| `packages/desktop-native/Sources/Services/HostBridgeService.swift` | Native macOS host bridge |
+| `packages/desktop-native/Bridge/native-rpc.mjs` | Compact native bridge codecs |
 
-```
-packages/backend/
-└── src/
-    ├── index.js            # Main exports
-    ├── orchestrator.js     # Backend orchestration
-    ├── storage.js          # Corestore/Hyperdrive management
-    ├── swarm.js            # Hyperswarm networking
-    ├── public-feed.js      # P2P discovery protocol
-    ├── video-stats.js      # Video streaming stats
-    ├── seeding.js          # Content seeding
-    ├── api.js              # RPC API handlers
-    ├── identity.js         # User identity management
-    └── upload.js           # Video upload handling
-```
+## Development Commands
 
-### `@peartube/platform` - Platform Abstraction
-
-**Location:** `packages/platform/`
-
-Abstracts platform differences between mobile (Bare Kit) and desktop (Pear).
-
-```
-packages/platform/
-└── src/
-    ├── index.js            # Main exports
-    ├── detection.js        # Platform detection
-    ├── storage.js          # Platform-specific storage
-    ├── rpc.native.ts       # Mobile RPC (Bare Kit IPC)
-    └── rpc.web.ts          # Desktop RPC (Pear worker pipe)
-```
-
-**Conditional Exports:**
-```json
-{
-  "./rpc": {
-    "react-native": "./src/rpc.native.ts",
-    "default": "./src/rpc.web.ts"
-  }
-}
-```
-
-### `@peartube/core` - Shared Core
-
-**Location:** `packages/core/`
-
-Shared UI components, hooks, types, and stores.
-
-```
-packages/core/
-└── src/
-    ├── components/         # Shared UI components
-    ├── hooks/              # Shared hooks
-    ├── types/              # TypeScript types
-    ├── utils/              # Utility functions
-    └── stores/             # State stores
-```
-
-### `@peartube/spec` - HRPC Schema
-
-**Location:** `packages/spec/`
-
-HRPC schema definitions and generated code for RPC communication.
-
-```
-packages/spec/
-├── schema.cjs              # Schema generator script
-└── spec/
-    ├── hrpc/
-    │   ├── index.js        # HRPC exports
-    │   └── messages.js     # Generated message types
-    └── schema/
-        ├── index.js        # Schema exports
-        └── schema.json     # JSON schema
-```
-
----
-
-## App Package
-
-### Key Scripts
+Root scripts:
 
 ```bash
-# Mobile Development
-npm start              # Start Metro dev server
-npm run ios            # Build + run on iOS simulator
-npm run android        # Build + run on Android
-npm run bundle:backend # Compile Bare backend for mobile
-
-# Desktop Development
-npm run pear:dev       # Build + run Pear desktop app
-npm run pear:build     # Full Pear build pipeline
-npm run pear:stage     # Stage for release
-npm run pear:release   # Release to Pear network
+npm run install:all
+npm run schema
+npm run typecheck
+npm test
 ```
 
-### Build Pipelines
-
-**Mobile Build:**
-```bash
-npm run bundle:backend  # bare-pack -> backend.bundle.js
-npm run ios             # expo run:ios
-```
-
-**Desktop Build (pear:build):**
-```bash
-npm run pear:export     # expo export --platform web
-npm run pear:merge      # Copy web assets to pear/
-npm run pear:copy       # Copy pear-src files
-npm run pear:install    # npm install in pear/
-npm run pear:worker     # Compile worker with SWC
-npm run pear:inject     # Inject Pear bar into HTML
-```
-
-### Platform-Specific Files
-
-Metro bundler resolves platform-specific extensions:
-- `Component.tsx` - Native iOS/Android
-- `Component.web.tsx` - Web/Desktop (Pear)
-- `Component.ios.tsx` - iOS only
-- `Component.android.tsx` - Android only
-
-**Important:** When debugging desktop issues, check for `.web.tsx` versions!
-
-### Pear Configuration
-
-**`pear-src/package.json`:**
-```json
-{
-  "pear": {
-    "name": "peartube",
-    "type": "desktop",
-    "pre": "pear-electron/pre",
-    "gui": {
-      "width": 1280,
-      "height": 800,
-      "backgroundColor": "#000000"
-    }
-  }
-}
-```
-
-### Worker Architecture
-
-**Desktop (Pear):**
-```
-React UI <-> Pipe (JSON) <-> Core Worker (pear-src/workers/core/index.ts)
-```
-
-**Mobile (Bare Kit):**
-```
-React Native <-> BareKit.IPC <-> Bare Worklet (backend/index.mjs)
-```
-
----
-
-## Backend Package
-
-### Architecture
-
-The backend orchestrates all P2P functionality:
-
-```typescript
-// Main initialization flow
-import { createOrchestrator } from '@peartube/backend/orchestrator'
-
-const backend = await createOrchestrator({
-  storagePath: '/path/to/storage',
-  onReady: (data) => { /* blob server port, etc */ },
-  onVideoStats: (stats) => { /* streaming progress */ },
-  onError: (err) => { /* handle errors */ }
-})
-```
-
-### Key Modules
-
-| Module | Purpose |
-|--------|---------|
-| `orchestrator.js` | Main backend lifecycle management |
-| `storage.js` | Corestore, Hyperdrive, Hyperbee setup |
-| `swarm.js` | Hyperswarm P2P networking |
-| `public-feed.js` | Channel discovery gossip protocol |
-| `video-stats.js` | Real-time streaming stats |
-| `seeding.js` | Background content seeding |
-| `api.js` | RPC request handlers |
-| `identity.js` | User keypair management |
-| `upload.js` | Video upload + transcoding |
-
----
-
-## Hypercore Protocol Stack
-
-| Package | Version | Purpose |
-|---------|---------|---------|
-| `hypercore` | ^10.37.0 | Append-only logs |
-| `hyperdrive` | ^13.0.0 | Distributed file storage (videos) |
-| `hyperbee` | ^2.26.0 | Key-value metadata database |
-| `hyperswarm` | ^4.15.0 | P2P networking and discovery |
-| `corestore` | ^7.7.0 | Storage management |
-| `hypercore-crypto` | ^3.6.0 | Ed25519 cryptography |
-| `hypercore-blob-server` | ^1.12.0 | Video streaming server |
-
-### Data Model
-
-**Per-Channel Hyperdrive:**
-```
-/videos/{id}.mp4          # Video file
-/videos/{id}.json         # Video metadata
-/thumbnails/{id}.jpg      # Thumbnail
-/channel.json             # Channel metadata
-```
-
-### P2P Discovery Protocol
-
-**Topic:** `peartube-public-feed-v1`
-
-**Flow:**
-1. Join hardcoded discovery topic via Hyperswarm
-2. On peer connect: Exchange known channel keys
-3. New channel: Gossip to all connected peers
-4. Peers re-gossip to their neighbors
-
----
-
-## Build System
-
-### Root Scripts
+Client scripts:
 
 ```bash
-npm run build           # Build all packages
-npm run dev             # Development mode
-npm run typecheck       # TypeScript validation
-npm run gen:schema      # Regenerate HRPC schema
-```
-
-### Package-Specific Scripts
-
-```bash
-# In packages/app
-npm run bundle:backend  # bare-pack for mobile
-npm run pear:dev        # Pear desktop dev
-
-# In packages/spec
-npm run gen:schema      # Generate HRPC messages
-```
-
----
-
-## Development Workflow
-
-### Initial Setup
-
-```bash
-git clone <repo>
-cd peartube
-npm install
-
-# Mobile (iOS)
-cd packages/app
-npm run bundle:backend
-npx pod-install
 npm run ios
-
-# Desktop (Pear)
-npm run pear:dev
+npm run android
+npm run desktop
+npm run desktop:build
+npm run desktop:native:build
+npm run desktop:native:test
 ```
 
-### Making Changes
+Schema workflow:
 
-**Frontend changes:** Hot reload works automatically
-
-**Backend changes:**
 ```bash
-# Mobile
-npm run bundle:backend
-npm run ios  # Rebuild required
-
-# Desktop
-npm run pear:dev  # Rebuilds worker automatically
+npm run schema:full
 ```
 
-**Schema changes:**
-```bash
-cd packages/spec
-npm run gen:schema
-```
+`schema:full` regenerates JS schema/HRPC output and copies generated Swift files into `packages/desktop-native/Sources/Support/`.
 
----
+## Architecture Rules
 
-## Design System
+- Treat `@peartube/backend` as the single backend implementation.
+- Add backend-facing capabilities to `packages/spec/schema.cjs` first, then expose them through `@peartube/protocol` and `@peartube/platform`.
+- Keep `@peartube/host` as the only place that defines the protocol version.
+- Native clients must reject unsupported protocol versions before applying backend data.
+- Network empty states should use structured swarm diagnostics, not generic “no content” copy.
+- Do not add platform-only backend behavior unless the limitation is truly runtime-specific.
 
-### Colors
+## Hypercore Stack
 
-```typescript
-const colors = {
-  primary: '#9147ff',      // Vibrant purple
-  bg: '#0e0e10',           // Almost black
-  bgHover: '#1f1f23',      // Card background
-  border: '#303035',       // Borders
-  text: '#efeff1',         // Primary text
-  textMuted: '#7a7a85',    // Secondary text
-}
-```
-
-### Video Player
-
-The video player uses a global overlay pattern:
-
-```
-RootLayout
-  └── VideoPlayerProvider (context)
-      └── App Content
-      └── VideoPlayerOverlay (fixed position, animated)
-```
-
-**Key States:**
-- `hidden` - No video playing
-- `mini` - Mini player at bottom
-- `fullscreen` - Full screen portrait
-- `landscape` - Landscape fullscreen (mobile only)
-
-**Important Notes:**
-- Uses VLC player on mobile for broad codec support
-- Animated with react-native-reanimated
-- Shared values (`isLandscapeFullscreenShared`) used for smooth transitions
-
----
+| Package | Purpose |
+| --- | --- |
+| `hypercore` | Append-only logs |
+| `hyperdrive` | Distributed video and asset storage |
+| `hyperbee` | Metadata database |
+| `hyperswarm` | P2P discovery and connections |
+| `corestore` | Core lifecycle and storage management |
+| `hypercore-crypto` | Ed25519 cryptography |
+| `hypercore-blob-server` | Local video streaming URLs |
 
 ## Troubleshooting
 
-### "Cannot find module"
+Protocol version mismatch:
+Check `packages/host/src/contracts.js`, the native bridge codecs, and generated Swift schema output. All clients should speak the same `PROTOCOL_VERSION`.
 
-**Cause:** Pear's DependencyStream failing to resolve paths
+Backend ready but feed empty:
+Call `getSwarmStatus`. Distinguish DHT bootstrap, zero swarm peers, missing feed channels, and zero feed entries before changing UI behavior.
 
-**Solutions:**
-1. Ensure relative paths in HTML (`./_expo/` not `/_expo/`)
-2. Remove `type="module"` from script tags
-3. Rebuild: `npm run pear:build`
+Native macOS bridge failures:
+Check `packages/desktop-native/Sources/Services/HostBridgeService.swift`, sidecar logs, and generated bridge bundles under `packages/desktop-native/Resources/Generated/`.
 
-### Worker not responding
+Schema drift:
+Update `packages/spec/schema.cjs`, run `npm run schema:full`, then run the focused protocol/spec tests.
 
-**Cause:** Worker crashed or initialization timeout
+## Storage
 
-**Debug:**
-1. Check worker console logs
-2. Verify worker path in `worker-client.js`
-3. Ensure `pear/build/workers/core/index.js` exists
-4. Ensure shared HRPC handlers are registered via `packages/backend/src/backend-entry.js`
+Desktop native data is stored under:
 
-### "No handler registered for command" on desktop
-
-**Cause:** Worker and backend handler wiring out of sync or stale build output.
-
-**Fix:**
-1. Rebuild desktop output: `npm run pear:build`
-2. Relaunch desktop app: `npm run pear:dev`
-3. Confirm logs show backend ready and feed API calls succeeding
-
-### Desktop changes not working
-
-**Cause:** Editing wrong file - `.web.tsx` version exists
-
-**Solution:**
-1. Check for `Component.web.tsx` files
-2. Desktop uses web export which loads `.web.tsx` via Metro
-
-### Pear HLS transcode crash (macOS)
-
-**Cause:** VideoToolbox hardware decode can corrupt memory in the local `bare-ffmpeg` fork when the HW→SW transfer format is invalid (common with 10-bit HEVC).
-
-**Solution:**
-1. Disable VideoToolbox decode: **Settings → Transcoding → VideoToolbox Decode (Pear)**
-2. Or set `PEARTUBE_ENABLE_VT_DECODE=0` to lock it off
-3. If enabling, pick the transfer format from `hwFramesCtx.getConstraints().validSwFormats` and transfer into a dedicated software frame before scaling.
-
----
-
-## Key Files Reference
-
-| File | Purpose |
-|------|---------|
-| `packages/app/app/_layout.tsx` | Root layout + backend init |
-| `packages/app/components/VideoPlayerOverlay.tsx` | Global video player |
-| `packages/app/lib/VideoPlayerContext.tsx` | Video player state |
-| `packages/app/pear-src/workers/core/index.ts` | Desktop P2P backend |
-| `packages/app/backend/index.mjs` | Mobile P2P backend entry |
-| `packages/backend/src/orchestrator.js` | Backend orchestration |
-| `packages/platform/src/rpc.native.ts` | Mobile RPC |
-| `packages/platform/src/rpc.web.ts` | Desktop RPC |
-| `packages/spec/spec/hrpc/messages.js` | Generated RPC messages |
-
----
-
-## Helpful Links
-
-### Pear Runtime & Documentation
-
-| Resource | URL |
-|----------|-----|
-| **Pear Runtime Docs** | https://docs.pears.com |
-| **Pear Runtime GitHub** | https://github.com/holepunchto/pear |
-
-### Bare Runtime
-
-| Resource | URL |
-|----------|-----|
-| **Bare Runtime** | https://github.com/holepunchto/bare |
-| **Bare Kit (React Native)** | https://github.com/holepunchto/bare-kit |
-| **Bare Pack (Bundler)** | https://github.com/holepunchto/bare-pack |
-
-### Hypercore Protocol
-
-| Resource | URL |
-|----------|-----|
-| **Hypercore** | https://github.com/holepunchto/hypercore |
-| **Hyperdrive** | https://github.com/holepunchto/hyperdrive |
-| **Hyperbee** | https://github.com/holepunchto/hyperbee |
-| **Hyperswarm** | https://github.com/holepunchto/hyperswarm |
-
-### Community
-
-| Resource | URL |
-|----------|-----|
-| **Holepunch Discord** | https://discord.gg/holepunch |
-
----
-
-## Architecture Diagram
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                         PearTube                                 │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                  │
-│  ┌──────────────────┐              ┌──────────────────┐         │
-│  │   Desktop App    │              │   Mobile App     │         │
-│  │  (Pear Runtime)  │              │ (Expo + Bare Kit)│         │
-│  └────────┬─────────┘              └────────┬─────────┘         │
-│           │                                  │                   │
-│           ▼                                  ▼                   │
-│  ┌──────────────────┐              ┌──────────────────┐         │
-│  │  @peartube/platform (rpc.web)   │  @peartube/platform (rpc.native)
-│  └────────┬─────────┘              └────────┬─────────┘         │
-│           │                                  │                   │
-│           └──────────────┬───────────────────┘                   │
-│                          ▼                                       │
-│           ┌──────────────────────────────┐                      │
-│           │       @peartube/backend      │                      │
-│           │  (orchestrator, storage,     │                      │
-│           │   swarm, api, upload, etc)   │                      │
-│           └──────────────┬───────────────┘                      │
-│                          ▼                                       │
-│           ┌──────────────────────────────┐                      │
-│           │     Hypercore Protocol       │                      │
-│           │  ┌─────────┐ ┌─────────────┐ │                      │
-│           │  │Hyperdrive│ │  Hyperbee  │ │                      │
-│           │  │ (Files)  │ │ (Metadata) │ │                      │
-│           │  └─────────┘ └─────────────┘ │                      │
-│           │  ┌─────────────────────────┐ │                      │
-│           │  │      Hyperswarm         │ │                      │
-│           │  │   (P2P Networking)      │ │                      │
-│           │  └─────────────────────────┘ │                      │
-│           └──────────────────────────────┘                      │
-│                          │                                       │
-│                          ▼                                       │
-│           ┌──────────────────────────────┐                      │
-│           │       Other Peers            │                      │
-│           │  (Discovery + Replication)   │                      │
-│           └──────────────────────────────┘                      │
-│                                                                  │
-└─────────────────────────────────────────────────────────────────┘
+```text
+~/Library/Application Support/PearTubeDesktopNative/
 ```
 
----
-
-*Last updated: February 2026*
+Other clients resolve their storage paths through `@peartube/platform` and the active runner.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ A decentralized P2P video streaming platform built on Hypercore Protocol. Runs o
 
 ## Architecture
 
+PearTube uses a **universal backend** for every client. The UI shells differ by
+platform, but they all talk through `@peartube/protocol` to `@peartube/host`,
+which boots the shared `@peartube/backend` P2P stack.
+
 ```
 packages/
 ├── app/                # Unified app (iOS, Android, Electrobun Desktop)
@@ -217,6 +221,8 @@ npm run lint:fix         # Fix linting issues
 | Native macOS (experimental) | SwiftUI | bare-native sidecar | HRPC over stdin/stdout |
 
 All platforms share:
+- The same universal backend host boundary (`@peartube/host`)
+- The same protocol client/event map (`@peartube/protocol`)
 - The same backend business logic (`@peartube/backend`)
 - The same HRPC schema (`@peartube/spec`)
 - The same Hypercore Protocol stack

--- a/package.json
+++ b/package.json
@@ -34,12 +34,12 @@
     "build:eas:android": "npm run build:eas:android --prefix packages/app",
     "build:eas:all": "npm run build:eas:all --prefix packages/app",
     "typecheck": "npm run typecheck --prefix packages/platform",
-    "test": "npm test --prefix packages/backend",
+    "test": "npm test --prefix packages/backend && npm test --prefix packages/host && npm test --prefix packages/protocol && npm test --prefix packages/spec",
     "test:watch": "npm run test:watch --prefix packages/backend",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx --quiet",
     "lint:changed": "node scripts/lint-changed.mjs",
     "lint:fix": "npm run lint -- --fix",
-    "install:all": "npm install && npm install --prefix packages/spec && npm install --prefix packages/backend && npm install --prefix packages/host && npm install --prefix packages/platform && npm install --prefix packages/app --legacy-peer-deps"
+    "install:all": "npm install && npm install --prefix packages/spec && npm install --prefix packages/backend && npm install --prefix packages/host && npm install --prefix packages/protocol && npm install --prefix packages/platform && npm install --prefix packages/app --legacy-peer-deps && npm install --prefix packages/desktop-native"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.41.0",

--- a/packages/app/backend/mobile-handlers.mjs
+++ b/packages/app/backend/mobile-handlers.mjs
@@ -163,6 +163,7 @@ export function attachMobileHandlers(B, deps) {
       peerPoolJoined: Boolean(s.peerPoolJoined),
       publicFeedDiscoveryJoined: Boolean(s.publicFeedDiscoveryJoined),
       feedTopicHex: s.feedTopicHex || null,
+      recommendedBoundary: s.recommendedBoundary || s.doctor?.recommendedBoundary || null,
     }
   }
 

--- a/packages/app/tests/universal-backend-architecture-regression.test.mjs
+++ b/packages/app/tests/universal-backend-architecture-regression.test.mjs
@@ -1,0 +1,68 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const appRoot = path.resolve(__dirname, '..')
+const workspaceRoot = path.resolve(appRoot, '..', '..')
+
+function readWorkspaceFile(relativePath) {
+  return fs.readFileSync(path.join(workspaceRoot, relativePath), 'utf8')
+}
+
+test('top-level developer docs describe the current universal backend architecture', () => {
+  const readme = readWorkspaceFile('README.md')
+  const agents = readWorkspaceFile('AGENTS.md')
+
+  for (const source of [readme, agents]) {
+    assert.match(source, /universal backend/i)
+    assert.match(source, /@peartube\/host/)
+    assert.match(source, /@peartube\/protocol/)
+    assert.match(source, /desktop-native/)
+    assert.match(source, /Electrobun/)
+    assert.doesNotMatch(source, /pear-src/)
+    assert.doesNotMatch(source, /pear:dev/)
+    assert.doesNotMatch(source, /Pear Runtime/)
+  }
+})
+
+test('root scripts cover universal backend packages and native desktop dependencies', () => {
+  const pkg = JSON.parse(readWorkspaceFile('package.json'))
+
+  assert.match(pkg.scripts.test, /packages\/host/)
+  assert.match(pkg.scripts.test, /packages\/protocol/)
+  assert.match(pkg.scripts.test, /packages\/spec/)
+  assert.match(pkg.scripts['install:all'], /packages\/protocol/)
+  assert.match(pkg.scripts['install:all'], /packages\/desktop-native/)
+})
+
+test('native desktop validates protocol version and exposes network-aware empty state copy', () => {
+  const hostBridge = readWorkspaceFile('packages/desktop-native/Sources/Services/HostBridgeService.swift')
+  const emptyState = readWorkspaceFile('packages/desktop-native/Sources/Views/SectionEmptyStateView.swift')
+
+  assert.match(hostBridge, /supportedProtocolVersion = 2/)
+  assert.match(hostBridge, /validateProtocolVersion/)
+  assert.match(hostBridge, /try Self\.validateProtocolVersion\(response\.protocolVersion\)/)
+  assert.match(hostBridge, /NativeNetworkStatus/)
+  assert.match(hostBridge, /refreshNetworkStatus/)
+  assert.match(emptyState, /networkEmptyDescription/)
+  assert.match(emptyState, /Connected to the DHT/)
+})
+
+test('shared protocol exposes network status for universal clients', () => {
+  const events = readWorkspaceFile('packages/protocol/src/event-map.js')
+  const protocol = readWorkspaceFile('packages/protocol/src/create-client.js')
+  const platformBridge = readWorkspaceFile('packages/platform/src/rpc.shared.ts')
+  const backendRuntime = readWorkspaceFile('packages/backend/src/runtime.js')
+  const schema = readWorkspaceFile('packages/spec/schema.cjs')
+
+  assert.match(events, /NETWORK_STATUS: 'network.status'/)
+  assert.match(protocol, /PROTOCOL_EVENTS\.NETWORK_STATUS/)
+  assert.match(platformBridge, /networkStatus/)
+  assert.match(backendRuntime, /swarmListenResolved/)
+  assert.match(schema, /swarmListenResolved/)
+  assert.match(schema, /feedEntries/)
+})

--- a/packages/app/workers/desktop/index.ts
+++ b/packages/app/workers/desktop/index.ts
@@ -607,6 +607,7 @@ B.getSwarmStatus = async () => {
     peerPoolJoined: Boolean(s.peerPoolJoined),
     publicFeedDiscoveryJoined: Boolean(s.publicFeedDiscoveryJoined),
     feedTopicHex: s.feedTopicHex || null,
+    recommendedBoundary: s.recommendedBoundary || s.doctor?.recommendedBoundary || null,
   }
 }
 B.getBlobServerPort = async () => ({ port: getBlobPort() })

--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -2704,6 +2704,7 @@ export function createApi({
         network: networkDebug,
         startupTiming,
         doctor,
+        recommendedBoundary: doctor.recommendedBoundary,
         swarmOffline: Boolean(ctx.swarm?._peartubeOffline),
         swarmOfflineReason: ctx.swarm?._peartubeOfflineReason || null,
         swarmListenResolved: Boolean(ctx.swarm?._peartubeListenResolved),

--- a/packages/backend/src/runtime.js
+++ b/packages/backend/src/runtime.js
@@ -90,11 +90,24 @@ export function buildSharedSystemHandlers(backend) {
     },
     async GetSwarmStatus() {
       const swarmStatus = backend?.api?.getSwarmStatus?.() || {}
-      const peerCount = swarmStatus.peerCount ?? swarmStatus.swarmConnections ?? 0
+      const swarmConnections = swarmStatus.swarmConnections ?? 0
+      const peerCount = swarmStatus.peerCount ?? swarmConnections
 
       return {
-        connected: peerCount > 0,
-        peerCount
+        connected: (swarmConnections || peerCount) > 0,
+        peerCount,
+        swarmConnections,
+        swarmPeers: swarmStatus.swarmPeers ?? 0,
+        feedConnections: swarmStatus.feedConnections ?? 0,
+        feedEntries: swarmStatus.feedEntries ?? 0,
+        channelsLoaded: swarmStatus.channelsLoaded ?? 0,
+        swarmOffline: Boolean(swarmStatus.swarmOffline),
+        swarmOfflineReason: swarmStatus.swarmOfflineReason ?? null,
+        swarmListenResolved: Boolean(swarmStatus.swarmListenResolved),
+        peerPoolJoined: Boolean(swarmStatus.peerPoolJoined),
+        publicFeedDiscoveryJoined: Boolean(swarmStatus.publicFeedDiscoveryJoined),
+        feedTopicHex: swarmStatus.feedTopicHex ?? null,
+        recommendedBoundary: swarmStatus.recommendedBoundary ?? swarmStatus.doctor?.recommendedBoundary ?? null
       }
     }
   }

--- a/packages/desktop-native/Bridge/native-rpc.mjs
+++ b/packages/desktop-native/Bridge/native-rpc.mjs
@@ -1,5 +1,7 @@
 import c from 'compact-encoding'
 
+export const NATIVE_BRIDGE_PROTOCOL_VERSION = 2
+
 export const BRIDGE_COMMANDS = Object.freeze({
   bootstrap: 1,
   refreshBrowse: 2,
@@ -47,6 +49,7 @@ export const BRIDGE_EVENTS = Object.freeze({
   workletReady: 4,
   feedUpdated: 5,
   uploadProgress: 6,
+  networkStatus: 7,
 })
 
 class IgnoredRPCFrameError extends Error {}
@@ -192,7 +195,7 @@ export const browseSnapshotCodec = objectCodec([
 
 export const bootstrapResponseCodec = objectCodec([
   field('blobServerPort', optionalUIntCodec, null),
-  field('protocolVersion', c.uint, 1),
+  field('protocolVersion', c.uint, NATIVE_BRIDGE_PROTOCOL_VERSION),
   field('storagePath', c.string),
   field('snapshot', browseSnapshotCodec),
 ])
@@ -450,6 +453,17 @@ export const uploadProgressEventCodec = objectCodec([
   field('totalBytes', optionalUIntCodec, null),
   field('speed', optionalUIntCodec, null),
   field('eta', optionalUIntCodec, null),
+])
+
+export const networkStatusEventCodec = objectCodec([
+  field('bootstrapped', c.bool, false),
+  field('firewalled', c.bool, false),
+  field('peerCount', c.uint, 0),
+  field('connectionCount', c.uint, 0),
+  field('feedPeerCount', c.uint, 0),
+  field('feedEntries', c.uint, 0),
+  field('offline', c.bool, false),
+  field('offlineReason', optionalStringCodec, null),
 ])
 
 export const mpvAvailableResponseCodec = objectCodec([

--- a/packages/desktop-native/Bridge/native-rpc.test.mjs
+++ b/packages/desktop-native/Bridge/native-rpc.test.mjs
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict'
 import {
   BRIDGE_COMMANDS,
   BRIDGE_EVENTS,
+  NATIVE_BRIDGE_PROTOCOL_VERSION,
   bootstrapResponseCodec,
   createRPCFrameParser,
   decodeFrame,
@@ -22,6 +23,7 @@ import {
   mpvCreateResponseCodec,
   encodeResponseFrame,
   hostReadyEventCodec,
+  networkStatusEventCodec,
   searchRequestCodec,
   searchResponseCodec,
   setVideoThumbnailFromFileRequestCodec,
@@ -93,6 +95,29 @@ test('bootstrap payload roundtrips through compact encoding', () => {
   assert.deepEqual(decoded.snapshot.state, snapshot.state)
 })
 
+test('bootstrap response defaults to the current native bridge protocol version', () => {
+  const encoded = encodePayload(bootstrapResponseCodec, {
+    storagePath: '/tmp/native',
+    snapshot: {
+      generatedAt: 1234,
+      sections: { home: [], subscriptions: [], library: [], studio: [], diagnostics: [] },
+      stats: { homeCount: 0, subscriptionCount: 0, libraryCount: 0, channelCount: 0 },
+      state: {
+        subscriptionChannelKeys: [],
+        identityChannelKeys: [],
+        activeIdentityName: null,
+        activeIdentityChannelKey: null,
+        activeChannelPublished: false,
+      },
+    },
+  })
+
+  const decoded = decodePayload(bootstrapResponseCodec, encoded)
+
+  assert.equal(NATIVE_BRIDGE_PROTOCOL_VERSION, 2)
+  assert.equal(decoded.protocolVersion, NATIVE_BRIDGE_PROTOCOL_VERSION)
+})
+
 test('rpc frame parser assembles chunked request frames', () => {
   const parser = createRPCFrameParser()
   const request = encodeRequestFrame({
@@ -155,6 +180,40 @@ test('feed update events roundtrip through compact encoding', () => {
     {
       channelKey: 'feed',
       action: 'update',
+    }
+  )
+})
+
+test('network status events roundtrip through compact encoding', () => {
+  const eventFrame = encodeEventFrame({
+    command: BRIDGE_EVENTS.networkStatus,
+    data: encodePayload(networkStatusEventCodec, {
+      bootstrapped: true,
+      firewalled: false,
+      peerCount: 2,
+      connectionCount: 1,
+      feedPeerCount: 1,
+      feedEntries: 3,
+      offline: false,
+      offlineReason: null,
+    }),
+  })
+
+  const eventMessage = decodeFrame(eventFrame)
+
+  assert.equal(eventMessage.kind, 'event')
+  assert.equal(eventMessage.command, BRIDGE_EVENTS.networkStatus)
+  assert.deepEqual(
+    decodePayload(networkStatusEventCodec, eventMessage.data),
+    {
+      bootstrapped: true,
+      firewalled: false,
+      peerCount: 2,
+      connectionCount: 1,
+      feedPeerCount: 1,
+      feedEntries: 3,
+      offline: false,
+      offlineReason: null,
     }
   )
 })

--- a/packages/desktop-native/Sources/Services/HostBridgeService.swift
+++ b/packages/desktop-native/Sources/Services/HostBridgeService.swift
@@ -9,6 +9,7 @@ import Observation
 @MainActor
 @Observable
 final class HostBridgeService {
+  private static let supportedProtocolVersion = 2
   private static let supportedVideoUploadFileExtensions: Set<String> = [
     "mp4", "mov", "m4v", "mkv", "webm"
   ]
@@ -66,6 +67,7 @@ final class HostBridgeService {
   private(set) var mpvAvailable = false
   private(set) var ffmpegDecodeAvailable = false
   private(set) var ffmpegDecodeAvailabilityError: String?
+  private(set) var networkStatus: NativeNetworkStatus?
 
   @ObservationIgnored private var hostSession: (any NativeHostSession)?
   @ObservationIgnored private var hrpc: HRPC?
@@ -97,6 +99,55 @@ final class HostBridgeService {
     let url: URL
     let playerId: String?
     let frameServerPort: Int?
+  }
+
+  struct NativeNetworkStatus: Equatable {
+    let connected: Bool
+    let peerCount: Int
+    let swarmConnections: Int
+    let swarmPeers: Int
+    let feedConnections: Int
+    let feedEntries: Int
+    let channelsLoaded: Int
+    let swarmOffline: Bool
+    let swarmOfflineReason: String?
+    let swarmListenResolved: Bool
+    let peerPoolJoined: Bool
+    let publicFeedDiscoveryJoined: Bool
+    let feedTopicHex: String?
+    let recommendedBoundary: String?
+
+    init(schema: GetSwarmStatusResponse) {
+      let resolvedSwarmConnections = Self.intValue(schema.swarmConnections)
+      connected = schema.connected
+      peerCount = Self.intValue(schema.peerCount, defaultValue: resolvedSwarmConnections)
+      swarmConnections = resolvedSwarmConnections
+      swarmPeers = Self.intValue(schema.swarmPeers)
+      feedConnections = Self.intValue(schema.feedConnections)
+      feedEntries = Self.intValue(schema.feedEntries)
+      channelsLoaded = Self.intValue(schema.channelsLoaded)
+      swarmOffline = schema.swarmOffline
+      swarmOfflineReason = schema.swarmOfflineReason
+      swarmListenResolved = schema.swarmListenResolved
+      peerPoolJoined = schema.peerPoolJoined
+      publicFeedDiscoveryJoined = schema.publicFeedDiscoveryJoined
+      feedTopicHex = schema.feedTopicHex
+      recommendedBoundary = schema.recommendedBoundary
+    }
+
+    var diagnosticSummary: String {
+      if swarmOffline {
+        return "Network status: offline (\(swarmOfflineReason ?? "unknown reason"))."
+      }
+      if !swarmListenResolved {
+        return "Network status: DHT bootstrap still pending."
+      }
+      return "Network status: peers=\(peerCount), swarmConnections=\(swarmConnections), feedConnections=\(feedConnections), feedEntries=\(feedEntries)."
+    }
+
+    private static func intValue(_ value: UInt?, defaultValue: Int = 0) -> Int {
+      value.map(Int.init) ?? defaultValue
+    }
   }
 
   var isReady: Bool {
@@ -205,10 +256,12 @@ final class HostBridgeService {
         )
       }
 
+      try Self.validateProtocolVersion(response.protocolVersion)
       appendLog("Bootstrap snapshot received from shared host.")
       let blobPort = response.blobServerPort.flatMap { $0 > 0 ? Int($0) : nil }
       phase = .ready(blobServerPort: blobPort)
       lastHeartbeat = Date()
+      _ = await refreshNetworkStatus()
       let responseSnapshot = NativeBrowseSnapshot(schema: response.snapshot)
       let displaySnapshot = Self.preferredBrowseSnapshot(
         liveSnapshot: responseSnapshot,
@@ -344,6 +397,7 @@ final class HostBridgeService {
       let response = try await gatedRPC { hrpc in
         try await hrpc.desktopRefreshBrowse(DesktopRefreshBrowseRequest())
       }
+      _ = await refreshNetworkStatus()
       let liveSnapshot = NativeBrowseSnapshot(schema: response.snapshot)
       let snapshot = Self.preferredBrowseSnapshot(
         liveSnapshot: liveSnapshot,
@@ -364,6 +418,25 @@ final class HostBridgeService {
     }
 
     appState.setLoading(false)
+  }
+
+  @discardableResult
+  func refreshNetworkStatus() async -> NativeNetworkStatus? {
+    guard hrpc != nil else { return networkStatus }
+
+    do {
+      let response = try await gatedRPC { hrpc in
+        try await hrpc.getSwarmStatus(GetSwarmStatusRequest())
+      }
+      let status = NativeNetworkStatus(schema: response)
+      networkStatus = status
+      lastHeartbeat = Date()
+      appendLog(status.diagnosticSummary)
+      return status
+    } catch {
+      appendLog("Network status refresh failed: \(error.localizedDescription)")
+      return networkStatus
+    }
   }
 
   func searchVideos(query: String, into appState: AppState, topK: Int = 12) async {
@@ -1780,6 +1853,7 @@ final class HostBridgeService {
     forceAVPlayerFallback = false
     activeMpvPlayerID = nil
     activeMpvFrameServerPort = nil
+    networkStatus = nil
   }
 
   private func makeHRPC(
@@ -2007,6 +2081,7 @@ final class HostBridgeService {
     hrpc = nil
     hrpcDelegate = nil
     stopPlaybackStatsPolling()
+    networkStatus = nil
 
     if case .booting = phase {
       phase = .failed(disconnectError.localizedDescription)
@@ -2062,6 +2137,16 @@ final class HostBridgeService {
   private func gatedRPC<T>(_ body: (HRPC) async throws -> T) async throws -> T {
     let hrpc = try await ensureHRPC()
     return try await body(hrpc)
+  }
+
+  private static func validateProtocolVersion(_ version: UInt?) throws {
+    let actual = version.map(Int.init)
+    guard actual == supportedProtocolVersion else {
+      throw HostBridgeError.protocolVersionMismatch(
+        expected: supportedProtocolVersion,
+        actual: actual
+      )
+    }
   }
 
   /// Performs any HRPC call, then refreshes the browse snapshot afterward.
@@ -3038,6 +3123,7 @@ private enum HostBridgeError: LocalizedError {
   case bridgeInputUnavailable
   case bridgeResponse(String)
   case bridgeDisconnected
+  case protocolVersionMismatch(expected: Int, actual: Int?)
 
   var errorDescription: String? {
     switch self {
@@ -3051,6 +3137,9 @@ private enum HostBridgeError: LocalizedError {
       return message
     case .bridgeDisconnected:
       return "Native host bridge disconnected."
+    case .protocolVersionMismatch(let expected, let actual):
+      let actualDescription = actual.map(String.init) ?? "missing"
+      return "Native host protocol version mismatch. Expected \(expected), received \(actualDescription)."
     }
   }
 }

--- a/packages/desktop-native/Sources/Views/SectionEmptyStateView.swift
+++ b/packages/desktop-native/Sources/Views/SectionEmptyStateView.swift
@@ -67,6 +67,9 @@ struct SectionEmptyStateView: View {
       if !appState.activeChannelPublished {
         return "Your channel exists locally. Publish it to the public feed or upload your first video."
       }
+      if let description = networkEmptyDescription {
+        return description
+      }
       return "The native shell is ready. Refresh the feed or upload your first video."
     case .subscriptions:
       return "Subscribed channels will appear here after you follow creators from Home or Search."
@@ -79,8 +82,37 @@ struct SectionEmptyStateView: View {
         ? "Use the native Studio flow to upload and publish your channel."
         : "Create a channel to unlock native upload and publishing controls."
     case .diagnostics:
-      return "Inspect host logs and connection health while the embedded Bare host runs."
+      return "Inspect host logs and connection health while the universal backend host runs."
     }
+  }
+
+  private var networkEmptyDescription: String? {
+    guard section == .home, let status = hostBridge.networkStatus else {
+      return nil
+    }
+
+    if status.swarmOffline {
+      let reason = status.swarmOfflineReason ?? "the backend reported networking is unavailable"
+      return "P2P networking is offline: \(reason)."
+    }
+
+    if !status.swarmListenResolved {
+      return "Connecting to the DHT. Public feed entries will appear after the backend joins the discovery network."
+    }
+
+    if status.peerCount == 0 && status.swarmConnections == 0 {
+      return "Connected to the DHT, but no PearTube peers are reachable yet."
+    }
+
+    if status.feedConnections == 0 {
+      return "Connected to the DHT, but no PearTube feed channels have opened yet."
+    }
+
+    if status.feedEntries == 0 {
+      return "Connected to the DHT and feed peers, but no public feed entries have arrived yet."
+    }
+
+    return nil
   }
 
   @ViewBuilder

--- a/packages/platform/src/rpc.native.ts
+++ b/packages/platform/src/rpc.native.ts
@@ -44,6 +44,7 @@ declare const HRPC: new (stream: any) => {
   subscribeChannel(req: { channelKey: string }): Promise<any>;
   joinChannel(req: { channelKey: string }): Promise<any>;
   getSubscriptions(req: {}): Promise<any>;
+  getCanonicalFeed(req: {}): Promise<any>;
   getPublicFeed(req: {}): Promise<any>;
   refreshFeed(req: {}): Promise<any>;
   submitToFeed(req: {}): Promise<any>;
@@ -996,6 +997,10 @@ export const rpc = {
   },
 
   // Public Feed
+  async getCanonicalFeed() {
+    return ensureRPC().getCanonicalFeed({});
+  },
+
   async getPublicFeed() {
     return ensureRPC().getPublicFeed({});
   },
@@ -1110,6 +1115,10 @@ export const rpc = {
   },
 
   async getSwarmStatus() {
+    const client = mainBridge.getClient() as any;
+    if (typeof client?.system?.getSwarmStatus === 'function') {
+      return client.system.getSwarmStatus({});
+    }
     return ensureRPC().getSwarmStatus({});
   },
 

--- a/packages/platform/src/rpc.shared.ts
+++ b/packages/platform/src/rpc.shared.ts
@@ -16,6 +16,23 @@ export type HostErrorData = {
   retryable: boolean
 }
 
+export type NetworkStatusData = {
+  connected?: boolean
+  peerCount?: number
+  swarmConnections?: number
+  swarmPeers?: number
+  feedConnections?: number
+  feedEntries?: number
+  channelsLoaded?: number
+  swarmOffline?: boolean
+  swarmOfflineReason?: string | null
+  swarmListenResolved?: boolean
+  peerPoolJoined?: boolean
+  publicFeedDiscoveryJoined?: boolean
+  feedTopicHex?: string | null
+  recommendedBoundary?: string | null
+}
+
 export type PlatformLifecycleEvent =
   | { type: 'host.ready'; data: HostReadyData }
   | ({ type: 'host.error' } & HostErrorData)
@@ -63,6 +80,9 @@ export type ProtocolClientLike = {
     on(event: string, listener: (payload: any) => void): () => void
   }
   ready(): Promise<HostReadyData>
+  system?: {
+    getSwarmStatus?(request?: any): Promise<NetworkStatusData>
+  }
 }
 
 type ReadyCallback = (data: HostReadyData) => void
@@ -71,6 +91,7 @@ type VideoStatsCallback = (data: any) => void
 type UploadProgressCallback = (data: any) => void
 type DownloadProgressCallback = (data: any) => void
 type FeedUpdateCallback = (data: any) => void
+type NetworkStatusCallback = (data: NetworkStatusData) => void
 type CastDeviceFoundCallback = (data: any) => void
 type CastDeviceLostCallback = (data: any) => void
 type CastPlaybackStateCallback = (data: any) => void
@@ -85,6 +106,7 @@ type PlatformCallbacks = {
   uploadProgress: UploadProgressCallback[]
   downloadProgress: DownloadProgressCallback[]
   feedUpdate: FeedUpdateCallback[]
+  networkStatus: NetworkStatusCallback[]
   castDeviceFound: CastDeviceFoundCallback[]
   castDeviceLost: CastDeviceLostCallback[]
   castPlaybackState: CastPlaybackStateCallback[]
@@ -114,6 +136,7 @@ function createCallbackStore(): PlatformCallbacks {
     uploadProgress: [],
     downloadProgress: [],
     feedUpdate: [],
+    networkStatus: [],
     castDeviceFound: [],
     castDeviceLost: [],
     castPlaybackState: [],
@@ -179,6 +202,7 @@ export function createPlatformRpcBridge(options: PlatformRpcBridgeOptions) {
       nextClient.events.on(PROTOCOL_EVENTS.LOG, (data: any) => safeDispatch(callbacks.log, data)),
       nextClient.events.on(PROTOCOL_EVENTS.DOWNLOAD_PROGRESS, (data: any) => safeDispatch(callbacks.downloadProgress, data)),
       nextClient.events.on(PROTOCOL_EVENTS.FEED_UPDATED, (data: any) => safeDispatch(callbacks.feedUpdate, data)),
+      nextClient.events.on(PROTOCOL_EVENTS.NETWORK_STATUS, (data: any) => safeDispatch(callbacks.networkStatus, data)),
       nextClient.events.on(PROTOCOL_EVENTS.VIDEO_STATS, (data: any) => safeDispatch(callbacks.videoStats, data)),
       nextClient.events.on(PROTOCOL_EVENTS.CAST_DEVICE_FOUND, (data: any) => safeDispatch(callbacks.castDeviceFound, data)),
       nextClient.events.on(PROTOCOL_EVENTS.CAST_DEVICE_LOST, (data: any) => safeDispatch(callbacks.castDeviceLost, data)),
@@ -244,6 +268,10 @@ export function createPlatformRpcBridge(options: PlatformRpcBridgeOptions) {
       onFeedUpdate(callback: FeedUpdateCallback) {
         callbacks.feedUpdate.push(callback)
         return () => removeCallback(callbacks.feedUpdate, callback)
+      },
+      onNetworkStatus(callback: NetworkStatusCallback) {
+        callbacks.networkStatus.push(callback)
+        return () => removeCallback(callbacks.networkStatus, callback)
       },
       onCastDeviceFound(callback: CastDeviceFoundCallback) {
         callbacks.castDeviceFound.push(callback)

--- a/packages/platform/src/rpc.web.ts
+++ b/packages/platform/src/rpc.web.ts
@@ -482,6 +482,10 @@ export const rpc = {
   },
 
   async getSwarmStatus() {
+    const client = mainBridge.getClient() as any;
+    if (typeof client?.system?.getSwarmStatus === 'function') {
+      return client.system.getSwarmStatus({});
+    }
     return ensureRPC().getSwarmStatus({});
   },
 

--- a/packages/protocol/src/create-client.js
+++ b/packages/protocol/src/create-client.js
@@ -35,6 +35,7 @@ const NAMESPACE_METHODS = Object.freeze({
     verifyAttestation: 'verifyAttestation'
   },
   feed: {
+    getCanonicalFeed: 'getCanonicalFeed',
     getPublicFeed: 'getPublicFeed',
     refreshFeed: 'refreshFeed',
     submitToFeed: 'submitToFeed',
@@ -171,6 +172,28 @@ function normalizeHostErrorPayload(payload) {
   )
 }
 
+function normalizeNetworkStatusPayload(payload = {}) {
+  const swarmConnections = payload?.swarmConnections ?? payload?.peerCount ?? 0
+  const peerCount = payload?.peerCount ?? swarmConnections
+
+  return {
+    connected: Boolean(payload?.connected ?? (swarmConnections > 0 || peerCount > 0)),
+    peerCount,
+    swarmConnections,
+    swarmPeers: payload?.swarmPeers ?? 0,
+    feedConnections: payload?.feedConnections ?? 0,
+    feedEntries: payload?.feedEntries ?? 0,
+    channelsLoaded: payload?.channelsLoaded ?? 0,
+    swarmOffline: Boolean(payload?.swarmOffline),
+    swarmOfflineReason: payload?.swarmOfflineReason ?? null,
+    swarmListenResolved: Boolean(payload?.swarmListenResolved),
+    peerPoolJoined: Boolean(payload?.peerPoolJoined),
+    publicFeedDiscoveryJoined: Boolean(payload?.publicFeedDiscoveryJoined),
+    feedTopicHex: payload?.feedTopicHex ?? null,
+    recommendedBoundary: payload?.recommendedBoundary ?? null
+  }
+}
+
 function createTransportClosedError(reason) {
   const suffix = reason ? `: ${reason}` : ''
   return createHostError(
@@ -197,6 +220,14 @@ function createMethodCaller(rpc, ready, methodName) {
     } catch (error) {
       throw normalizeProtocolError(error)
     }
+  }
+}
+
+function createNetworkStatusCaller(rpc, ready) {
+  return async (request = {}) => {
+    const response = await createMethodCaller(rpc, ready, 'getSwarmStatus')(request)
+    const status = normalizeNetworkStatusPayload(response)
+    return status
   }
 }
 
@@ -361,6 +392,12 @@ export function createProtocolClient({ stream, HRPCImpl } = {}) {
     return readyPromise
   }
 
+  const getNetworkStatus = async (request = {}) => {
+    const status = await createNetworkStatusCaller(rpc, ready)(request)
+    events.emit(PROTOCOL_EVENTS.NETWORK_STATUS, status)
+    return status
+  }
+
   return {
     stream,
     rpc,
@@ -371,7 +408,7 @@ export function createProtocolClient({ stream, HRPCImpl } = {}) {
     },
     system: {
       getStatus: createMethodCaller(rpc, ready, 'getStatus'),
-      getSwarmStatus: createMethodCaller(rpc, ready, 'getSwarmStatus'),
+      getSwarmStatus: getNetworkStatus,
       getBlobServerPort: createMethodCaller(rpc, ready, 'getBlobServerPort')
     },
     identity: createNamespace(rpc, ready, NAMESPACE_METHODS.identity),

--- a/packages/protocol/src/event-map.d.ts
+++ b/packages/protocol/src/event-map.d.ts
@@ -5,6 +5,7 @@ export const PROTOCOL_EVENTS: {
   readonly UPLOAD_PROGRESS: 'upload.progress'
   readonly DOWNLOAD_PROGRESS: 'download.progress'
   readonly FEED_UPDATED: 'feed.updated'
+  readonly NETWORK_STATUS: 'network.status'
   readonly VIDEO_STATS: 'video.stats'
   readonly CAST_DEVICE_FOUND: 'cast.deviceFound'
   readonly CAST_DEVICE_LOST: 'cast.deviceLost'

--- a/packages/protocol/src/event-map.js
+++ b/packages/protocol/src/event-map.js
@@ -5,6 +5,7 @@ export const PROTOCOL_EVENTS = Object.freeze({
   UPLOAD_PROGRESS: 'upload.progress',
   DOWNLOAD_PROGRESS: 'download.progress',
   FEED_UPDATED: 'feed.updated',
+  NETWORK_STATUS: 'network.status',
   VIDEO_STATS: 'video.stats',
   CAST_DEVICE_FOUND: 'cast.deviceFound',
   CAST_DEVICE_LOST: 'cast.deviceLost',

--- a/packages/protocol/src/index.d.ts
+++ b/packages/protocol/src/index.d.ts
@@ -3,6 +3,23 @@ export type ProtocolReadyData = {
   protocolVersion: 2
 }
 
+export type ProtocolNetworkStatus = {
+  connected: boolean
+  peerCount: number
+  swarmConnections: number
+  swarmPeers: number
+  feedConnections: number
+  feedEntries: number
+  channelsLoaded: number
+  swarmOffline: boolean
+  swarmOfflineReason: string | null
+  swarmListenResolved: boolean
+  peerPoolJoined: boolean
+  publicFeedDiscoveryJoined: boolean
+  feedTopicHex: string | null
+  recommendedBoundary: string | null
+}
+
 export const PROTOCOL_VERSION: 2
 
 export const HOST_ERROR_CODES: {
@@ -25,6 +42,7 @@ export const PROTOCOL_EVENTS: {
   readonly UPLOAD_PROGRESS: 'upload.progress'
   readonly DOWNLOAD_PROGRESS: 'download.progress'
   readonly FEED_UPDATED: 'feed.updated'
+  readonly NETWORK_STATUS: 'network.status'
   readonly VIDEO_STATS: 'video.stats'
   readonly CAST_DEVICE_FOUND: 'cast.deviceFound'
   readonly CAST_DEVICE_LOST: 'cast.deviceLost'

--- a/packages/protocol/test/create-client.test.mjs
+++ b/packages/protocol/test/create-client.test.mjs
@@ -33,6 +33,24 @@ class FakeHRPC {
   onEventError(handler) {
     this.handlers.error = handler
   }
+
+  getSwarmStatus() {
+    return Promise.resolve({
+      connected: true,
+      peerCount: 3,
+      swarmConnections: 3,
+      swarmPeers: 4,
+      feedConnections: 2,
+      feedEntries: 8,
+      channelsLoaded: 5,
+      swarmOffline: false,
+      swarmListenResolved: true,
+      peerPoolJoined: true,
+      publicFeedDiscoveryJoined: true,
+      feedTopicHex: 'feed-topic',
+      recommendedBoundary: 'content-playback-or-ui'
+    })
+  }
 }
 
 test('createProtocolClient remaps feed update events', async (t) => {
@@ -134,6 +152,40 @@ test('createProtocolClient forwards log events through the shared event map', as
   FakeHRPC.instances[0].handlers.log({ level: 'info', message: 'backend ready' })
 
   t.alike(logEvents, [{ level: 'info', message: 'backend ready' }])
+})
+
+test('createProtocolClient emits normalized network status from the system namespace', async (t) => {
+  FakeHRPC.instances.length = 0
+  const networkEvents = []
+
+  const client = createProtocolClient({
+    stream: {},
+    HRPCImpl: FakeHRPC
+  })
+
+  client.events.on(PROTOCOL_EVENTS.NETWORK_STATUS, (payload) => {
+    networkEvents.push(payload)
+  })
+
+  const status = await client.system.getSwarmStatus()
+
+  t.alike(status, {
+    connected: true,
+    peerCount: 3,
+    swarmConnections: 3,
+    swarmPeers: 4,
+    feedConnections: 2,
+    feedEntries: 8,
+    channelsLoaded: 5,
+    swarmOffline: false,
+    swarmOfflineReason: null,
+    swarmListenResolved: true,
+    peerPoolJoined: true,
+    publicFeedDiscoveryJoined: true,
+    feedTopicHex: 'feed-topic',
+    recommendedBoundary: 'content-playback-or-ui'
+  })
+  t.alike(networkEvents, [status])
 })
 
 test('createProtocolClient fails fast on protocol version mismatch', async (t) => {

--- a/packages/spec/lib/app-rpc-adapter-codegen.cjs
+++ b/packages/spec/lib/app-rpc-adapter-codegen.cjs
@@ -23,6 +23,7 @@ const APP_RPC_NAMESPACES = Object.freeze({
     'verify-attestation'
   ],
   feed: [
+    'get-canonical-feed',
     'get-public-feed',
     'refresh-feed',
     'submit-to-feed',

--- a/packages/spec/schema.cjs
+++ b/packages/spec/schema.cjs
@@ -492,6 +492,12 @@ ns.register({
     { name: 'thumbnailBlobsCoreKey', type: 'string', required: false },
     { name: 'thumbnailMimeType', type: 'string', required: false },
     { name: 'availability', type: 'string', required: false },
+    { name: 'description', type: 'string', required: false },
+    { name: 'thumbnailUrl', type: 'string', required: false },
+    { name: 'byteAvailability', type: 'string', required: false },
+    { name: 'channelKey', type: 'string', required: false },
+    { name: 'driveKey', type: 'string', required: false },
+    { name: 'publicBeeKey', type: 'string', required: false },
   ]
 })
 
@@ -506,7 +512,11 @@ ns.register({
     { name: 'lastSeen', type: 'uint', required: false },
     { name: 'source', type: 'string', required: false },
     { name: 'manifestUpdatedAt', type: 'uint', required: false },
-    { name: 'previewVideos', type: '@peartube/feed-entry-preview-video', array: true }
+    { name: 'previewVideos', type: '@peartube/feed-entry-preview-video', array: true },
+    { name: 'driveKey', type: 'string', required: false },
+    { name: 'relayRole', type: 'string', required: false },
+    { name: 'relayServing', type: 'bool', required: false },
+    { name: 'previewVideosHash', type: 'string', required: false }
   ]
 })
 
@@ -521,6 +531,24 @@ ns.register({
   name: 'get-public-feed-response',
   fields: [
     { name: 'entries', type: '@peartube/feed-entry', array: true }
+  ]
+})
+
+ns.register({
+  name: 'get-canonical-feed-request',
+  fields: [
+    { name: 'limit', type: 'uint', required: false }
+  ]
+})
+
+ns.register({
+  name: 'get-canonical-feed-response',
+  fields: [
+    { name: 'version', type: 'uint', required: false },
+    { name: 'savedAt', type: 'uint', required: false },
+    { name: 'identityDriveKey', type: 'string', required: false },
+    { name: 'entries', type: '@peartube/feed-entry', array: true },
+    { name: 'videos', type: '@peartube/feed-entry-preview-video', array: true }
   ]
 })
 
@@ -612,7 +640,19 @@ ns.register({
   name: 'get-swarm-status-response',
   fields: [
     { name: 'connected', type: 'bool', required: true },
-    { name: 'peerCount', type: 'uint', required: false }
+    { name: 'peerCount', type: 'uint', required: false },
+    { name: 'swarmConnections', type: 'uint', required: false },
+    { name: 'swarmPeers', type: 'uint', required: false },
+    { name: 'feedConnections', type: 'uint', required: false },
+    { name: 'feedEntries', type: 'uint', required: false },
+    { name: 'channelsLoaded', type: 'uint', required: false },
+    { name: 'swarmOffline', type: 'bool', required: false },
+    { name: 'swarmOfflineReason', type: 'string', required: false },
+    { name: 'swarmListenResolved', type: 'bool', required: false },
+    { name: 'peerPoolJoined', type: 'bool', required: false },
+    { name: 'publicFeedDiscoveryJoined', type: 'bool', required: false },
+    { name: 'feedTopicHex', type: 'string', required: false },
+    { name: 'recommendedBoundary', type: 'string', required: false }
   ]
 })
 
@@ -2360,6 +2400,12 @@ rpcNs.register({
   name: 'get-public-feed',
   request: { name: '@peartube/get-public-feed-request', stream: false },
   response: { name: '@peartube/get-public-feed-response', stream: false }
+})
+
+rpcNs.register({
+  name: 'get-canonical-feed',
+  request: { name: '@peartube/get-canonical-feed-request', stream: false },
+  response: { name: '@peartube/get-canonical-feed-response', stream: false }
 })
 
 rpcNs.register({

--- a/packages/spec/spec/hrpc/app-rpc-adapter.mjs
+++ b/packages/spec/spec/hrpc/app-rpc-adapter.mjs
@@ -1235,6 +1235,17 @@ export const APP_RPC_METADATA = Object.freeze({
       "send": true,
       "requestStream": false,
       "responseStream": false
+    },
+    {
+      "id": 23,
+      "command": "get-canonical-feed",
+      "method": "getCanonicalFeed",
+      "handler": "GetCanonicalFeed",
+      "request": "@peartube/get-canonical-feed-request",
+      "response": "@peartube/get-canonical-feed-response",
+      "send": false,
+      "requestStream": false,
+      "responseStream": false
     }
   ],
   "namespaces": {
@@ -1397,6 +1408,17 @@ export const APP_RPC_METADATA = Object.freeze({
       }
     ],
     "feed": [
+      {
+        "id": 23,
+        "command": "get-canonical-feed",
+        "method": "getCanonicalFeed",
+        "handler": "GetCanonicalFeed",
+        "request": "@peartube/get-canonical-feed-request",
+        "response": "@peartube/get-canonical-feed-response",
+        "send": false,
+        "requestStream": false,
+        "responseStream": false
+      },
       {
         "id": 22,
         "command": "get-public-feed",
@@ -2340,6 +2362,7 @@ export const APP_RPC_METADATA = Object.freeze({
     "download-video",
     "ffmpeg-decode-available",
     "get-blob-server-port",
+    "get-canonical-feed",
     "get-channel",
     "get-channel-meta",
     "get-identities",


### PR DESCRIPTION
## Summary

- Document the current universal backend architecture across README and AGENTS.md.
- Align native bridge protocol version handling with `@peartube/host` protocol version 2 and add Swift-side validation.
- Extend shared swarm/network diagnostics through schema, backend runtime, protocol events, platform bridge, and native empty-state copy.
- Add regression coverage for architecture drift, native bridge protocol defaults, and protocol network status events.

## Why

The docs and several client boundaries still reflected older desktop/mobile split assumptions. PearTube clients should share one backend contract through `@peartube/host`, `@peartube/protocol`, and `@peartube/backend`, with platform shells only responsible for launching/connecting to that backend.

## Validation

- `node --test packages/desktop-native/Bridge/native-rpc.test.mjs packages/app/tests/universal-backend-architecture-regression.test.mjs`
- `node node_modules/brittle/bin/node.js packages/protocol/test/create-client.test.mjs`
- `node node_modules/brittle/bin/node.js packages/spec/test/app-rpc-adapter.test.mjs`
- `node --test packages/app/tests/native-backend-startup-regression.test.mjs`
- `node node_modules/typescript/bin/tsc --noEmit` from `packages/platform`
- `node --check` on changed JS modules
- `git diff --check`

Note: root `npm` scripts were not runnable in this shell because `npm` was not on PATH, so focused checks were run directly with `node`.