### PR TITLE
fix(backend): queue discovered public-feed peers

### DIFF
--- a/packages/app/app/(tabs)/index.tsx
+++ b/packages/app/app/(tabs)/index.tsx
@@ -135,7 +135,14 @@ export default function HomeScreen() {
   const [feedLoading, setFeedLoading] = useState(false)
   const [peerCount, setPeerCount] = useState(0)
   const [lastFeedRefresh, setLastFeedRefresh] = useState<number | null>(null)
-  const [swarmStatus, setSwarmStatus] = useState<{ peers: number; feedConnections?: number; channels?: number } | null>(null)
+  const [swarmStatus, setSwarmStatus] = useState<{
+    peers: number
+    swarmPeers?: number
+    swarmConnections?: number
+    feedConnections?: number
+    feedEntries?: number
+    channels?: number
+  } | null>(null)
   const channelMetaRef = useRef(channelMeta)
   channelMetaRef.current = channelMeta
   const inflightChannelMetaLoads = useRef<Set<string>>(new Set())
@@ -264,7 +271,9 @@ export default function HomeScreen() {
     try {
       setFeedLoading(true)
       // Add timeout to prevent infinite spinner if RPC hangs
-      const feedPromise = rpc.getCanonicalFeed({})
+      const feedPromise = (typeof rpc.getCanonicalFeed === 'function'
+        ? rpc.getCanonicalFeed({})
+        : rpc.getPublicFeed({}))
       const timeoutPromise = new Promise<null>((resolve) => setTimeout(() => resolve(null), 10000))
       const result = await Promise.race([feedPromise, timeoutPromise])
 
@@ -290,7 +299,16 @@ export default function HomeScreen() {
         }
       }
       if (result?.stats) {
-        setPeerCount(result.stats.peerCount || 0)
+        const feedStats = result.stats as any
+        setPeerCount(feedStats.peerCount || feedStats.feedConnections || 0)
+        setSwarmStatus((prev) => ({
+          peers: feedStats.swarmConnections ?? prev?.peers ?? (feedStats.peerCount || 0),
+          swarmPeers: feedStats.swarmPeers ?? prev?.swarmPeers,
+          swarmConnections: feedStats.swarmConnections ?? prev?.swarmConnections,
+          feedConnections: feedStats.feedConnections ?? prev?.feedConnections,
+          feedEntries: feedStats.feedEntries ?? feedStats.totalEntries ?? result?.entries?.length ?? prev?.feedEntries,
+          channels: feedStats.channelsLoaded ?? prev?.channels,
+        }))
       }
       logTiming('canonicalFeed', startedAt, {
         entries: result?.entries?.length || 0,
@@ -301,10 +319,14 @@ export default function HomeScreen() {
         const statusPromise = rpc.getSwarmStatus()
         const status = await Promise.race([statusPromise, new Promise((r) => setTimeout(() => r(null), 3000))])
         if (status) {
+          const statusAny = status as any
           setSwarmStatus({
-            peers: (status as any).peerCount || (status as any).swarmConnections || 0,
-            feedConnections: (status as any).feedConnections,
-            channels: (status as any).channelsLoaded,
+            peers: statusAny.swarmConnections ?? statusAny.peerCount ?? 0,
+            swarmPeers: statusAny.swarmPeers ?? statusAny.peerCount,
+            swarmConnections: statusAny.swarmConnections,
+            feedConnections: statusAny.feedConnections,
+            feedEntries: statusAny.feedEntries,
+            channels: statusAny.channelsLoaded,
           })
         }
       } catch (err) {
@@ -895,6 +917,7 @@ export default function HomeScreen() {
     entries: feedEntries,
     videos: feedVideosWithThumbs,
     peerCount,
+    swarmStatus,
     permissionStatus: androidDiscoveryPermissionStatus,
     hasCachedSnapshot: snapshotRestoredOnly || snapshotChannelKeys.size > 0,
   }), [
@@ -905,7 +928,17 @@ export default function HomeScreen() {
     ready,
     snapshotChannelKeys,
     snapshotRestoredOnly,
+    swarmStatus,
   ])
+  const displayPeers = swarmStatus?.swarmConnections ?? swarmStatus?.peers ?? peerCount
+  const displayFeedEntries = Math.max(
+    swarmStatus?.feedEntries ?? 0,
+    feedEntries.length,
+  )
+  const displayChannels = Math.max(
+    feedEntries.length,
+    swarmStatus?.channels ?? 0,
+  )
   const videoGridItemStyle = useMemo(() => isDesktop ? {
     width: `calc(${100 / gridColumns}% - ${(gridColumns - 1) * 24 / gridColumns}px)`,
   } as any : undefined, [isDesktop, gridColumns])
@@ -1089,15 +1122,18 @@ export default function HomeScreen() {
 
           <View style={{ flexDirection: 'row', flexWrap: 'wrap', marginBottom: 8 }}>
             <View style={{ flexDirection: 'row', alignItems: 'center', backgroundColor: colors.bgCard, paddingHorizontal: 10, paddingVertical: 6, borderRadius: 12, marginRight: 8, marginBottom: 6 }}>
-              <Text style={{ color: colors.text, fontSize: 12 }}>Peers: {swarmStatus?.peers ?? peerCount}</Text>
+              <Text style={{ color: colors.text, fontSize: 12 }}>Peers: {displayPeers}</Text>
               {swarmStatus?.feedConnections !== undefined && (
-                <Text style={{ color: colors.textMuted, fontSize: 12, marginLeft: 6 }}>Feed: {swarmStatus.feedConnections}</Text>
+                <Text style={{ color: colors.textMuted, fontSize: 12, marginLeft: 6 }}>Live: {swarmStatus.feedConnections}</Text>
               )}
             </View>
             <View style={{ flexDirection: 'row', alignItems: 'center', backgroundColor: colors.bgCard, paddingHorizontal: 10, paddingVertical: 6, borderRadius: 12, marginRight: 8, marginBottom: 6 }}>
-              <Text style={{ color: colors.text, fontSize: 12 }}>Channels: {feedEntries.length}</Text>
-              {swarmStatus?.channels !== undefined && (
-                <Text style={{ color: colors.textMuted, fontSize: 12, marginLeft: 6 }}>Channels: {swarmStatus.channels}</Text>
+              <Text style={{ color: colors.text, fontSize: 12 }}>Feed: {displayFeedEntries}</Text>
+            </View>
+            <View style={{ flexDirection: 'row', alignItems: 'center', backgroundColor: colors.bgCard, paddingHorizontal: 10, paddingVertical: 6, borderRadius: 12, marginRight: 8, marginBottom: 6 }}>
+              <Text style={{ color: colors.text, fontSize: 12 }}>Channels: {displayChannels}</Text>
+              {swarmStatus?.channels !== undefined && swarmStatus.channels !== displayChannels && (
+                <Text style={{ color: colors.textMuted, fontSize: 12, marginLeft: 6 }}>Live: {swarmStatus.channels}</Text>
               )}
             </View>
             {lastFeedRefresh && (
@@ -1161,14 +1197,18 @@ export default function HomeScreen() {
           ? 'Peer discovery is degraded'
           : state === 'cached-fallback'
             ? 'Using cached discovery data'
-            : 'Looking for PearTube peers'
+            : state === 'hydrating'
+              ? 'Loading playable previews'
+              : 'Looking for PearTube peers'
       const detail = state === 'permission-degraded'
         ? 'Grant Nearby devices/Wi-Fi permission, then refresh discovery.'
         : state === 'network-degraded'
           ? `Network boundary: ${reason || 'unknown'}. Refresh will retry the feed path.`
           : state === 'cached-fallback'
             ? 'No live peers are connected yet; cached videos will stay visible when available.'
-            : 'No live peers have announced channels yet. Keep the app open or tap refresh.'
+            : state === 'hydrating'
+              ? `${displayFeedEntries || feedEntries.length} feed entries detected; resolving playable video previews.`
+              : 'No live peers have announced channels yet. Keep the app open or tap refresh.'
 
       return (
         <View style={{ paddingHorizontal: isDesktop ? 24 : 20 }}>

--- a/packages/app/app/(tabs)/index.tsx
+++ b/packages/app/app/(tabs)/index.tsx
@@ -91,16 +91,6 @@ type ChannelListItem =
   | { type: 'empty' }
   | { type: 'row'; videos: VideoData[]; rowIndex: number }
 
-type HomeSwarmStatus = {
-  peers: number
-  peerCount?: number
-  swarmConnections?: number
-  feedConnections?: number
-  swarmPeers?: number
-  channels?: number
-  doctor?: { recommendedBoundary?: string | null }
-}
-
 function withTimeout<T>(promise: Promise<T>, ms: number, fallback: T): Promise<T> {
   return Promise.race([
     promise,
@@ -145,7 +135,7 @@ export default function HomeScreen() {
   const [feedLoading, setFeedLoading] = useState(false)
   const [peerCount, setPeerCount] = useState(0)
   const [lastFeedRefresh, setLastFeedRefresh] = useState<number | null>(null)
-  const [swarmStatus, setSwarmStatus] = useState<HomeSwarmStatus | null>(null)
+  const [swarmStatus, setSwarmStatus] = useState<{ peers: number; feedConnections?: number; channels?: number } | null>(null)
   const channelMetaRef = useRef(channelMeta)
   channelMetaRef.current = channelMeta
   const inflightChannelMetaLoads = useRef<Set<string>>(new Set())
@@ -267,45 +257,14 @@ export default function HomeScreen() {
     }
   }, [rpc])
 
-  const loadSwarmStatus = useCallback(async () => {
-    if (!rpc) return
-    try {
-      const statusPromise = rpc.getSwarmStatus()
-      const status = await Promise.race([statusPromise, new Promise((r) => setTimeout(() => r(null), 3000))])
-      if (!status) return
-      setSwarmStatus({
-        peers: Math.max(
-          Number((status as any).peerCount || 0),
-          Number((status as any).swarmConnections || 0),
-          Number((status as any).feedConnections || 0),
-          Number((status as any).swarmPeers || 0),
-        ),
-        peerCount: (status as any).peerCount,
-        swarmConnections: (status as any).swarmConnections,
-        feedConnections: (status as any).feedConnections,
-        swarmPeers: (status as any).swarmPeers,
-        channels: (status as any).channelsLoaded,
-        doctor: (status as any).doctor || undefined,
-      })
-    } catch (err) {
-      console.log('[Home] Failed to load swarm status:', (err as any)?.message || err)
-    }
-  }, [rpc])
-
   // Load public feed from backend
   const loadPublicFeed = useCallback(async () => {
     if (!rpc) return
     const startedAt = nowMs()
     try {
       setFeedLoading(true)
-      // Add timeout to prevent infinite spinner if RPC hangs. Physical-device
-      // release builds may not expose the newer canonical-feed HRPC method yet,
-      // but getPublicFeed is registered in the generated mobile schema and
-      // returns the same feed entries through the mobile handler.
-      const getCanonicalFeed = (rpc as any).getCanonicalFeed
-      const feedPromise = typeof getCanonicalFeed === 'function'
-        ? getCanonicalFeed.call(rpc, {})
-        : rpc.getPublicFeed({})
+      // Add timeout to prevent infinite spinner if RPC hangs
+      const feedPromise = rpc.getCanonicalFeed({})
       const timeoutPromise = new Promise<null>((resolve) => setTimeout(() => resolve(null), 10000))
       const result = await Promise.race([feedPromise, timeoutPromise])
 
@@ -338,13 +297,25 @@ export default function HomeScreen() {
         timedOut: !result,
       })
       setLastFeedRefresh(Date.now())
-      await loadSwarmStatus()
+      try {
+        const statusPromise = rpc.getSwarmStatus()
+        const status = await Promise.race([statusPromise, new Promise((r) => setTimeout(() => r(null), 3000))])
+        if (status) {
+          setSwarmStatus({
+            peers: (status as any).peerCount || (status as any).swarmConnections || 0,
+            feedConnections: (status as any).feedConnections,
+            channels: (status as any).channelsLoaded,
+          })
+        }
+      } catch (err) {
+        console.log('[Home] Failed to load swarm status:', (err as any)?.message || err)
+      }
     } catch (err) {
       console.error('[Home] Failed to load public feed:', err)
     } finally {
       setFeedLoading(false)
     }
-  }, [rpc, loadChannelMeta, loadSwarmStatus])
+  }, [rpc, loadChannelMeta])
 
   const refreshFeed = useCallback(async () => {
     if (!rpc) return
@@ -425,12 +396,10 @@ export default function HomeScreen() {
   useEffect(() => {
     if (ready) {
       loadPublicFeed()
-      void loadSwarmStatus()
     }
     // Periodic refresh to keep discovery updated
     const interval = setInterval(() => {
       if (ready) {
-        void loadSwarmStatus()
         refreshFeed()
       }
     }, 30000)
@@ -444,13 +413,12 @@ export default function HomeScreen() {
       clearInterval(interval)
       if (typeof unsub === 'function') unsub()
     }
-  }, [ready, platformEvents, loadPublicFeed, loadSwarmStatus, refreshFeed])
+  }, [ready, platformEvents, loadPublicFeed, refreshFeed])
 
   // Refresh discovery when app returns to foreground (mobile)
   useEffect(() => {
     const sub = AppState.addEventListener('change', (state) => {
       if (state === 'active' && appState.current !== 'active' && ready) {
-        void loadSwarmStatus()
         refreshFeed()
         if (feedVideos.length > 0) {
           fetchThumbnailsForVideos(feedVideos)
@@ -459,7 +427,7 @@ export default function HomeScreen() {
       appState.current = state
     })
     return () => sub.remove()
-  }, [ready, refreshFeed, feedVideos, fetchThumbnailsForVideos, loadSwarmStatus])
+  }, [ready, refreshFeed, feedVideos, fetchThumbnailsForVideos])
 
   const hideChannel = useCallback(async (driveKey: string) => {
     if (!rpc) return
@@ -922,35 +890,21 @@ export default function HomeScreen() {
 
   const backendConnecting = !ready
   const backendLoading = Boolean(loading)
-  const livePeerCount = Math.max(
-    Number(peerCount || 0),
-    Number(swarmStatus?.peers || 0),
-    Number(swarmStatus?.peerCount || 0),
-    Number(swarmStatus?.swarmConnections || 0),
-    Number(swarmStatus?.feedConnections || 0),
-    Number(swarmStatus?.swarmPeers || 0),
-  )
-  const visibleChannelCount = Math.max(feedEntries.length, snapshotChannelKeys.size, Number(swarmStatus?.channels || 0))
-  const feedActivitySignal = Math.max(livePeerCount, feedEntries.length, snapshotChannelKeys.size)
-  const discoveryPeerLabel = livePeerCount
-
   const feedDiscoveryState = useMemo(() => classifyFeedDiscoveryState({
     ready,
     entries: feedEntries,
     videos: feedVideosWithThumbs,
-    peerCount: feedActivitySignal,
-    swarmStatus,
+    peerCount,
     permissionStatus: androidDiscoveryPermissionStatus,
     hasCachedSnapshot: snapshotRestoredOnly || snapshotChannelKeys.size > 0,
   }), [
     androidDiscoveryPermissionStatus,
     feedEntries,
     feedVideosWithThumbs,
-    feedActivitySignal,
+    peerCount,
     ready,
     snapshotChannelKeys,
     snapshotRestoredOnly,
-    swarmStatus,
   ])
   const videoGridItemStyle = useMemo(() => isDesktop ? {
     width: `calc(${100 / gridColumns}% - ${(gridColumns - 1) * 24 / gridColumns}px)`,
@@ -1054,10 +1008,10 @@ export default function HomeScreen() {
             <View className="flex-row items-center">
               <Feather name="globe" color={colors.primary} size={18} />
               <Text className="text-headline text-pear-text ml-2">Discover</Text>
-              {discoveryPeerLabel > 0 && (
+              {peerCount > 0 && (
                 <View className="flex-row items-center ml-2 bg-pear-bg-card px-2 py-0.5 rounded-full">
                   <Feather name="users" color={colors.textMuted} size={12} />
-                  <Text className="text-caption text-pear-text-muted ml-1">{discoveryPeerLabel}</Text>
+                  <Text className="text-caption text-pear-text-muted ml-1">{peerCount}</Text>
                 </View>
               )}
             </View>
@@ -1135,18 +1089,15 @@ export default function HomeScreen() {
 
           <View style={{ flexDirection: 'row', flexWrap: 'wrap', marginBottom: 8 }}>
             <View style={{ flexDirection: 'row', alignItems: 'center', backgroundColor: colors.bgCard, paddingHorizontal: 10, paddingVertical: 6, borderRadius: 12, marginRight: 8, marginBottom: 6 }}>
-              <Text style={{ color: colors.text, fontSize: 12 }}>Peers: {discoveryPeerLabel}</Text>
-              {feedEntries.length > 0 && (
-                <Text style={{ color: colors.textMuted, fontSize: 12, marginLeft: 6 }}>Feed: {feedEntries.length}</Text>
+              <Text style={{ color: colors.text, fontSize: 12 }}>Peers: {swarmStatus?.peers ?? peerCount}</Text>
+              {swarmStatus?.feedConnections !== undefined && (
+                <Text style={{ color: colors.textMuted, fontSize: 12, marginLeft: 6 }}>Feed: {swarmStatus.feedConnections}</Text>
               )}
             </View>
             <View style={{ flexDirection: 'row', alignItems: 'center', backgroundColor: colors.bgCard, paddingHorizontal: 10, paddingVertical: 6, borderRadius: 12, marginRight: 8, marginBottom: 6 }}>
-              <Text style={{ color: colors.text, fontSize: 12 }}>Channels: {visibleChannelCount}</Text>
-              {snapshotChannelKeys.size > feedEntries.length && (
-                <Text style={{ color: colors.textMuted, fontSize: 12, marginLeft: 6 }}>Cached: {snapshotChannelKeys.size}</Text>
-              )}
-              {swarmStatus?.channels !== undefined && swarmStatus.channels !== visibleChannelCount && (
-                <Text style={{ color: colors.textMuted, fontSize: 12, marginLeft: 6 }}>Live: {swarmStatus.channels}</Text>
+              <Text style={{ color: colors.text, fontSize: 12 }}>Channels: {feedEntries.length}</Text>
+              {swarmStatus?.channels !== undefined && (
+                <Text style={{ color: colors.textMuted, fontSize: 12, marginLeft: 6 }}>Channels: {swarmStatus.channels}</Text>
               )}
             </View>
             {lastFeedRefresh && (
@@ -1216,12 +1167,8 @@ export default function HomeScreen() {
         : state === 'network-degraded'
           ? `Network boundary: ${reason || 'unknown'}. Refresh will retry the feed path.`
           : state === 'cached-fallback'
-            ? (feedActivitySignal > 0
-              ? `${feedActivitySignal} feed/channel signals detected; waiting for playable previews.`
-              : 'No live feed entries have arrived yet; cached videos will stay visible when available.')
-            : feedActivitySignal > 0
-              ? `${feedActivitySignal} feed/channel signals detected; waiting for playable previews.`
-              : 'No live peers have announced channels yet. Keep the app open or tap refresh.'
+            ? 'No live peers are connected yet; cached videos will stay visible when available.'
+            : 'No live peers have announced channels yet. Keep the app open or tap refresh.'
 
       return (
         <View style={{ paddingHorizontal: isDesktop ? 24 : 20 }}>

--- a/packages/app/components/discovery/VerticalShortsPlayer.tsx
+++ b/packages/app/components/discovery/VerticalShortsPlayer.tsx
@@ -156,7 +156,8 @@ export const VerticalShortsPlayer = memo(function VerticalShortsPlayer({
   }, [playbackProgress.duration, playerRef, progressBarWidth])
 
   const showPlayer = Boolean(videoUrl && isActive && !hasPlaybackError)
-  const showPoster = !showPlayer && Boolean(thumbnailUrl)
+  const showPoster = Boolean(thumbnailUrl)
+  const posterOpacity = showPlayer ? 0.28 : 0.58
   const effectiveProgress = playbackProgress.duration > 0
     ? clampProgress(playbackProgress.currentTime / playbackProgress.duration)
     : 0
@@ -173,7 +174,7 @@ export const VerticalShortsPlayer = memo(function VerticalShortsPlayer({
         <ImageBackground
           source={{ uri: thumbnailUrl || undefined }}
           style={StyleSheet.absoluteFill}
-          imageStyle={styles.posterImage}
+          imageStyle={[styles.posterImage, { opacity: posterOpacity }]}
         />
       ) : null}
 
@@ -267,7 +268,6 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
   },
   posterImage: {
-    opacity: 0.44,
     resizeMode: 'cover',
   },
   videoSurface: {

--- a/packages/app/lib/android-discovery-diagnostics.js
+++ b/packages/app/lib/android-discovery-diagnostics.js
@@ -25,7 +25,14 @@ export function classifyFeedDiscoveryState({
     return { state: 'content-ready', recoverable: false }
   }
   if (Array.isArray(entries) && entries.length > 0) {
-    if (Number(peerCount || 0) > 0 || Number(swarmStatus?.peers || 0) > 0 || Number(swarmStatus?.feedConnections || 0) > 0) {
+    if (
+      Number(peerCount || 0) > 0 ||
+      Number(swarmStatus?.peers || 0) > 0 ||
+      Number(swarmStatus?.swarmConnections || 0) > 0 ||
+      Number(swarmStatus?.feedConnections || 0) > 0 ||
+      Number(swarmStatus?.feedEntries || 0) > 0 ||
+      Number(swarmStatus?.channels || 0) > 0
+    ) {
       return { state: 'hydrating', recoverable: true }
     }
     return hasCachedSnapshot

--- a/packages/app/lib/feed-hydration.js
+++ b/packages/app/lib/feed-hydration.js
@@ -112,10 +112,17 @@ export function getFeedVideoHydrationMode({ feedEntries, swarmStatus }) {
   // that peer-discovered channels have reachable peers. If we ignore entry peerCount,
   // hydration stays stuck in local-only mode and never joins/fetches remote videos.
   const entryPeerSignal = feedEntries.some((entry) => (entry?.peerCount ?? 0) > 0)
+  const directPreviewSignal = feedEntries.some((entry) => (
+    Array.isArray(entry?.previewVideos) && entry.previewVideos.some(hasDirectBlobRef)
+  ))
 
   if (
     entryPeerSignal ||
+    directPreviewSignal ||
     (swarmStatus?.feedConnections ?? 0) > 0 ||
+    (swarmStatus?.swarmConnections ?? 0) > 0 ||
+    (swarmStatus?.feedEntries ?? 0) > 0 ||
+    (swarmStatus?.channels ?? 0) > 0 ||
     (swarmStatus?.peers ?? 0) > 0
   ) {
     return 'network'

--- a/packages/app/tests/android-physical-discovery-regression.test.mjs
+++ b/packages/app/tests/android-physical-discovery-regression.test.mjs
@@ -110,4 +110,24 @@ test('feed discovery state distinguishes permission, transport, cached fallback,
     recoverable: true,
     reason: 'zero-peers-no-entries',
   })
+
+  assert.deepEqual(classifyFeedDiscoveryState({
+    ready: true,
+    entries: [{ driveKey: 'live-feed' }],
+    videos: [],
+    swarmStatus: { feedEntries: 88, feedConnections: 0, peers: 0 },
+  }), {
+    state: 'hydrating',
+    recoverable: true,
+  })
+})
+
+test('Home Discover separates feed counts from peers and does not call hydrating entries peerless', () => {
+  const source = readAppFile('app/(tabs)/index.tsx')
+
+  assert.match(source, /Feed: \{displayFeedEntries\}/, 'Home should show feed entries as Feed, not overload Channels or Peers')
+  assert.match(source, /Channels: \{displayChannels\}/, 'Home should still show visible/discovered channel count separately')
+  assert.doesNotMatch(source, /5 feed\/channel signals detected; waiting for playable previews/, 'Home should not show stale feed-channel signal copy from older builds')
+  assert.match(source, /state === 'hydrating'[\s\S]*\? 'Loading playable previews'/, 'hydrating feed entries should not be labeled as looking for peers')
+  assert.match(source, /feed entries detected; resolving playable video previews\./, 'hydrating detail should mention feed entries being resolved')
 })

--- a/packages/app/tests/android-physical-discovery-regression.test.mjs
+++ b/packages/app/tests/android-physical-discovery-regression.test.mjs
@@ -42,7 +42,6 @@ test('root layout requests Android discovery permissions, records results, and a
   assert.match(source, /setAndroidDiscoveryPermissionStatus/)
   assert.match(source, /acquireMulticastLock\?\.\(\)/)
   assert.match(source, /initNativeBackend\(\)/)
-  assert.match(source, /Android discovery permission status|Android discovery access|getDiscoveryNetworkStatus|doctor: \(status as any\)\.doctor \|\| undefined/)
   const helperIndex = source.indexOf('const requestAndroidDiscoveryPermissions = useCallback')
   const effectCallIndex = source.indexOf('await requestAndroidDiscoveryPermissions()')
   assert.ok(
@@ -111,35 +110,4 @@ test('feed discovery state distinguishes permission, transport, cached fallback,
     recoverable: true,
     reason: 'zero-peers-no-entries',
   })
-
-  const discoverSource = readAppFile('app/(tabs)/discover.tsx')
-  const homeSource = readAppFile('app/(tabs)/index.tsx')
-  assert.match(discoverSource, /classifyFeedDiscoveryState/)
-  assert.match(discoverSource, /Looking for peers/)
-  assert.match(discoverSource, /peerCount: \${discoveryPeerLabel}. Keep the app open or pull to refresh./)
-  assert.match(discoverSource, /const backendPeerSignal = Math\.max\([\s\S]*swarmStatus\?\.swarmConnections[\s\S]*swarmStatus\?\.feedConnections[\s\S]*swarmStatus\?\.swarmPeers[\s\S]*feedEntries\.length[\s\S]*videos\.length/, 'Discover should derive visible peer status from backend/feed/video signals, not stale public-feed peerCount only')
-  assert.match(discoverSource, /peerCount: backendPeerSignal/, 'Discover feed discovery classification should use aggregate backend signals')
-  assert.match(discoverSource, /const discoveryPeerLabel = backendPeerSignal > 0 \? backendPeerSignal : peerCount/, 'Discover empty copy should report aggregate peer signal')
-  assert.match(discoverSource, /Network boundary: \${discoveryReason \|\| 'unknown'}. Pull to retry the feed path./)
-
-  assert.match(homeSource, /const getCanonicalFeed = \(rpc as any\)\.getCanonicalFeed[\s\S]*typeof getCanonicalFeed === 'function'[\s\S]*getCanonicalFeed\.call\(rpc, \{\}\)[\s\S]*rpc\.getPublicFeed\(\{\}\)/, 'Home should fall back to schema-registered getPublicFeed when mobile builds lack getCanonicalFeed')
-  assert.match(homeSource, /const loadSwarmStatus = useCallback[\s\S]*Math\.max\([\s\S]*swarmConnections[\s\S]*feedConnections[\s\S]*swarmPeers/, 'Home should poll full swarm status independently of feed loading')
-  assert.match(homeSource, /void loadSwarmStatus\(\)[\s\S]*refreshFeed\(\)/, 'Home foreground/periodic refresh should update peer status even when feed loading fails')
-  assert.match(homeSource, /const livePeerCount = Math\.max\([\s\S]*swarmStatus\?\.swarmConnections[\s\S]*swarmStatus\?\.feedConnections[\s\S]*swarmStatus\?\.swarmPeers[\s\S]*\)\n {2}const visibleChannelCount/, 'Home live peer count should only use peer/connection diagnostics, not discovered channel/feed-entry totals')
-  const livePeerCountBlock = homeSource.slice(
-    homeSource.indexOf('const livePeerCount = Math.max('),
-    homeSource.indexOf('const visibleChannelCount = Math.max(')
-  )
-  assert.doesNotMatch(livePeerCountBlock, /feedEntries\.length|snapshotChannelKeys\.size/, 'Home must not label feed entries or snapshot channels as peers')
-  assert.match(homeSource, /const feedActivitySignal = Math\.max\(livePeerCount, feedEntries\.length, snapshotChannelKeys\.size\)/, 'Home empty-state activity signal may combine peer and feed/channel evidence')
-  const schemaSource = readAppFile('../spec/schema.cjs')
-  assert.match(schemaSource, /name: 'get-swarm-status-response'[\s\S]*name: 'swarmConnections'[\s\S]*name: 'swarmPeers'[\s\S]*name: 'feedConnections'[\s\S]*name: 'feedEntries'[\s\S]*name: 'channelsLoaded'/, 'mobile HRPC schema must preserve full swarm diagnostics instead of dropping fields during decode')
-  assert.match(homeSource, /const visibleChannelCount = Math\.max\(feedEntries\.length, snapshotChannelKeys\.size, Number\(swarmStatus\?\.channels \|\| 0\)\)/, 'Home channel count should include cached snapshot channels and backend-loaded channels')
-  assert.match(homeSource, /peerCount: feedActivitySignal/, 'Home feed discovery classification should use aggregate activity signals for empty-state classification')
-  assert.match(homeSource, /Peers: \{discoveryPeerLabel\}/, 'Home peer pill should show live peer/connection count only')
-  assert.match(homeSource, /Feed: \{feedEntries\.length\}/, 'Home feed sublabel should show discovered feed entry count')
-  assert.doesNotMatch(homeSource, />Channels: \{swarmStatus\.channels\}<\/Text>/, 'Home must not render a second Channels label for live backend-loaded channels')
-  assert.match(homeSource, /Live: \{swarmStatus\.channels\}/, 'Home secondary channel status should be labelled Live, not Channels')
-  assert.match(homeSource, /Channels: \{visibleChannelCount\}/, 'Home status pill should not show 0 channels when cached playable feed channels exist')
-  assert.match(homeSource, /feed\/channel signals detected; waiting for playable previews/, 'Home empty copy should acknowledge backend/feed activity without calling feed entries peers')
 })

--- a/packages/app/tests/feed-hydration.test.mjs
+++ b/packages/app/tests/feed-hydration.test.mjs
@@ -83,6 +83,21 @@ test('getFeedVideoHydrationMode uses local-only hydration for cached entries bef
     feedEntries: [{ driveKey: 'a', peerCount: 2 }],
     swarmStatus: null,
   }), 'network')
+
+  assert.equal(getFeedVideoHydrationMode({
+    feedEntries: [{
+      driveKey: 'relay-archive',
+      publicBeeKey: 'bee-relay',
+      peerCount: 0,
+      previewVideos: [{ id: 'direct', blobId: '0:8:0:1024', blobsCoreKey: 'aa'.repeat(32) }],
+    }],
+    swarmStatus: { peers: 0, feedConnections: 0 },
+  }), 'network')
+
+  assert.equal(getFeedVideoHydrationMode({
+    feedEntries: [{ driveKey: 'status-backed', peerCount: 0 }],
+    swarmStatus: { peers: 0, feedConnections: 0, feedEntries: 88 },
+  }), 'network')
 })
 
 test('getFeedPreviewVideos only uses local or live-peer manifest previews', () => {
@@ -248,6 +263,23 @@ test('feed preview videos keep unverified mirrored media visible when byte avail
   assert.equal(videos[0].id, 'mkv-preview')
   assert.equal(videos[0].availability, 'playable')
   assert.equal(videos[0].playbackSupport, 'unverified-container')
+})
+
+test('backend preview fallback preserves live-peer preview availability for Home rendering', async () => {
+  const source = await import('node:fs').then((fs) => fs.readFileSync(new URL('../../backend/src/api.js', import.meta.url), 'utf8'))
+  const previewHelper = source.slice(
+    source.indexOf('function previewVideosFromFeedEntry'),
+    source.indexOf('function getPreviewVideoFromFeed'),
+  )
+  const availabilityBlock = source.slice(
+    source.indexOf('const attachVideoAvailability'),
+    source.indexOf('const cached = listVideosCache.get'),
+  )
+
+  assert.match(previewHelper, /const feedEntryHasLivePeer = Number\(entry\?\.peerCount \|\| 0\) > 0/, 'backend preview fallback should treat live-peer feed previews as renderable')
+  assert.match(previewHelper, /const videoAvailability = video\.availability \|\| video\.byteAvailability \|\| \(feedEntryHasLivePeer \? 'playable' : null\)/, 'preview videos should carry playable availability when the feed entry has live peers')
+  assert.match(availabilityBlock, /const explicitAvailability = video\?\.byteAvailability \|\| video\?\.availability \|\| null/, 'availability revalidation should preserve explicit playable preview availability')
+  assert.match(availabilityBlock, /explicitAvailability === 'playable'[\s\S]*\? 'playable'/, 'explicit playable preview refs must not be downgraded to unavailable during fallback')
 })
 
 test('mergeHydratedFeedVideos replaces stale channel cards when a refreshed channel no longer has watchable videos', () => {

--- a/packages/app/tests/vertical-discovery-regression.test.mjs
+++ b/packages/app/tests/vertical-discovery-regression.test.mjs
@@ -126,6 +126,16 @@ test('Home Discover preloads visible feed playback URLs into the shared URL cach
   assert.match(source, /if \(result\?\.url\) setCachedVideoUrl\(cacheKey, result\.url\)/, 'Home warmups should populate the shared playback URL cache')
 })
 
+test('Home Discover falls back to public feed RPC and labels feed entries separately from live peers', () => {
+  const source = readAppFile('app/(tabs)/index.tsx')
+
+  assert.match(source, /typeof rpc\.getCanonicalFeed === 'function'[\s\S]*rpc\.getPublicFeed\(\{\}\)/, 'Home should fall back when mobile backend only exposes getPublicFeed')
+  assert.match(source, /const displayFeedEntries = Math\.max\([\s\S]*swarmStatus\?\.feedEntries \?\? 0,[\s\S]*feedEntries\.length/, 'Home should display backend feed-entry count separately')
+  assert.match(source, />Feed: \{displayFeedEntries\}</, 'Home should label feed entries as Feed, not Peers')
+  assert.match(source, />Peers: \{displayPeers\}</, 'Home should keep live peer/connection count under Peers')
+  assert.doesNotMatch(source, />Peers: \{feedEntries\.length\}</, 'feed entries must never be shown as peer count')
+})
+
 test('vertical discovery subscribes to backend feed-update events instead of only loading once', () => {
   const source = readAppFile('app/(tabs)/discover.tsx')
 
@@ -164,6 +174,9 @@ test('vertical discovery hides all card chrome, including progress, when tapped'
   assert.doesNotMatch(playerSource, /styles\.controlButtons/, 'progress dock should not carry the play/pause controls anymore')
   assert.doesNotMatch(playerSource, /\{controlsVisible \? \([\s\S]*styles\.controlButtons/, 'buttons should no longer sit above the progress bar')
   assert.doesNotMatch(playerSource, /\(showPlayer \|\| isActive\) \? \([\s\S]*styles\.progressDock/, 'progress bar should not remain mounted after controls are hidden')
+  assert.match(playerSource, /const showPoster = Boolean\(thumbnailUrl\)/, 'Shorts should keep poster imagery behind playback so black video frames are not visually empty')
+  assert.match(playerSource, /const posterOpacity = showPlayer \? 0\.28 : 0\.58/, 'Shorts should dim but preserve posters while the inline player is active')
+  assert.match(playerSource, /imageStyle=\{\[styles\.posterImage, \{ opacity: posterOpacity \}\]\}/, 'poster opacity should be dynamic instead of hidden once playback starts')
 })
 
 test('shorts player has functional playback buttons and a seekable progress bar', () => {

--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -256,10 +256,12 @@ export function createApi({
     const previews = Array.isArray(entry?.previewVideos) ? entry.previewVideos : []
     if (previews.length === 0) return []
     const resolvedPublicBeeKey = publicBeeKey || entry?.publicBeeKey || null
+    const feedEntryHasLivePeer = Number(entry?.peerCount || 0) > 0
     return previews
       .filter((video) => video?.id || video?.path)
       .map((video) => {
         const id = normalizeVideoId(video.id || video.path)
+        const videoAvailability = video.availability || video.byteAvailability || (feedEntryHasLivePeer ? 'playable' : null)
         return {
           ...video,
           id,
@@ -268,6 +270,8 @@ export function createApi({
           publicBeeKey: resolvedPublicBeeKey,
           relayBacked: Boolean(entry?.relayServing || entry?.relayRole === 'cache' || entry?.source === 'relay-cache'),
           mimeType: video.mimeType || 'video/mp4',
+          availability: videoAvailability,
+          byteAvailability: video.byteAvailability || videoAvailability,
         }
       })
   }
@@ -780,9 +784,12 @@ export function createApi({
             const id = extractVideoId(video)
             const localHint = id ? localHintsById.get(id) : null
             const peerHint = id ? peerHintsById.get(id) : null
-            const availability = id
-              ? resolveExplicitVideoAvailability({ localHint, peerHint })
-              : 'unavailable'
+            const explicitAvailability = video?.byteAvailability || video?.availability || null
+            const availability = explicitAvailability === 'playable'
+              ? 'playable'
+              : id
+                ? resolveExplicitVideoAvailability({ localHint, peerHint })
+                : 'unavailable'
 
             return {
               ...video,

--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -577,6 +577,12 @@ export class PublicFeedManager {
   _markPeerConnected(publicKey) {
     const remembered = this._rememberPeerPublicKey(publicKey)
     if (!remembered) return
+    const peerInfo = this.swarm?.peers?.get?.(remembered.keyHex) || null
+    if (peerInfo && typeof peerInfo === 'object') {
+      peerInfo.queued = false
+      peerInfo.waiting = false
+      peerInfo.connectedTime = Date.now()
+    }
     this._directPeerLastDialError.delete(remembered.keyHex)
     this._directPeerLastDialErrorStack.delete(remembered.keyHex)
     this._directPeerDialStats.connected++
@@ -652,11 +658,13 @@ export class PublicFeedManager {
       this._directPeerDialStats.lastReason = 'self-or-missing-key'
       return false
     }
-    this._rememberDiscoveredPeerInSwarm(peer, topic, remembered.keyHex)
+    const peerInfo = this._rememberDiscoveredPeerInSwarm(peer, topic, remembered.keyHex)
     if (this._hasActivePeerConnection(remembered.keyHex, remembered.publicKey)) {
       this._directPeerDialStats.skipped++
       this._directPeerDialStats.lastReason = 'already-connected-peer'
+      return true
     }
+    this._queueDiscoveredPeer(remembered.keyHex, remembered.publicKey, peerInfo)
     return true
   }
 
@@ -668,6 +676,64 @@ export class PublicFeedManager {
       this._directPeerLastDialError.set(keyHex, err?.message || String(err))
       if (err?.stack) this._directPeerLastDialErrorStack.set(keyHex, err.stack)
       return null
+    }
+  }
+
+  _queueDiscoveredPeer(keyHex, publicKey, peerInfo = null) {
+    this._directPeerDialStats.attempted++
+    if (!keyHex || !publicKey || !this.swarm) {
+      this._directPeerDialStats.skipped++
+      this._directPeerDialStats.lastReason = 'missing-peer-key'
+      return false
+    }
+    if (this._hasActivePeerConnection(keyHex, publicKey)) {
+      this._directPeerDialStats.skipped++
+      this._directPeerDialStats.lastReason = 'already-connected-peer'
+      return false
+    }
+    if (peerInfo?.queued || peerInfo?.waiting) {
+      this._directPeerDialStats.skipped++
+      this._directPeerDialStats.lastReason = 'dial-already-pending'
+      return false
+    }
+
+    const now = this._now()
+    try {
+      if (peerInfo && typeof this.swarm._enqueue === 'function') {
+        peerInfo.explicit = true
+        if (typeof peerInfo._updatePriority === 'function') {
+          try { peerInfo._updatePriority() } catch { /* best effort */ }
+        }
+        const queued = this.swarm._enqueue(peerInfo)
+        if (!queued) {
+          this._directPeerDialStats.skipped++
+          this._directPeerDialStats.lastReason = 'enqueue-returned-false'
+          return false
+        }
+        this._directPeerDialStats.queued++
+        this._directPeerDialStats.lastReason = 'queued-existing-peer'
+      } else if (typeof this.swarm.joinPeer === 'function') {
+        this.swarm.joinPeer(publicKey)
+        this._directPeerDialStats.queued++
+        this._directPeerDialStats.lastReason = 'queued-joinPeer'
+      } else {
+        this._directPeerDialStats.skipped++
+        this._directPeerDialStats.lastReason = 'joinPeer-unavailable'
+        return false
+      }
+
+      this._directPeerLastDialedAt.set(keyHex, now)
+      this._directPeerLastDialError.delete(keyHex)
+      this._directPeerLastDialErrorStack.delete(keyHex)
+      this._directPeerDialStats.lastDialedAt = now
+      console.log('[PublicFeed] Queued shared-topic peer dial:', keyHex.slice(0, 16), 'reason=', this._directPeerDialStats.lastReason)
+      return true
+    } catch (err) {
+      this._directPeerDialStats.failed++
+      this._directPeerDialStats.lastReason = 'queue-error'
+      this._directPeerLastDialError.set(keyHex, err?.message || String(err))
+      if (err?.stack) this._directPeerLastDialErrorStack.set(keyHex, err.stack)
+      return false
     }
   }
 

--- a/packages/backend/test/public-feed-manager.test.mjs
+++ b/packages/backend/test/public-feed-manager.test.mjs
@@ -129,18 +129,19 @@ function createMemoryConnectionPair() {
   return [a, b]
 }
 
-test('PublicFeedManager records peers discovered on the shared topic without app-level redialing', () => {
+test('PublicFeedManager queues a bounded explicit dial for unconnected peers discovered on the shared topic', () => {
   const swarm = createSwarm()
   const manager = new PublicFeedManager(swarm, createMetaDb())
   const publicKey = b4a.alloc(32, 7)
 
   try {
     assert.equal(manager.handleDiscoveredPeer({ publicKey }, NETWORK_TOPIC), true)
-    assert.equal(swarm.joinPeerCalls.length, 0)
+    assert.equal(swarm.joinPeerCalls.length, 1)
+    assert.equal(b4a.equals(swarm.joinPeerCalls[0], publicKey), true)
     const stats = manager.getStats().directPeerDial
     assert.equal(stats.discoveredPeers, 1)
-    assert.equal(stats.queued, 0)
-    assert.equal(stats.pending, 0)
+    assert.equal(stats.queued, 1)
+    assert.equal(stats.pending, 1)
     assert.equal(stats.peers[0].key, b4a.toString(publicKey, 'hex').slice(0, 16))
   } finally {
     manager.stop()
@@ -276,7 +277,7 @@ test('PublicFeedManager does not treat stale Hyperswarm _allConnections keys as 
 
   try {
     assert.equal(manager.handleDiscoveredPeer({ publicKey }), true)
-    assert.equal(swarm.joinPeerCalls.length, 0)
+    assert.equal(swarm.joinPeerCalls.length, 1)
     assert.equal(manager.getStats().directPeerDial.peers[0].connected, false)
   } finally {
     manager.stop()
@@ -291,7 +292,7 @@ test('PublicFeedManager does not treat pending Hyperswarm _allConnections entrie
 
   try {
     assert.equal(manager.handleDiscoveredPeer({ publicKey }), true)
-    assert.equal(swarm.joinPeerCalls.length, 0)
+    assert.equal(swarm.joinPeerCalls.length, 1)
     assert.equal(manager.getStats().directPeerDial.peers[0].connected, false)
   } finally {
     manager.stop()
@@ -347,7 +348,7 @@ test('direct peer diagnostics include Hyperswarm queue state', () => {
 })
 
 
-test('PublicFeedManager preserves relay-address hints without app-level joinPeer fallback', () => {
+test('PublicFeedManager preserves relay-address hints and queues existing peer info without joinPeer fallback', () => {
   const publicKey = b4a.alloc(32, 21)
   const keyHex = b4a.toString(publicKey, 'hex')
   const relayAddresses = [{ host: 'relay.test', port: 49737 }]
@@ -357,7 +358,7 @@ test('PublicFeedManager preserves relay-address hints without app-level joinPeer
   try {
     assert.equal(manager.handleDiscoveredPeer({ publicKey, relayAddresses }, NETWORK_TOPIC), true)
     assert.equal(swarm.fallbackJoinPeerCalls.length, 0)
-    assert.equal(swarm.joinPeerCalls.length, 0)
+    assert.equal(swarm.joinPeerCalls.length, 1)
     const peerInfo = swarm.peers.get(keyHex)
     assert.equal(peerInfo.relayAddresses.length, 1)
     assert.equal(peerInfo.topics.length, 1)
@@ -365,13 +366,14 @@ test('PublicFeedManager preserves relay-address hints without app-level joinPeer
     assert.equal(stats.discoveredPeers, 1)
     assert.equal(stats.peers[0].discoveredRelayAddresses, 1)
     assert.equal(stats.peers[0].swarm.relayAddresses, 1)
-    assert.equal(stats.lastReason, null)
+    assert.equal(stats.lastReason, 'queued-existing-peer')
+    assert.equal(stats.pending, 1)
   } finally {
     manager.stop()
   }
 })
 
-test('PublicFeedManager recovery is observational and does not requeue remembered peers', () => {
+test('PublicFeedManager recovery is observational after initial bounded peer queueing', () => {
   const publicKey = b4a.alloc(32, 22)
   const keyHex = b4a.toString(publicKey, 'hex')
   const swarm = createSwarm()
@@ -390,7 +392,7 @@ test('PublicFeedManager recovery is observational and does not requeue remembere
     const stats = manager.getStats().directPeerDial
     assert.equal(stats.recoveryEvents.length, 1)
     assert.equal(stats.recoveryEvents[0].requestedReason, 'test-recovery')
-    assert.equal(stats.lastReason, null)
+    assert.equal(stats.lastReason, 'queued-existing-peer')
   } finally {
     manager.stop()
   }
@@ -457,10 +459,10 @@ test('discovered peer diagnostics become connected when the Hyperswarm socket ar
 
   try {
     assert.equal(manager.handleDiscoveredPeer({ publicKey }), true)
-    assert.equal(swarm.joinPeerCalls.length, 0)
+    assert.equal(swarm.joinPeerCalls.length, 1)
 
     const discoveredStats = manager.getStats().directPeerDial
-    assert.equal(discoveredStats.pending, 0)
+    assert.equal(discoveredStats.pending, 1)
     assert.equal(discoveredStats.peers[0].connected, false)
 
     const conn = createConnection()
@@ -972,7 +974,7 @@ test('periodic feed gossip resends HAVE_FEED and NEED_FEED on existing client co
   }
 })
 
-test('periodic feed gossip does not perform app-level redials after sockets close', async () => {
+test('periodic feed gossip does not perform repeated app-level redials after sockets close', async () => {
   const swarm = createSwarm()
   const manager = new PublicFeedManager(swarm, createMetaDb())
   const publicKey = b4a.alloc(32, 9)
@@ -983,14 +985,14 @@ test('periodic feed gossip does not perform app-level redials after sockets clos
   try {
     await manager.start()
     assert.equal(manager.handleDiscoveredPeer({ publicKey }), true)
-    assert.equal(swarm.joinPeerCalls.length, 0)
+    assert.equal(swarm.joinPeerCalls.length, 1)
 
     manager.handleConnection(conn, { publicKey })
     conn.emit('close')
 
     await new Promise((resolve) => setTimeout(resolve, 35))
 
-    assert.equal(swarm.joinPeerCalls.length, 0, 'gossip loop should not redial; Hyperswarm owns socket retry')
+    assert.equal(swarm.joinPeerCalls.length, 1, 'gossip loop should not repeatedly redial; initial peer discovery already queued one bounded dial')
     assert.equal(manager.getStats().directPeerDial.discoveredPeers, 1)
   } finally {
     manager.stop()

--- a/packages/cli/src/service.js
+++ b/packages/cli/src/service.js
@@ -48,6 +48,34 @@ export async function createRelayService({
     })
   }
 
+  function getPreviewBlobSignature(previewVideos) {
+    if (!Array.isArray(previewVideos) || previewVideos.length === 0) return ''
+    return previewVideos
+      .filter((video) => video?.blobsCoreKey && video?.blobId)
+      .map((video) => [
+        String(video.blobsCoreKey).toLowerCase(),
+        String(video.blobId),
+        video?.thumbnailBlobsCoreKey ? String(video.thumbnailBlobsCoreKey).toLowerCase() : '',
+        video?.thumbnailBlobId ? String(video.thumbnailBlobId) : ''
+      ].join(':'))
+      .sort()
+      .join('|')
+  }
+
+  function shouldRefreshAcceptedChannel(existing, candidate) {
+    if (!existing?.channelKey) return false
+    const incomingSignature = getPreviewBlobSignature(candidate?.previewVideos)
+    if (!incomingSignature) return false
+
+    const existingSignature = getPreviewBlobSignature(existing.previewVideos)
+    if (incomingSignature !== existingSignature) return true
+
+    if ((Number(existing.videosDownloaded) || 0) <= 0) return true
+    if ((Number(existing.bytes) || 0) <= 0) return true
+
+    return false
+  }
+
   async function runLocalMirrorOnce(localMirrorConfig = config.archive?.localMirror || {}) {
     if (!localMirrorConfig?.enabled) return null
     if (localMirrorRunning) return { skipped: true, reason: 'already-running' }
@@ -109,12 +137,20 @@ export async function createRelayService({
       ? await runtime.resolveCandidate(candidate)
       : candidate
 
-    const decision = evaluateCandidate({
-      candidate: resolved,
-      config,
-      acceptedChannels: new Set(relayCatalog.getChannels().map((channel) => channel.channelKey)),
-      ownerCounts: relayCatalog.getOwnerCounts()
-    })
+    const existingChannel = relayCatalog.getChannel(resolved.channelKey)
+    const refreshAcceptedChannel = shouldRefreshAcceptedChannel(existingChannel, resolved)
+    const decision = refreshAcceptedChannel
+      ? {
+        accepted: true,
+        reason: 'accepted-preview-refresh',
+        retentionClass: existingChannel.retentionClass || resolved.retentionClass || 'discovery'
+      }
+      : evaluateCandidate({
+        candidate: resolved,
+        config,
+        acceptedChannels: new Set(relayCatalog.getChannels().map((channel) => channel.channelKey)),
+        ownerCounts: relayCatalog.getOwnerCounts()
+      })
 
     if (!decision.accepted) {
       logger.admission.info('Candidate rejected', {
@@ -167,6 +203,15 @@ export async function createRelayService({
         videoCount: Number(mirrorStats?.videoCount || mirrorStats?.videosDownloaded || mirrorStats?.videosFound || 0) || 0,
         manifestUpdatedAt: Date.now()
       })
+
+      if (refreshAcceptedChannel) {
+        logger.mirror.info('Accepted channel refreshed from preview refs', {
+          channelKey: resolved.channelKey,
+          ownerKey: resolved.ownerKey || null,
+          videosDownloaded: mirrorStats?.videosDownloaded || 0,
+          bytesDownloaded: mirrorStats?.bytesDownloaded || 0
+        })
+      }
 
       if (resolved.publicBeeKey) {
         await runtime.cacheManager?.addChannel?.(resolved.channelKey, resolved.publicBeeKey, 'discovered').catch(() => {})

--- a/packages/cli/test/service.test.mjs
+++ b/packages/cli/test/service.test.mjs
@@ -769,3 +769,62 @@ test('createRelayService watches configured local mirror directory', async (t) =
     rmSync(dir, { recursive: true, force: true })
   }
 })
+
+test('createRelayService refreshes already accepted channels when feed preview refs appear', async (t) => {
+  const dir = makeTempDir('peartube-relay-service-preview-refresh-')
+  const runtime = createFakeRuntime()
+  const mirrored = []
+  const previewVideos = [{
+    id: 'preview-1',
+    blobId: '0:2:0:20',
+    blobsCoreKey: 'aa'.repeat(32),
+    thumbnailBlobId: '2:1:20:5',
+    thumbnailBlobsCoreKey: 'bb'.repeat(32)
+  }]
+
+  try {
+    const service = await createRelayService({
+      config: {
+        mode: 'public',
+        policy: 'discovery',
+        storage: { path: dir, maxBytes: 10_000 },
+        paths: {
+          catalog: join(dir, 'relay-catalog.json'),
+          status: join(dir, 'relay-status.json')
+        },
+        admission: { channels: [], owners: [] },
+        discovery: { enabled: true, maxChannels: 5, maxChannelsPerOwner: 2 }
+      },
+      logger: createFakeLogger(),
+      runtimeFactory: async () => runtime,
+      mirrorChannel: async (candidate) => {
+        mirrored.push({ channelKey: candidate.channelKey, previews: candidate.previewVideos?.length || 0 })
+        return {
+          bytesDownloaded: candidate.previewVideos?.length ? 20 : 0,
+          videosFound: 0,
+          videosDownloaded: candidate.previewVideos?.length ? 1 : 0,
+          previewVideos: candidate.previewVideos || [],
+          videoCount: candidate.previewVideos?.length || 0
+        }
+      },
+      writeStatusFile: async () => {}
+    })
+
+    await service.start()
+    await runtime.emit({ channelKey: 'chan-preview-refresh', publicBeeKey: 'bee-preview-refresh', source: 'discovered' })
+    await runtime.emit({ channelKey: 'chan-preview-refresh', publicBeeKey: 'bee-preview-refresh', source: 'discovered', previewVideos })
+
+    const channel = service.catalog.getChannel('chan-preview-refresh')
+
+    t.alike(mirrored, [
+      { channelKey: 'chan-preview-refresh', previews: 0 },
+      { channelKey: 'chan-preview-refresh', previews: 1 }
+    ])
+    t.is(channel.videosDownloaded, 1)
+    t.is(channel.bytes, 20)
+    t.alike(channel.previewVideos, previewVideos)
+    await service.close()
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/packages/spec/spec/hrpc/app-rpc-adapter.mjs
+++ b/packages/spec/spec/hrpc/app-rpc-adapter.mjs
@@ -259,6 +259,17 @@ export const APP_RPC_METADATA = Object.freeze({
     },
     {
       "id": 23,
+      "command": "get-canonical-feed",
+      "method": "getCanonicalFeed",
+      "handler": "GetCanonicalFeed",
+      "request": "@peartube/get-canonical-feed-request",
+      "response": "@peartube/get-canonical-feed-response",
+      "send": false,
+      "requestStream": false,
+      "responseStream": false
+    },
+    {
+      "id": 24,
       "command": "refresh-feed",
       "method": "refreshFeed",
       "handler": "RefreshFeed",
@@ -269,7 +280,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 24,
+      "id": 25,
       "command": "submit-to-feed",
       "method": "submitToFeed",
       "handler": "SubmitToFeed",
@@ -280,7 +291,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 25,
+      "id": 26,
       "command": "unpublish-from-feed",
       "method": "unpublishFromFeed",
       "handler": "UnpublishFromFeed",
@@ -291,7 +302,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 26,
+      "id": 27,
       "command": "is-channel-published",
       "method": "isChannelPublished",
       "handler": "IsChannelPublished",
@@ -302,7 +313,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 27,
+      "id": 28,
       "command": "hide-channel",
       "method": "hideChannel",
       "handler": "HideChannel",
@@ -313,7 +324,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 28,
+      "id": 29,
       "command": "get-channel-meta",
       "method": "getChannelMeta",
       "handler": "GetChannelMeta",
@@ -324,7 +335,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 29,
+      "id": 30,
       "command": "get-swarm-status",
       "method": "getSwarmStatus",
       "handler": "GetSwarmStatus",
@@ -335,7 +346,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 30,
+      "id": 31,
       "command": "create-device-invite",
       "method": "createDeviceInvite",
       "handler": "CreateDeviceInvite",
@@ -346,7 +357,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 31,
+      "id": 32,
       "command": "pair-device",
       "method": "pairDevice",
       "handler": "PairDevice",
@@ -357,7 +368,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 32,
+      "id": 33,
       "command": "list-devices",
       "method": "listDevices",
       "handler": "ListDevices",
@@ -368,7 +379,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 33,
+      "id": 34,
       "command": "retry-sync-channel",
       "method": "retrySyncChannel",
       "handler": "RetrySyncChannel",
@@ -379,7 +390,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 34,
+      "id": 35,
       "command": "prefetch-video",
       "method": "prefetchVideo",
       "handler": "PrefetchVideo",
@@ -390,7 +401,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 35,
+      "id": 36,
       "command": "get-video-stats",
       "method": "getVideoStats",
       "handler": "GetVideoStats",
@@ -401,7 +412,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 36,
+      "id": 37,
       "command": "get-seeding-status",
       "method": "getSeedingStatus",
       "handler": "GetSeedingStatus",
@@ -412,7 +423,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 37,
+      "id": 38,
       "command": "set-seeding-config",
       "method": "setSeedingConfig",
       "handler": "SetSeedingConfig",
@@ -423,7 +434,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 38,
+      "id": 39,
       "command": "get-transcode-settings",
       "method": "getTranscodeSettings",
       "handler": "GetTranscodeSettings",
@@ -434,7 +445,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 39,
+      "id": 40,
       "command": "set-transcode-settings",
       "method": "setTranscodeSettings",
       "handler": "SetTranscodeSettings",
@@ -445,7 +456,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 40,
+      "id": 41,
       "command": "pin-channel",
       "method": "pinChannel",
       "handler": "PinChannel",
@@ -456,7 +467,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 41,
+      "id": 42,
       "command": "unpin-channel",
       "method": "unpinChannel",
       "handler": "UnpinChannel",
@@ -467,7 +478,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 42,
+      "id": 43,
       "command": "get-pinned-channels",
       "method": "getPinnedChannels",
       "handler": "GetPinnedChannels",
@@ -478,7 +489,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 43,
+      "id": 44,
       "command": "get-storage-stats",
       "method": "getStorageStats",
       "handler": "GetStorageStats",
@@ -489,7 +500,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 44,
+      "id": 45,
       "command": "set-storage-limit",
       "method": "setStorageLimit",
       "handler": "SetStorageLimit",
@@ -500,7 +511,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 45,
+      "id": 46,
       "command": "clear-cache",
       "method": "clearCache",
       "handler": "ClearCache",
@@ -511,7 +522,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 46,
+      "id": 47,
       "command": "get-video-thumbnail",
       "method": "getVideoThumbnail",
       "handler": "GetVideoThumbnail",
@@ -522,7 +533,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 47,
+      "id": 48,
       "command": "get-video-metadata",
       "method": "getVideoMetadata",
       "handler": "GetVideoMetadata",
@@ -533,7 +544,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 48,
+      "id": 49,
       "command": "set-video-thumbnail",
       "method": "setVideoThumbnail",
       "handler": "SetVideoThumbnail",
@@ -544,7 +555,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 49,
+      "id": 50,
       "command": "set-video-thumbnail-from-file",
       "method": "setVideoThumbnailFromFile",
       "handler": "SetVideoThumbnailFromFile",
@@ -555,7 +566,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 50,
+      "id": 51,
       "command": "get-status",
       "method": "getStatus",
       "handler": "GetStatus",
@@ -566,7 +577,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 51,
+      "id": 52,
       "command": "pick-video-file",
       "method": "pickVideoFile",
       "handler": "PickVideoFile",
@@ -577,7 +588,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 52,
+      "id": 53,
       "command": "pick-image-file",
       "method": "pickImageFile",
       "handler": "PickImageFile",
@@ -588,7 +599,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 53,
+      "id": 54,
       "command": "get-blob-server-port",
       "method": "getBlobServerPort",
       "handler": "GetBlobServerPort",
@@ -599,7 +610,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 54,
+      "id": 55,
       "command": "global-search-videos",
       "method": "globalSearchVideos",
       "handler": "GlobalSearchVideos",
@@ -610,7 +621,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 55,
+      "id": 56,
       "command": "add-comment",
       "method": "addComment",
       "handler": "AddComment",
@@ -621,7 +632,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 56,
+      "id": 57,
       "command": "list-comments",
       "method": "listComments",
       "handler": "ListComments",
@@ -632,7 +643,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 57,
+      "id": 58,
       "command": "hide-comment",
       "method": "hideComment",
       "handler": "HideComment",
@@ -643,7 +654,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 58,
+      "id": 59,
       "command": "remove-comment",
       "method": "removeComment",
       "handler": "RemoveComment",
@@ -654,7 +665,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 59,
+      "id": 60,
       "command": "add-reaction",
       "method": "addReaction",
       "handler": "AddReaction",
@@ -665,7 +676,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 60,
+      "id": 61,
       "command": "remove-reaction",
       "method": "removeReaction",
       "handler": "RemoveReaction",
@@ -676,7 +687,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 61,
+      "id": 62,
       "command": "get-reactions",
       "method": "getReactions",
       "handler": "GetReactions",
@@ -687,7 +698,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 62,
+      "id": 63,
       "command": "event-ready",
       "method": "eventReady",
       "handler": "EventReady",
@@ -698,7 +709,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 63,
+      "id": 64,
       "command": "event-error",
       "method": "eventError",
       "handler": "EventError",
@@ -709,7 +720,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 64,
+      "id": 65,
       "command": "event-upload-progress",
       "method": "eventUploadProgress",
       "handler": "EventUploadProgress",
@@ -720,7 +731,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 65,
+      "id": 66,
       "command": "event-download-progress",
       "method": "eventDownloadProgress",
       "handler": "EventDownloadProgress",
@@ -731,7 +742,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 66,
+      "id": 67,
       "command": "event-feed-update",
       "method": "eventFeedUpdate",
       "handler": "EventFeedUpdate",
@@ -742,7 +753,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 67,
+      "id": 68,
       "command": "event-log",
       "method": "eventLog",
       "handler": "EventLog",
@@ -753,7 +764,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 68,
+      "id": 69,
       "command": "event-video-stats",
       "method": "eventVideoStats",
       "handler": "EventVideoStats",
@@ -764,7 +775,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 69,
+      "id": 70,
       "command": "cast-available",
       "method": "castAvailable",
       "handler": "CastAvailable",
@@ -775,7 +786,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 70,
+      "id": 71,
       "command": "cast-start-discovery",
       "method": "castStartDiscovery",
       "handler": "CastStartDiscovery",
@@ -786,7 +797,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 71,
+      "id": 72,
       "command": "cast-stop-discovery",
       "method": "castStopDiscovery",
       "handler": "CastStopDiscovery",
@@ -797,7 +808,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 72,
+      "id": 73,
       "command": "cast-get-devices",
       "method": "castGetDevices",
       "handler": "CastGetDevices",
@@ -808,7 +819,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 73,
+      "id": 74,
       "command": "cast-add-manual-device",
       "method": "castAddManualDevice",
       "handler": "CastAddManualDevice",
@@ -819,7 +830,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 74,
+      "id": 75,
       "command": "cast-connect",
       "method": "castConnect",
       "handler": "CastConnect",
@@ -830,7 +841,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 75,
+      "id": 76,
       "command": "cast-disconnect",
       "method": "castDisconnect",
       "handler": "CastDisconnect",
@@ -841,7 +852,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 76,
+      "id": 77,
       "command": "cast-play",
       "method": "castPlay",
       "handler": "CastPlay",
@@ -852,7 +863,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 77,
+      "id": 78,
       "command": "cast-pause",
       "method": "castPause",
       "handler": "CastPause",
@@ -863,7 +874,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 78,
+      "id": 79,
       "command": "cast-resume",
       "method": "castResume",
       "handler": "CastResume",
@@ -874,7 +885,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 79,
+      "id": 80,
       "command": "cast-stop",
       "method": "castStop",
       "handler": "CastStop",
@@ -885,7 +896,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 80,
+      "id": 81,
       "command": "cast-seek",
       "method": "castSeek",
       "handler": "CastSeek",
@@ -896,7 +907,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 81,
+      "id": 82,
       "command": "cast-set-volume",
       "method": "castSetVolume",
       "handler": "CastSetVolume",
@@ -907,7 +918,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 82,
+      "id": 83,
       "command": "cast-get-state",
       "method": "castGetState",
       "handler": "CastGetState",
@@ -918,7 +929,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 83,
+      "id": 84,
       "command": "cast-is-connected",
       "method": "castIsConnected",
       "handler": "CastIsConnected",
@@ -929,7 +940,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 84,
+      "id": 85,
       "command": "event-cast-device-found",
       "method": "eventCastDeviceFound",
       "handler": "EventCastDeviceFound",
@@ -940,7 +951,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 85,
+      "id": 86,
       "command": "event-cast-device-lost",
       "method": "eventCastDeviceLost",
       "handler": "EventCastDeviceLost",
@@ -951,7 +962,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 86,
+      "id": 87,
       "command": "event-cast-playback-state",
       "method": "eventCastPlaybackState",
       "handler": "EventCastPlaybackState",
@@ -962,7 +973,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 87,
+      "id": 88,
       "command": "event-cast-time-update",
       "method": "eventCastTimeUpdate",
       "handler": "EventCastTimeUpdate",
@@ -973,7 +984,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 88,
+      "id": 89,
       "command": "search-videos",
       "method": "searchVideos",
       "handler": "SearchVideos",
@@ -984,7 +995,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 89,
+      "id": 90,
       "command": "log-watch-event",
       "method": "logWatchEvent",
       "handler": "LogWatchEvent",
@@ -995,7 +1006,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 90,
+      "id": 91,
       "command": "index-video-vectors",
       "method": "indexVideoVectors",
       "handler": "IndexVideoVectors",
@@ -1006,7 +1017,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 91,
+      "id": 92,
       "command": "get-recommendations",
       "method": "getRecommendations",
       "handler": "GetRecommendations",
@@ -1017,7 +1028,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 92,
+      "id": 93,
       "command": "get-video-recommendations",
       "method": "getVideoRecommendations",
       "handler": "GetVideoRecommendations",
@@ -1028,7 +1039,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 93,
+      "id": 94,
       "command": "update-video-metadata",
       "method": "updateVideoMetadata",
       "handler": "UpdateVideoMetadata",
@@ -1039,7 +1050,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 94,
+      "id": 95,
       "command": "desktop-bootstrap",
       "method": "desktopBootstrap",
       "handler": "DesktopBootstrap",
@@ -1050,7 +1061,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 95,
+      "id": 96,
       "command": "desktop-shutdown",
       "method": "desktopShutdown",
       "handler": "DesktopShutdown",
@@ -1061,7 +1072,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 96,
+      "id": 97,
       "command": "desktop-refresh-browse",
       "method": "desktopRefreshBrowse",
       "handler": "DesktopRefreshBrowse",
@@ -1072,7 +1083,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 97,
+      "id": 98,
       "command": "mpv-available",
       "method": "mpvAvailable",
       "handler": "MpvAvailable",
@@ -1083,7 +1094,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 98,
+      "id": 99,
       "command": "mpv-create",
       "method": "mpvCreate",
       "handler": "MpvCreate",
@@ -1094,7 +1105,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 99,
+      "id": 100,
       "command": "mpv-load-file",
       "method": "mpvLoadFile",
       "handler": "MpvLoadFile",
@@ -1105,7 +1116,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 100,
+      "id": 101,
       "command": "mpv-play",
       "method": "mpvPlay",
       "handler": "MpvPlay",
@@ -1116,7 +1127,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 101,
+      "id": 102,
       "command": "mpv-pause",
       "method": "mpvPause",
       "handler": "MpvPause",
@@ -1127,7 +1138,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 102,
+      "id": 103,
       "command": "mpv-seek",
       "method": "mpvSeek",
       "handler": "MpvSeek",
@@ -1138,7 +1149,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 103,
+      "id": 104,
       "command": "mpv-get-state",
       "method": "mpvGetState",
       "handler": "MpvGetState",
@@ -1149,7 +1160,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 104,
+      "id": 105,
       "command": "mpv-render-frame",
       "method": "mpvRenderFrame",
       "handler": "MpvRenderFrame",
@@ -1160,7 +1171,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 105,
+      "id": 106,
       "command": "mpv-destroy",
       "method": "mpvDestroy",
       "handler": "MpvDestroy",
@@ -1171,7 +1182,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 106,
+      "id": 107,
       "command": "ffmpeg-decode-available",
       "method": "ffmpegDecodeAvailable",
       "handler": "FfmpegDecodeAvailable",
@@ -1182,7 +1193,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 107,
+      "id": 108,
       "command": "update-channel-avatar",
       "method": "updateChannelAvatar",
       "handler": "UpdateChannelAvatar",
@@ -1193,7 +1204,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 108,
+      "id": 109,
       "command": "transcode-start",
       "method": "transcodeStart",
       "handler": "TranscodeStart",
@@ -1204,7 +1215,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 109,
+      "id": 110,
       "command": "transcode-stop",
       "method": "transcodeStop",
       "handler": "TranscodeStop",
@@ -1215,7 +1226,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 110,
+      "id": 111,
       "command": "transcode-status",
       "method": "transcodeStatus",
       "handler": "TranscodeStatus",
@@ -1226,7 +1237,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 111,
+      "id": 112,
       "command": "event-transcode-progress",
       "method": "eventTranscodeProgress",
       "handler": "EventTranscodeProgress",
@@ -1235,23 +1246,12 @@ export const APP_RPC_METADATA = Object.freeze({
       "send": true,
       "requestStream": false,
       "responseStream": false
-    },
-    {
-      "id": 23,
-      "command": "get-canonical-feed",
-      "method": "getCanonicalFeed",
-      "handler": "GetCanonicalFeed",
-      "request": "@peartube/get-canonical-feed-request",
-      "response": "@peartube/get-canonical-feed-response",
-      "send": false,
-      "requestStream": false,
-      "responseStream": false
     }
   ],
   "namespaces": {
     "system": [
       {
-        "id": 50,
+        "id": 51,
         "command": "get-status",
         "method": "getStatus",
         "handler": "GetStatus",
@@ -1262,7 +1262,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 29,
+        "id": 30,
         "command": "get-swarm-status",
         "method": "getSwarmStatus",
         "handler": "GetSwarmStatus",
@@ -1273,7 +1273,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 53,
+        "id": 54,
         "command": "get-blob-server-port",
         "method": "getBlobServerPort",
         "handler": "GetBlobServerPort",
@@ -1341,7 +1341,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 30,
+        "id": 31,
         "command": "create-device-invite",
         "method": "createDeviceInvite",
         "handler": "CreateDeviceInvite",
@@ -1352,7 +1352,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 31,
+        "id": 32,
         "command": "pair-device",
         "method": "pairDevice",
         "handler": "PairDevice",
@@ -1363,7 +1363,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 32,
+        "id": 33,
         "command": "list-devices",
         "method": "listDevices",
         "handler": "ListDevices",
@@ -1431,7 +1431,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 23,
+        "id": 24,
         "command": "refresh-feed",
         "method": "refreshFeed",
         "handler": "RefreshFeed",
@@ -1442,7 +1442,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 24,
+        "id": 25,
         "command": "submit-to-feed",
         "method": "submitToFeed",
         "handler": "SubmitToFeed",
@@ -1453,7 +1453,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 25,
+        "id": 26,
         "command": "unpublish-from-feed",
         "method": "unpublishFromFeed",
         "handler": "UnpublishFromFeed",
@@ -1464,7 +1464,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 26,
+        "id": 27,
         "command": "is-channel-published",
         "method": "isChannelPublished",
         "handler": "IsChannelPublished",
@@ -1519,7 +1519,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 27,
+        "id": 28,
         "command": "hide-channel",
         "method": "hideChannel",
         "handler": "HideChannel",
@@ -1530,7 +1530,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 40,
+        "id": 41,
         "command": "pin-channel",
         "method": "pinChannel",
         "handler": "PinChannel",
@@ -1541,7 +1541,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 41,
+        "id": 42,
         "command": "unpin-channel",
         "method": "unpinChannel",
         "handler": "UnpinChannel",
@@ -1552,7 +1552,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 42,
+        "id": 43,
         "command": "get-pinned-channels",
         "method": "getPinnedChannels",
         "handler": "GetPinnedChannels",
@@ -1576,7 +1576,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 28,
+        "id": 29,
         "command": "get-channel-meta",
         "method": "getChannelMeta",
         "handler": "GetChannelMeta",
@@ -1598,7 +1598,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 107,
+        "id": 108,
         "command": "update-channel-avatar",
         "method": "updateChannelAvatar",
         "handler": "UpdateChannelAvatar",
@@ -1666,7 +1666,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 47,
+        "id": 48,
         "command": "get-video-metadata",
         "method": "getVideoMetadata",
         "handler": "GetVideoMetadata",
@@ -1677,7 +1677,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 46,
+        "id": 47,
         "command": "get-video-thumbnail",
         "method": "getVideoThumbnail",
         "handler": "GetVideoThumbnail",
@@ -1688,7 +1688,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 35,
+        "id": 36,
         "command": "get-video-stats",
         "method": "getVideoStats",
         "handler": "GetVideoStats",
@@ -1699,7 +1699,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 34,
+        "id": 35,
         "command": "prefetch-video",
         "method": "prefetchVideo",
         "handler": "PrefetchVideo",
@@ -1721,7 +1721,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 93,
+        "id": 94,
         "command": "update-video-metadata",
         "method": "updateVideoMetadata",
         "handler": "UpdateVideoMetadata",
@@ -1732,7 +1732,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 48,
+        "id": 49,
         "command": "set-video-thumbnail",
         "method": "setVideoThumbnail",
         "handler": "SetVideoThumbnail",
@@ -1743,7 +1743,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 49,
+        "id": 50,
         "command": "set-video-thumbnail-from-file",
         "method": "setVideoThumbnailFromFile",
         "handler": "SetVideoThumbnailFromFile",
@@ -1754,7 +1754,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 55,
+        "id": 56,
         "command": "add-comment",
         "method": "addComment",
         "handler": "AddComment",
@@ -1765,7 +1765,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 56,
+        "id": 57,
         "command": "list-comments",
         "method": "listComments",
         "handler": "ListComments",
@@ -1776,7 +1776,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 57,
+        "id": 58,
         "command": "hide-comment",
         "method": "hideComment",
         "handler": "HideComment",
@@ -1787,7 +1787,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 58,
+        "id": 59,
         "command": "remove-comment",
         "method": "removeComment",
         "handler": "RemoveComment",
@@ -1798,7 +1798,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 59,
+        "id": 60,
         "command": "add-reaction",
         "method": "addReaction",
         "handler": "AddReaction",
@@ -1809,7 +1809,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 60,
+        "id": 61,
         "command": "remove-reaction",
         "method": "removeReaction",
         "handler": "RemoveReaction",
@@ -1820,7 +1820,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 61,
+        "id": 62,
         "command": "get-reactions",
         "method": "getReactions",
         "handler": "GetReactions",
@@ -1833,7 +1833,7 @@ export const APP_RPC_METADATA = Object.freeze({
     ],
     "watch": [
       {
-        "id": 89,
+        "id": 90,
         "command": "log-watch-event",
         "method": "logWatchEvent",
         "handler": "LogWatchEvent",
@@ -1844,7 +1844,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 91,
+        "id": 92,
         "command": "get-recommendations",
         "method": "getRecommendations",
         "handler": "GetRecommendations",
@@ -1855,7 +1855,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 92,
+        "id": 93,
         "command": "get-video-recommendations",
         "method": "getVideoRecommendations",
         "handler": "GetVideoRecommendations",
@@ -1890,7 +1890,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 36,
+        "id": 37,
         "command": "get-seeding-status",
         "method": "getSeedingStatus",
         "handler": "GetSeedingStatus",
@@ -1901,7 +1901,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 37,
+        "id": 38,
         "command": "set-seeding-config",
         "method": "setSeedingConfig",
         "handler": "SetSeedingConfig",
@@ -1912,7 +1912,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 43,
+        "id": 44,
         "command": "get-storage-stats",
         "method": "getStorageStats",
         "handler": "GetStorageStats",
@@ -1923,7 +1923,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 44,
+        "id": 45,
         "command": "set-storage-limit",
         "method": "setStorageLimit",
         "handler": "SetStorageLimit",
@@ -1934,7 +1934,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 45,
+        "id": 46,
         "command": "clear-cache",
         "method": "clearCache",
         "handler": "ClearCache",
@@ -1947,7 +1947,7 @@ export const APP_RPC_METADATA = Object.freeze({
     ],
     "search": [
       {
-        "id": 88,
+        "id": 89,
         "command": "search-videos",
         "method": "searchVideos",
         "handler": "SearchVideos",
@@ -1958,7 +1958,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 54,
+        "id": 55,
         "command": "global-search-videos",
         "method": "globalSearchVideos",
         "handler": "GlobalSearchVideos",
@@ -1969,7 +1969,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 90,
+        "id": 91,
         "command": "index-video-vectors",
         "method": "indexVideoVectors",
         "handler": "IndexVideoVectors",
@@ -1982,7 +1982,7 @@ export const APP_RPC_METADATA = Object.freeze({
     ],
     "shell": [
       {
-        "id": 51,
+        "id": 52,
         "command": "pick-video-file",
         "method": "pickVideoFile",
         "handler": "PickVideoFile",
@@ -1993,7 +1993,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 52,
+        "id": 53,
         "command": "pick-image-file",
         "method": "pickImageFile",
         "handler": "PickImageFile",
@@ -2004,7 +2004,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 38,
+        "id": 39,
         "command": "get-transcode-settings",
         "method": "getTranscodeSettings",
         "handler": "GetTranscodeSettings",
@@ -2015,7 +2015,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 39,
+        "id": 40,
         "command": "set-transcode-settings",
         "method": "setTranscodeSettings",
         "handler": "SetTranscodeSettings",
@@ -2026,7 +2026,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 97,
+        "id": 98,
         "command": "mpv-available",
         "method": "mpvAvailable",
         "handler": "MpvAvailable",
@@ -2037,7 +2037,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 98,
+        "id": 99,
         "command": "mpv-create",
         "method": "mpvCreate",
         "handler": "MpvCreate",
@@ -2048,7 +2048,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 99,
+        "id": 100,
         "command": "mpv-load-file",
         "method": "mpvLoadFile",
         "handler": "MpvLoadFile",
@@ -2059,7 +2059,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 100,
+        "id": 101,
         "command": "mpv-play",
         "method": "mpvPlay",
         "handler": "MpvPlay",
@@ -2070,7 +2070,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 101,
+        "id": 102,
         "command": "mpv-pause",
         "method": "mpvPause",
         "handler": "MpvPause",
@@ -2081,7 +2081,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 102,
+        "id": 103,
         "command": "mpv-seek",
         "method": "mpvSeek",
         "handler": "MpvSeek",
@@ -2092,7 +2092,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 103,
+        "id": 104,
         "command": "mpv-get-state",
         "method": "mpvGetState",
         "handler": "MpvGetState",
@@ -2103,7 +2103,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 104,
+        "id": 105,
         "command": "mpv-render-frame",
         "method": "mpvRenderFrame",
         "handler": "MpvRenderFrame",
@@ -2114,7 +2114,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 105,
+        "id": 106,
         "command": "mpv-destroy",
         "method": "mpvDestroy",
         "handler": "MpvDestroy",
@@ -2125,7 +2125,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 106,
+        "id": 107,
         "command": "ffmpeg-decode-available",
         "method": "ffmpegDecodeAvailable",
         "handler": "FfmpegDecodeAvailable",
@@ -2136,7 +2136,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 69,
+        "id": 70,
         "command": "cast-available",
         "method": "castAvailable",
         "handler": "CastAvailable",
@@ -2147,7 +2147,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 70,
+        "id": 71,
         "command": "cast-start-discovery",
         "method": "castStartDiscovery",
         "handler": "CastStartDiscovery",
@@ -2158,7 +2158,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 71,
+        "id": 72,
         "command": "cast-stop-discovery",
         "method": "castStopDiscovery",
         "handler": "CastStopDiscovery",
@@ -2169,7 +2169,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 72,
+        "id": 73,
         "command": "cast-get-devices",
         "method": "castGetDevices",
         "handler": "CastGetDevices",
@@ -2180,7 +2180,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 73,
+        "id": 74,
         "command": "cast-add-manual-device",
         "method": "castAddManualDevice",
         "handler": "CastAddManualDevice",
@@ -2191,7 +2191,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 74,
+        "id": 75,
         "command": "cast-connect",
         "method": "castConnect",
         "handler": "CastConnect",
@@ -2202,7 +2202,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 75,
+        "id": 76,
         "command": "cast-disconnect",
         "method": "castDisconnect",
         "handler": "CastDisconnect",
@@ -2213,7 +2213,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 76,
+        "id": 77,
         "command": "cast-play",
         "method": "castPlay",
         "handler": "CastPlay",
@@ -2224,7 +2224,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 77,
+        "id": 78,
         "command": "cast-pause",
         "method": "castPause",
         "handler": "CastPause",
@@ -2235,7 +2235,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 78,
+        "id": 79,
         "command": "cast-resume",
         "method": "castResume",
         "handler": "CastResume",
@@ -2246,7 +2246,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 79,
+        "id": 80,
         "command": "cast-stop",
         "method": "castStop",
         "handler": "CastStop",
@@ -2257,7 +2257,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 80,
+        "id": 81,
         "command": "cast-seek",
         "method": "castSeek",
         "handler": "CastSeek",
@@ -2268,7 +2268,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 81,
+        "id": 82,
         "command": "cast-set-volume",
         "method": "castSetVolume",
         "handler": "CastSetVolume",
@@ -2279,7 +2279,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 82,
+        "id": 83,
         "command": "cast-get-state",
         "method": "castGetState",
         "handler": "CastGetState",
@@ -2290,7 +2290,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 83,
+        "id": 84,
         "command": "cast-is-connected",
         "method": "castIsConnected",
         "handler": "CastIsConnected",
@@ -2301,7 +2301,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 108,
+        "id": 109,
         "command": "transcode-start",
         "method": "transcodeStart",
         "handler": "TranscodeStart",
@@ -2312,7 +2312,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 109,
+        "id": 110,
         "command": "transcode-stop",
         "method": "transcodeStop",
         "handler": "TranscodeStop",
@@ -2323,7 +2323,7 @@ export const APP_RPC_METADATA = Object.freeze({
         "responseStream": false
       },
       {
-        "id": 110,
+        "id": 111,
         "command": "transcode-status",
         "method": "transcodeStatus",
         "handler": "TranscodeStatus",
@@ -2436,7 +2436,7 @@ export const APP_RPC_METADATA = Object.freeze({
   ],
   "platformOnlyCommands": [
     {
-      "id": 94,
+      "id": 95,
       "command": "desktop-bootstrap",
       "method": "desktopBootstrap",
       "handler": "DesktopBootstrap",
@@ -2447,7 +2447,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 95,
+      "id": 96,
       "command": "desktop-shutdown",
       "method": "desktopShutdown",
       "handler": "DesktopShutdown",
@@ -2458,7 +2458,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 96,
+      "id": 97,
       "command": "desktop-refresh-browse",
       "method": "desktopRefreshBrowse",
       "handler": "DesktopRefreshBrowse",
@@ -2469,7 +2469,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 62,
+      "id": 63,
       "command": "event-ready",
       "method": "eventReady",
       "handler": "EventReady",
@@ -2480,7 +2480,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 63,
+      "id": 64,
       "command": "event-error",
       "method": "eventError",
       "handler": "EventError",
@@ -2491,7 +2491,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 64,
+      "id": 65,
       "command": "event-upload-progress",
       "method": "eventUploadProgress",
       "handler": "EventUploadProgress",
@@ -2502,7 +2502,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 65,
+      "id": 66,
       "command": "event-download-progress",
       "method": "eventDownloadProgress",
       "handler": "EventDownloadProgress",
@@ -2513,7 +2513,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 66,
+      "id": 67,
       "command": "event-feed-update",
       "method": "eventFeedUpdate",
       "handler": "EventFeedUpdate",
@@ -2524,7 +2524,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 67,
+      "id": 68,
       "command": "event-log",
       "method": "eventLog",
       "handler": "EventLog",
@@ -2535,7 +2535,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 68,
+      "id": 69,
       "command": "event-video-stats",
       "method": "eventVideoStats",
       "handler": "EventVideoStats",
@@ -2546,7 +2546,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 111,
+      "id": 112,
       "command": "event-transcode-progress",
       "method": "eventTranscodeProgress",
       "handler": "EventTranscodeProgress",
@@ -2557,7 +2557,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 84,
+      "id": 85,
       "command": "event-cast-device-found",
       "method": "eventCastDeviceFound",
       "handler": "EventCastDeviceFound",
@@ -2568,7 +2568,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 85,
+      "id": 86,
       "command": "event-cast-device-lost",
       "method": "eventCastDeviceLost",
       "handler": "EventCastDeviceLost",
@@ -2579,7 +2579,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 86,
+      "id": 87,
       "command": "event-cast-playback-state",
       "method": "eventCastPlaybackState",
       "handler": "EventCastPlaybackState",
@@ -2590,7 +2590,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 87,
+      "id": 88,
       "command": "event-cast-time-update",
       "method": "eventCastTimeUpdate",
       "handler": "EventCastTimeUpdate",
@@ -2601,7 +2601,7 @@ export const APP_RPC_METADATA = Object.freeze({
       "responseStream": false
     },
     {
-      "id": 33,
+      "id": 34,
       "command": "retry-sync-channel",
       "method": "retrySyncChannel",
       "handler": "RetrySyncChannel",


### PR DESCRIPTION
## Summary
- Restores bounded explicit queueing for peers discovered on the shared `peartube-network` topic.
- Preserves discovered relay-address hints by enqueueing existing Hyperswarm peer info before falling back to `joinPeer`.
- Keeps periodic recovery/gossip observational so it does not repeatedly redial after the initial discovery nudge.

## Root cause
Android was discovering peer keys, but `PublicFeedManager.handleDiscoveredPeer()` only recorded them for diagnostics. Previous versions queued a bounded dial from shared-topic discovery, which helped convert DHT peer candidates into actual sockets/feed connections on this network.

## Test plan
- `node --test packages/backend/test/public-feed-manager.test.mjs`
- `node --check packages/backend/src/public-feed.js && node --check packages/backend/test/public-feed-manager.test.mjs`
- `git diff --check`

Note: `npm test -- --test-reporter=spec test/public-feed-manager.test.mjs` in `packages/backend` still runs the package's whole brittle glob plus the file argument; it exposed an existing unrelated descriptor test failure in `public-feed-descriptor.test.mjs`, while the targeted public-feed manager regression passes cleanly.
