### PR TITLE
fix(app): prevent Android playback mount crash

### DIFF
--- a/packages/app/components/video-player/PearInlineVideoView.tsx
+++ b/packages/app/components/video-player/PearInlineVideoView.tsx
@@ -131,23 +131,6 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
     setSourceKey(0)
   }, [videoUrl])
 
-  useEffect(() => {
-    if (Platform.OS !== 'android') return
-    const subscription = AppState.addEventListener('change', (nextState) => {
-      appStateRef.current = nextState
-      if (nextState !== 'active') {
-        // Peer-backed blob streams can legitimately stall for a few seconds while
-        // Android backgrounds or enters PiP. Treat that as a transition, not a
-        // fatal stuck-playback signal that should remount the player.
-        suppressStuckPlaybackRecoveryUntilRef.current = Date.now() + 6000
-        if (!autoEnterPipOnLeave) {
-          void adapter.destroy?.()
-        }
-      }
-    })
-    return () => subscription.remove()
-  }, [adapter, autoEnterPipOnLeave])
-
   const shouldSuppressStuckPlaybackRecovery = useCallback(() => {
     if (Platform.OS !== 'android') return false
     if (isInPipMode) return true
@@ -222,6 +205,23 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
     ),
     [showNotificationControls],
   )
+
+  useEffect(() => {
+    if (Platform.OS !== 'android') return
+    const subscription = AppState.addEventListener('change', (nextState) => {
+      appStateRef.current = nextState
+      if (nextState !== 'active') {
+        // Peer-backed blob streams can legitimately stall for a few seconds while
+        // Android backgrounds or enters PiP. Treat that as a transition, not a
+        // fatal stuck-playback signal that should remount the player.
+        suppressStuckPlaybackRecoveryUntilRef.current = Date.now() + 6000
+        if (!autoEnterPipOnLeave) {
+          void adapter.destroy?.()
+        }
+      }
+    })
+    return () => subscription.remove()
+  }, [adapter, autoEnterPipOnLeave])
 
   useEffect(() => {
     if (!playerRef) return

--- a/packages/app/components/video-player/PearInlineVideoView.tsx
+++ b/packages/app/components/video-player/PearInlineVideoView.tsx
@@ -237,7 +237,10 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
     return () => {
       try {
         void adapter.destroy?.()
-      } catch {}
+      } catch {
+        // Best-effort cleanup only. Some native player refs are already disposed
+        // while React tears down the playback surface.
+      }
       if (playerRef.current === adapter) {
         playerRef.current = null
       }

--- a/packages/app/tests/pear-inline-player-view.test.mjs
+++ b/packages/app/tests/pear-inline-player-view.test.mjs
@@ -43,6 +43,19 @@ test('PearInlineVideoView adapter controls the shared VideoRef directly', () => 
   assert.doesNotMatch(source, /controller\./)
 })
 
+test('PearInlineVideoView declares the adapter before AppState effects use it', () => {
+  const source = readAppFile('components/video-player/PearInlineVideoView.tsx')
+  const adapterDeclarationIndex = source.indexOf('const adapter = useMemo')
+  const appStateEffectIndex = source.indexOf("AppState.addEventListener('change'")
+
+  assert.notEqual(adapterDeclarationIndex, -1, 'adapter useMemo should exist')
+  assert.notEqual(appStateEffectIndex, -1, 'Android AppState effect should exist')
+  assert.ok(
+    adapterDeclarationIndex < appStateEffectIndex,
+    'adapter must be initialized before AppState effect closes over it; otherwise playback mount can crash from TDZ access',
+  )
+})
+
 test('legacy MpvMobileVideoView implementation stays removed or only exists as a shim', () => {
   const shimPath = path.join(appRoot, 'components/video-player/MpvMobileVideoView.tsx')
   if (!fs.existsSync(shimPath)) {


### PR DESCRIPTION
## Summary
- Moves the Android AppState playback effect below the `PearInlineVideoView` adapter initialization
- Prevents playback screen mount from closing over `adapter` while it is still in the temporal dead zone
- Adds a regression guard so future player edits keep adapter initialization before AppState effects that use it

## Test Plan
- `node --test packages/app/tests/pear-inline-player-view.test.mjs packages/app/tests/player-port-contract-regression.test.mjs packages/app/tests/vertical-discovery-regression.test.mjs`
- `npm run typecheck --prefix packages/platform`
- `git diff --check`

## Notes
- Tried to install the `v0.1.133` release APK on the local Android emulator first, but the release APK is arm64-only and the emulator is x86_64, so `adb install --abi x86_64` correctly failed with `INSTALL_FAILED_NO_MATCHING_ABIS`.
- Started an x86_64 local APK build for emulator smoke testing, but the BareKit addon relink loop did not produce an APK in the tool window; source/type/regression coverage is included here and CI should validate the branch.
