### PR TITLE
fix(relay): rely on Hyperswarm connection events

### DIFF
--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -3535,7 +3535,6 @@ export function createApi({
     async resumeNetwork() {
       try {
         await resumeNetworking()
-        publicFeed?.runBoundedPeerRecovery?.('foreground-resume')
         return { success: true }
       } catch (err) {
         console.error('[API] resumeNetwork error:', err.message)

--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -21,7 +21,6 @@ import b4a from 'b4a'
 import { NETWORK_TOPIC_STRING, PROTOCOL_NAME } from './types.js';
 import { logger } from './logger.js'
 import { hashFeedEntries, hashPreviewVideos } from './hash-utils.js'
-import { swarmHasConnection } from './swarm-peer-dial.js'
 import {
   SIGNED_CHANNEL_ROOT_DESCRIPTOR_SCHEMA,
   CHANNEL_ROOT_DESCRIPTOR_SCHEMA
@@ -77,32 +76,10 @@ export class PublicFeed {
     this._nextAvailabilityRequestId = 1;
     /** @type {Map<string, { resolve: Function, timeout: any }>} */
     this.pendingAvailabilityRequests = new Map();
-    /** @type {Map<string, any>} Remembered Hyperswarm peer candidates for diagnostics/recovery. */
+    /** @type {Map<string, { publicKey: any, relayAddressesSeen: number, topics: Set<string>, firstSeenAt: number, lastSeenAt: number }>} Discovered peers retained only for diagnostics. */
     this._discoveredPeers = new Map();
-    /** @type {Map<string, any>} Remembered discovered peer objects with relay-address hints. */
-    this._discoveredPeerHints = new Map();
-    /** @type {Array<{at: number, action: string, reason?: string, discoveredPeers: number, connections: number, queued: number}>} */
-    this._recoveryEvents = [];
     /** @type {number} */
-    this._lastRecoveryAt = 0;
-    /** @type {number} */
-    this._recoveryCooldownMs = 30000;
-    /** @type {Map<string, number>} */
-    this._directPeerLastDialedAt = new Map();
-    /** @type {Map<string, string>} */
-    this._directPeerLastDialError = new Map();
-    /** @type {Map<string, string>} */
-    this._directPeerLastDialErrorStack = new Map();
-    /** @type {{attempted: number, queued: number, skipped: number, failed: number, connected: number, lastReason: string | null, lastDialedAt: number | null}} */
-    this._directPeerDialStats = {
-      attempted: 0,
-      queued: 0,
-      skipped: 0,
-      failed: 0,
-      connected: 0,
-      lastReason: null,
-      lastDialedAt: null,
-    };
+    this._connectionOpenCount = 0;
     /** @type {() => number} */
     this._now = () => Date.now();
     /** @type {any | null} */
@@ -133,15 +110,6 @@ export class PublicFeed {
     this._persistDebounceMs = 1500
     /** @type {number} */
     this._persistMaxEntries = 500
-
-    /** @type {number} */
-    this.maxPeers = Math.max(1, Number(options.maxPeers || this.swarm?.maxPeers || 48) || 48)
-    /** @type {Map<string, {publicKey: any, score: number, firstSeenAt: number, lastSeenAt: number, joined: boolean, demoted: boolean, joinAttempts: number, lastJoinedAt: number | null, lastConnectionAt: number | null, relayHints: number, topics?: Set<string>, lastJoinError?: string | null}>} */
-    this._peerDirectory = new Map()
-    /** @type {Map<any, any>} */
-    this._connectionPeerKeys = new Map()
-    /** @type {number} */
-    this._peerJoinCooldownMs = 30000
 
     log.info('Initialized')
   }
@@ -549,56 +517,48 @@ export class PublicFeed {
     return null
   }
 
-  _peerEntryIsConnected(entry) {
-    if (!entry || typeof entry !== 'object') return false
-    const nestedPeer = entry.value || entry.peer || entry[1]
-    return (
-      entry.connected === true ||
-      entry.opened === true ||
-      (Number.isFinite(entry.connectedTime) && entry.connectedTime >= 0) ||
-      nestedPeer?.connected === true ||
-      nestedPeer?.opened === true ||
-      (Number.isFinite(nestedPeer?.connectedTime) && nestedPeer.connectedTime >= 0) ||
-      Boolean(entry.stream || nestedPeer?.stream)
-    )
+  _peerKeyHex(publicKey) {
+    if (!publicKey) return null
+    if (typeof publicKey === 'string' && /^[a-f0-9]{64}$/i.test(publicKey)) return publicKey.toLowerCase()
+    if (b4a.isBuffer(publicKey) || publicKey instanceof Uint8Array) return b4a.toString(publicKey, 'hex')
+    return null
   }
 
-  _activeSwarmConnectionEntries() {
-    const allConnections = this.swarm?._allConnections
-    if (!allConnections || typeof allConnections[Symbol.iterator] !== 'function') return []
-    return Array.from(allConnections).filter((entry) => (
-      entry &&
-      typeof entry === 'object' &&
-      !b4a.isBuffer(entry) &&
-      !(entry instanceof Uint8Array)
-    ))
-  }
-
-  _peerEntryMatchesKey(entry, keyHex, { requireConnected = false } = {}) {
-    const publicKey = this._peerEntryPublicKey(entry)
-    if (!publicKey) return false
-    if (b4a.toString(publicKey, 'hex') !== keyHex) return false
-    return !requireConnected || this._peerEntryIsConnected(entry)
-  }
-
-  _hasActivePeerConnection(keyHex, publicKey = null) {
-    return swarmHasConnection(this.swarm, keyHex, publicKey)
-  }
-
-  _markPeerConnected(publicKey) {
-    const remembered = this._rememberPeerPublicKey(publicKey)
-    if (!remembered) return
-    const peerInfo = this.swarm?.peers?.get?.(remembered.keyHex) || null
-    if (peerInfo && typeof peerInfo === 'object') {
-      peerInfo.queued = false
-      peerInfo.waiting = false
-      peerInfo.connectedTime = Date.now()
+  _hasActivePeerConnection(keyHex) {
+    if (!this.swarm?.connections || typeof this.swarm.connections[Symbol.iterator] !== 'function') return false
+    for (const conn of this.swarm.connections) {
+      const remoteKey = conn?.remotePublicKey || conn?.publicKey
+      if (remoteKey && this._peerKeyHex(remoteKey) === keyHex) return true
     }
-    this._directPeerLastDialError.delete(remembered.keyHex)
-    this._directPeerLastDialErrorStack.delete(remembered.keyHex)
-    this._directPeerDialStats.connected++
-    this._directPeerDialStats.lastReason = 'connected'
+    return false
   }
+
+  _rememberDiscoveredPeer(peer, topic = null) {
+    const publicKey = this._peerEntryPublicKey(peer)
+    const keyHex = this._peerKeyHex(publicKey)
+    if (!keyHex || keyHex === this._peerKeyHex(this.swarm?.keyPair?.publicKey)) return null
+
+    const now = this._now()
+    const relayAddresses = Array.isArray(peer?.relayAddresses) ? peer.relayAddresses : []
+    const existing = this._discoveredPeers.get(keyHex)
+    const record = existing || {
+      publicKey,
+      relayAddressesSeen: 0,
+      topics: new Set(),
+      firstSeenAt: now,
+      lastSeenAt: now,
+    }
+    record.publicKey = publicKey || record.publicKey
+    record.relayAddressesSeen = Math.max(Number(record.relayAddressesSeen || 0), relayAddresses.length)
+    record.lastSeenAt = now
+    if (topic) {
+      const topicHex = this._topicToHex(topic)
+      if (topicHex) record.topics.add(topicHex)
+    }
+    this._discoveredPeers.set(keyHex, record)
+    return { keyHex, publicKey: record.publicKey, record }
+  }
+
 
   _connectionLabel(conn, info = null) {
     if (!conn) return 'conn:unknown'
@@ -625,276 +585,46 @@ export class PublicFeed {
     this.wiredConnections.delete(conn)
     this.peerChannels.delete(conn)
     this.feedConnections.delete(conn)
-    this._connectionPeerKeys.delete(conn)
     this._connectionIds.delete(conn)
     this._connectionStartedAt.delete(conn)
   }
 
-  _rememberPeerPublicKey(publicKey, peer = null, topic = null) {
-    if (!publicKey) return null
-    const keyHex = b4a.toString(publicKey, 'hex')
-    if (!keyHex || keyHex === b4a.toString(this.swarm?.keyPair?.publicKey || [], 'hex')) return null
-    this._discoveredPeers.set(keyHex, publicKey)
-    if (peer && typeof peer === 'object') {
-      const relayAddresses = Array.isArray(peer.relayAddresses) ? peer.relayAddresses : []
-      const existing = this._discoveredPeerHints.get(keyHex) || {}
-      this._discoveredPeerHints.set(keyHex, {
-        peer,
-        topic,
-        relayAddresses,
-        relayAddressesSeen: Math.max(Number(existing.relayAddressesSeen || 0), relayAddresses.length),
-        firstSeenAt: existing.firstSeenAt || this._now(),
-        lastSeenAt: this._now(),
-      })
-    }
-    return { keyHex, publicKey }
-  }
-
-  _peerKeyHex(publicKey) {
-    if (!publicKey) return null
-    if (typeof publicKey === 'string' && /^[a-f0-9]{64}$/i.test(publicKey)) return publicKey.toLowerCase()
-    if (b4a.isBuffer(publicKey) || publicKey instanceof Uint8Array) return b4a.toString(publicKey, 'hex')
-    return null
-  }
-
-  _lowestScoringPeer(excludeKeyHex = null) {
-    let lowest = null
-    for (const record of this._peerDirectory.values()) {
-      if (!record || record.keyHex === excludeKeyHex) continue
-      if (!lowest) {
-        lowest = record
-        continue
-      }
-      if (record.score < lowest.score) {
-        lowest = record
-        continue
-      }
-      if (record.score === lowest.score && record.lastSeenAt < lowest.lastSeenAt) {
-        lowest = record
-      }
-    }
-    return lowest
-  }
-
-  _enforcePeerDirectoryLimit() {
-    while (this._peerDirectory.size > this.maxPeers) {
-      const victim = this._lowestScoringPeer()
-      if (!victim) break
-      victim.demoted = true
-      victim.demotedAt = this._now()
-      this._peerDirectory.delete(victim.keyHex)
-      log.info('Demoted low-scoring peer', { key: victim.keyHex.slice(0, 16), score: victim.score, maxPeers: this.maxPeers })
-    }
-  }
-
-  _scorePeerRecord(record, peer = null, { connectionAgeMs = 0, connected = false, reason = 'seen' } = {}) {
-    if (!record) return null
-    let delta = 0
-    const relayCount = Array.isArray(peer?.relayAddresses) ? peer.relayAddresses.length : Number(record.relayHints || 0)
-    if (relayCount > 0) delta += Math.min(1.5, relayCount * 0.15)
-    if (peer?.client === true) delta -= 0.1
-    if (peer?.queued === true) delta += 0.05
-    if (reason === 'connected') delta += 0.2
-    if (connected && connectionAgeMs > 0) {
-      delta += Math.min(5, connectionAgeMs / 60000)
-    }
-    if (reason === 'transient-client' || (peer?.client === true && connectionAgeMs < 30000)) {
-      delta -= 0.05
-    }
-    record.score = Number(record.score || 0) + delta
-    record.lastScoredAt = this._now()
-    record.lastSeenAt = record.lastSeenAt || record.lastScoredAt
-    return record
-  }
-
-  _registerPeerCandidate(publicKey, peer = null, topic = null, scoreOptions = {}) {
-    const keyHex = this._peerKeyHex(publicKey)
-    if (!keyHex) return null
-    if (keyHex === b4a.toString(this.swarm?.keyPair?.publicKey || [], 'hex')) return null
-
-    let record = this._peerDirectory.get(keyHex)
-    if (!record) {
-      record = {
-        keyHex,
-        publicKey,
-        score: 0,
-        firstSeenAt: this._now(),
-        lastSeenAt: this._now(),
-        joined: false,
-        demoted: false,
-        joinAttempts: 0,
-        lastJoinedAt: null,
-        lastConnectionAt: null,
-        relayHints: Array.isArray(peer?.relayAddresses) ? peer.relayAddresses.length : 0,
-        topics: new Set(),
-        lastJoinError: null,
-      }
-    } else {
-      record.publicKey = publicKey || record.publicKey
-      record.lastSeenAt = this._now()
-      if (Array.isArray(peer?.relayAddresses)) {
-        record.relayHints = Math.max(Number(record.relayHints || 0), peer.relayAddresses.length)
-      }
-    }
-
-    if (topic) {
-      const topicHex = this._topicToHex(topic)
-      if (topicHex) record.topics.add(topicHex)
-    }
-
-    this._scorePeerRecord(record, peer, scoreOptions)
-    this._peerDirectory.set(keyHex, record)
-    this._enforcePeerDirectoryLimit()
-    return this._peerDirectory.get(keyHex) || null
-  }
-
-  _recordPeerConnectionOutcome(conn, reason = 'closed') {
-    const remoteKey = this._connectionPeerKeys.get(conn) || conn?.remotePublicKey || conn?.publicKey || null
-    const keyHex = this._peerKeyHex(remoteKey)
-    const record = keyHex ? this._peerDirectory.get(keyHex) : null
-    if (!record) return
-    const ageMs = this._connectionAgeMs(conn)
-    const swarmState = this._swarmDialState(keyHex, remoteKey)
-    record.lastConnectionAt = this._now()
-    this._scorePeerRecord(record, { relayAddresses: Array.from({ length: Number(record.relayHints || 0) }, () => null), client: swarmState?.client }, { connectionAgeMs: ageMs, connected: true, reason: swarmState?.client ? 'transient-client' : reason })
-  }
-
-  /**
-   * Remember a shared-topic peer candidate. Hyperswarm owns dialing and retry
-   * lifecycle after discovery; PublicFeedManager only uses opened sockets.
-   * @param {any} peer
-   * @param {Buffer | Uint8Array | string | null} [topic]
-   * @returns {boolean}
-   */
   handleDiscoveredPeer(peer, topic = null) {
     if (topic && !this._isNetworkTopic(topic)) return false
-    if (!this.swarm) return false
-    const publicKey = this._peerEntryPublicKey(peer)
-    const remembered = this._rememberPeerPublicKey(publicKey, peer, topic)
-    if (remembered) {
-      this._recordStartupEvent('feed-peer-discovered', { key: remembered.keyHex.slice(0, 16), topic: topic ? (this._isNetworkTopic(topic) ? 'peartube-network' : 'other') : 'unknown', relayAddresses: Array.isArray(peer?.relayAddresses) ? peer.relayAddresses.length : 0 })
-    }
-    if (!remembered) {
-      this._directPeerDialStats.skipped++
-      this._directPeerDialStats.lastReason = 'self-or-missing-key'
-      return false
-    }
-
-    const record = this._registerPeerCandidate(remembered.publicKey, peer, topic, { reason: 'discovered' })
-    if (!record) {
-      this._directPeerDialStats.skipped++
-      this._directPeerDialStats.lastReason = 'peer-demoted'
-      return false
-    }
-
-    if (this._hasActivePeerConnection(remembered.keyHex, remembered.publicKey)) {
-      this._directPeerDialStats.skipped++
-      this._directPeerDialStats.lastReason = 'already-connected-peer'
-      return true
-    }
-
-    this._directPeerDialStats.skipped++
-    this._directPeerDialStats.lastReason = 'hyperswarm-owned-discovery'
-    this._rememberDiscoveredPeerInSwarm(peer, topic, remembered.keyHex)
+    const remembered = this._rememberDiscoveredPeer(peer, topic)
+    if (!remembered) return false
+    this._recordStartupEvent('feed-peer-discovered', {
+      key: remembered.keyHex.slice(0, 16),
+      topic: topic ? (this._isNetworkTopic(topic) ? 'peartube-network' : 'other') : 'unknown',
+      relayAddresses: Array.isArray(peer?.relayAddresses) ? peer.relayAddresses.length : 0,
+    })
     return true
   }
 
-  _rememberDiscoveredPeerInSwarm(peer, topic, keyHex) {
-    if (!this.swarm || !peer || typeof peer !== 'object') return null
-    try {
-      return this._discoveredPeerHints.get(keyHex) || null
-    } catch (err) {
-      this._directPeerLastDialError.set(keyHex, err?.message || String(err))
-      if (err?.stack) this._directPeerLastDialErrorStack.set(keyHex, err.stack)
-      return null
-    }
-  }
-
-
-  runBoundedPeerRecovery(reason = 'heartbeat') {
-    const event = {
-      at: this._now(),
-      action: 'observed-peers-without-sockets',
-      reason: 'hyperswarm-owned-dialing',
-      requestedReason: reason,
-      discoveredPeers: this._discoveredPeers.size,
-      connections: this.swarm?.connections?.size || 0,
-      queued: 0,
-    }
-    this._recoveryEvents.push(event)
-    while (this._recoveryEvents.length > 10) this._recoveryEvents.shift()
-    return event
-  }
-
-  _swarmDialState(keyHex, publicKey = null) {
-    const peers = this.swarm?.peers
-    let peerInfo = peers && typeof peers.get === 'function' ? peers.get(keyHex) : null
-    if (!peerInfo && peers && typeof peers.get === 'function' && publicKey) {
-      try { peerInfo = peers.get(publicKey) } catch { peerInfo = null }
-    }
-    if (!peerInfo || typeof peerInfo !== 'object') return null
-
-    const relayAddresses = Array.isArray(peerInfo.relayAddresses) ? peerInfo.relayAddresses : []
-    const topics = Array.isArray(peerInfo.topics) ? peerInfo.topics : []
-    return {
-      attempts: Number(peerInfo.attempts || 0),
-      queued: Boolean(peerInfo.queued),
-      waiting: Boolean(peerInfo.waiting),
-      explicit: Boolean(peerInfo.explicit),
-      banned: Boolean(peerInfo.banned),
-      proven: Boolean(peerInfo.proven),
-      client: Boolean(peerInfo.client),
-      connectedTime: Number(peerInfo.connectedTime ?? -1),
-      disconnectedTime: Number(peerInfo.disconnectedTime || 0),
-      relayAddresses: relayAddresses.length,
-      topics: topics.length,
-    }
-  }
 
   getDirectPeerDialStats() {
     const peers = []
-    for (const [keyHex] of this._discoveredPeers) {
-      const publicKey = this._discoveredPeers.get(keyHex)
-      const swarm = this._swarmDialState(keyHex, publicKey)
-      const hint = this._discoveredPeerHints.get(keyHex)
-      const record = this._peerDirectory.get(keyHex)
-      const connected = this._hasActivePeerConnection(keyHex, publicKey)
+    for (const [keyHex, record] of this._discoveredPeers) {
       peers.push({
         key: keyHex.slice(0, 16),
-        attempts: swarm?.attempts || 0,
-        discoveredRelayAddresses: Number(hint?.relayAddressesSeen || 0),
-        lastSeenAt: hint?.lastSeenAt || null,
-        lastDialedAt: this._directPeerLastDialedAt.get(keyHex) || null,
-        lastQueuedAt: null,
-        lastError: this._directPeerLastDialError.get(keyHex) || null,
-        lastErrorStack: this._directPeerLastDialErrorStack.get(keyHex) || null,
-        pending: Boolean(!connected && (swarm?.queued || swarm?.waiting || record?.joined)),
-        connected,
-        score: Number(record?.score || 0),
-        joined: Boolean(record?.joined),
-        demoted: Boolean(record?.demoted),
-        swarm,
+        discoveredRelayAddresses: Number(record.relayAddressesSeen || 0),
+        topics: record.topics?.size || 0,
+        firstSeenAt: record.firstSeenAt || null,
+        lastSeenAt: record.lastSeenAt || null,
+        connected: this._hasActivePeerConnection(keyHex),
       })
     }
 
     return {
-      ...this._directPeerDialStats,
       discoveredPeers: this._discoveredPeers.size,
-      pending: peers.filter((peer) => peer.pending).length,
-      maxDirectPeers: null,
-      maxDirectPeerRetries: null,
+      connected: this._connectionOpenCount,
       swarmPeers: this.swarm?.peers?.size || 0,
       swarmConnections: this.swarm?.connections?.size || 0,
-      swarmAllConnections: this.swarm?._allConnections?.size || 0,
       swarmConnecting: Number(this.swarm?.connecting || 0),
-      swarmExplicitPeers: this.swarm?.explicitPeers?.size || 0,
-      swarmQueueSize: this.swarm?._queue?.length || 0,
-      recoveryEvents: this._recoveryEvents.slice(-5),
-      recoveryCooldownMs: this._recoveryCooldownMs,
-      lastRecoveryAt: this._lastRecoveryAt || null,
       peers,
     }
   }
+
 
   /**
    * Start the public feed manager - restore cache and wire current connections
@@ -1099,13 +829,6 @@ export class PublicFeed {
       }
       this.pendingAvailabilityRequests.clear()
       this._discoveredPeers.clear()
-      this._discoveredPeerHints.clear()
-      this._peerDirectory.clear()
-      this._connectionPeerKeys.clear()
-      this._recoveryEvents.length = 0
-      this._directPeerLastDialedAt.clear()
-      this._directPeerLastDialError.clear()
-      this._directPeerLastDialErrorStack.clear()
       if (this._ownsFeedDiscovery) {
         try { this.feedDiscovery?.destroy?.() } catch {}
       }
@@ -1201,9 +924,7 @@ export class PublicFeed {
     }
 
     const label = this._connectionLabel(conn, info)
-    const remoteKey = info?.publicKey || conn.remotePublicKey || conn.publicKey
-    this._connectionPeerKeys.set(conn, remoteKey)
-    this._markPeerConnected(remoteKey)
+    this._connectionOpenCount++
     console.log('[PublicFeed] handleConnection:', label, 'setting up feed protocol on new connection');
     this._recordStartupEvent('feed-socket-connected', { connection: label })
     this.wiredConnections.add(conn);
@@ -1232,13 +953,11 @@ export class PublicFeed {
     // Clean up on connection close
     conn.on('close', () => {
       console.log('[PublicFeed] Connection closed:', label, 'ageMs=', this._connectionAgeMs(conn));
-      this._recordPeerConnectionOutcome(conn, 'closed');
       this._forgetConnection(conn);
     });
 
     conn.on('error', (err) => {
       console.error('[PublicFeed] Connection error:', label, err.message, 'ageMs=', this._connectionAgeMs(conn));
-      this._recordPeerConnectionOutcome(conn, 'error');
       this._forgetConnection(conn);
     });
   }

--- a/packages/backend/test/public-feed-api.test.mjs
+++ b/packages/backend/test/public-feed-api.test.mjs
@@ -852,22 +852,22 @@ test('getPublicFeed exposes relay catalog fields', (t) => {
   t.is(result.entries[0].previewVideosHash, 'hash-value')
 })
 
-test('resumeNetwork triggers bounded discovered-peer recovery after foreground resume', (t) => {
-  let recoveredReason = null
+test('resumeNetwork delegates to storage networking without app-level peer recovery', (t) => {
+  let recoveryCalls = 0
   const api = createApi({
     ctx: {
       swarm: { connections: new Set(), peers: new Set() },
       channels: new Map(),
     },
     publicFeed: {
-      runBoundedPeerRecovery(reason) {
-        recoveredReason = reason
+      runBoundedPeerRecovery() {
+        recoveryCalls += 1
       },
     },
   })
 
   return api.resumeNetwork().then((result) => {
     t.is(result.success, true)
-    t.is(recoveredReason, 'foreground-resume')
+    t.is(recoveryCalls, 0)
   })
 })

--- a/packages/backend/test/public-feed-manager.test.mjs
+++ b/packages/backend/test/public-feed-manager.test.mjs
@@ -134,7 +134,7 @@ function createMemoryConnectionPair() {
   return [a, b]
 }
 
-test('PublicFeedManager records discovered peers without app-level explicit dialing', () => {
+test('PublicFeedManager records discovered peers without app-level dialing', () => {
   const swarm = createSwarm()
   const manager = new PublicFeedManager(swarm, createMetaDb())
   const publicKey = b4a.alloc(32, 7)
@@ -144,10 +144,7 @@ test('PublicFeedManager records discovered peers without app-level explicit dial
     assert.equal(swarm.joinPeerCalls.length, 0)
     const stats = manager.getStats().directPeerDial
     assert.equal(stats.discoveredPeers, 1)
-    assert.equal(stats.attempted, 0)
-    assert.equal(stats.queued, 0)
-    assert.equal(stats.pending, 0)
-    assert.equal(stats.lastReason, 'hyperswarm-owned-discovery')
+    assert.equal(stats.swarmConnections, 0)
     assert.equal(stats.peers[0].key, b4a.toString(publicKey, 'hex').slice(0, 16))
   } finally {
     manager.stop()
@@ -182,7 +179,7 @@ test('PublicFeedManager keeps discovered relay address hints as Hyperswarm diagn
     assert.equal(swarm.joinPeerCalls.length, 0)
     assert.equal(swarm.peers.get(keyHex).relayAddresses, relayAddresses)
     assert.deepEqual(swarm.peers.get(keyHex).topics, [NETWORK_TOPIC])
-    assert.equal(manager.getStats().directPeerDial.peers[0].swarm.relayAddresses, 1)
+    assert.equal(manager.getStats().directPeerDial.peers[0].discoveredRelayAddresses, 1)
   } finally {
     manager.stop()
   }
@@ -227,12 +224,9 @@ test('PublicFeedManager does not recurse through the storage peer emitter wrappe
 
     const stats = manager.getStats().directPeerDial
     assert.equal(emitted, 1)
-    assert.equal(stats.queued, 0)
-    assert.equal(stats.failed, 0)
     assert.equal(stats.discoveredPeers, 1)
-    assert.equal(stats.peers[0].lastError, null)
     assert.equal(swarm.peers.get(keyHex).relayAddresses, relayAddresses)
-    assert.equal(stats.peers[0].swarm.relayAddresses, 3)
+    assert.equal(stats.peers[0].discoveredRelayAddresses, 3)
   } finally {
     manager.stop()
   }
@@ -268,8 +262,6 @@ test('PublicFeedManager treats swarm.peers and _allConnections as diagnostics, n
     assert.equal(manager.handleDiscoveredPeer({ publicKey }), true)
     const stats = manager.getStats().directPeerDial
     assert.equal(stats.peers[0].connected, false)
-    assert.equal(stats.peers[0].swarm.connectedTime >= 0, true)
-    assert.equal(stats.swarmAllConnections, 1)
   } finally {
     manager.stop()
   }
@@ -305,7 +297,7 @@ test('PublicFeedManager does not treat pending Hyperswarm _allConnections entrie
   }
 })
 
-test('direct peer diagnostics include Hyperswarm queue state', () => {
+test('direct peer diagnostics stay scoped to public counters', () => {
   const publicKey = b4a.alloc(32, 13)
   const keyHex = b4a.toString(publicKey, 'hex')
   const swarm = createSwarm()
@@ -331,23 +323,9 @@ test('direct peer diagnostics include Hyperswarm queue state', () => {
     assert.equal(manager.handleDiscoveredPeer({ publicKey }), true)
     const stats = manager.getStats().directPeerDial
     assert.equal(stats.swarmConnecting, 1)
-    assert.equal(stats.swarmAllConnections, 1)
-    assert.equal(stats.swarmExplicitPeers, 1)
-    assert.equal(stats.swarmQueueSize, 2)
-    assert.equal(stats.pending, 1)
-    assert.deepEqual(stats.peers[0].swarm, {
-      attempts: 2,
-      queued: true,
-      waiting: true,
-      explicit: true,
-      banned: false,
-      proven: false,
-      client: false,
-      connectedTime: -1,
-      disconnectedTime: 123,
-      relayAddresses: 1,
-      topics: 1,
-    })
+    assert.equal(stats.swarmConnections, 0)
+    assert.equal(stats.peers[0].discoveredRelayAddresses, 0)
+    assert.equal(stats.peers[0].connected, false)
   } finally {
     manager.stop()
   }
@@ -369,15 +347,12 @@ test('PublicFeedManager preserves relay-address hints without joinPeer fallback'
     const stats = manager.getStats().directPeerDial
     assert.equal(stats.discoveredPeers, 1)
     assert.equal(stats.peers[0].discoveredRelayAddresses, 1)
-    assert.equal(stats.peers[0].swarm, null)
-    assert.equal(stats.lastReason, 'hyperswarm-owned-discovery')
-    assert.equal(stats.pending, 0)
   } finally {
     manager.stop()
   }
 })
 
-test('PublicFeedManager leaves pending discovered peer candidates under Hyperswarm ownership', () => {
+test('PublicFeedManager leaves pending Hyperswarm peer candidates untouched', () => {
   const publicKey = b4a.alloc(32, 23)
   const keyHex = b4a.toString(publicKey, 'hex')
   const swarm = createSwarm()
@@ -403,15 +378,13 @@ test('PublicFeedManager leaves pending discovered peer candidates under Hyperswa
     assert.equal(peerInfo.explicit, false)
     assert.equal(priorityUpdates, 0)
     const stats = manager.getStats().directPeerDial
-    assert.equal(stats.lastReason, 'hyperswarm-owned-discovery')
-    assert.equal(stats.peers[0].pending, true)
-    assert.equal(stats.peers[0].lastDialedAt, null)
+    assert.equal(stats.peers[0].connected, false)
   } finally {
     manager.stop()
   }
 })
 
-test('PublicFeedManager recovery is observational without app-level peer queueing', () => {
+test('PublicFeedManager has no app-level foreground peer recovery loop', () => {
   const publicKey = b4a.alloc(32, 22)
   const swarm = createSwarm()
   const manager = new PublicFeedManager(swarm, createMetaDb())
@@ -419,16 +392,9 @@ test('PublicFeedManager recovery is observational without app-level peer queuein
   try {
     assert.equal(manager.handleDiscoveredPeer({ publicKey, relayAddresses: [{ host: 'relay.test', port: 1 }] }, NETWORK_TOPIC), true)
     const statsBeforeRecovery = manager.getStats().directPeerDial
-    assert.equal(statsBeforeRecovery.peers[0].pending, false)
-    swarm.joinPeerCalls.length = 0
-    const recovery = manager.runBoundedPeerRecovery('test-recovery')
-    assert.equal(recovery.queued, 0)
-    assert.equal(recovery.reason, 'hyperswarm-owned-dialing')
+    assert.equal(statsBeforeRecovery.peers[0].connected, false)
+    assert.equal(typeof manager.runBoundedPeerRecovery, 'undefined')
     assert.equal(swarm.joinPeerCalls.length, 0)
-    const stats = manager.getStats().directPeerDial
-    assert.equal(stats.recoveryEvents.length, 1)
-    assert.equal(stats.recoveryEvents[0].requestedReason, 'test-recovery')
-    assert.equal(stats.lastReason, 'hyperswarm-owned-discovery')
   } finally {
     manager.stop()
   }
@@ -501,7 +467,6 @@ test('discovered peer diagnostics become connected when the Hyperswarm socket ar
     assert.equal(swarm.joinPeerCalls.length, 0)
 
     const discoveredStats = manager.getStats().directPeerDial
-    assert.equal(discoveredStats.pending, 0)
     assert.equal(discoveredStats.peers[0].connected, false)
 
     const conn = createConnection()
@@ -510,10 +475,7 @@ test('discovered peer diagnostics become connected when the Hyperswarm socket ar
     manager.handleConnection(conn, { publicKey })
 
     const connectedStats = manager.getStats().directPeerDial
-    assert.equal(connectedStats.pending, 0)
-    assert.equal(connectedStats.peers[0].pending, false)
     assert.equal(connectedStats.peers[0].connected, true)
-    assert.equal(connectedStats.lastReason, 'connected')
     assert.equal(connectedStats.connected, 1)
   } finally {
     manager.stop()


### PR DESCRIPTION
## Summary
- removes PublicFeed's app-level direct peer dialing/recovery layer
- keeps discovered peer handling diagnostic-only and lets Hyperswarm own dialing/retry/socket lifecycle
- keeps feed protocol setup tied to real `swarm.on('connection')` sockets via `handleConnection`
- updates regressions to assert no `joinPeer`/queue/private-state mutation from feed discovery or foreground resume

## Test Plan
- `node --test packages/backend/test/gossip-relay-core.test.mjs packages/backend/test/public-feed-manager.test.mjs packages/backend/test/blob-ref.test.mjs packages/backend/test/swarm-peer-dial.test.mjs packages/backend/test/swarm-status-diagnostics.test.mjs packages/backend/test/storage-startup-regression.test.mjs packages/backend/test/public-feed-api.test.mjs packages/app/tests/android-physical-discovery-regression.test.mjs`
- `git diff --check`
- `./node_modules/.bin/eslint --quiet packages/backend/src/public-feed.js packages/backend/src/api.js packages/backend/test/public-feed-manager.test.mjs packages/backend/test/public-feed-api.test.mjs`
