### PR TITLE
fix(android): recover peer sockets after resume

### DIFF
--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -3527,6 +3527,7 @@ export function createApi({
     async resumeNetwork() {
       try {
         await resumeNetworking()
+        publicFeed?.runBoundedPeerRecovery?.('foreground-resume')
         return { success: true }
       } catch (err) {
         console.error('[API] resumeNetwork error:', err.message)

--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -871,15 +871,62 @@ export class PublicFeed {
 
 
   runBoundedPeerRecovery(reason = 'heartbeat') {
+    const now = this._now()
+    const connections = this.swarm?.connections?.size || 0
+    const discoveredPeers = this._discoveredPeers.size
     const event = {
-      at: this._now(),
+      at: now,
       action: 'observed-peers-without-sockets',
       reason: 'hyperswarm-owned-dialing',
       requestedReason: reason,
-      discoveredPeers: this._discoveredPeers.size,
-      connections: this.swarm?.connections?.size || 0,
+      discoveredPeers,
+      connections,
       queued: 0,
     }
+
+    if (this.swarm && discoveredPeers > 0 && connections === 0 && now - this._lastRecoveryAt >= this._recoveryCooldownMs) {
+      this._lastRecoveryAt = now
+      event.action = 'requeued-discovered-peers'
+      event.reason = 'foreground-resume-no-sockets'
+
+      for (const record of this._peerDirectory.values()) {
+        if (!record?.publicKey || record.demoted) continue
+        try {
+          const peerInfo = this.swarm.peers?.get?.(record.keyHex) || null
+          if (peerInfo) {
+            try {
+              peerInfo.explicit = true
+              if (typeof peerInfo._updatePriority === 'function') peerInfo._updatePriority()
+            } catch { /* best effort */ }
+            if (swarmQueuePeer(this.swarm, peerInfo)) {
+              event.queued++
+              record.joined = true
+              record.lastJoinedAt = now
+              this._directPeerDialStats.queued++
+              this._directPeerDialStats.lastReason = 'resume-requeued-existing-peer'
+              this._directPeerDialStats.lastDialedAt = now
+              continue
+            }
+          }
+
+          this.swarm.joinPeer(record.publicKey)
+          event.queued++
+          record.joined = true
+          record.demoted = false
+          record.joinAttempts++
+          record.lastJoinedAt = now
+          record.lastJoinError = null
+          this._directPeerDialStats.queued++
+          this._directPeerDialStats.lastReason = 'resume-joinPeer'
+          this._directPeerDialStats.lastDialedAt = now
+        } catch (err) {
+          record.lastJoinError = err?.message || String(err)
+          this._directPeerDialStats.failed++
+          this._directPeerDialStats.lastReason = 'resume-joinPeer-error'
+        }
+      }
+    }
+
     this._recoveryEvents.push(event)
     while (this._recoveryEvents.length > 10) this._recoveryEvents.shift()
     return event

--- a/packages/backend/src/storage.js
+++ b/packages/backend/src/storage.js
@@ -1198,6 +1198,7 @@ export async function initializeStorage(config) {
   // `swarm.joinPeer(pk)` them directly without waiting for a topic DHT lookup.
   const selfKeyHex = swarm.keyPair?.publicKey ? b4a.toString(swarm.keyPair.publicKey, 'hex') : null
   const knownPeerCache = createKnownPeerCache(metaDb, { selfKeyHex })
+  swarm._peartubeMetaDb = metaDb
   globalKnownPeerCache = knownPeerCache
 
   // Register handlers BEFORE swarm.join so any incoming connection is replicated
@@ -2393,6 +2394,15 @@ export async function resumeNetworking() {
         }
       }
       console.log('[Network] Wakeup sessions marked active');
+    }
+
+    if (globalKnownPeerCache && globalSwarm) {
+      loadKnownPeers(globalSwarm._peartubeMetaDb).then((known) => {
+        const dialed = dialKnownPeers(globalSwarm, known)
+        if (dialed > 0) console.log('[Network] Resume warm-dialed', dialed, 'known peers')
+      }).catch((err) => {
+        console.log('[Network] Resume warm-dial skipped:', err?.message)
+      })
     }
 
     console.log('[Network] Resumed successfully');

--- a/packages/backend/test/public-feed-api.test.mjs
+++ b/packages/backend/test/public-feed-api.test.mjs
@@ -851,3 +851,23 @@ test('getPublicFeed exposes relay catalog fields', (t) => {
   t.is(result.entries[0].catalogVersion, 1)
   t.is(result.entries[0].previewVideosHash, 'hash-value')
 })
+
+test('resumeNetwork triggers bounded discovered-peer recovery after foreground resume', (t) => {
+  let recoveredReason = null
+  const api = createApi({
+    ctx: {
+      swarm: { connections: new Set(), peers: new Set() },
+      channels: new Map(),
+    },
+    publicFeed: {
+      runBoundedPeerRecovery(reason) {
+        recoveredReason = reason
+      },
+    },
+  })
+
+  return api.resumeNetwork().then((result) => {
+    t.is(result.success, true)
+    t.is(recoveredReason, 'foreground-resume')
+  })
+})

--- a/packages/backend/test/public-feed-manager.test.mjs
+++ b/packages/backend/test/public-feed-manager.test.mjs
@@ -407,7 +407,7 @@ test('PublicFeedManager promotes pending discovered peer candidates to explicit'
   }
 })
 
-test('PublicFeedManager recovery is observational after initial bounded peer queueing', () => {
+test('PublicFeedManager recovery requeues discovered peers after foreground resume with no sockets', () => {
   const publicKey = b4a.alloc(32, 22)
   const swarm = createSwarm()
   const manager = new PublicFeedManager(swarm, createMetaDb())
@@ -417,14 +417,14 @@ test('PublicFeedManager recovery is observational after initial bounded peer que
     const statsBeforeRecovery = manager.getStats().directPeerDial
     assert.equal(statsBeforeRecovery.peers[0].pending, true)
     swarm.joinPeerCalls.length = 0
-    const recovery = manager.runBoundedPeerRecovery('test-recovery')
-    assert.equal(recovery.queued, 0)
-    assert.equal(recovery.reason, 'hyperswarm-owned-dialing')
-    assert.equal(swarm.joinPeerCalls.length, 0)
+    const recovery = manager.runBoundedPeerRecovery('foreground-resume')
+    assert.equal(recovery.queued, 1)
+    assert.equal(recovery.reason, 'foreground-resume-no-sockets')
+    assert.equal(swarm.joinPeerCalls.length, 1) // requeued existing pending peer through Hyperswarm-owned queue
     const stats = manager.getStats().directPeerDial
     assert.equal(stats.recoveryEvents.length, 1)
-    assert.equal(stats.recoveryEvents[0].requestedReason, 'test-recovery')
-    assert.equal(stats.lastReason, 'queued-existing-peer')
+    assert.equal(stats.recoveryEvents[0].requestedReason, 'foreground-resume')
+    assert.equal(stats.lastReason, 'resume-requeued-existing-peer')
   } finally {
     manager.stop()
   }


### PR DESCRIPTION
## Summary
- requeue remembered/discovered Hyperswarm peers when Android resumes with discovered candidates but zero sockets
- warm-dial persisted known peers on network resume using the existing known-peer cache
- trigger bounded public-feed recovery from the mobile `resumeNetwork` RPC path

## Test Plan
- `node --test packages/backend/test/public-feed-api.test.mjs packages/backend/test/storage-startup-regression.test.mjs packages/backend/test/public-feed-manager.test.mjs`
- `git diff --check`
- `npm run lint:changed`
- `./node_modules/.bin/eslint --quiet packages/backend/src/api.js packages/backend/src/public-feed.js packages/backend/src/storage.js packages/backend/test/public-feed-api.test.mjs packages/backend/test/public-feed-manager.test.mjs`

## Notes
This targets the Android foreground/background lifecycle failure mode where discovery survives, but after a few app open/close cycles Hyperswarm has remembered peers/pending candidates and no live sockets/feed channels. The recovery remains bounded and Hyperswarm-owned; it does not fabricate active connections from diagnostic peer records.
