### PR TITLE
fix(mobile): bootstrap relay peers for playback

### DIFF
--- a/packages/app/app/_layout.tsx
+++ b/packages/app/app/_layout.tsx
@@ -77,6 +77,12 @@ const BACKEND_SOURCE_CACHE_KEY = '__PEARTUBE_BACKEND_SOURCE__'
 const DOWNLOADER_SOURCE_CACHE_KEY = '__PEARTUBE_DOWNLOADER_WORKER_SOURCE__'
 const CAST_ACTIVE_GLOBAL_KEY = '__PEARTUBE_CAST_ACTIVE__'
 const PeartubeNetworkDiscovery = (NativeModules as any).PeartubeNetworkDiscovery
+const MOBILE_RELAY_PEERS = [
+  '9890785d1a1b5af8e4bfba0f585f54272b6951e3dc0fdc43a30ed73f1d740f13',
+  'd10f6fbdae2d8e439cf9b6e29cbb42199fff101a8e707345eb455faab92e7d7a',
+  '8cdc6bc7d9d1bfe99644d06dee042023c54d55af178cfa12bf778fe51f01152a',
+  '43f48db991cc40002ebd9661239b49e83c1d6b41c86b06b94a57925d00e5ab05',
+]
 
 function requirePeartubeNetworkDiscovery(): any {
   const mod = (NativeModules as any).PeartubeNetworkDiscovery
@@ -544,6 +550,11 @@ const BACKEND_STARTUP_TIMEOUT_MS = 30000
         ),
         loadBackendSource: async () => sources.backendSource,
         loadDownloaderWorkerSource: async () => sources.downloaderWorkerSource ?? null,
+        launchOptions: {
+          __peartubeLaunchOptions: true,
+          network: { relayPeers: MOBILE_RELAY_PEERS },
+          swarmOptions: { knownPeers: MOBILE_RELAY_PEERS },
+        },
       })
       startupLog('[Startup] initPlatformRPC returned ms=', Date.now() - t0)
 

--- a/packages/app/tests/native-bundle-version-key-regression.test.mjs
+++ b/packages/app/tests/native-bundle-version-key-regression.test.mjs
@@ -53,3 +53,19 @@ test('native backend version key includes embedded bundle fingerprint so upgrade
     'backend version key must be derived from loaded sources, not app metadata alone',
   )
 })
+
+test('initPlatformRPC forwards relay launch options into native backend startup', () => {
+  const source = readAppFile('app/_layout.tsx')
+
+  assert.match(
+    source,
+    /const MOBILE_RELAY_PEERS = \[[\s\S]*?[a-f0-9]{64}[\s\S]*?\]/,
+    'mobile startup must define relay public keys for backend direct dialing',
+  )
+
+  assert.match(
+    source,
+    /launchOptions:\s*\{[\s\S]*?__peartubeLaunchOptions:\s*true[\s\S]*?network:\s*\{[\s\S]*?relayPeers:\s*MOBILE_RELAY_PEERS[\s\S]*?swarmOptions:\s*\{[\s\S]*?knownPeers:\s*MOBILE_RELAY_PEERS/s,
+    'mobile startup must pass explicit relay peer launch options into the backend worklet',
+  )
+})

--- a/packages/platform/src/rpc.native.ts
+++ b/packages/platform/src/rpc.native.ts
@@ -505,6 +505,10 @@ export async function initPlatformRPC(config: {
   loadBackendSource?: () => Promise<string>;
   loadDownloaderWorkerSource?: () => Promise<string | null | undefined>;
   storagePath?: string;
+  launchOptions?: {
+    network?: Record<string, unknown>;
+    swarmOptions?: Record<string, unknown>;
+  };
 }): Promise<void> {
   if (_isInitialized && mainBridge.isInitialized()) {
     _startupState = 'ready';
@@ -591,7 +595,17 @@ export async function initPlatformRPC(config: {
 
     nativeRuntimeConfig.backendPath = backendPath;
     nativeRuntimeConfig.backendSource = backendPath ? '' : backendSource;
-    nativeRuntimeConfig.workerArgs = downloaderWorkerPath ? [downloaderWorkerPath] : [];
+    const launchOptionsArg = config.launchOptions
+      ? JSON.stringify({
+        __peartubeLaunchOptions: true,
+        network: config.launchOptions.network,
+        swarmOptions: config.launchOptions.swarmOptions,
+      })
+      : null;
+    nativeRuntimeConfig.workerArgs = [
+      ...(launchOptionsArg ? [launchOptionsArg] : []),
+      ...(downloaderWorkerPath ? [downloaderWorkerPath] : []),
+    ];
 
     if (backendPath) {
       console.log('[Platform RPC] Backend worklet will launch from file:', backendPath);

--- a/packages/platform/test/native-worklet-launch.test.mjs
+++ b/packages/platform/test/native-worklet-launch.test.mjs
@@ -48,6 +48,34 @@ test('launchNativeWorklet falls back to the embedded source when no file path ex
   ]])
 })
 
+test('launchNativeWorklet preserves entrypoint and launch options in argv', () => {
+  const calls = []
+  const worklet = {
+    start(...args) {
+      calls.push(args)
+    },
+  }
+  const launchOptions = JSON.stringify({
+    __peartubeLaunchOptions: true,
+    network: { relayPeers: ['a'.repeat(64)] },
+    swarmOptions: { knownPeers: ['b'.repeat(64)] },
+  })
+  const launchArgs = ['/tmp/storage', 'mobile-entry', launchOptions, 'downloader.bundle']
+
+  const mode = launchNativeWorklet(worklet, {
+    backendPath: '/tmp/peartube/backend.bundle.js',
+    backendSource: '',
+    workletId: '/peartube-backend-core.bundle',
+    launchArgs,
+  })
+
+  assert.equal(mode, 'file')
+  assert.deepEqual(calls, [[
+    '/tmp/peartube/backend.bundle.js',
+    launchArgs,
+  ]])
+})
+
 test('launchNativeWorklet rejects missing file and source inputs', () => {
   assert.throws(() => launchNativeWorklet(
     { start() {} },


### PR DESCRIPTION
## Summary
- passes the four local relay public keys into Android backend startup as `network.relayPeers` and `swarmOptions.knownPeers`
- serializes those launch options ahead of the downloader worker arg so `sidecar-entry` can parse them
- adds regression coverage for mobile startup launch options and native worklet argv preservation

## Test Plan
- `node --test packages/platform/test/native-worklet-launch.test.mjs packages/app/tests/native-bundle-version-key-regression.test.mjs`
- `npm run typecheck --prefix packages/platform`
- `git diff --check`

## Notes
Relay mesh is currently healthy locally (`connections=6`, `feedConnections=6`, `feedEntries=89` on all four relays). ADB currently reports no attached device, so physical phone playback proof still needs the next APK installed and logcat checked for selected-video `blobPeerIds` / peer count while watching.
