### PR TITLE
fix(mobile): expose canonical feed API alias

### DIFF
--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -1531,6 +1531,10 @@ export function createApi({
      * Get public feed entries
      * @returns {{entries: Array, stats: Object}}
      */
+    getCanonicalFeed() {
+      return this.getPublicFeed()
+    },
+
     getPublicFeed() {
       if (!publicFeed) {
         return { entries: [], stats: { totalEntries: 0, hiddenCount: 0, peerCount: 0 } };

--- a/packages/backend/test/public-feed-api.test.mjs
+++ b/packages/backend/test/public-feed-api.test.mjs
@@ -53,6 +53,10 @@ test('getPublicFeed returns peer entries even when publicBeeKey is absent', (t) 
     channelName: null,
     videoCount: 0,
     peerCount: 0,
+    discoveryOnly: false,
+    restoredFromCache: false,
+    restoredFrom: null,
+    requiresAvailabilityProbe: false,
     lastSeen: 1,
     manifestUpdatedAt: 0,
     previewVideos: [],
@@ -846,4 +850,32 @@ test('getPublicFeed exposes relay catalog fields', (t) => {
   t.is(result.entries[0].relayServing, true)
   t.is(result.entries[0].catalogVersion, 1)
   t.is(result.entries[0].previewVideosHash, 'hash-value')
+})
+
+
+test('createApi exposes getCanonicalFeed as the HRPC canonical feed handler alias', (t) => {
+  const api = createApi({
+    ctx: {},
+    publicFeed: {
+      getFeed() {
+        return [{
+          driveKey: 'aa'.repeat(32),
+          channelKey: 'aa'.repeat(32),
+          source: 'peer',
+          publicBeeKey: 'bb'.repeat(32),
+          channelName: 'Canonical Alias',
+          videoCount: 1,
+          peerCount: 1,
+          lastSeen: 321,
+          previewVideos: [{ id: 'v1', title: 'Preview' }],
+        }]
+      },
+      getStats() {
+        return { totalEntries: 1, hiddenCount: 0, peerCount: 1 }
+      },
+    },
+  })
+
+  t.is(typeof api.getCanonicalFeed, 'function')
+  t.alike(api.getCanonicalFeed(), api.getPublicFeed())
 })


### PR DESCRIPTION
## Summary
- add `createApi().getCanonicalFeed()` as the canonical HRPC feed handler alias used by mobile handlers
- keep behavior identical to `getPublicFeed()` so older/public-feed callers still work
- add a regression for the reported runtime error: `api.getCanonicalFeed is not a function`

## Verification
- `node --test packages/backend/test/public-feed-api.test.mjs`
- `node --test packages/app/backend/mobile-handlers.test.mjs`
- `node --check packages/backend/src/api.js`
- `git diff --check`
