### PR TITLE
fix(backend): direct dial known peers for blob topics

### DIFF
--- a/packages/backend/src/known-peers.js
+++ b/packages/backend/src/known-peers.js
@@ -89,13 +89,46 @@ export async function loadKnownPeers(metaDb) {
 export function dialKnownPeers(swarm, knownList) {
   if (!swarm || typeof swarm.joinPeer !== 'function' || swarm._peartubeOffline) return 0
   let dialed = 0
+  const seen = new Set()
   for (const entry of knownList) {
     try {
-      const pk = b4a.from(entry.key, 'hex')
+      const key = typeof entry?.key === 'string' ? entry.key.toLowerCase() : null
+      if (!key || !/^[0-9a-f]{64}$/.test(key) || seen.has(key)) continue
+      seen.add(key)
+      const pk = b4a.from(key, 'hex')
       if (pk.length !== 32) continue
       swarm.joinPeer(pk)
       dialed++
     } catch { /* best effort */ }
   }
   return dialed
+}
+
+function normalizeExplicitPeerKey(value) {
+  const keyHex = toKeyHex(value?.key || value?.publicKey || value)
+  return keyHex ? { key: keyHex, lastSeen: Date.now(), source: value?.source || 'explicit' } : null
+}
+
+export function getExplicitPeerList(ctx) {
+  const configured = [
+    ctx?.network?.relayPeers,
+    ctx?.network?.knownPeers,
+    ctx?.swarmOptions?.relayPeers,
+    ctx?.swarmOptions?.knownPeers,
+  ]
+  const out = []
+  for (const value of configured) {
+    const list = Array.isArray(value) ? value : (value ? String(value).split(/[\s,]+/) : [])
+    for (const item of list) {
+      const normalized = normalizeExplicitPeerKey(item)
+      if (normalized) out.push(normalized)
+    }
+  }
+  return out
+}
+
+export async function getDialableKnownPeers(ctx) {
+  const explicit = getExplicitPeerList(ctx)
+  const persisted = await loadKnownPeers(ctx?._peartubeMetaDb || ctx?.metaDb)
+  return [...explicit, ...persisted]
 }

--- a/packages/backend/src/storage.js
+++ b/packages/backend/src/storage.js
@@ -25,7 +25,7 @@ import {
 } from './runtime-modules.js'
 import { NETWORK_TOPIC_STRING } from './types.js'
 import { normalizeBlobRefInput } from './blob-ref.js'
-import { createKnownPeerCache, loadKnownPeers, dialKnownPeers } from './known-peers.js'
+import { createKnownPeerCache, loadKnownPeers, dialKnownPeers, getDialableKnownPeers } from './known-peers.js'
 
 const DEFAULT_BLOBS_CORE_UPDATE_TIMEOUT_MS = 15000
 
@@ -769,6 +769,20 @@ export function retainSwarmDiscovery(ctx, discoveryKey, options = {}) {
   const handle = ctx.swarm.join(discoveryKey, { server: true, client: true })
   handles.set(discoveryKeyHex, handle)
 
+  if (!ctx.swarm._peartubeOffline) {
+    getDialableKnownPeers(ctx)
+      .then((known) => {
+        const dialed = dialKnownPeers(ctx.swarm, known)
+        if (dialed > 0) {
+          const label = options.label || discoveryKeyHex.slice(0, 16)
+          console.log(`[Storage] Direct-dialed ${dialed} known peer(s) for ${label}`)
+        }
+      })
+      .catch((err) => {
+        console.log('[Storage] Direct peer dial skipped:', err?.message)
+      })
+  }
+
   try {
     const flushed = handle?.flushed?.()
     if (flushed && typeof flushed.then === 'function') {
@@ -1262,6 +1276,8 @@ export async function initializeStorage(config) {
   const selfKeyHex = swarm.keyPair?.publicKey ? b4a.toString(swarm.keyPair.publicKey, 'hex') : null
   const knownPeerCache = createKnownPeerCache(metaDb, { selfKeyHex })
   swarm._peartubeMetaDb = metaDb
+  ctx.network = network
+  ctx.swarmOptions = swarmOptions
   globalKnownPeerCache = knownPeerCache
 
   // Register handlers BEFORE swarm.join so any incoming connection is replicated

--- a/packages/backend/src/storage.js
+++ b/packages/backend/src/storage.js
@@ -1276,8 +1276,6 @@ export async function initializeStorage(config) {
   const selfKeyHex = swarm.keyPair?.publicKey ? b4a.toString(swarm.keyPair.publicKey, 'hex') : null
   const knownPeerCache = createKnownPeerCache(metaDb, { selfKeyHex })
   swarm._peartubeMetaDb = metaDb
-  ctx.network = network
-  ctx.swarmOptions = swarmOptions
   globalKnownPeerCache = knownPeerCache
 
   // Register handlers BEFORE swarm.join so any incoming connection is replicated
@@ -1452,6 +1450,8 @@ export async function initializeStorage(config) {
     blobSessionToken, // Session token for URL authentication
     channels,
     wakeup,
+    network,
+    swarmOptions,
     peerPoolDiscovery: globalPeerPoolDiscovery
   };
 }

--- a/packages/backend/test/known-peers.test.mjs
+++ b/packages/backend/test/known-peers.test.mjs
@@ -1,0 +1,35 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { dialKnownPeers, getExplicitPeerList } from '../src/known-peers.js'
+
+const keyA = 'aa'.repeat(32)
+const keyB = 'bb'.repeat(32)
+
+test('dialKnownPeers dedupes repeated keys and ignores invalid entries', () => {
+  const calls = []
+  const swarm = {
+    joinPeer(publicKey) {
+      calls.push(Buffer.from(publicKey).toString('hex'))
+    }
+  }
+
+  const count = dialKnownPeers(swarm, [
+    { key: keyA },
+    { key: keyA.toUpperCase() },
+    { key: 'not-a-key' },
+    { key: keyB },
+  ])
+
+  assert.equal(count, 2)
+  assert.deepEqual(calls, [keyA, keyB])
+})
+
+test('getExplicitPeerList accepts relayPeers and knownPeers from network and swarmOptions', () => {
+  const peers = getExplicitPeerList({
+    network: { relayPeers: [keyA], knownPeers: keyB },
+    swarmOptions: { relayPeers: `${keyA},${keyB}` },
+  }).map((entry) => entry.key)
+
+  assert.deepEqual(peers, [keyA, keyB, keyA, keyB])
+})

--- a/packages/backend/test/storage-startup-regression.test.mjs
+++ b/packages/backend/test/storage-startup-regression.test.mjs
@@ -178,8 +178,8 @@ test('storage captures Hyperswarm connection lifecycle diagnostics', () => {
 test('retained content discovery direct-dials configured or cached peers for blob topics', () => {
   assert.match(storageSource, /getDialableKnownPeers\(ctx\)/)
   assert.match(storageSource, /dialKnownPeers\(ctx\.swarm, known\)/)
-  assert.match(storageSource, /ctx\.network = network/)
-  assert.match(storageSource, /ctx\.swarmOptions = swarmOptions/)
+  assert.match(storageSource, /network,/)
+  assert.match(storageSource, /swarmOptions,/)
 })
 
 test('storage captures pre-open DHT connect close diagnostics', () => {

--- a/packages/backend/test/storage-startup-regression.test.mjs
+++ b/packages/backend/test/storage-startup-regression.test.mjs
@@ -175,6 +175,13 @@ test('storage captures Hyperswarm connection lifecycle diagnostics', () => {
   assert.match(storageSource, /hyperswarm: diagnostics/)
 })
 
+test('retained content discovery direct-dials configured or cached peers for blob topics', () => {
+  assert.match(storageSource, /getDialableKnownPeers\(ctx\)/)
+  assert.match(storageSource, /dialKnownPeers\(ctx\.swarm, known\)/)
+  assert.match(storageSource, /ctx\.network = network/)
+  assert.match(storageSource, /ctx\.swarmOptions = swarmOptions/)
+})
+
 test('storage captures pre-open DHT connect close diagnostics', () => {
   assert.match(storageSource, /function installSwarmConnectDiagnostics\(swarm, diagnostics\)/)
   assert.match(storageSource, /installSwarmConnectDiagnostics\(swarm, globalSwarmDiagnostics\)/)


### PR DESCRIPTION
## Summary
- direct-dial configured/cached known peers whenever a retained content/blob discovery topic is joined
- preserve backend `network`/`swarmOptions` on the storage context so blob-topic dialing can use explicit relay/known peer config
- dedupe invalid/repeated known peer keys before `swarm.joinPeer()` calls

## Test Plan
- `node --test packages/backend/test/known-peers.test.mjs packages/backend/test/storage-startup-regression.test.mjs packages/backend/test/swarm-peer-dial.test.mjs packages/backend/test/swarm-peer-requeue.test.mjs packages/backend/test/playback-service.test.mjs`
- `git diff --check`

## Runtime context
This targets the selected-video blob-core boundary: feed peers/catalog entries can exist while the exact `blobsCoreKey` has too few connected peers. The patch keeps canonical topic discovery and adds explicit known-peer dialing for those retained blob topics, matching the working simple-seeder primitive more closely.
