### PR TITLE
fix(relay): clear stale playable preview refs

### DIFF
--- a/packages/app/components/video-player/P2PStatsBar.tsx
+++ b/packages/app/components/video-player/P2PStatsBar.tsx
@@ -31,6 +31,7 @@ export const P2PStatsBar = memo(function P2PStatsBar({ stats }: P2PStatsBarProps
     if (!stats) return { color: '#6b7280', label: 'Starting player' }
     if (stats.isComplete) return { color: '#4ade80', label: 'Cached' }
     if (stats.status === 'downloading') return { color: '#fbbf24', label: 'Downloading' }
+    if (downloadSpeed > 0) return { color: '#fbbf24', label: 'Downloading' }
     if (stats.status === 'connecting') return { color: '#60a5fa', label: 'Finding video peers' }
     if (stats.status === 'resolving') return { color: '#a78bfa', label: 'Resolving video' }
     if (stats.status === 'error') return { color: '#f87171', label: 'Playback error' }

--- a/packages/app/tests/p2p-stats-bar-regression.test.mjs
+++ b/packages/app/tests/p2p-stats-bar-regression.test.mjs
@@ -1,0 +1,10 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const source = readFileSync(resolve('components/video-player/P2PStatsBar.tsx'), 'utf8')
+
+test('P2P stats bar does not claim preparing when bytes are actively transferring', () => {
+  assert.match(source, /if \(downloadSpeed > 0\) return \{ color: '#fbbf24', label: 'Downloading' \}/)
+})

--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -283,8 +283,8 @@ export class PublicFeed {
     if (entry.channelName) serialized.channelName = entry.channelName
     if (Number(entry.videoCount || 0) > 0) serialized.videoCount = Number(entry.videoCount || 0)
     if (Number(entry.manifestUpdatedAt || 0) > 0) serialized.manifestUpdatedAt = Number(entry.manifestUpdatedAt || 0)
-    const previewVideos = this._sanitizePreviewVideos(entry.previewVideos)
-    if (previewVideos.length > 0) serialized.previewVideos = previewVideos
+    if (Array.isArray(entry.previewVideos)) serialized.previewVideos = this._sanitizePreviewVideos(entry.previewVideos)
+    const previewVideos = Array.isArray(serialized.previewVideos) ? serialized.previewVideos : []
     const previewVideosHash = entry.previewVideosHash || hashPreviewVideos(previewVideos)
     if (previewVideosHash) serialized.previewVideosHash = previewVideosHash
     const signedDescriptor = this._normalizeSignedDescriptor(entry.signedDescriptor)
@@ -400,7 +400,9 @@ export class PublicFeed {
           channelName: snapshot.channelName || byKey.get(driveKey)?.channelName || null,
           videoCount: Number(snapshot.videoCount || byKey.get(driveKey)?.videoCount || 0) || 0,
           manifestUpdatedAt: Number(snapshot.manifestUpdatedAt || byKey.get(driveKey)?.manifestUpdatedAt || 0) || 0,
-          previewVideos: this._sanitizePreviewVideos(snapshot.previewVideos || byKey.get(driveKey)?.previewVideos),
+          previewVideos: Array.isArray(snapshot.previewVideos)
+            ? this._sanitizePreviewVideos(snapshot.previewVideos)
+            : this._sanitizePreviewVideos(byKey.get(driveKey)?.previewVideos),
         }
         byKey.set(driveKey, merged)
         this._applyEntrySnapshot(driveKey, merged)

--- a/packages/backend/test/public-feed-manager.test.mjs
+++ b/packages/backend/test/public-feed-manager.test.mjs
@@ -1206,3 +1206,83 @@ test('relay catalog entries stay visible and do not become published channels', 
   assert.equal(entries[0].relayServing, true)
   assert.equal(entries[0].peerCount, 0)
 })
+test('relay catalog empty preview snapshots clear stale previews', async () => {
+  const manager = new PublicFeedManager(createSwarm(), createMetaDb())
+
+  try {
+    await manager.submitRelayCatalogEntry({
+      driveKey: DRIVE_KEY,
+      publicBeeKey: PUBLIC_BEE_KEY,
+      manifestUpdatedAt: 100,
+      previewVideos: [{
+        id: 'stale-preview',
+        title: 'Stale Preview',
+        blobId: '0:4:0:512',
+        blobsCoreKey: 'cc'.repeat(32),
+        availability: 'playable',
+      }],
+    })
+    assert.equal(manager.getFeed()[0].previewVideos.length, 1)
+
+    await manager.submitRelayCatalogEntry({
+      driveKey: DRIVE_KEY,
+      publicBeeKey: PUBLIC_BEE_KEY,
+      manifestUpdatedAt: 101,
+      previewVideos: [],
+    })
+
+    const feed = manager.getFeed()
+    assert.equal(feed.length, 1)
+    assert.deepEqual(feed[0].previewVideos, [])
+    assert.equal(feed[0].manifestUpdatedAt, 101)
+  } finally {
+    manager.stop()
+  }
+})
+
+test('feed snapshot provider propagates explicit empty previews', async () => {
+  const swarm = createSwarm()
+  const manager = new PublicFeedManager(swarm, createMetaDb())
+  const conn = createConnection()
+  const sent = []
+
+  manager.addEntry(DRIVE_KEY, 'local', PUBLIC_BEE_KEY, {
+    manifestUpdatedAt: 100,
+    previewVideos: [{
+      id: 'old-preview',
+      blobId: '0:4:0:512',
+      blobsCoreKey: 'dd'.repeat(32),
+      availability: 'playable',
+    }],
+  })
+  manager.setFeedSnapshotProvider(async () => [{
+    driveKey: DRIVE_KEY,
+    publicBeeKey: PUBLIC_BEE_KEY,
+    manifestUpdatedAt: 101,
+    previewVideos: [],
+  }])
+
+  const originalFrom = Protomux.from
+  Protomux.from = () => ({
+    pair() {},
+    createChannel(opts) {
+      return {
+        messages: [{ send(msg) { sent.push(msg) } }],
+        open() { opts.onopen() }
+      }
+    }
+  })
+
+  try {
+    manager.handleConnection(conn, {})
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    const refreshed = sent.find((msg) => msg.type === 'HAVE_FEED' && msg.entries?.[0]?.manifestUpdatedAt === 101)
+    assert.ok(refreshed)
+    assert.deepEqual(refreshed.entries[0].previewVideos, [])
+    assert.deepEqual(manager.getFeed()[0].previewVideos, [])
+  } finally {
+    Protomux.from = originalFrom
+    manager.stop()
+  }
+})

--- a/packages/cli/src/cache-manager.js
+++ b/packages/cli/src/cache-manager.js
@@ -70,7 +70,7 @@ export class CacheManager {
         existing.source = 'pinned'
         changed = true
       }
-      if (previewVideos.length > 0) {
+      if (Array.isArray(options.previewVideos)) {
         const nextSignature = JSON.stringify(previewVideos)
         const currentSignature = JSON.stringify(existing.previewVideos || [])
         if (nextSignature !== currentSignature) {

--- a/packages/cli/src/seeding.js
+++ b/packages/cli/src/seeding.js
@@ -13,6 +13,14 @@ function emptyStats() {
     blobCores: 0,
     discoveryHandles: 0,
     blindPeer: null,
+    blobAvailability: {
+      playable: 0,
+      available: 0,
+      unavailable: 0,
+      missing: 0,
+      unknown: 0,
+      videos: []
+    },
     lastSeededAt: null,
     lastError: null
   }
@@ -43,6 +51,24 @@ function getVideoKey(video) {
   return String(video?.id || video?.path || video?.videoId || video?.blobId || '')
 }
 
+function mergeBlobAvailability(target, source) {
+  if (!source) return target
+  target.playable += Number(source.playable || 0)
+  target.available += Number(source.available || 0)
+  target.unavailable += Number(source.unavailable || 0)
+  target.missing += Number(source.missing || 0)
+  target.unknown += Number(source.unknown || 0)
+  if (Array.isArray(source.videos)) target.videos.push(...source.videos)
+  return target
+}
+
+function parseBlockBlobId(blobId) {
+  if (typeof blobId !== 'string') return null
+  const parts = blobId.split(':').map((part) => Number(part))
+  if (parts.length < 2 || !Number.isFinite(parts[0]) || !Number.isFinite(parts[1])) return null
+  return { blockOffset: parts[0], blockLength: parts[1] }
+}
+
 function pushPreview(previews, video) {
   if (!video?.id || !video?.blobId || !video?.blobsCoreKey) return false
   const id = getVideoKey(video)
@@ -62,6 +88,12 @@ function pushPreview(previews, video) {
     thumbnailMimeType: video?.thumbnailMimeType || null
   })
   return true
+}
+
+function getVideoRefKey(video) {
+  const id = getVideoKey(video)
+  if (!id || !video?.blobsCoreKey || !video?.blobId) return null
+  return `${id}:${String(video.blobsCoreKey).toLowerCase()}:${String(video.blobId)}`
 }
 
 export function createRelaySeeder({ ctx, loadPublicBee, logger = {}, blindPeer = null }) {
@@ -113,6 +145,66 @@ export function createRelaySeeder({ ctx, loadPublicBee, logger = {}, blindPeer =
     }
   }
 
+  async function inspectVideoBlobAvailability(video, core) {
+    const id = getVideoKey(video)
+    const blob = parseBlockBlobId(video?.blobId)
+    const result = {
+      id,
+      blobsCoreKey: video?.blobsCoreKey || null,
+      blobId: video?.blobId || null,
+      availability: 'unknown',
+      contiguousBlocks: 0,
+      hasHeadBlock: false
+    }
+    if (!id || !core || !blob) return result
+
+    const start = blob.blockOffset
+    const end = blob.blockOffset + blob.blockLength
+    try {
+      const fullyCached = await core.has?.(start, end)
+      if (fullyCached) {
+        result.availability = 'playable'
+        result.contiguousBlocks = blob.blockLength
+        result.hasHeadBlock = true
+      } else {
+        result.availability = 'unavailable'
+        result.contiguousBlocks = 0
+        const headEnd = Math.min(end, start + Math.max(1, Math.min(32, blob.blockLength || 32)))
+        const hasHead = await core.has?.(start, headEnd).catch?.(() => false)
+        result.hasHeadBlock = Boolean(hasHead)
+      }
+      return result
+    } catch (err) {
+      result.error = err?.message || String(err)
+      return result
+    }
+  }
+
+  async function collectBlobAvailability(videos, blobCores) {
+    const availability = emptyStats().blobAvailability
+    const seen = new Set()
+    for (const video of videos) {
+      const id = getVideoKey(video)
+      if (!id || !video?.blobsCoreKey || !video?.blobId) continue
+      const key = `${id}:${video.blobsCoreKey}:${video.blobId}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      const core = blobCores.get(String(video.blobsCoreKey).toLowerCase()) || null
+      const detail = await inspectVideoBlobAvailability(video, core)
+      if (detail.availability === 'playable') {
+        availability.playable += 1
+        availability.available += 1
+      } else if (detail.availability === 'unavailable') {
+        availability.unavailable += 1
+        availability.missing += 1
+      } else {
+        availability.unknown += 1
+      }
+      availability.videos.push(detail)
+    }
+    return availability
+  }
+
   async function seedChannel(channel) {
     const driveKey = channel?.driveKey || channel?.channelKey
     const publicBeeKey = channel?.publicBeeKey || null
@@ -131,7 +223,9 @@ export function createRelaySeeder({ ctx, loadPublicBee, logger = {}, blindPeer =
       const videos = await bee?.listVideos?.().catch(() => [])
       const meta = await bee?.getMetadata?.().catch(() => null)
       const blobCoreKeys = new Map()
+      const blobCores = new Map()
       const previewVideos = []
+      const availabilityVideos = []
 
       // Seed every core reference we know, not only what PublicBee.listVideos() returns.
       // Playback often starts from public-feed/catalog previews; if those refs are
@@ -143,14 +237,19 @@ export function createRelaySeeder({ ctx, loadPublicBee, logger = {}, blindPeer =
       addPreviewCoreKeys(blobCoreKeys, channel?.feedEntry?.previewVideos)
 
       if (Array.isArray(channel?.previewVideos)) {
+        availabilityVideos.push(...channel.previewVideos)
         for (const video of channel.previewVideos) {
           if (previewVideos.length >= 3) break
           pushPreview(previewVideos, video)
         }
       }
+      if (Array.isArray(channel?.videos)) availabilityVideos.push(...channel.videos)
+      if (Array.isArray(channel?.catalogEntry?.previewVideos)) availabilityVideos.push(...channel.catalogEntry.previewVideos)
+      if (Array.isArray(channel?.feedEntry?.previewVideos)) availabilityVideos.push(...channel.feedEntry.previewVideos)
 
       if (Array.isArray(videos)) {
         stats.videos = Math.max(videos.length, previewVideos.length)
+        availabilityVideos.push(...videos)
         for (const video of videos) {
           addCoreKey(blobCoreKeys, video?.blobsCoreKey, 'blob')
           addCoreKey(blobCoreKeys, video?.thumbnailBlobsCoreKey, 'thumbnail')
@@ -161,11 +260,22 @@ export function createRelaySeeder({ ctx, loadPublicBee, logger = {}, blindPeer =
       for (const [keyHex, kind] of blobCoreKeys) {
         const core = await resolveBlobCore(keyHex)
         if (core?.discoveryKey) {
+          blobCores.set(keyHex, core)
           retainDiscovery(core.discoveryKey, `${kind}:${keyHex.slice(0, 16)}`)
           try { blindPeer?.addCore?.(core, { announce: true, referrer: b4a.from(publicBeeKey, 'hex') }) } catch {}
           stats.blobCores += 1
         }
       }
+
+      stats.blobAvailability = await collectBlobAvailability(availabilityVideos, blobCores)
+      stats.videos = Math.max(stats.videos, stats.blobAvailability.videos.length)
+      const playableRefs = new Set(
+        stats.blobAvailability.videos
+          .filter((video) => video?.availability === 'playable')
+          .map(getVideoRefKey)
+          .filter(Boolean)
+      )
+      const playablePreviewVideos = previewVideos.filter((video) => playableRefs.has(getVideoRefKey(video)))
 
       stats.channels = 1
       stats.discoveryHandles = handles.size
@@ -176,6 +286,7 @@ export function createRelaySeeder({ ctx, loadPublicBee, logger = {}, blindPeer =
         videos: stats.videos,
         publicBeeCores: stats.publicBeeCores,
         blobCores: stats.blobCores,
+        blobAvailability: stats.blobAvailability,
         lastSeededAt: stats.lastSeededAt,
         lastError: null
       })
@@ -196,7 +307,7 @@ export function createRelaySeeder({ ctx, loadPublicBee, logger = {}, blindPeer =
         channelName: meta?.name || channel?.channelName || null,
         videoCount: stats.videos,
         manifestUpdatedAt: Number(meta?.updatedAt || meta?.createdAt || 0) || Date.now(),
-        previewVideos
+        previewVideos: playablePreviewVideos
       }
       return stats
     } catch (err) {
@@ -237,6 +348,7 @@ export function createRelaySeeder({ ctx, loadPublicBee, logger = {}, blindPeer =
       stats.videos += Number(channel.videos || 0)
       stats.publicBeeCores += Number(channel.publicBeeCores || 0)
       stats.blobCores += Number(channel.blobCores || 0)
+      mergeBlobAvailability(stats.blobAvailability, channel.blobAvailability)
       if (channel.lastSeededAt && (!stats.lastSeededAt || channel.lastSeededAt > stats.lastSeededAt)) {
         stats.lastSeededAt = channel.lastSeededAt
       }

--- a/packages/cli/src/service.js
+++ b/packages/cli/src/service.js
@@ -64,16 +64,13 @@ export async function createRelayService({
 
   function shouldRefreshAcceptedChannel(existing, candidate) {
     if (!existing?.channelKey) return false
-    const incomingSignature = getPreviewBlobSignature(candidate?.previewVideos)
-    if (!incomingSignature) return false
+    if (!Array.isArray(candidate?.previewVideos)) return false
 
+    const incomingSignature = getPreviewBlobSignature(candidate.previewVideos)
     const existingSignature = getPreviewBlobSignature(existing.previewVideos)
     if (incomingSignature !== existingSignature) return true
 
-    if ((Number(existing.videosDownloaded) || 0) <= 0) return true
-    if ((Number(existing.bytes) || 0) <= 0) return true
-
-    return false
+    return true
   }
 
   async function runLocalMirrorOnce(localMirrorConfig = config.archive?.localMirror || {}) {
@@ -199,11 +196,9 @@ export async function createRelayService({
         videosDownloaded: mirrorStats?.videosDownloaded || 0,
         mirroredAt: Date.now(),
         lastError: null,
-        previewVideos: Array.isArray(mirrorStats?.previewVideos) && mirrorStats.previewVideos.length > 0
+        previewVideos: Array.isArray(mirrorStats?.previewVideos)
           ? mirrorStats.previewVideos
-          : (Array.isArray(existingChannel?.previewVideos) && existingChannel.previewVideos.length > 0
-              ? existingChannel.previewVideos
-              : undefined),
+          : undefined,
         videoCount: Number(mirrorStats?.videoCount || mirrorStats?.videosDownloaded || mirrorStats?.videosFound || 0) || 0,
         manifestUpdatedAt: Date.now()
       })
@@ -218,12 +213,9 @@ export async function createRelayService({
       }
 
       if (resolved.publicBeeKey) {
-        const seedPreviewVideos = Array.isArray(mirrorStats?.previewVideos) && mirrorStats.previewVideos.length > 0
+        const seedPreviewVideos = Array.isArray(mirrorStats?.previewVideos)
           ? mirrorStats.previewVideos
-          : (Array.isArray(resolved.previewVideos) ? resolved.previewVideos : [])
-        const persistedPreviewVideos = seedPreviewVideos.length > 0
-          ? seedPreviewVideos
-          : (Array.isArray(existingChannel?.previewVideos) ? existingChannel.previewVideos : [])
+          : []
         await runtime.cacheManager?.addChannel?.(resolved.channelKey, resolved.publicBeeKey, 'discovered', {
           previewVideos: seedPreviewVideos
         }).catch(() => {})
@@ -240,8 +232,8 @@ export async function createRelayService({
           source: 'relay-cache',
           relayRole: 'cache',
           relayServing: true,
-          previewVideos: persistedPreviewVideos,
-          videoCount: Number(mirrorStats?.videoCount || mirrorStats?.videosDownloaded || mirrorStats?.videosFound || persistedPreviewVideos.length || 0) || 0,
+          previewVideos: seedPreviewVideos,
+          videoCount: Number(mirrorStats?.videoCount || mirrorStats?.videosDownloaded || mirrorStats?.videosFound || seedPreviewVideos.length || 0) || 0,
           manifestUpdatedAt: Date.now()
         }
         await runtime.publishRelayCatalogEntry?.(catalogEntry).catch(() => {})
@@ -258,6 +250,10 @@ export async function createRelayService({
     } catch (err) {
       await relayCatalog.upsertChannel({
         ...baseRecord,
+        videosDownloaded: 0,
+        bytes: 0,
+        previewVideos: [],
+        videoCount: 0,
         lastError: err?.message || String(err)
       })
 

--- a/packages/cli/src/status.js
+++ b/packages/cli/src/status.js
@@ -54,6 +54,7 @@ export function buildRelayStatus({ config, catalog, runtimeStats = {} }) {
         publicBeeCores: runtimeStats.seeding?.publicBeeCores || 0,
         blobCores: runtimeStats.seeding?.blobCores || 0,
         discoveryHandles: runtimeStats.seeding?.discoveryHandles || 0,
+        blobAvailability: runtimeStats.seeding?.blobAvailability || null,
         lastSeededAt: runtimeStats.seeding?.lastSeededAt || null,
         lastError: runtimeStats.seeding?.lastError || null
       }
@@ -100,7 +101,8 @@ export function formatRelayStatus(status) {
     `directPeerDial: discovered=${status.runtime.directPeerDial?.discoveredPeers || 0} pending=${status.runtime.directPeerDial?.pending || 0} queued=${status.runtime.directPeerDial?.queued || 0} skipped=${status.runtime.directPeerDial?.skipped || 0} failed=${status.runtime.directPeerDial?.failed || 0} connected=${status.runtime.directPeerDial?.connected || 0} lastReason=${status.runtime.directPeerDial?.lastReason || 'none'} lastError=${firstDialError || 'none'}`,
     `doctor: boundary=${status.runtime.doctor?.recommendedBoundary || 'unknown'} discovered=${status.runtime.doctor?.discovery?.discoveredPeers ?? status.runtime.directPeerDial?.discoveredPeers ?? 0} sockets=${status.runtime.doctor?.socket?.swarmConnections ?? status.runtime.connections ?? 0} feedConnections=${status.runtime.doctor?.feed?.feedConnections ?? status.runtime.feedConnections ?? 0}`,
     `blindPeer: enabled=${Boolean(status.runtime.blindPeer?.enabled)} key=${status.runtime.blindPeer?.publicKey || 'none'} mirroredCores=${status.runtime.blindPeer?.mirroredCores || 0} mirroredAutobases=${status.runtime.blindPeer?.mirroredAutobases || 0}`,
-    `seeding: channels=${status.runtime.seeding.channels} videos=${status.runtime.seeding.videos} publicBeeCores=${status.runtime.seeding.publicBeeCores} blobCores=${status.runtime.seeding.blobCores} discoveryHandles=${status.runtime.seeding.discoveryHandles}`
+    `seeding: channels=${status.runtime.seeding.channels} videos=${status.runtime.seeding.videos} publicBeeCores=${status.runtime.seeding.publicBeeCores} blobCores=${status.runtime.seeding.blobCores} discoveryHandles=${status.runtime.seeding.discoveryHandles}`,
+    `blobAvailability: playable=${status.runtime.seeding.blobAvailability?.playable || 0} unavailable=${status.runtime.seeding.blobAvailability?.unavailable || 0} unknown=${status.runtime.seeding.blobAvailability?.unknown || 0}`
   ]
 
   if (status.evictionCandidates.length > 0) {

--- a/packages/cli/test/relay-seeding.test.mjs
+++ b/packages/cli/test/relay-seeding.test.mjs
@@ -74,9 +74,35 @@ test('cache manager preserves refreshed preview refs for relay restart seeding',
   t.is(metaDb.writes[0].value[0].previewVideos[0].id, 'video-1')
 })
 
+test('cache manager clears refreshed preview refs when relay download has no playable videos', async (t) => {
+  const metaDb = createMetaDb()
+  const manager = new CacheManager({}, metaDb, 1024)
+
+  await manager.addChannel('aa'.padEnd(64, '0'), 'bb'.padEnd(64, '0'), 'discovered', {
+    previewVideos: [{
+      id: 'video-1',
+      blobId: '0:1:0:10',
+      blobsCoreKey: 'cc'.padEnd(64, '0')
+    }]
+  })
+
+  const changed = await manager.addChannel('aa'.padEnd(64, '0'), 'bb'.padEnd(64, '0'), 'discovered', {
+    previewVideos: []
+  })
+
+  t.is(changed, true)
+  t.alike(manager.getChannels()[0].previewVideos, [])
+  t.alike(metaDb.writes.at(-1).value[0].previewVideos, [])
+})
+
 test('relay seeder retains PublicBee and blob-core discovery handles for mirrored channels', async (t) => {
   const publicBeeCore = createCore('11')
-  const videoCore = createCore('22')
+  const videoCore = {
+    ...createCore('22'),
+    async has(start, end) {
+      return start === 0 && end === 1
+    }
+  }
   const thumbnailCore = createCore('33')
   const swarm = createSwarm()
   const store = {
@@ -140,7 +166,12 @@ test('relay seeder retains PublicBee and blob-core discovery handles for mirrore
 
 test('relay seeder refreshes all cached channels and deduplicates retained joins', async (t) => {
   const publicBeeCore = createCore('44')
-  const blobCore = createCore('55')
+  const blobCore = {
+    ...createCore('55'),
+    async has(start, end) {
+      return start === 0 && end === 1
+    }
+  }
   const swarm = createSwarm()
   const ctx = {
     swarm,
@@ -175,10 +206,117 @@ test('relay seeder refreshes all cached channels and deduplicates retained joins
   t.is(swarm.joins.length, 2)
 })
 
+test('relay seeder exposes per-video local blob availability diagnostics', async (t) => {
+  const publicBeeCore = createCore('21')
+  const availableVideoCore = {
+    ...createCore('31'),
+    async has(start, end) {
+      return start === 10 && end === 14
+    }
+  }
+  const missingVideoCore = {
+    ...createCore('32'),
+    async has() {
+      return false
+    }
+  }
+  const swarm = createSwarm()
+  const ctx = {
+    swarm,
+    store: {
+      get(key) {
+        const keyHex = Buffer.isBuffer(key) ? key.toString('hex') : String(key)
+        if (keyHex.startsWith('31')) return availableVideoCore
+        if (keyHex.startsWith('32')) return missingVideoCore
+        throw new Error(`unexpected core key ${keyHex}`)
+      }
+    }
+  }
+  const seeder = createRelaySeeder({
+    ctx,
+    loadPublicBee: async () => ({
+      core: publicBeeCore,
+      async listVideos() {
+        return []
+      }
+    }),
+    logger: { info() {}, warn() {}, debug() {} }
+  })
+
+  const seedStats = await seeder.seedChannel({
+    driveKey: 'aa'.padEnd(64, '0'),
+    publicBeeKey: 'bb'.padEnd(64, '0'),
+    previewVideos: [
+      { id: 'available', blobId: '10:4:0:100', blobsCoreKey: '31'.padEnd(64, '0') },
+      { id: 'missing', blobId: '20:4:0:100', blobsCoreKey: '32'.padEnd(64, '0') }
+    ]
+  })
+
+  const stats = seeder.getStats()
+  t.is(stats.videos, 2)
+  t.is(stats.blobAvailability.available, 1)
+  t.is(stats.blobAvailability.missing, 1)
+  t.alike(stats.blobAvailability.videos.map((video) => ({ id: video.id, availability: video.availability, contiguousBlocks: video.contiguousBlocks, hasHeadBlock: video.hasHeadBlock })), [
+    { id: 'available', availability: 'playable', contiguousBlocks: 4, hasHeadBlock: true },
+    { id: 'missing', availability: 'unavailable', contiguousBlocks: 0, hasHeadBlock: false }
+  ])
+  t.alike(seedStats.catalogEntry.previewVideos.map((video) => video.id), ['available'])
+})
+
+test('relay seeder does not advertise partially cached preview ranges as playable', async (t) => {
+  const publicBeeCore = createCore('23')
+  const partialVideoCore = {
+    ...createCore('34'),
+    async has(start, end) {
+      return start === 10 && end <= 32
+    }
+  }
+  const swarm = createSwarm()
+  const ctx = {
+    swarm,
+    store: {
+      get(key) {
+        const keyHex = Buffer.isBuffer(key) ? key.toString('hex') : String(key)
+        if (keyHex.startsWith('34')) return partialVideoCore
+        throw new Error(`unexpected core key ${keyHex}`)
+      }
+    }
+  }
+  const seeder = createRelaySeeder({
+    ctx,
+    loadPublicBee: async () => ({
+      core: publicBeeCore,
+      async listVideos() {
+        return []
+      }
+    }),
+    logger: { info() {}, warn() {}, debug() {} }
+  })
+
+  const seedStats = await seeder.seedChannel({
+    driveKey: 'aa'.padEnd(64, '0'),
+    publicBeeKey: 'bb'.padEnd(64, '0'),
+    previewVideos: [
+      { id: 'partial', blobId: '10:40:0:100', blobsCoreKey: '34'.padEnd(64, '0') }
+    ]
+  })
+
+  const detail = seeder.getStats().blobAvailability.videos[0]
+  t.is(detail.availability, 'unavailable')
+  t.is(detail.hasHeadBlock, false)
+  t.is(detail.contiguousBlocks, 0)
+  t.alike(seedStats.catalogEntry.previewVideos, [])
+})
+
 
 test('relay seeder also seeds preview/catalog blob refs when PublicBee is sparse', async (t) => {
   const publicBeeCore = createCore('99')
-  const previewVideoCore = createCore('aa')
+  const previewVideoCore = {
+    ...createCore('aa'),
+    async has(start, end) {
+      return start === 0 && end === 1
+    }
+  }
   const previewThumbnailCore = createCore('ab')
   const catalogVideoCore = createCore('ac')
   const swarm = createSwarm()
@@ -306,7 +444,14 @@ test('relay status surfaces DHT and seeding stats for phone connectivity diagnos
       swarmOfflineReason: null,
       swarmListenResolved: true,
       blindPeer: { enabled: true, publicKey: 'abcd', mirroredCores: 4, mirroredAutobases: 0, error: null },
-      seeding: { channels: 2, videos: 5, publicBeeCores: 2, blobCores: 8, discoveryHandles: 10 },
+      seeding: {
+        channels: 2,
+        videos: 5,
+        publicBeeCores: 2,
+        blobCores: 8,
+        discoveryHandles: 10,
+        blobAvailability: { playable: 4, unavailable: 1, unknown: 0, videos: [] }
+      },
       directPeerDial: {
         discoveredPeers: 2,
         pending: 1,
@@ -327,6 +472,7 @@ test('relay status surfaces DHT and seeding stats for phone connectivity diagnos
     publicBeeCores: 2,
     blobCores: 8,
     discoveryHandles: 10,
+    blobAvailability: { playable: 4, unavailable: 1, unknown: 0, videos: [] },
     lastSeededAt: null,
     lastError: null
   })
@@ -338,4 +484,5 @@ test('relay status surfaces DHT and seeding stats for phone connectivity diagnos
   t.ok(formatted.includes('lastError=Maximum call stack size exceeded'))
   t.ok(formatted.includes('blindPeer: enabled=true key=abcd mirroredCores=4 mirroredAutobases=0'))
   t.ok(formatted.includes('seeding: channels=2 videos=5 publicBeeCores=2 blobCores=8 discoveryHandles=10'))
+  t.ok(formatted.includes('blobAvailability: playable=4 unavailable=1 unknown=0'))
 })

--- a/packages/cli/test/service.test.mjs
+++ b/packages/cli/test/service.test.mjs
@@ -830,9 +830,25 @@ test('createRelayService refreshes already accepted channels when feed preview r
 })
 
 
-test('createRelayService keeps previous playable previews when refresh downloads no videos', async (t) => {
-  const dir = makeTempDir('peartube-relay-service-preview-preserve-')
+test('createRelayService removes playable previews when refresh downloads no videos', async (t) => {
+  const dir = makeTempDir('peartube-relay-service-preview-remove-hollow-')
   const runtime = createFakeRuntime()
+  const published = []
+  const cachedAdds = []
+  const seeded = []
+  runtime.publishRelayCatalogEntry = async (entry) => { published.push(entry); return entry }
+  runtime.cacheManager = {
+    async addChannel(channelKey, publicBeeKey, source, options) {
+      cachedAdds.push({ channelKey, publicBeeKey, source, previewVideos: options?.previewVideos || [] })
+    }
+  }
+  runtime.seeder = {
+    async seedChannel(channel) {
+      seeded.push(channel)
+      return null
+    },
+    getStats() { return {} }
+  }
   const previewVideos = [{
     id: 'preview-1',
     blobId: '0:2:0:20',
@@ -856,7 +872,7 @@ test('createRelayService keeps previous playable previews when refresh downloads
       logger: createFakeLogger(),
       runtimeFactory: async () => runtime,
       mirrorChannel: async (candidate) => {
-        const firstRefresh = !service?.catalog?.getChannel?.(candidate.channelKey)?.previewVideos
+        const firstRefresh = !service?.catalog?.getChannel?.(candidate.channelKey)?.mirroredAt
         return {
           bytesDownloaded: firstRefresh ? 20 : 0,
           videosFound: candidate.previewVideos?.length || 0,
@@ -869,12 +885,69 @@ test('createRelayService keeps previous playable previews when refresh downloads
     })
 
     await service.start()
-    await runtime.emit({ channelKey: 'chan-preview-preserve', publicBeeKey: 'bee-preview-preserve', source: 'discovered', previewVideos })
-    await runtime.emit({ channelKey: 'chan-preview-preserve', publicBeeKey: 'bee-preview-preserve', source: 'discovered', previewVideos })
+    await runtime.emit({ channelKey: 'chan-preview-remove', publicBeeKey: 'bee-preview-remove', source: 'discovered', previewVideos })
+    await runtime.emit({ channelKey: 'chan-preview-remove', publicBeeKey: 'bee-preview-remove', source: 'discovered', previewVideos })
 
-    const channel = service.catalog.getChannel('chan-preview-preserve')
-    t.alike(channel.previewVideos, previewVideos)
-    t.is(channel.videosDownloaded, 1)
+    const channel = service.catalog.getChannel('chan-preview-remove')
+    t.alike(channel.previewVideos, [])
+    t.is(channel.videosDownloaded, 0)
+    t.is(channel.bytes, 0)
+    t.alike(cachedAdds.at(-1).previewVideos, [])
+    t.alike(seeded.at(-1).previewVideos, [])
+    t.alike(published.at(-1).previewVideos, [])
+    await service.close()
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+test('createRelayService clears playable previews when accepted refresh mirror throws', async (t) => {
+  const dir = makeTempDir('peartube-relay-service-preview-error-clear-')
+  const runtime = createFakeRuntime()
+  const previewVideos = [{
+    id: 'preview-error',
+    blobId: '0:2:0:20',
+    blobsCoreKey: 'aa'.repeat(32)
+  }]
+
+  try {
+    let calls = 0
+    const service = await createRelayService({
+      config: {
+        mode: 'public',
+        policy: 'discovery',
+        storage: { path: dir, maxBytes: 10_000 },
+        paths: {
+          catalog: join(dir, 'relay-catalog.json'),
+          status: join(dir, 'relay-status.json')
+        },
+        admission: { channels: [], owners: [] },
+        discovery: { enabled: true, maxChannels: 5, maxChannelsPerOwner: 2 }
+      },
+      logger: createFakeLogger(),
+      runtimeFactory: async () => runtime,
+      mirrorChannel: async (candidate) => {
+        calls += 1
+        if (calls > 1) throw new Error('mirror unavailable')
+        return {
+          bytesDownloaded: 20,
+          videosFound: candidate.previewVideos?.length || 0,
+          videosDownloaded: 1,
+          previewVideos: candidate.previewVideos,
+          videoCount: candidate.previewVideos?.length || 0
+        }
+      },
+      writeStatusFile: async () => {}
+    })
+
+    await service.start()
+    await runtime.emit({ channelKey: 'chan-preview-error', publicBeeKey: 'bee-preview-error', source: 'discovered', previewVideos })
+    await runtime.emit({ channelKey: 'chan-preview-error', publicBeeKey: 'bee-preview-error', source: 'discovered', previewVideos })
+
+    const channel = service.catalog.getChannel('chan-preview-error')
+    t.alike(channel.previewVideos, [])
+    t.is(channel.videosDownloaded, 0)
+    t.is(channel.bytes, 0)
+    t.is(channel.lastError, 'mirror unavailable')
     await service.close()
   } finally {
     rmSync(dir, { recursive: true, force: true })


### PR DESCRIPTION
## Summary
- clear relay preview metadata when a refresh produces no locally playable blob ranges or mirror fails
- require full local blob range availability before relay catalog previews are advertised as playable
- propagate explicit empty preview snapshots through feed gossip/provider hydration
- show active download transfer state in the mobile P2P stats bar

## Review
- Codex reviewed the diff in read-only mode and flagged stale-preview clearing gaps; addressed with service error clearing, backend explicit-empty preview propagation, and partial-range regression tests.

## Tests
- cd packages/cli && npm test
- cd packages/backend && npx brittle test/public-feed-manager.test.mjs
- cd packages/app && node --test tests/p2p-stats-bar-regression.test.mjs
- git diff --check