### PR TITLE
fix(relay): guard corestore layout and redial stale peers

### DIFF
--- a/packages/app/tests/android-physical-discovery-regression.test.mjs
+++ b/packages/app/tests/android-physical-discovery-regression.test.mjs
@@ -119,10 +119,21 @@ test('feed discovery state distinguishes permission, transport, cached fallback,
     ready: true,
     entries: [{ driveKey: 'live-feed' }],
     videos: [],
-    swarmStatus: { feedEntries: 88, feedConnections: 0, peers: 0 },
+    swarmStatus: { feedEntries: 88, feedConnections: 0, swarmPeers: 8 },
   }), {
     state: 'hydrating',
     recoverable: true,
+  })
+
+  assert.deepEqual(classifyFeedDiscoveryState({
+    ready: true,
+    entries: [],
+    videos: [],
+    swarmStatus: { swarmPeers: 8, swarmConnections: 0, feedConnections: 0, doctor: { recommendedBoundary: 'transport-socket' } },
+  }), {
+    state: 'network-degraded',
+    recoverable: true,
+    reason: 'transport-socket',
   })
 })
 

--- a/packages/backend/src/storage-layout.js
+++ b/packages/backend/src/storage-layout.js
@@ -15,7 +15,9 @@ function moveFileWithFallback(srcPath, destPath, fsModule) {
   try {
     fsModule.renameSync(srcPath, destPath)
     return
-  } catch {}
+  } catch {
+    // Fall back to copy/unlink for cross-device or platform-specific renames.
+  }
 
   const contents = fsModule.readFileSync(srcPath)
   fsModule.writeFileSync(destPath, contents)
@@ -50,10 +52,14 @@ export function relocateLegacyCorestoreDir(storagePath, fsModule, pathModule) {
   let dbStats = null
   try {
     legacyStats = fsModule.statSync(legacyCorestoreDir)
-  } catch {}
+  } catch {
+    // Missing legacy directory is a no-op.
+  }
   try {
     dbStats = fsModule.statSync(dbCorestoreDir)
-  } catch {}
+  } catch {
+    // Missing canonical directory is a no-op.
+  }
 
   if (!legacyStats?.isDirectory?.() || !dbStats?.isDirectory?.()) return null
 
@@ -73,7 +79,9 @@ export function relocateLegacyBlindPeerDir(storagePath, fsModule, pathModule) {
   let legacyStats = null
   try {
     legacyStats = fsModule.statSync(legacyBlindPeerDir)
-  } catch {}
+  } catch {
+    // Missing legacy directory is a no-op.
+  }
 
   if (!legacyStats?.isDirectory?.()) return null
   fsModule.mkdirSync(pathModule.dirname(corestoreBlindPeerDir), { recursive: true })
@@ -99,7 +107,9 @@ export function relocateLegacyLogsDir(storagePath, fsModule, pathModule) {
   let legacyStats = null
   try {
     legacyStats = fsModule.statSync(legacyLogsDir)
-  } catch {}
+  } catch {
+    // Missing legacy directory is a no-op.
+  }
 
   if (!legacyStats?.isDirectory?.()) return null
   if (!fsModule.existsSync(dbLogsDir)) return null

--- a/packages/backend/src/storage-layout.js
+++ b/packages/backend/src/storage-layout.js
@@ -40,6 +40,29 @@ function moveDirectoryContents(srcDir, destDir, fsModule, pathModule) {
   }
 }
 
