### PR TITLE
fix(android): expose swarm diagnostics and peer dial state

### DIFF
--- a/packages/backend/src/mobile-handlers.js
+++ b/packages/backend/src/mobile-handlers.js
@@ -11,6 +11,15 @@
  * @param {Object} B - Backend object to attach handlers to
  * @param {Object} deps - Dependencies from the backend context
  */
+function safeJson(value) {
+  if (value == null) return null
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return null
+  }
+}
+
 export function attachMobileHandlers(B, deps) {
   const { api, identityManager, uploadManager, ctx, initializeIdentityFromMnemonic, rpc, fs, path, generateAndStoreThumbnail, transcoder } = deps
   const refreshPublishedChannelFeed = async (driveKey) => {
@@ -181,6 +190,10 @@ export function attachMobileHandlers(B, deps) {
       peerPoolJoined: Boolean(s.peerPoolJoined),
       publicFeedDiscoveryJoined: Boolean(s.publicFeedDiscoveryJoined),
       feedTopicHex: s.feedTopicHex ?? null,
+      networkJson: safeJson(s.network),
+      startupTimingJson: safeJson(s.startupTiming),
+      doctorJson: safeJson(s.doctor),
+      directPeerDialJson: safeJson(s.doctor?.feed?.directPeerDial),
       recommendedBoundary: s.recommendedBoundary ?? s.doctor?.recommendedBoundary ?? null,
       network: s.network ?? null,
       startupTiming: s.startupTiming ?? null,

--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -916,6 +916,8 @@ export class PublicFeed {
       const publicKey = this._discoveredPeers.get(keyHex)
       const swarm = this._swarmDialState(keyHex, publicKey)
       const hint = this._discoveredPeerHints.get(keyHex)
+      const record = this._peerDirectory.get(keyHex)
+      const connected = this._hasActivePeerConnection(keyHex, publicKey)
       peers.push({
         key: keyHex.slice(0, 16),
         attempts: swarm?.attempts || 0,
@@ -925,11 +927,11 @@ export class PublicFeed {
         lastQueuedAt: null,
         lastError: this._directPeerLastDialError.get(keyHex) || null,
         lastErrorStack: this._directPeerLastDialErrorStack.get(keyHex) || null,
-        pending: Boolean(swarm?.queued || swarm?.waiting),
-        connected: this._hasActivePeerConnection(keyHex, publicKey),
-        score: Number(this._peerDirectory.get(keyHex)?.score || 0),
-        joined: Boolean(this._peerDirectory.get(keyHex)?.joined),
-        demoted: Boolean(this._peerDirectory.get(keyHex)?.demoted),
+        pending: Boolean(!connected && (swarm?.queued || swarm?.waiting || record?.joined)),
+        connected,
+        score: Number(record?.score || 0),
+        joined: Boolean(record?.joined),
+        demoted: Boolean(record?.demoted),
         swarm,
       })
     }

--- a/packages/backend/src/runtime.js
+++ b/packages/backend/src/runtime.js
@@ -44,6 +44,15 @@ function getIdentityCount(backend) {
   return backend?.identityManager?.getIdentities?.().length || 0
 }
 
+function safeJson(value) {
+  if (value == null) return null
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return null
+  }
+}
+
 export function buildSharedSystemHandlers(backend) {
   return {
     async DesktopBootstrap(req) {
@@ -107,6 +116,10 @@ export function buildSharedSystemHandlers(backend) {
         peerPoolJoined: Boolean(swarmStatus.peerPoolJoined),
         publicFeedDiscoveryJoined: Boolean(swarmStatus.publicFeedDiscoveryJoined),
         feedTopicHex: swarmStatus.feedTopicHex ?? null,
+        networkJson: safeJson(swarmStatus.network),
+        startupTimingJson: safeJson(swarmStatus.startupTiming),
+        doctorJson: safeJson(swarmStatus.doctor),
+        directPeerDialJson: safeJson(swarmStatus.doctor?.feed?.directPeerDial),
         recommendedBoundary: swarmStatus.recommendedBoundary ?? swarmStatus.doctor?.recommendedBoundary ?? null,
         network: swarmStatus.network ?? null,
         startupTiming: swarmStatus.startupTiming ?? null,

--- a/packages/backend/src/swarm-peer-dial.js
+++ b/packages/backend/src/swarm-peer-dial.js
@@ -65,15 +65,21 @@ export function swarmRememberPeer(swarm, peer, topic = null) {
   if (!peerInfo && swarm.peers && typeof swarm.peers.get === 'function') {
     try { peerInfo = swarm.peers.get(publicKey) || null } catch { peerInfo = null }
   }
-  if (!peerInfo) {
-    peerInfo = {
-      publicKey,
-      relayAddresses: Array.isArray(peer.relayAddresses) ? peer.relayAddresses : [],
-      topics: [],
-    }
-    try { swarm.peers?.set?.(keyHex, peerInfo) } catch { /* diagnostics only */ }
-  }
   const relayAddresses = Array.isArray(peer.relayAddresses) ? peer.relayAddresses : []
+  if (!peerInfo && typeof swarm._upsertPeer === 'function') {
+    try { peerInfo = swarm._upsertPeer(publicKey, relayAddresses) || null } catch { peerInfo = null }
+  }
+  if (!peerInfo) {
+    return {
+      publicKey,
+      relayAddresses,
+      topics: topic ? [topic] : [],
+      queued: false,
+      waiting: false,
+      explicit: false,
+      synthetic: true,
+    }
+  }
   if (relayAddresses.length > 0 && (!Array.isArray(peerInfo.relayAddresses) || peerInfo.relayAddresses.length === 0)) {
     peerInfo.relayAddresses = relayAddresses
   }
@@ -88,13 +94,10 @@ export function swarmRememberPeer(swarm, peer, topic = null) {
 }
 
 export function swarmQueuePeer(swarm, peerInfo) {
-  if (!swarm || !peerInfo) return false
-  peerInfo.explicit = true
-  if (typeof peerInfo._updatePriority === 'function') {
-    try { peerInfo._updatePriority() } catch { /* best effort */ }
-  }
-  if (typeof swarm.joinPeer === 'function' && peerInfo.publicKey) {
+  if (!swarm || !peerInfo || !peerInfo.publicKey) return false
+  if (typeof swarm.joinPeer === 'function') {
     swarm.joinPeer(peerInfo.publicKey)
+    peerInfo.explicit = true
     peerInfo.queued = true
     return true
   }

--- a/packages/backend/test/public-feed-manager.test.mjs
+++ b/packages/backend/test/public-feed-manager.test.mjs
@@ -359,7 +359,7 @@ test('PublicFeedManager preserves relay-address hints and queues existing peer i
     assert.equal(manager.handleDiscoveredPeer({ publicKey, relayAddresses }, NETWORK_TOPIC), true)
     assert.equal(swarm.fallbackJoinPeerCalls.length, 1)
     assert.equal(swarm.joinPeerCalls.length, 1)
-    const peerInfo = swarm.peers.get(keyHex)
+    const peerInfo = swarm.peers.get(keyHex) || manager.getStats().directPeerDial.peers[0].swarm
     assert.equal(peerInfo.relayAddresses.length, 1)
     assert.equal(peerInfo.topics.length, 1)
     const stats = manager.getStats().directPeerDial
@@ -409,20 +409,18 @@ test('PublicFeedManager promotes pending discovered peer candidates to explicit'
 
 test('PublicFeedManager recovery is observational after initial bounded peer queueing', () => {
   const publicKey = b4a.alloc(32, 22)
-  const keyHex = b4a.toString(publicKey, 'hex')
   const swarm = createSwarm()
   const manager = new PublicFeedManager(swarm, createMetaDb())
 
   try {
     assert.equal(manager.handleDiscoveredPeer({ publicKey, relayAddresses: [{ host: 'relay.test', port: 1 }] }, NETWORK_TOPIC), true)
-    const peerInfo = swarm.peers.get(keyHex)
-    peerInfo.queued = false
+    const statsBeforeRecovery = manager.getStats().directPeerDial
+    assert.equal(statsBeforeRecovery.peers[0].pending, true)
     swarm.joinPeerCalls.length = 0
     const recovery = manager.runBoundedPeerRecovery('test-recovery')
     assert.equal(recovery.queued, 0)
     assert.equal(recovery.reason, 'hyperswarm-owned-dialing')
     assert.equal(swarm.joinPeerCalls.length, 0)
-    assert.equal(peerInfo.queued, false)
     const stats = manager.getStats().directPeerDial
     assert.equal(stats.recoveryEvents.length, 1)
     assert.equal(stats.recoveryEvents[0].requestedReason, 'test-recovery')

--- a/packages/backend/test/swarm-peer-dial-regression.test.mjs
+++ b/packages/backend/test/swarm-peer-dial-regression.test.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import b4a from 'b4a'
+
+import { swarmQueuePeer, swarmRememberPeer } from '../src/swarm-peer-dial.js'
+
+test('swarmRememberPeer does not fabricate Hyperswarm peer info when peer is unknown', () => {
+  const publicKey = b4a.alloc(32, 7)
+  const keyHex = b4a.toString(publicKey, 'hex')
+  const swarm = {
+    peers: new Map(),
+  }
+
+  const remembered = swarmRememberPeer(swarm, {
+    publicKey,
+    relayAddresses: [{ host: 'relay.test', port: 49737 }],
+  }, b4a.alloc(32, 8))
+
+  assert.equal(remembered.publicKey, publicKey)
+  assert.equal(remembered.relayAddresses.length, 1)
+  assert.equal(swarm.peers.has(keyHex), false)
+})
+
+test('swarmQueuePeer queues through public joinPeer and avoids private priority mutation', () => {
+  const publicKey = b4a.alloc(32, 9)
+  const peerInfo = {
+    publicKey,
+    queued: false,
+    explicit: false,
+    _updatePriority() {
+      throw new Error('caller must not mutate Hyperswarm internals directly')
+    },
+  }
+  const swarm = {
+    joinPeerCalls: [],
+    joinPeer(key) {
+      this.joinPeerCalls.push(key)
+    },
+  }
+
+  assert.equal(swarmQueuePeer(swarm, peerInfo), true)
+  assert.deepEqual(swarm.joinPeerCalls, [publicKey])
+  assert.equal(peerInfo.queued, true)
+  assert.equal(peerInfo.explicit, true)
+})

--- a/packages/backend/test/swarm-peer-dial.test.mjs
+++ b/packages/backend/test/swarm-peer-dial.test.mjs
@@ -75,6 +75,7 @@ test('swarmRememberPeer installs a public-key peer candidate without private Hyp
 
   const remembered = swarmRememberPeer(swarm, { publicKey }, b4a.alloc(32, 6))
   assert.equal(remembered.publicKey, publicKey)
-  assert.equal(swarm.peers.get(b4a.toString(publicKey, 'hex')), remembered)
+  assert.equal(swarm.peers.has(b4a.toString(publicKey, 'hex')), false)
   assert.equal(remembered.topics.length, 1)
+  assert.equal(remembered.synthetic, true)
 })

--- a/packages/protocol/src/create-client.js
+++ b/packages/protocol/src/create-client.js
@@ -172,9 +172,23 @@ function normalizeHostErrorPayload(payload) {
   )
 }
 
+function parseOptionalJson(value) {
+  if (value == null || value === '') return null
+  if (typeof value !== 'string') return value
+  try {
+    return JSON.parse(value)
+  } catch {
+    return null
+  }
+}
+
 function normalizeNetworkStatusPayload(payload = {}) {
   const swarmConnections = payload?.swarmConnections ?? payload?.peerCount ?? 0
   const peerCount = payload?.peerCount ?? swarmConnections
+  const network = payload?.network ?? parseOptionalJson(payload?.networkJson)
+  const startupTiming = payload?.startupTiming ?? parseOptionalJson(payload?.startupTimingJson)
+  const doctor = payload?.doctor ?? parseOptionalJson(payload?.doctorJson)
+  const directPeerDial = payload?.directPeerDial ?? parseOptionalJson(payload?.directPeerDialJson) ?? doctor?.feed?.directPeerDial ?? null
 
   return {
     connected: Boolean(payload?.connected ?? (swarmConnections > 0 || peerCount > 0)),
@@ -190,7 +204,11 @@ function normalizeNetworkStatusPayload(payload = {}) {
     peerPoolJoined: Boolean(payload?.peerPoolJoined),
     publicFeedDiscoveryJoined: Boolean(payload?.publicFeedDiscoveryJoined),
     feedTopicHex: payload?.feedTopicHex ?? null,
-    recommendedBoundary: payload?.recommendedBoundary ?? null
+    recommendedBoundary: payload?.recommendedBoundary ?? doctor?.recommendedBoundary ?? null,
+    network,
+    startupTiming,
+    doctor,
+    directPeerDial
   }
 }
 

--- a/packages/protocol/test/create-client.test.mjs
+++ b/packages/protocol/test/create-client.test.mjs
@@ -48,7 +48,11 @@ class FakeHRPC {
       peerPoolJoined: true,
       publicFeedDiscoveryJoined: true,
       feedTopicHex: 'feed-topic',
-      recommendedBoundary: 'content-playback-or-ui'
+      recommendedBoundary: 'content-playback-or-ui',
+      networkJson: JSON.stringify({ hyperswarm: { recentConnections: [{ type: 'client-attempt' }] } }),
+      startupTimingJson: JSON.stringify({ events: [{ event: 'peer-discovered' }] }),
+      doctorJson: JSON.stringify({ recommendedBoundary: 'transport-socket', socket: { swarmConnections: 0 } }),
+      directPeerDialJson: JSON.stringify({ discoveredPeers: 6, pending: 3 })
     })
   }
 }
@@ -183,7 +187,11 @@ test('createProtocolClient emits normalized network status from the system names
     peerPoolJoined: true,
     publicFeedDiscoveryJoined: true,
     feedTopicHex: 'feed-topic',
-    recommendedBoundary: 'content-playback-or-ui'
+    recommendedBoundary: 'content-playback-or-ui',
+    network: { hyperswarm: { recentConnections: [{ type: 'client-attempt' }] } },
+    startupTiming: { events: [{ event: 'peer-discovered' }] },
+    doctor: { recommendedBoundary: 'transport-socket', socket: { swarmConnections: 0 } },
+    directPeerDial: { discoveredPeers: 6, pending: 3 }
   })
   t.alike(networkEvents, [status])
 })

--- a/packages/spec/schema.cjs
+++ b/packages/spec/schema.cjs
@@ -652,6 +652,10 @@ ns.register({
     { name: 'peerPoolJoined', type: 'bool', required: false },
     { name: 'publicFeedDiscoveryJoined', type: 'bool', required: false },
     { name: 'feedTopicHex', type: 'string', required: false },
+    { name: 'networkJson', type: 'string', required: false },
+    { name: 'startupTimingJson', type: 'string', required: false },
+    { name: 'doctorJson', type: 'string', required: false },
+    { name: 'directPeerDialJson', type: 'string', required: false },
     { name: 'recommendedBoundary', type: 'string', required: false }
   ]
 })


### PR DESCRIPTION
## Summary
- stop fabricating unknown peers into `swarm.peers`; use Hyperswarm's `_upsertPeer` only when present and otherwise keep synthetic candidates outside the internal peer map
- queue discovered peers through public `joinPeer()` and keep direct peer diagnostics pending until a real socket appears
- expose rich Android swarm diagnostics through HRPC-safe JSON fields so physical-device builds can show `network`, `startupTiming`, `doctor`, and `directPeerDial` instead of silently dropping them

## Why
Physical Android could discover relay peers and relay hints, but playback still had no usable peer/feed sockets. The app also could not surface the detailed diagnostic objects because the HRPC schema stripped undeclared object fields.

## Test Plan
- `npm run schema`
- `npx brittle test/swarm-peer-dial-regression.test.mjs test/swarm-peer-dial.test.mjs test/public-feed-manager.test.mjs` from `packages/backend`
- `npx brittle test/create-client.test.mjs` from `packages/protocol`
- `node --test packages/app/tests/android-physical-discovery-regression.test.mjs`
- `npm run lint:changed`
- `./node_modules/.bin/eslint --quiet packages/backend/src/mobile-handlers.js packages/backend/src/public-feed.js packages/backend/src/runtime.js packages/backend/src/swarm-peer-dial.js packages/backend/test/public-feed-manager.test.mjs packages/backend/test/swarm-peer-dial.test.mjs packages/backend/test/swarm-peer-dial-regression.test.mjs packages/protocol/src/create-client.js packages/protocol/test/create-client.test.mjs packages/spec/schema.cjs`
- `git diff --check`
