### PR TITLE
fix(relay): mirror preview blob bandwidth

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,7 +10,7 @@
     "peartube-peer-bare": "bare-bin.js"
   },
   "scripts": {
-    "test": "brittle test/admission.test.mjs test/archive-ui.test.mjs test/archive.test.mjs test/cli.test.mjs test/config.test.mjs test/local-drive-mirror.test.mjs test/relay-seeding.test.mjs test/service.test.mjs test/status.test.mjs",
+    "test": "brittle test/admission.test.mjs test/archive-ui.test.mjs test/archive.test.mjs test/blob-downloader.test.mjs test/cli.test.mjs test/config.test.mjs test/local-drive-mirror.test.mjs test/relay-seeding.test.mjs test/service.test.mjs test/status.test.mjs",
     "build:standalone": "node ./scripts/build-standalone.mjs",
     "build:standalone:linux-x64": "RELAY_STANDALONE_HOST=linux-x64 node ./scripts/build-standalone.mjs",
     "build:standalone:linux-arm64": "RELAY_STANDALONE_HOST=linux-arm64 node ./scripts/build-standalone.mjs",

--- a/packages/cli/src/blob-downloader.js
+++ b/packages/cli/src/blob-downloader.js
@@ -41,11 +41,97 @@ function parseBlobId(blobId) {
 
 function timeoutPromise(timeoutMs) {
   return new Promise((_, reject) => {
-    setTimeout(() => reject(new Error(`Blob download timeout (${timeoutMs}ms)`)), timeoutMs)
+    const timer = setTimeout(() => reject(new Error(`Blob download timeout (${timeoutMs}ms)`)), timeoutMs)
+    timer?.unref?.()
   })
 }
 
-export async function downloadChannelBlobs(ctx, publicBeeKey, driveKey, logger = {}) {
+function getVideoKey(video) {
+  return String(video?.id || video?.path || video?.videoId || video?.blobId || '')
+}
+
+function addDownloadRef(refs, video, { coreKeyField = 'blobsCoreKey', blobIdField = 'blobId', kind = 'video' } = {}) {
+  const coreKey = video?.[coreKeyField]
+  const blobId = video?.[blobIdField]
+  if (!coreKey || !blobId) return false
+  const key = `${String(coreKey).toLowerCase()}:${String(blobId)}`
+  if (refs.has(key)) return false
+  refs.set(key, {
+    kind,
+    videoId: getVideoKey(video) || '<unknown-video>',
+    coreKey: String(coreKey),
+    blobId,
+    sourceVideo: video
+  })
+  return true
+}
+
+function addVideoDownloadRefs(refs, videos) {
+  if (!Array.isArray(videos)) return 0
+  let added = 0
+  for (const video of videos) {
+    if (!video || typeof video !== 'object') continue
+    if (addDownloadRef(refs, video, { kind: 'video' })) added += 1
+    if (addDownloadRef(refs, video, {
+      coreKeyField: 'thumbnailBlobsCoreKey',
+      blobIdField: 'thumbnailBlobId',
+      kind: 'thumbnail'
+    })) added += 1
+  }
+  return added
+}
+
+function addPreviewVideo(previews, video) {
+  if (!video?.id || !video?.blobId || !video?.blobsCoreKey) return false
+  const id = getVideoKey(video)
+  if (previews.some((existing) => getVideoKey(existing) === id)) return false
+  previews.push({
+    id: String(video.id),
+    title: video?.title ? String(video.title) : 'Untitled',
+    uploadedAt: Number(video?.uploadedAt || 0) || 0,
+    duration: Number(video?.duration || 0) || 0,
+    thumbnail: video?.thumbnail || null,
+    blobId: String(video.blobId),
+    blobsCoreKey: String(video.blobsCoreKey),
+    mimeType: video?.mimeType || 'video/mp4',
+    availability: 'playable',
+    thumbnailBlobId: video?.thumbnailBlobId || null,
+    thumbnailBlobsCoreKey: video?.thumbnailBlobsCoreKey || null,
+    thumbnailMimeType: video?.thumbnailMimeType || null
+  })
+  return true
+}
+
+async function downloadBlobRef(ctx, ref) {
+  const { blockOffset, blockLength } = parseBlobId(ref.blobId)
+  const blobsCoreKey = b4a.from(ref.coreKey, 'hex')
+  const blobsCore = ctx.store.get(blobsCoreKey)
+  await blobsCore.ready()
+
+  if (ctx.swarm && !ctx.swarm.destroyed && blobsCore.discoveryKey) {
+    try {
+      ctx.swarm.join(blobsCore.discoveryKey, { server: true, client: true })
+    } catch {}
+  }
+
+  const download = blobsCore.download({
+    start: blockOffset,
+    end: blockOffset + blockLength
+  })
+
+  await Promise.race([
+    download.done(),
+    timeoutPromise(VIDEO_DOWNLOAD_TIMEOUT_MS)
+  ])
+
+  if (Number.isFinite(ref.blobId?.byteLength)) return Number(ref.blobId.byteLength)
+
+  const avgBytesPerBlock = blobsCore.length > 0 ? (blobsCore.byteLength / blobsCore.length) : 0
+  return Math.floor(blockLength * avgBytesPerBlock)
+}
+
+export async function downloadChannelBlobs(ctx, publicBeeKey, driveKey, logger = {}, options = {}, dependencies = {}) {
+  const loadBee = dependencies.loadPublicBee || loadPublicBee
   const logInfo = typeof logger.info === 'function' ? logger.info.bind(logger) : () => {}
   const logDebug = typeof logger.debug === 'function' ? logger.debug.bind(logger) : () => {}
   const logError = typeof logger.error === 'function' ? logger.error.bind(logger) : () => {}
@@ -53,7 +139,12 @@ export async function downloadChannelBlobs(ctx, publicBeeKey, driveKey, logger =
   const stats = {
     videosFound: 0,
     videosDownloaded: 0,
-    bytesDownloaded: 0
+    blobsFound: 0,
+    blobsDownloaded: 0,
+    thumbnailsDownloaded: 0,
+    bytesDownloaded: 0,
+    previewVideos: [],
+    videoCount: 0
   }
 
   try {
@@ -67,59 +158,63 @@ export async function downloadChannelBlobs(ctx, publicBeeKey, driveKey, logger =
       return stats
     }
 
-    const bee = await loadPublicBee(ctx, publicBeeKey)
+    const bee = await loadBee(ctx, publicBeeKey)
     const videos = await bee.listVideos().catch(() => [])
+    const refs = new Map()
 
-    if (!Array.isArray(videos) || videos.length === 0) {
-      logDebug('[blob-downloader] No videos found for channel', driveKey)
+    addVideoDownloadRefs(refs, options.previewVideos)
+    addVideoDownloadRefs(refs, options.videos)
+    addVideoDownloadRefs(refs, options.catalogEntry?.previewVideos)
+    addVideoDownloadRefs(refs, options.feedEntry?.previewVideos)
+
+    if (Array.isArray(options.previewVideos)) {
+      for (const video of options.previewVideos) {
+        if (stats.previewVideos.length >= 3) break
+        addPreviewVideo(stats.previewVideos, video)
+      }
+    }
+
+    if (Array.isArray(videos)) {
+      stats.videosFound = videos.length
+      stats.videoCount = videos.length
+      addVideoDownloadRefs(refs, videos)
+      for (const video of videos) {
+        if (stats.previewVideos.length >= 3) break
+        addPreviewVideo(stats.previewVideos, video)
+      }
+    }
+
+    if (refs.size === 0) {
+      logDebug('[blob-downloader] No blob refs found for channel', driveKey)
       return stats
     }
 
-    stats.videosFound = videos.length
+    stats.blobsFound = refs.size
 
-    for (const video of videos) {
-      if (!video || typeof video !== 'object') continue
-      if (!video.blobsCoreKey || !video.blobId) continue
-
+    for (const ref of refs.values()) {
       try {
-        const { blockOffset, blockLength } = parseBlobId(video.blobId)
-        const blobsCoreKey = b4a.from(video.blobsCoreKey, 'hex')
-        const blobsCore = ctx.store.get(blobsCoreKey)
-        await blobsCore.ready()
-
-        if (ctx.swarm && !ctx.swarm.destroyed && blobsCore.discoveryKey) {
-          try {
-            ctx.swarm.join(blobsCore.discoveryKey)
-          } catch {}
-        }
-
-        const download = blobsCore.download({
-          start: blockOffset,
-          end: blockOffset + blockLength
-        })
-
-        await Promise.race([
-          download.done(),
-          timeoutPromise(VIDEO_DOWNLOAD_TIMEOUT_MS)
-        ])
-
-        const avgBytesPerBlock = blobsCore.length > 0 ? (blobsCore.byteLength / blobsCore.length) : 0
-        stats.bytesDownloaded += Math.floor(blockLength * avgBytesPerBlock)
-        stats.videosDownloaded += 1
+        stats.bytesDownloaded += await downloadBlobRef(ctx, ref)
+        stats.blobsDownloaded += 1
+        if (ref.kind === 'video') stats.videosDownloaded += 1
+        if (ref.kind === 'thumbnail') stats.thumbnailsDownloaded += 1
       } catch (err) {
         logError(
-          '[blob-downloader] Video blob download failed',
+          '[blob-downloader] Blob download failed',
           driveKey,
-          video.id || video.videoPath || video.path || '<unknown-video>',
+          ref.videoId || '<unknown-video>',
+          ref.kind,
           err?.message || err
         )
       }
     }
 
+    stats.videoCount = Math.max(stats.videoCount, stats.previewVideos.length, stats.videosDownloaded)
+
     logInfo(
       '[blob-downloader] Channel blob download complete',
       driveKey,
-      `videos: ${stats.videosDownloaded}/${stats.videosFound}`,
+      `videos: ${stats.videosDownloaded}/${stats.videosFound || stats.videoCount}`,
+      `blobs: ${stats.blobsDownloaded}/${stats.blobsFound}`,
       `bytes: ${stats.bytesDownloaded}`
     )
 
@@ -136,6 +231,9 @@ export async function downloadAllCachedChannels(ctx, cacheManager, logger = {}) 
   const totals = {
     videosFound: 0,
     videosDownloaded: 0,
+    blobsFound: 0,
+    blobsDownloaded: 0,
+    thumbnailsDownloaded: 0,
     bytesDownloaded: 0
   }
 
@@ -149,9 +247,12 @@ export async function downloadAllCachedChannels(ctx, cacheManager, logger = {}) 
     if (!channel.publicBeeKey) continue
 
     try {
-      const stats = await downloadChannelBlobs(ctx, channel.publicBeeKey, channel.driveKey, logger)
+      const stats = await downloadChannelBlobs(ctx, channel.publicBeeKey, channel.driveKey, logger, channel)
       totals.videosFound += stats.videosFound
       totals.videosDownloaded += stats.videosDownloaded
+      totals.blobsFound += stats.blobsFound || 0
+      totals.blobsDownloaded += stats.blobsDownloaded || 0
+      totals.thumbnailsDownloaded += stats.thumbnailsDownloaded || 0
       totals.bytesDownloaded += stats.bytesDownloaded
 
       if (channel.driveKey) {
@@ -165,4 +266,4 @@ export async function downloadAllCachedChannels(ctx, cacheManager, logger = {}) 
   return totals
 }
 
-export { parseBlobId }
+export { parseBlobId, addVideoDownloadRefs }

--- a/packages/cli/src/blob-downloader.js
+++ b/packages/cli/src/blob-downloader.js
@@ -111,7 +111,9 @@ async function downloadBlobRef(ctx, ref) {
   if (ctx.swarm && !ctx.swarm.destroyed && blobsCore.discoveryKey) {
     try {
       ctx.swarm.join(blobsCore.discoveryKey, { server: true, client: true })
-    } catch {}
+    } catch (err) {
+      void err
+    }
   }
 
   const download = blobsCore.download({

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -38,7 +38,8 @@ export async function startRelay({ config, logger = null } = {}) {
         runtime.ctx,
         resolved.publicBeeKey,
         resolved.channelKey,
-        serviceLogger.download
+        serviceLogger.download,
+        resolved
       )
     }
   })

--- a/packages/cli/test/blob-downloader.test.mjs
+++ b/packages/cli/test/blob-downloader.test.mjs
@@ -1,0 +1,96 @@
+import test from 'brittle'
+import { downloadChannelBlobs, addVideoDownloadRefs } from '../src/blob-downloader.js'
+
+function createCore({ length = 10, byteLength = 100 } = {}) {
+  return {
+    length,
+    byteLength,
+    readyCalls: 0,
+    downloads: [],
+    discoveryKey: `discovery-${Math.random()}`,
+    async ready() {
+      this.readyCalls += 1
+    },
+    download(range) {
+      this.downloads.push(range)
+      return {
+        async done() {}
+      }
+    }
+  }
+}
+
+test('addVideoDownloadRefs collects video and thumbnail blob refs without duplicates', (t) => {
+  const refs = new Map()
+  const video = {
+    id: 'video-1',
+    blobsCoreKey: 'aa'.repeat(32),
+    blobId: '0:2:0:20',
+    thumbnailBlobsCoreKey: 'bb'.repeat(32),
+    thumbnailBlobId: '2:1:20:5'
+  }
+
+  t.is(addVideoDownloadRefs(refs, [video, video]), 2)
+  t.is(refs.size, 2)
+  t.alike([...refs.values()].map((ref) => ref.kind), ['video', 'thumbnail'])
+})
+
+test('downloadChannelBlobs downloads feed preview refs when PublicBee has no videos', async (t) => {
+  const videoCore = createCore({ length: 4, byteLength: 400 })
+  const thumbnailCore = createCore({ length: 2, byteLength: 20 })
+  const joins = []
+  const ctx = {
+    swarm: {
+      join(discoveryKey, opts) {
+        joins.push({ discoveryKey, opts })
+      }
+    },
+    store: {
+      get(key) {
+        const keyHex = Buffer.isBuffer(key) ? key.toString('hex') : String(key)
+        if (keyHex.startsWith('aa')) return videoCore
+        if (keyHex.startsWith('bb')) return thumbnailCore
+        throw new Error(`unexpected key ${keyHex}`)
+      }
+    }
+  }
+
+  const stats = await downloadChannelBlobs(
+    ctx,
+    'cc'.repeat(32),
+    'chan-preview',
+    { info() {}, debug() {}, error() {} },
+    {
+      previewVideos: [{
+        id: 'preview-1',
+        title: 'Preview 1',
+        blobId: '1:2:100:200',
+        blobsCoreKey: 'aa'.repeat(32),
+        thumbnailBlobId: '0:1:0:10',
+        thumbnailBlobsCoreKey: 'bb'.repeat(32)
+      }]
+    },
+    {
+      async loadPublicBee() {
+        return {
+          async listVideos() {
+            return []
+          }
+        }
+      }
+    }
+  )
+
+  t.is(stats.videosFound, 0)
+  t.is(stats.videoCount, 1)
+  t.is(stats.blobsFound, 2)
+  t.is(stats.blobsDownloaded, 2)
+  t.is(stats.videosDownloaded, 1)
+  t.is(stats.thumbnailsDownloaded, 1)
+  t.is(stats.bytesDownloaded, 210)
+  t.is(stats.previewVideos.length, 1)
+  t.alike(videoCore.downloads, [{ start: 1, end: 3 }])
+  t.alike(thumbnailCore.downloads, [{ start: 0, end: 1 }])
+  t.is(joins.length, 2)
+  t.ok(joins.every((join) => join.opts?.server === true && join.opts?.client === true))
+})

--- a/packages/cli/test/cli.test.mjs
+++ b/packages/cli/test/cli.test.mjs
@@ -51,7 +51,7 @@ test('package.json defines standalone relay build scripts', async (t) => {
   const packageJsonPath = join(__dirname, '..', 'package.json')
   const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf8'))
 
-  t.is(pkg.scripts['test'], 'brittle test/admission.test.mjs test/archive-ui.test.mjs test/archive.test.mjs test/cli.test.mjs test/config.test.mjs test/local-drive-mirror.test.mjs test/relay-seeding.test.mjs test/service.test.mjs test/status.test.mjs')
+  t.is(pkg.scripts['test'], 'brittle test/admission.test.mjs test/archive-ui.test.mjs test/archive.test.mjs test/blob-downloader.test.mjs test/cli.test.mjs test/config.test.mjs test/local-drive-mirror.test.mjs test/relay-seeding.test.mjs test/service.test.mjs test/status.test.mjs')
   t.is(pkg.imports['#subprocess'].bare, './src/shims/subprocess.bare.js')
   t.is(pkg.imports['#subprocess'].default, './src/shims/subprocess.node.js')
   t.is(pkg.imports['#http'].bare, './src/shims/http.bare.js')


### PR DESCRIPTION
## Summary
- Downloads relay preview/catalog blob refs even when PublicBee is sparse or empty
- Includes thumbnail blob refs so relay peers provide actual playback bandwidth, not only feed availability
- Passes discovered preview refs from relay candidate resolution into the downloader

## Test plan
- node --test test/blob-downloader.test.mjs test/service.test.mjs test/relay-seeding.test.mjs test/cli.test.mjs
- npm test -- --timeout=30000
- git diff --check