### PR TITLE
fix(mobile): forward host network options

### DIFF
--- a/packages/host/src/start-host.js
+++ b/packages/host/src/start-host.js
@@ -112,7 +112,9 @@ export async function startHost(options = {}) {
     stream,
     createBackendImpl,
     onFeedUpdate,
-    onVideoStats
+    onVideoStats,
+    network,
+    swarmOptions
   } = options
 
   const lifecycle = createLifecycleController()

--- a/packages/host/test/start-host.test.mjs
+++ b/packages/host/test/start-host.test.mjs
@@ -121,3 +121,29 @@ test('startHost forwards feed and video callbacks to createBackend', async (t) =
 
   t.alike(calls, ['feed', ['stats', 'channel-key', 'video-id', { peerCount: 3 }]])
 })
+
+test('startHost forwards explicit network options to createBackend', async (t) => {
+  const network = { announce: true, bootstrap: ['127.0.0.1:49737'] }
+  const swarmOptions = { relayThrough: ['relay.example:49737'] }
+  let received = null
+
+  const session = await startHost({
+    platform: 'mobile',
+    storagePath: '/tmp/peartube-host',
+    entrypoint: 'mobile-entry',
+    args: [],
+    stream: createFakeStream(),
+    network,
+    swarmOptions,
+    createBackendImpl: async ({ onReady, network: backendNetwork, swarmOptions: backendSwarmOptions }) => {
+      received = { network: backendNetwork, swarmOptions: backendSwarmOptions }
+      onReady({ blobServerPort: 7777, protocolVersion: 2 })
+      return { destroy: async () => {} }
+    }
+  })
+
+  await session.waitUntilReady()
+
+  t.is(received.network, network)
+  t.is(received.swarmOptions, swarmOptions)
+})


### PR DESCRIPTION
Fixes Android startup crash after v0.1.124.\n\nRoot cause: startHost forwarded network/swarmOptions to createBackend after PR #272, but startHost() did not destructure those names in its runtime scope. Mobile backend startup hit ReferenceError: network is not defined inside the Bare worklet and libbare-kit aborted the JS thread.\n\nVerification:\n- node --test packages/host/test/start-host.test.mjs\n- git diff --check