### PR TITLE
fix(relay): only advertise cached playable previews

### DIFF
--- a/packages/backend/test/playback-api.test.mjs
+++ b/packages/backend/test/playback-api.test.mjs
@@ -62,7 +62,7 @@ test('preparePlayback returns a playable URL before warmup settles or fails', as
 
   t.alike(calls, [
     ['getVideoUrl', ['channel-key', 'videos/demo.mp4', 'public-bee-key', 'blob-id', 'blobs-core-key', 'video/mp4']],
-    ['prefetchVideo', ['channel-key', 'videos/demo.mp4', 'public-bee-key']],
+    ['prefetchVideo', ['channel-key', 'videos/demo.mp4', 'public-bee-key', 'blob-id', 'blobs-core-key', 'video/mp4']],
     ['getVideoStats', ['channel-key', 'videos/demo.mp4']],
   ])
 })

--- a/packages/cli/src/blob-downloader.js
+++ b/packages/cli/src/blob-downloader.js
@@ -52,6 +52,11 @@ function addVideoDownloadRefs(refs, videos) {
   return added
 }
 
+function addSuccessfulPreviewVideo(previews, ref) {
+  if (ref?.kind !== 'video') return false
+  return addPreviewVideo(previews, ref.sourceVideo)
+}
+
 function addPreviewVideo(previews, video) {
   if (!video?.id || !video?.blobId || !video?.blobsCoreKey) return false
   const id = getVideoKey(video)
@@ -140,21 +145,10 @@ export async function downloadChannelBlobs(ctx, publicBeeKey, driveKey, logger =
     addVideoDownloadRefs(refs, options.catalogEntry?.previewVideos)
     addVideoDownloadRefs(refs, options.feedEntry?.previewVideos)
 
-    if (Array.isArray(options.previewVideos)) {
-      for (const video of options.previewVideos) {
-        if (stats.previewVideos.length >= 3) break
-        addPreviewVideo(stats.previewVideos, video)
-      }
-    }
-
     if (Array.isArray(videos)) {
       stats.videosFound = videos.length
-      stats.videoCount = videos.length
+      stats.videoCount = Math.max(stats.videoCount, videos.length)
       addVideoDownloadRefs(refs, videos)
-      for (const video of videos) {
-        if (stats.previewVideos.length >= 3) break
-        addPreviewVideo(stats.previewVideos, video)
-      }
     }
 
     if (refs.size === 0) {
@@ -168,7 +162,10 @@ export async function downloadChannelBlobs(ctx, publicBeeKey, driveKey, logger =
       try {
         stats.bytesDownloaded += await downloadBlobRef(ctx, ref)
         stats.blobsDownloaded += 1
-        if (ref.kind === 'video') stats.videosDownloaded += 1
+        if (ref.kind === 'video') {
+          stats.videosDownloaded += 1
+          addSuccessfulPreviewVideo(stats.previewVideos, ref)
+        }
         if (ref.kind === 'thumbnail') stats.thumbnailsDownloaded += 1
       } catch (err) {
         logError(

--- a/packages/cli/src/service.js
+++ b/packages/cli/src/service.js
@@ -199,7 +199,11 @@ export async function createRelayService({
         videosDownloaded: mirrorStats?.videosDownloaded || 0,
         mirroredAt: Date.now(),
         lastError: null,
-        previewVideos: Array.isArray(mirrorStats?.previewVideos) ? mirrorStats.previewVideos : undefined,
+        previewVideos: Array.isArray(mirrorStats?.previewVideos) && mirrorStats.previewVideos.length > 0
+          ? mirrorStats.previewVideos
+          : (Array.isArray(existingChannel?.previewVideos) && existingChannel.previewVideos.length > 0
+              ? existingChannel.previewVideos
+              : undefined),
         videoCount: Number(mirrorStats?.videoCount || mirrorStats?.videosDownloaded || mirrorStats?.videosFound || 0) || 0,
         manifestUpdatedAt: Date.now()
       })
@@ -214,15 +218,19 @@ export async function createRelayService({
       }
 
       if (resolved.publicBeeKey) {
+        const seedPreviewVideos = Array.isArray(mirrorStats?.previewVideos) && mirrorStats.previewVideos.length > 0
+          ? mirrorStats.previewVideos
+          : (Array.isArray(resolved.previewVideos) ? resolved.previewVideos : [])
+        const persistedPreviewVideos = seedPreviewVideos.length > 0
+          ? seedPreviewVideos
+          : (Array.isArray(existingChannel?.previewVideos) ? existingChannel.previewVideos : [])
         await runtime.cacheManager?.addChannel?.(resolved.channelKey, resolved.publicBeeKey, 'discovered', {
-          previewVideos: Array.isArray(mirrorStats?.previewVideos)
-            ? mirrorStats.previewVideos
-            : (Array.isArray(resolved.previewVideos) ? resolved.previewVideos : [])
+          previewVideos: seedPreviewVideos
         }).catch(() => {})
         const seedStats = await runtime.seeder?.seedChannel?.({
           driveKey: resolved.channelKey,
           publicBeeKey: resolved.publicBeeKey,
-          previewVideos: Array.isArray(mirrorStats?.previewVideos) ? mirrorStats.previewVideos : []
+          previewVideos: seedPreviewVideos
         }).catch(() => null)
         const catalogEntry = seedStats?.catalogEntry || {
           schema: 'peartube.relayCatalog',
@@ -232,8 +240,8 @@ export async function createRelayService({
           source: 'relay-cache',
           relayRole: 'cache',
           relayServing: true,
-          previewVideos: Array.isArray(mirrorStats?.previewVideos) ? mirrorStats.previewVideos : [],
-          videoCount: Number(mirrorStats?.videoCount || mirrorStats?.videosDownloaded || mirrorStats?.videosFound || 0) || 0,
+          previewVideos: persistedPreviewVideos,
+          videoCount: Number(mirrorStats?.videoCount || mirrorStats?.videosDownloaded || mirrorStats?.videosFound || persistedPreviewVideos.length || 0) || 0,
           manifestUpdatedAt: Date.now()
         }
         await runtime.publishRelayCatalogEntry?.(catalogEntry).catch(() => {})

--- a/packages/cli/test/blob-downloader.test.mjs
+++ b/packages/cli/test/blob-downloader.test.mjs
@@ -94,3 +94,66 @@ test('downloadChannelBlobs downloads feed preview refs when PublicBee has no vid
   t.is(joins.length, 2)
   t.ok(joins.every((join) => join.opts?.server === true && join.opts?.client === true))
 })
+
+
+test('downloadChannelBlobs only republishes successfully cached video previews', async (t) => {
+  const playableCore = createCore({ length: 4, byteLength: 400 })
+  const missingCore = {
+    discoveryKey: 'missing-discovery',
+    async ready() {},
+    download() {
+      return {
+        async done() { throw new Error('remote blocks unavailable') }
+      }
+    }
+  }
+  const ctx = {
+    swarm: { join() {} },
+    store: {
+      get(key) {
+        const keyHex = Buffer.isBuffer(key) ? key.toString('hex') : String(key)
+        if (keyHex.startsWith('aa')) return playableCore
+        if (keyHex.startsWith('cc')) return missingCore
+        throw new Error(`unexpected key ${keyHex}`)
+      }
+    }
+  }
+
+  const stats = await downloadChannelBlobs(
+    ctx,
+    'ee'.repeat(32),
+    'chan-partial',
+    { info() {}, debug() {}, error() {} },
+    {
+      previewVideos: [
+        {
+          id: 'playable',
+          title: 'Playable',
+          blobId: '1:2:100:200',
+          blobsCoreKey: 'aa'.repeat(32)
+        },
+        {
+          id: 'hollow',
+          title: 'Hollow',
+          blobId: '1:2:100:200',
+          blobsCoreKey: 'cc'.repeat(32)
+        }
+      ]
+    },
+    {
+      async loadPublicBee() {
+        return {
+          async listVideos() {
+            return []
+          }
+        }
+      }
+    }
+  )
+
+  t.is(stats.blobsFound, 2)
+  t.is(stats.blobsDownloaded, 1)
+  t.is(stats.videosDownloaded, 1)
+  t.is(stats.previewVideos.length, 1)
+  t.is(stats.previewVideos[0].id, 'playable')
+})

--- a/packages/cli/test/service.test.mjs
+++ b/packages/cli/test/service.test.mjs
@@ -828,3 +828,55 @@ test('createRelayService refreshes already accepted channels when feed preview r
     rmSync(dir, { recursive: true, force: true })
   }
 })
+
+
+test('createRelayService keeps previous playable previews when refresh downloads no videos', async (t) => {
+  const dir = makeTempDir('peartube-relay-service-preview-preserve-')
+  const runtime = createFakeRuntime()
+  const previewVideos = [{
+    id: 'preview-1',
+    blobId: '0:2:0:20',
+    blobsCoreKey: 'aa'.repeat(32)
+  }]
+
+  try {
+    let service
+    service = await createRelayService({
+      config: {
+        mode: 'public',
+        policy: 'discovery',
+        storage: { path: dir, maxBytes: 10_000 },
+        paths: {
+          catalog: join(dir, 'relay-catalog.json'),
+          status: join(dir, 'relay-status.json')
+        },
+        admission: { channels: [], owners: [] },
+        discovery: { enabled: true, maxChannels: 5, maxChannelsPerOwner: 2 }
+      },
+      logger: createFakeLogger(),
+      runtimeFactory: async () => runtime,
+      mirrorChannel: async (candidate) => {
+        const firstRefresh = !service?.catalog?.getChannel?.(candidate.channelKey)?.previewVideos
+        return {
+          bytesDownloaded: firstRefresh ? 20 : 0,
+          videosFound: candidate.previewVideos?.length || 0,
+          videosDownloaded: firstRefresh ? 1 : 0,
+          previewVideos: firstRefresh ? candidate.previewVideos : [],
+          videoCount: candidate.previewVideos?.length || 0
+        }
+      },
+      writeStatusFile: async () => {}
+    })
+
+    await service.start()
+    await runtime.emit({ channelKey: 'chan-preview-preserve', publicBeeKey: 'bee-preview-preserve', source: 'discovered', previewVideos })
+    await runtime.emit({ channelKey: 'chan-preview-preserve', publicBeeKey: 'bee-preview-preserve', source: 'discovered', previewVideos })
+
+    const channel = service.catalog.getChannel('chan-preview-preserve')
+    t.alike(channel.previewVideos, previewVideos)
+    t.is(channel.videosDownloaded, 1)
+    await service.close()
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary
- only republish relay preview videos after the relay successfully downloads the video blob
- preserve the last known playable preview refs when a later refresh finds no newly cached videos
- pass direct blob/core refs into playback warmup so phone playback targets exact blob cores instead of falling back to sparse feed metadata

## Test Plan
- `node --test packages/cli/test/blob-downloader.test.mjs packages/cli/test/service.test.mjs packages/cli/test/relay-seeding.test.mjs packages/backend/test/playback-service.test.mjs packages/backend/test/playback-api.test.mjs`
- `git diff --check`