+export function relocateLegacyCorestoreDir(storagePath, fsModule, pathModule) {
+  if (!storagePath || !fsModule || !pathModule) return null
+
+  const legacyCorestoreDir = pathModule.join(storagePath, 'corestore')
+  const dbCorestoreDir = pathModule.join(storagePath, 'db', 'corestore')
+
+  let legacyStats = null
+  let dbStats = null
+  try {
+    legacyStats = fsModule.statSync(legacyCorestoreDir)
+  } catch {}
+  try {
+    dbStats = fsModule.statSync(dbCorestoreDir)
+  } catch {}
+
+  if (!legacyStats?.isDirectory?.() || !dbStats?.isDirectory?.()) return null
+
+  const archiveDir = createArchiveDirPath(storagePath, pathModule, fsModule, 'corestore-legacy')
+  moveDirectoryContents(legacyCorestoreDir, archiveDir, fsModule, pathModule)
+  fsModule.rmdirSync(legacyCorestoreDir)
+  return archiveDir
+}
+
 export function relocateLegacyBlindPeerDir(storagePath, fsModule, pathModule) {
   if (!storagePath || !fsModule || !pathModule) return null
 

--- a/packages/backend/src/storage.js
+++ b/packages/backend/src/storage.js
@@ -13,7 +13,7 @@ import { MultiWriterChannel, ChannelPairer } from './channel/index.js'
 import { PublicChannelBee } from './channel/public-channel-bee.js'
 import { loadPublicBeeFromCache } from './public-bee-loader.js'
 import { logger } from './logger.js'
-import { relocateLegacyBlindPeerDir, relocateLegacyLogsDir } from './storage-layout.js'
+import { relocateLegacyBlindPeerDir, relocateLegacyCorestoreDir, relocateLegacyLogsDir } from './storage-layout.js'
 import { cleanupFailedCorestoreOpen } from './corestore-cleanup.js'
 import {
   loadBareOrNodeFsModule,
@@ -863,6 +863,18 @@ export async function initializeStorage(config) {
   if (isEmbeddedBareKitStoragePath()) {
     await appendDebugLine('[storage] relocateLegacyLogsDir skipped for embedded BareKit storage')
   } else {
+    try {
+      await appendDebugLine('[storage] relocateLegacyCorestoreDir start')
+      const relocatedCorestoreDir = relocateLegacyCorestoreDir(storagePath, fs, path)
+      await appendDebugLine(`[storage] relocateLegacyCorestoreDir done moved=${relocatedCorestoreDir || 'none'}`)
+      if (relocatedCorestoreDir) {
+        console.log('[Storage] Relocated stale top-level corestore dir to avoid Corestore migration conflict:', relocatedCorestoreDir)
+      }
+    } catch (error) {
+      await appendDebugLine(`[storage] relocateLegacyCorestoreDir failed ${describeDebugError(error)}`)
+      console.warn('[Storage] Failed to relocate stale top-level corestore dir before Corestore init:', error?.message)
+    }
+
     try {
       await appendDebugLine('[storage] relocateLegacyBlindPeerDir start')
       const relocatedBlindPeerDir = relocateLegacyBlindPeerDir(storagePath, fs, path)

--- a/packages/backend/src/swarm-peer-dial.js
+++ b/packages/backend/src/swarm-peer-dial.js
@@ -96,9 +96,10 @@ export function swarmRememberPeer(swarm, peer, topic = null) {
 export function swarmQueuePeer(swarm, peerInfo) {
   if (!swarm || !peerInfo || !peerInfo.publicKey) return false
   if (typeof swarm.joinPeer === 'function') {
-    swarm.joinPeer(peerInfo.publicKey)
     peerInfo.explicit = true
-    peerInfo.queued = true
+    peerInfo.queued = false
+    peerInfo.waiting = false
+    swarm.joinPeer(peerInfo.publicKey)
     return true
   }
   return false

--- a/packages/backend/test/corestore-layout-conflict.test.mjs
+++ b/packages/backend/test/corestore-layout-conflict.test.mjs
@@ -1,0 +1,43 @@
+import test from 'brittle'
+import os from 'node:os'
+import path from 'node:path'
+import fs from 'node:fs'
+
+import { relocateLegacyCorestoreDir } from '../src/storage-layout.js'
+
+test('relocateLegacyCorestoreDir archives stale top-level corestore when db/corestore exists', async (t) => {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'peartube-corestore-layout-'))
+  const legacyCorestoreDir = path.join(tmpRoot, 'corestore')
+  const dbCorestoreDir = path.join(tmpRoot, 'db', 'corestore')
+
+  fs.mkdirSync(legacyCorestoreDir, { recursive: true })
+  fs.mkdirSync(dbCorestoreDir, { recursive: true })
+  fs.writeFileSync(path.join(legacyCorestoreDir, 'legacy-block'), 'legacy-corestore')
+  fs.writeFileSync(path.join(dbCorestoreDir, 'current-block'), 'current-corestore')
+
+  const relocatedDir = relocateLegacyCorestoreDir(tmpRoot, fs, path)
+
+  t.ok(relocatedDir)
+  t.ok(relocatedDir.startsWith(path.join(tmpRoot, 'db', 'corestore-legacy-')))
+  t.absent(fs.existsSync(legacyCorestoreDir))
+  t.is(fs.readFileSync(path.join(relocatedDir, 'legacy-block'), 'utf8'), 'legacy-corestore')
+  t.is(fs.readFileSync(path.join(dbCorestoreDir, 'current-block'), 'utf8'), 'current-corestore')
+
+  fs.rmSync(tmpRoot, { recursive: true, force: true })
+})
+
+test('relocateLegacyCorestoreDir is a no-op when only top-level corestore exists', async (t) => {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'peartube-corestore-layout-'))
+  const legacyCorestoreDir = path.join(tmpRoot, 'corestore')
+
+  fs.mkdirSync(legacyCorestoreDir, { recursive: true })
+  fs.writeFileSync(path.join(legacyCorestoreDir, 'state'), 'only-corestore')
+
+  const relocatedDir = relocateLegacyCorestoreDir(tmpRoot, fs, path)
+
+  t.is(relocatedDir, null)
+  t.ok(fs.existsSync(legacyCorestoreDir))
+  t.is(fs.readFileSync(path.join(legacyCorestoreDir, 'state'), 'utf8'), 'only-corestore')
+
+  fs.rmSync(tmpRoot, { recursive: true, force: true })
+})

--- a/packages/backend/test/swarm-peer-dial-regression.test.mjs
+++ b/packages/backend/test/swarm-peer-dial-regression.test.mjs
@@ -40,6 +40,6 @@ test('swarmQueuePeer queues through public joinPeer and avoids private priority 
 
   assert.equal(swarmQueuePeer(swarm, peerInfo), true)
   assert.deepEqual(swarm.joinPeerCalls, [publicKey])
-  assert.equal(peerInfo.queued, true)
+  assert.equal(peerInfo.queued, false)
   assert.equal(peerInfo.explicit, true)
 })

--- a/packages/backend/test/swarm-peer-dial.test.mjs
+++ b/packages/backend/test/swarm-peer-dial.test.mjs
@@ -50,7 +50,7 @@ test('swarmQueuePeer promotes peer info and queues via public joinPeer without p
   assert.equal(swarmQueuePeer(swarm, peerInfo), true)
   assert.equal(swarm.enqueueCalls.length, 0)
   assert.equal(peerInfo.explicit, true)
-  assert.equal(peerInfo.queued, true)
+  assert.equal(peerInfo.queued, false)
   assert.equal(swarm.joinPeerCalls.length, 1)
   assert.equal(swarm.joinPeerCalls[0], publicKey)
 })

--- a/packages/backend/test/swarm-peer-requeue.test.mjs
+++ b/packages/backend/test/swarm-peer-requeue.test.mjs
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import b4a from 'b4a'
+
+import { swarmQueuePeer } from '../src/swarm-peer-dial.js'
+
+test('swarmQueuePeer clears stale queued/waiting flags before joinPeer requeue', () => {
+  const publicKey = b4a.alloc(32, 31)
+  const peerInfo = {
+    publicKey,
+    queued: true,
+    waiting: true,
+    explicit: false,
+  }
+  const swarm = {
+    joinPeerCalls: [],
+    joinPeer(key) {
+      this.joinPeerCalls.push(key)
+    },
+  }
+
+  assert.equal(swarmQueuePeer(swarm, peerInfo), true)
+  assert.deepEqual(swarm.joinPeerCalls, [publicKey])
+  assert.equal(peerInfo.explicit, true)
+  assert.equal(peerInfo.queued, false)
+  assert.equal(peerInfo.waiting, false)
+})


### PR DESCRIPTION
## Summary
- archive stale top-level `storage/corestore` when canonical `storage/db/corestore` already exists, preventing repeated relay ENOTEMPTY startup crashes
- clear stale Hyperswarm `queued`/`waiting` flags before explicit `joinPeer()` redials so Android-discovered peers can be requeued instead of staying stuck at discovered-without-sockets
- tighten Android discovery regression coverage for discovered peer counts vs transport-socket degradation

## Tests
- `node --test packages/backend/test/swarm-peer-requeue.test.mjs packages/backend/test/swarm-peer-dial.test.mjs packages/backend/test/swarm-peer-dial-regression.test.mjs packages/backend/test/public-feed-manager.test.mjs packages/app/tests/android-physical-discovery-regression.test.mjs`
- `cd packages/backend && npx brittle test/corestore-layout-conflict.test.mjs test/storage-layout.test.mjs`