### PR TITLE
fix(mobile): preserve blob peer launch options

### DIFF
--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -212,7 +212,23 @@ export function createApi({
     }
   }
 
-  function getVideoCorePeerCount(driveKey, videoPath) {
+  function describeCorePeer(peer) {
+    try {
+      const key = peer?.remotePublicKey || peer?.publicKey || peer?.key || peer?.id || peer?.stream?.remotePublicKey || null
+      const keyHex = key
+        ? (typeof key === 'string' ? key : b4a.toString(key, 'hex'))
+        : null
+      return {
+        key: keyHex && /^[a-f0-9]{64}$/i.test(keyHex) ? keyHex : null,
+        remoteAddress: peer?.remoteAddress || peer?.stream?.remoteAddress || null,
+        type: peer?.constructor?.name || null
+      }
+    } catch {
+      return { key: null, remoteAddress: null, type: null }
+    }
+  }
+
+  function getVideoCorePeerDetails(driveKey, videoPath) {
     try {
       const channel = ctx.channels?.get?.(driveKey)
       const normalizedId = normalizeVideoId(videoPath)
@@ -225,14 +241,35 @@ export function createApi({
 
       for (const candidate of candidates) {
         const core = channel?.videoCores?.get?.(candidate) || channel?.cores?.get?.(candidate)
-        const peers = core?.peers
-        if (Array.isArray(peers)) return peers.length
-        if (typeof peers?.length === 'number') return peers.length
-        if (typeof peers?.size === 'number') return peers.size
+        if (!core) continue
+        const peers = core.peers
+        const peerList = Array.isArray(peers)
+          ? peers
+          : peers && typeof peers.values === 'function'
+            ? Array.from(peers.values())
+            : []
+        const peerCount = Array.isArray(peers)
+          ? peers.length
+          : typeof peers?.length === 'number'
+            ? peers.length
+            : typeof peers?.size === 'number'
+              ? peers.size
+              : peerList.length
+        const blobPeers = peerList.map(describeCorePeer)
+        return {
+          peerCount,
+          blobPeerIds: blobPeers.map((peer) => peer.key).filter(Boolean),
+          blobPeers,
+          blobCoreKey: core.key ? b4a.toString(core.key, 'hex') : null
+        }
       }
     } catch { /* best effort */ }
 
-    return 0
+    return { peerCount: 0, blobPeerIds: [], blobPeers: [], blobCoreKey: null }
+  }
+
+  function getVideoCorePeerCount(driveKey, videoPath) {
+    return getVideoCorePeerDetails(driveKey, videoPath).peerCount
   }
 
   function getFeedEntryVideoCount(driveKey, publicBeeKey = null) {
@@ -2240,12 +2277,16 @@ export function createApi({
      * @returns {Object}
      */
     getVideoStats(driveKey, videoPath) {
-      const videoPeerCount = getVideoCorePeerCount(driveKey, videoPath);
+      const videoPeerDetails = getVideoCorePeerDetails(driveKey, videoPath);
+      const videoPeerCount = videoPeerDetails.peerCount;
       if (videoStats) {
         const stats = videoStats.getStats(driveKey, videoPath);
         if (stats) {
           stats.swarmConnections = ctx.swarm?.connections?.size || 0;
           stats.peerCount = videoPeerCount || stats.peerCount || 0;
+          stats.blobPeerIds = videoPeerDetails.blobPeerIds;
+          stats.blobPeers = videoPeerDetails.blobPeers;
+          stats.blobCoreKey = videoPeerDetails.blobCoreKey;
           return stats;
         }
       }
@@ -2258,6 +2299,9 @@ export function createApi({
         totalBytes: 0,
         downloadedBytes: 0,
         peerCount: videoPeerCount,
+        blobPeerIds: videoPeerDetails.blobPeerIds,
+        blobPeers: videoPeerDetails.blobPeers,
+        blobCoreKey: videoPeerDetails.blobCoreKey,
         swarmConnections: ctx.swarm?.connections?.size || 0,
         speedMBps: '0',
         elapsed: 0,

--- a/packages/backend/test/playback-api.test.mjs
+++ b/packages/backend/test/playback-api.test.mjs
@@ -140,6 +140,30 @@ test('getVideoStats keeps video peer count separate from global swarm connection
   t.is(stats.swarmConnections, 4)
 })
 
+test('getVideoStats exposes blob core peer identities for transfer proof', (t) => {
+  const peerA = { remotePublicKey: Buffer.from('a'.repeat(64), 'hex'), remoteAddress: 'relay-a' }
+  const peerB = { publicKey: Buffer.from('b'.repeat(64), 'hex'), remoteAddress: 'relay-b' }
+  const videoCore = {
+    key: Buffer.from('c'.repeat(64), 'hex'),
+    peers: [peerA, peerB],
+  }
+  const api = createApi({
+    ctx: {
+      swarm: { connections: new Set([1, 2, 3, 4]) },
+      channels: new Map([
+        ['channel-key', { videoCores: new Map([['videos/demo.mp4', videoCore]]) }],
+      ]),
+    },
+  })
+
+  const stats = api.getVideoStats('channel-key', 'videos/demo.mp4')
+
+  t.is(stats.peerCount, 2)
+  t.alike(stats.blobPeerIds, ['a'.repeat(64), 'b'.repeat(64)])
+  t.is(stats.blobCoreKey, 'c'.repeat(64))
+  t.is(stats.swarmConnections, 4)
+})
+
 test('getVideoStats does not fall back to global swarm connections as video peers', (t) => {
   const api = createApi({
     ctx: {

--- a/packages/host/src/sidecar-entry.js
+++ b/packages/host/src/sidecar-entry.js
@@ -76,7 +76,7 @@ export function createProcessTransport() {
   return transport
 }
 
-export async function runHostSidecar({ platform = 'desktop', storagePath, entrypoint = 'sidecar-entry', args = [] } = {}) {
+export async function runHostSidecar({ platform = 'desktop', storagePath, entrypoint = 'sidecar-entry', args = [], network, swarmOptions } = {}) {
   const stream = createProcessTransport()
 
   return startHost({
@@ -84,13 +84,38 @@ export async function runHostSidecar({ platform = 'desktop', storagePath, entryp
     storagePath,
     entrypoint,
     args,
-    stream
+    stream,
+    network,
+    swarmOptions
   })
 }
 
+function parseLaunchOptions(value) {
+  if (typeof value !== 'string' || value.length === 0) return null
+  try {
+    const parsed = JSON.parse(value)
+    if (!parsed || typeof parsed !== 'object') return null
+    if (parsed.__peartubeLaunchOptions !== true && !parsed.network && !parsed.swarmOptions) return null
+    return {
+      network: parsed.network,
+      swarmOptions: parsed.swarmOptions
+    }
+  } catch {
+    return null
+  }
+}
+
 export function parseSidecarArgv(argv = []) {
-  const [storagePath = '', entrypoint = 'sidecar-entry', ...args] = argv
-  return { storagePath, entrypoint, args }
+  const [storagePath = '', entrypoint = 'sidecar-entry', ...rawArgs] = argv
+  const launchOptions = parseLaunchOptions(rawArgs[0])
+  const args = launchOptions ? rawArgs.slice(1) : rawArgs
+  return {
+    storagePath,
+    entrypoint,
+    args,
+    network: launchOptions?.network,
+    swarmOptions: launchOptions?.swarmOptions
+  }
 }
 
 function isDirectRun() {

--- a/packages/host/test/sidecar-entry.test.mjs
+++ b/packages/host/test/sidecar-entry.test.mjs
@@ -16,11 +16,30 @@ test('sidecar entry exports sidecar helpers', async (t) => {
 })
 
 test('parseSidecarArgv preserves entrypoint and trailing args', async (t) => {
-  t.alike(parseSidecarArgv(['/tmp/peartube-host', 'custom-entry', '--inspect']), {
-    storagePath: '/tmp/peartube-host',
-    entrypoint: 'custom-entry',
-    args: ['--inspect']
-  })
+  const parsed = parseSidecarArgv(['/tmp/peartube-host', 'custom-entry', '--inspect'])
+  t.is(parsed.storagePath, '/tmp/peartube-host')
+  t.is(parsed.entrypoint, 'custom-entry')
+  t.alike(parsed.args, ['--inspect'])
+  t.absent(parsed.network)
+  t.absent(parsed.swarmOptions)
+})
+
+test('parseSidecarArgv decodes network launch options from trailing JSON arg', async (t) => {
+  const launchOptions = {
+    network: { relayPeers: ['a'.repeat(64)] },
+    swarmOptions: { knownPeers: ['b'.repeat(64)] }
+  }
+
+  const parsed = parseSidecarArgv([
+    '/tmp/peartube-host',
+    'mobile-entry',
+    JSON.stringify(launchOptions)
+  ])
+  t.is(parsed.storagePath, '/tmp/peartube-host')
+  t.is(parsed.entrypoint, 'mobile-entry')
+  t.alike(parsed.args, [])
+  t.alike(parsed.network, launchOptions.network)
+  t.alike(parsed.swarmOptions, launchOptions.swarmOptions)
 })
 
 test('createProcessTransport exposes a chainable stream-like API', async (t) => {


### PR DESCRIPTION
## Summary
- preserve mobile host launch `network` / `swarmOptions` through the Bare sidecar argv path so explicit relay/known peer options can reach backend startup
- expose selected-video blob-core peer identities (`blobPeerIds`, `blobPeers`, `blobCoreKey`) from `getVideoStats`
- add regressions for sidecar launch option decoding and blob peer identity diagnostics

## Why
`v0.1.128` added blob-topic direct dialing, but the physical phone still reports 2 peers. The likely remaining divergence is that mobile launch options can be dropped before `startHost()`, and the app still cannot prove which peers are attached to the selected `blobsCoreKey`. This patch fixes the launch-option path and adds the diagnostic proof needed for the next physical run.

## Test Plan
- `node --test packages/backend/test/playback-api.test.mjs packages/host/test/sidecar-entry.test.mjs packages/host/test/start-host.test.mjs packages/backend/test/known-peers.test.mjs packages/backend/test/storage-startup-regression.test.mjs` — relevant subtests passed; command hit timeout because the combined brittle/node-test process did not exit cleanly after passing printed tests
- `./node_modules/.bin/eslint --quiet packages/backend/src/api.js packages/backend/test/playback-api.test.mjs packages/host/src/sidecar-entry.js packages/host/test/sidecar-entry.test.mjs`
- `git diff --check`
