### PR TITLE
fix(relay): persist preview refs for cache seeding

### DIFF
--- a/packages/cli/src/cache-manager.js
+++ b/packages/cli/src/cache-manager.js
@@ -6,7 +6,15 @@
  * @property {number} addedAt - Unix timestamp (ms)
  * @property {number} bytes - Tracked byte usage for this channel
  * @property {boolean} pinned - Whether this channel is pinned (never evicted)
+ * @property {Array<Object>} previewVideos - Compact playable preview refs used to rejoin blob-core swarms after restart
  */
+
+function normalizePreviewVideos(previewVideos) {
+  if (!Array.isArray(previewVideos)) return [];
+  return previewVideos
+    .filter((video) => video && typeof video === 'object')
+    .map((video) => ({ ...video }))
+}
 
 export class CacheManager {
   /**
@@ -36,7 +44,8 @@ export class CacheManager {
         source: record.source === 'pinned' ? 'pinned' : 'discovered',
         addedAt: Number.isFinite(record.addedAt) ? record.addedAt : Date.now(),
         bytes: Number.isFinite(record.bytes) ? record.bytes : 0,
-        pinned: Boolean(record.pinned)
+        pinned: Boolean(record.pinned),
+        previewVideos: normalizePreviewVideos(record.previewVideos)
       };
       this.channels.set(normalized.driveKey, normalized);
     }
@@ -47,8 +56,31 @@ export class CacheManager {
    * @param {string} publicBeeKey
    * @param {'discovered'|'pinned'} source
    */
-  async addChannel(driveKey, publicBeeKey, source) {
-    if (this.channels.has(driveKey)) return false;
+  async addChannel(driveKey, publicBeeKey, source, options = {}) {
+    const previewVideos = normalizePreviewVideos(options.previewVideos)
+    const existing = this.channels.get(driveKey)
+    if (existing) {
+      let changed = false
+      if (typeof publicBeeKey === 'string' && publicBeeKey && existing.publicBeeKey !== publicBeeKey) {
+        existing.publicBeeKey = publicBeeKey
+        changed = true
+      }
+      if (source === 'pinned' && !existing.pinned) {
+        existing.pinned = true
+        existing.source = 'pinned'
+        changed = true
+      }
+      if (previewVideos.length > 0) {
+        const nextSignature = JSON.stringify(previewVideos)
+        const currentSignature = JSON.stringify(existing.previewVideos || [])
+        if (nextSignature !== currentSignature) {
+          existing.previewVideos = previewVideos
+          changed = true
+        }
+      }
+      if (changed) await this._persist()
+      return changed;
+    }
 
     /** @type {CacheChannelRecord} */
     const record = {
@@ -57,7 +89,8 @@ export class CacheManager {
       source,
       addedAt: Date.now(),
       bytes: 0,
-      pinned: source === 'pinned'
+      pinned: source === 'pinned',
+      previewVideos
     };
 
     this.channels.set(driveKey, record);
@@ -94,7 +127,8 @@ export class CacheManager {
         source: 'pinned',
         addedAt: Date.now(),
         bytes: 0,
-        pinned: true
+        pinned: true,
+        previewVideos: []
       });
     }
 

--- a/packages/cli/src/init.js
+++ b/packages/cli/src/init.js
@@ -24,7 +24,9 @@ export async function initPeer ({ storagePath, maxBytes, pinnedChannels = [] }) 
   publicFeed.setOnFeedUpdate(() => {
     for (const entry of publicFeed.entries.values()) {
       if (entry.driveKey && entry.publicBeeKey) {
-        cacheManager.addChannel(entry.driveKey, entry.publicBeeKey, 'discovered').catch(() => {})
+        cacheManager.addChannel(entry.driveKey, entry.publicBeeKey, 'discovered', {
+          previewVideos: Array.isArray(entry.previewVideos) ? entry.previewVideos : []
+        }).catch(() => {})
       }
     }
   })

--- a/packages/cli/src/runtime.js
+++ b/packages/cli/src/runtime.js
@@ -143,7 +143,9 @@ export async function createRelayRuntime({ config, logger }) {
     try {
       for (const entry of publicFeed.entries.values()) {
         if (entry?.driveKey && entry?.publicBeeKey) {
-          cacheManager.addChannel(entry.driveKey, entry.publicBeeKey, 'discovered').catch(() => {})
+          cacheManager.addChannel(entry.driveKey, entry.publicBeeKey, 'discovered', {
+            previewVideos: Array.isArray(entry.previewVideos) ? entry.previewVideos : []
+          }).catch(() => {})
         }
       }
       emitFeedEntries()

--- a/packages/cli/src/service.js
+++ b/packages/cli/src/service.js
@@ -214,7 +214,11 @@ export async function createRelayService({
       }
 
       if (resolved.publicBeeKey) {
-        await runtime.cacheManager?.addChannel?.(resolved.channelKey, resolved.publicBeeKey, 'discovered').catch(() => {})
+        await runtime.cacheManager?.addChannel?.(resolved.channelKey, resolved.publicBeeKey, 'discovered', {
+          previewVideos: Array.isArray(mirrorStats?.previewVideos)
+            ? mirrorStats.previewVideos
+            : (Array.isArray(resolved.previewVideos) ? resolved.previewVideos : [])
+        }).catch(() => {})
         const seedStats = await runtime.seeder?.seedChannel?.({
           driveKey: resolved.channelKey,
           publicBeeKey: resolved.publicBeeKey,

--- a/packages/cli/test/relay-seeding.test.mjs
+++ b/packages/cli/test/relay-seeding.test.mjs
@@ -1,6 +1,7 @@
 import test from 'brittle'
 import { createRelaySeeder } from '../src/seeding.js'
 import { buildRelayStatus, formatRelayStatus } from '../src/status.js'
+import { CacheManager } from '../src/cache-manager.js'
 
 function createCore(keyHex, discoveryKey = `discovery:${keyHex}`) {
   return {
@@ -29,6 +30,49 @@ function createSwarm() {
     }
   }
 }
+
+function createMetaDb(initial = new Map()) {
+  const writes = []
+  return {
+    writes,
+    async get(key) {
+      return initial.has(key) ? { value: initial.get(key) } : null
+    },
+    async put(key, value) {
+      writes.push({ key, value })
+      initial.set(key, value)
+    }
+  }
+}
+
+test('cache manager preserves refreshed preview refs for relay restart seeding', async (t) => {
+  const metaDb = createMetaDb(new Map([
+    ['cache-channels', [{
+      driveKey: 'aa'.padEnd(64, '0'),
+      publicBeeKey: 'bb'.padEnd(64, '0'),
+      source: 'discovered',
+      addedAt: 1,
+      bytes: 0,
+      pinned: false
+    }]]
+  ]))
+  const manager = new CacheManager({}, metaDb, 1024)
+  await manager.init()
+
+  const changed = await manager.addChannel('aa'.padEnd(64, '0'), 'bb'.padEnd(64, '0'), 'discovered', {
+    previewVideos: [{
+      id: 'video-1',
+      blobId: '0:1:0:10',
+      blobsCoreKey: 'cc'.padEnd(64, '0')
+    }]
+  })
+
+  t.is(changed, true)
+  t.is(manager.getChannels()[0].previewVideos.length, 1)
+  t.is(manager.getChannels()[0].previewVideos[0].blobsCoreKey, 'cc'.padEnd(64, '0'))
+  t.is(metaDb.writes.length, 1)
+  t.is(metaDb.writes[0].value[0].previewVideos[0].id, 'video-1')
+})
 
 test('relay seeder retains PublicBee and blob-core discovery handles for mirrored channels', async (t) => {
   const publicBeeCore = createCore('11')


### PR DESCRIPTION
## Summary
- persist feed preview video refs in the relay cache manager
- update existing cache entries when refreshed feed previews arrive
- pass preview refs through relay runtime/service cache writes so relay restarts can rejoin blob-core swarms instead of only gossiping catalogs

## Tests
- node --test packages/cli/test/relay-seeding.test.mjs packages/backend/test/gossip-relay-core.test.mjs packages/backend/test/public-feed-manager.test.mjs
- npm test --prefix packages/cli
- git diff --check