### PR TITLE
[codex] fix android video open-close performance

### DIFF
--- a/packages/app/app/(tabs)/index.tsx
+++ b/packages/app/app/(tabs)/index.tsx
@@ -10,7 +10,7 @@ import { useApp, colors } from '../_layout'
 import { VideoCard } from '../../components/video'
 import type { VideoData } from '@peartube/core'
 import { CastHeaderButton } from '@/components/cast'
-import { useVideoPlayerContext } from '@/lib/VideoPlayerContext'
+import { useVideoPlayerActions } from '@/lib/VideoPlayerContext'
 import { usePlatform } from '@/lib/PlatformProvider'
 import { fetchThumbnailUrlWithRetry } from '@/lib/thumbnail'
 import { formatTimeAgo } from '@/lib/formatters'
@@ -116,7 +116,7 @@ export default function HomeScreen() {
   const insets = useSafeAreaInsets()
   const router = useRouter()
   const { ready, identity, videos, loading, loadVideos, rpc, backendError, startupStatus, retryBackend, platformEvents, blobServerPort, androidDiscoveryPermissionStatus } = useApp()
-  const { loadAndPlayVideo } = useVideoPlayerContext()
+  const { loadAndPlayVideo } = useVideoPlayerActions()
   const { isDesktop } = usePlatform()
   const { width: screenWidth } = useWindowDimensions()
   const tabBarMetrics = useTabBarMetrics()

--- a/packages/app/app/(tabs)/search.tsx
+++ b/packages/app/app/(tabs)/search.tsx
@@ -7,7 +7,7 @@ import { useApp, colors } from '../_layout'
 import { VideoCard, type VideoData } from '../../components/video'
 import type { VideoData as CoreVideoData } from '@peartube/core'
 import { CastHeaderButton } from '@/components/cast'
-import { useVideoPlayerContext } from '@/lib/VideoPlayerContext'
+import { useVideoPlayerActions } from '@/lib/VideoPlayerContext'
 import { usePlatform } from '@/lib/PlatformProvider'
 import { useTabBarMetrics } from '@/lib/tabBarHeight'
 import { fetchThumbnailUrlWithRetry } from '@/lib/thumbnail'
@@ -71,7 +71,7 @@ export default function SearchTab() {
   const [query, setQuery] = useState('')
 
   const { ready, rpc, blobServerPort } = useApp()
-  const { loadAndPlayVideo, closeVideo } = useVideoPlayerContext()
+  const { loadAndPlayVideo, closeVideo } = useVideoPlayerActions()
   const { isDesktop } = usePlatform()
   const { width: screenWidth } = useWindowDimensions()
 

--- a/packages/app/app/(tabs)/studio.tsx
+++ b/packages/app/app/(tabs)/studio.tsx
@@ -516,7 +516,7 @@ export default function StudioScreen() {
               {!isPear && thumbnailError ? (
                 <View className="bg-pear-bg-elevated border border-pear-border rounded-lg p-4">
                   <Text className="text-caption text-pear-text-muted">
-                    Thumbnail generation failed. Tap "Add Thumbnail" to pick an image.
+                    Thumbnail generation failed. Tap Add Thumbnail to pick an image.
                   </Text>
                 </View>
               ) : null}

--- a/packages/app/app/(tabs)/studio.tsx
+++ b/packages/app/app/(tabs)/studio.tsx
@@ -11,7 +11,7 @@ import * as ImagePicker from 'expo-image-picker'
 import * as VideoThumbnails from 'expo-video-thumbnails'
 import { useApp, colors } from '../_layout'
 import { CastHeaderButton } from '@/components/cast'
-import { useVideoPlayerContext } from '@/lib/VideoPlayerContext'
+import { useVideoPlayerActions } from '@/lib/VideoPlayerContext'
 import { VideoEditModal } from '@/components/VideoEditModal'
 import { formatBytes } from '@/lib/formatters'
 import { useTabBarMetrics } from '@/lib/tabBarHeight'
@@ -40,7 +40,7 @@ export default function StudioScreen() {
   const insets = useSafeAreaInsets()
   const router = useRouter()
   const { identity, videos, rpc, uploadVideo, pickVideoFile, pickImageFile, loadVideos, removeVideo } = useApp()
-  const { pauseVideo, closeVideo, suppressForegroundRestoreOnce, suppressForegroundRestoreFor, clearLastClosedVideo } = useVideoPlayerContext()
+  const { pauseVideo, closeVideo, suppressForegroundRestoreOnce, suppressForegroundRestoreFor, clearLastClosedVideo } = useVideoPlayerActions()
   const [uploading, setUploading] = useState(false)
   const [uploadProgress, setUploadProgress] = useState(0)
   const [uploadSpeed, setUploadSpeed] = useState(0)  // bytes/sec

--- a/packages/app/app/search.tsx
+++ b/packages/app/app/search.tsx
@@ -10,7 +10,7 @@ import { useApp, colors } from './_layout'
 import { VideoCard, VideoData } from '../components/video'
 import type { VideoData as CoreVideoData } from '@peartube/core'
 import { CastHeaderButton } from '@/components/cast'
-import { useVideoPlayerContext } from '@/lib/VideoPlayerContext'
+import { useVideoPlayerActions } from '@/lib/VideoPlayerContext'
 import { usePlatform } from '@/lib/PlatformProvider'
 import { fetchThumbnailUrlWithRetry } from '@/lib/thumbnail'
 import { getDesktopVideoGridColumns } from '@/lib/video-layout'
@@ -101,7 +101,7 @@ export default function SearchScreen() {
   const query = typeof params.q === 'string' ? params.q : ''
 
   const { ready, rpc, platformEvents, blobServerPort } = useApp()
-  const { loadAndPlayVideo, closeVideo } = useVideoPlayerContext()
+  const { loadAndPlayVideo, closeVideo } = useVideoPlayerActions()
   const { isDesktop } = usePlatform()
   const { width: screenWidth } = useWindowDimensions()
 

--- a/packages/app/components/video-player/PearInlineVideoView.tsx
+++ b/packages/app/components/video-player/PearInlineVideoView.tsx
@@ -171,11 +171,9 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
         },
         stop: async () => {
           player.pause()
-          player.currentTime = 0
         },
         destroy: async () => {
           player.pause()
-          player.currentTime = 0
         },
         seek: async (timeSeconds: number) => {
           player.currentTime = Math.max(0, timeSeconds)

--- a/packages/app/lib/SocialContext.tsx
+++ b/packages/app/lib/SocialContext.tsx
@@ -2,7 +2,7 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useRef, use
 import { Alert } from 'react-native'
 import { rpc } from '@peartube/platform/rpc'
 import { useApp } from '@/lib/AppContext'
-import { useVideoPlayerContext } from '@/lib/VideoPlayerContext'
+import { useVideoPlayerSession } from '@/lib/VideoPlayerContext'
 import { COMMENTS_PER_PAGE } from '@/components/video-player'
 
 const SOCIAL_RPC_TIMEOUT_MS = 8000
@@ -58,9 +58,7 @@ export function useSocial() {
 
 export function SocialProvider({ children }: { children: React.ReactNode }) {
   const { identity } = useApp()
-  const player = useVideoPlayerContext()
-  const currentVideo = player.currentVideo
-  const playerMode = player.playerMode
+  const { currentVideo, playerMode } = useVideoPlayerSession()
 
   const commentsLengthRef = useRef(0)
 

--- a/packages/app/lib/VideoPlayerContext.tsx
+++ b/packages/app/lib/VideoPlayerContext.tsx
@@ -138,6 +138,7 @@ type VideoPlayerActionsContextType = Pick<
 
 const VideoPlayerContext = createContext<VideoPlayerContextType | null>(null)
 const VideoPlayerActionsContext = createContext<VideoPlayerActionsContextType | null>(null)
+const VideoPlayerSessionContext = createContext<Pick<VideoPlayerContextType, 'currentVideo' | 'playerMode'> | null>(null)
 
 export function useVideoPlayerContext() {
   const ctx = useContext(VideoPlayerContext)
@@ -148,6 +149,12 @@ export function useVideoPlayerContext() {
 export function useVideoPlayerActions() {
   const ctx = useContext(VideoPlayerActionsContext)
   if (!ctx) throw new Error('useVideoPlayerActions must be used within VideoPlayerProvider')
+  return ctx
+}
+
+export function useVideoPlayerSession() {
+  const ctx = useContext(VideoPlayerSessionContext)
+  if (!ctx) throw new Error('useVideoPlayerSession must be used within VideoPlayerProvider')
   return ctx
 }
 
@@ -1300,6 +1307,11 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
     setPlaybackRate,
   ])
 
+  const sessionValue = useMemo(() => ({
+    currentVideo,
+    playerMode,
+  }), [currentVideo, playerMode])
+
   // PERFORMANCE: Memoize context value to prevent unnecessary re-renders
   // Components consuming this context will only re-render when these specific values change
   const contextValue = useMemo<VideoPlayerContextType>(() => ({
@@ -1366,9 +1378,11 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
 
   return (
     <VideoPlayerActionsContext.Provider value={actionsValue}>
-      <VideoPlayerContext.Provider value={contextValue}>
-        {children}
-      </VideoPlayerContext.Provider>
+      <VideoPlayerSessionContext.Provider value={sessionValue}>
+        <VideoPlayerContext.Provider value={contextValue}>
+          {children}
+        </VideoPlayerContext.Provider>
+      </VideoPlayerSessionContext.Provider>
     </VideoPlayerActionsContext.Provider>
   )
 }

--- a/packages/app/lib/VideoPlayerContext.tsx
+++ b/packages/app/lib/VideoPlayerContext.tsx
@@ -17,12 +17,23 @@ import type { ModeBeforePip, PlayerState } from './playerStateMachine'
 
 const ENABLE_ANDROID_SPLIT_PLAYER_ACTIVITY = false
 const CAST_ACTIVE_GLOBAL_KEY = '__PEARTUBE_CAST_ACTIVE__'
+const VIDEO_PLAYER_DEBUG_GLOBAL_KEY = '__PEARTUBE_DEBUG_VIDEO_PLAYER__'
 let ACTIVE_VIDEO_PLAYER_CONTROLLER_ID: number | null = null
 let NEXT_VIDEO_PLAYER_CONTROLLER_ID = 1
 
 function isCastSessionLikelyActiveGlobally(): boolean {
   const g = globalThis as Record<string, unknown>
   return g[CAST_ACTIVE_GLOBAL_KEY] === true
+}
+
+function isVideoPlayerDebugEnabled(): boolean {
+  if (!__DEV__) return false
+  const g = globalThis as Record<string, unknown>
+  return g[VIDEO_PLAYER_DEBUG_GLOBAL_KEY] === true
+}
+
+function debugPlayerLog(...args: unknown[]) {
+  if (isVideoPlayerDebugEnabled()) console.debug(...args)
 }
 
 // Re-export types for backwards compatibility
@@ -105,11 +116,38 @@ interface VideoPlayerContextType {
   onVideoStateChange: (data: { type?: string; mVideoWidth?: number; mVideoHeight?: number }) => void
 }
 
+type VideoPlayerActionsContextType = Pick<
+  VideoPlayerContextType,
+  | 'loadAndPlayVideo'
+  | 'setAmbientVideoContext'
+  | 'pauseVideo'
+  | 'resumeVideo'
+  | 'closeVideo'
+  | 'enterBackgroundAudio'
+  | 'suppressForegroundRestoreOnce'
+  | 'suppressForegroundRestoreFor'
+  | 'clearLastClosedVideo'
+  | 'minimizePlayer'
+  | 'maximizePlayer'
+  | 'seekTo'
+  | 'seekBy'
+  | 'setPlaybackRate'
+  | 'setVideoStats'
+  | 'setIsLoading'
+>
+
 const VideoPlayerContext = createContext<VideoPlayerContextType | null>(null)
+const VideoPlayerActionsContext = createContext<VideoPlayerActionsContextType | null>(null)
 
 export function useVideoPlayerContext() {
   const ctx = useContext(VideoPlayerContext)
   if (!ctx) throw new Error('useVideoPlayerContext must be used within VideoPlayerProvider')
+  return ctx
+}
+
+export function useVideoPlayerActions() {
+  const ctx = useContext(VideoPlayerActionsContext)
+  if (!ctx) throw new Error('useVideoPlayerActions must be used within VideoPlayerProvider')
   return ctx
 }
 
@@ -299,7 +337,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
     // Avoid log spam while still surfacing what happened.
     if (__DEV__ && now - pipExitReassertLoggedAtRef.current > 1000) {
       pipExitReassertLoggedAtRef.current = now
-      console.log('[VideoPlayerContext] Reasserting play after PiP exit:', reason)
+      debugPlayerLog('[VideoPlayerContext] Reasserting play after PiP exit:', reason)
     }
   }, [])
 
@@ -309,7 +347,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
 
   const restoreLastClosedVideo = useCallback((reason: string) => {
     if (!lastClosedVideoRef.current || !lastClosedUrlRef.current) return false
-    console.log('[VideoPlayerContext] Restoring last closed video:', reason)
+    debugPlayerLog('[VideoPlayerContext] Restoring last closed video:', reason)
     currentVideoRef.current = lastClosedVideoRef.current
     videoUrlRef.current = lastClosedUrlRef.current
     setPlaybackSession((prev) => prev + 1)
@@ -332,7 +370,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
     const video = currentVideoRef.current
     const url = videoUrlRef.current
     if (!video || !url) return false
-    console.log('[VideoPlayerContext] Forcing playback reload:', reason)
+    debugPlayerLog('[VideoPlayerContext] Forcing playback reload:', reason)
     setPlaybackSession((prev) => prev + 1)
     dispatch({
       type: 'FORCE_RELOAD_PLAYBACK',
@@ -363,7 +401,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
     reason: 'user' | 'remote-stop' | 'android-minimize-close' | 'pip-close' | 'background-audio' = 'user',
     opts?: { preserveLastClosed?: boolean },
   ) => {
-    console.log('[VideoPlayerContext] Closing session:', reason)
+    debugPlayerLog('[VideoPlayerContext] Closing session:', reason)
 
     const preserveNativeSession =
       reason === 'android-minimize-close' &&
@@ -452,7 +490,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
 
   const enterBackgroundAudio = useCallback(() => {
     if (!currentVideoRef.current || !videoUrlRef.current) return
-    console.log('[VideoPlayerContext] Entering background audio mode')
+    debugPlayerLog('[VideoPlayerContext] Entering background audio mode')
     // Transition to background_audio mode WITHOUT unmounting the Video component.
     // This keeps state.video and state.url intact so ExoPlayer continues playing
     // via VideoPlaybackService. When the app returns to foreground, the state machine
@@ -566,7 +604,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
             isPlaying: wasPlaying,
           })
         }
-        console.log(
+        debugPlayerLog(
           '[VideoPlayerContext] Going to background, wasPlaying:',
           wasPlaying,
           'playerMode:',
@@ -582,7 +620,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
           // The player was already running — any buffering is surface reattach, not a real stall.
           suppressTransientBufferingRef.current = true
           setIsLoading(false)
-          console.log('[VideoPlayerContext] Coming to foreground, wasPlaying:', wasPlayingWhenBackgroundedRef.current, 'wasInPiP:', wasInPip, 'pipInFlight:', pipTransitionInFlightRef.current)
+          debugPlayerLog('[VideoPlayerContext] Coming to foreground, wasPlaying:', wasPlayingWhenBackgroundedRef.current, 'wasInPiP:', wasInPip, 'pipInFlight:', pipTransitionInFlightRef.current)
 
          // IMPORTANT: Don't clear PiP state on foreground if we were in PiP.
          // When returning from PiP, Android can deliver the AppState "active" event
@@ -590,7 +628,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
          // makes the PiP exit handler think we were never in PiP, so it won't
          // restore playback state (leading to unintended pauses).
           if (!wasInPip) {
-            console.log('[VideoPlayerContext] Clearing PiP state on foreground')
+            debugPlayerLog('[VideoPlayerContext] Clearing PiP state on foreground')
             isInPipModeRef.current = false
             setPipWindowSize(null)
             if (pipTransitionTimeoutRef.current) {
@@ -660,7 +698,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
   useEffect(() => {
     if (Platform.OS !== 'android') return
     const closeSub = DeviceEventEmitter.addListener('onPipClosed', () => {
-      console.log('[VideoPlayerContext] PiP closed (X button) — pausing')
+      debugPlayerLog('[VideoPlayerContext] PiP closed (X button) — pausing')
       setDesiredPlaying(false)
     })
     return () => closeSub.remove()
@@ -674,7 +712,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
      const unsubscribe = _videoStatsEventEmitter.subscribe((driveKey, videoPath, stats) => {
        // Use ref for synchronous access (state may not be updated yet)
        const video = currentVideoRef.current
-       console.log('[VideoPlayerContext] Stats event received, checking match:', {
+       debugPlayerLog('[VideoPlayerContext] Stats event received, checking match:', {
          videoPath,
          driveKey,
          currentPath: video?.path,
@@ -708,7 +746,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
       const sameVideo = Boolean(video) && (samePath || sameId) && (keysCompatible || sameId)
 
        if (sameVideo) {
-         console.log('[VideoPlayerContext] Received stats event:', stats.progress + '%')
+         debugPlayerLog('[VideoPlayerContext] Received stats event:', stats.progress + '%')
         setVideoStats(stats)
         if (typeof stats.progress === 'number' && stats.progress > 0) {
           // Once the backend is serving bytes, stop showing the generic
@@ -730,7 +768,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
       now - lastPlaybackStartAtRef.current < 1000
     ) {
       if (__DEV__) {
-        console.log('[VideoPlayerContext] Skipping duplicate playback start:', source)
+        debugPlayerLog('[VideoPlayerContext] Skipping duplicate playback start:', source)
       }
       return
     }
@@ -827,7 +865,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
 
   // Load and play a new video (triggers overlay to fullscreen)
   const loadAndPlayVideo = useCallback((video: VideoData, url: string) => {
-    console.log('[VideoPlayerContext] Loading video:', video.title, 'URL:', url)
+    debugPlayerLog('[VideoPlayerContext] Loading video:', video.title, 'URL:', url)
 
     const requestKey = `${video.channelKey || ''}:${video.id || video.path || ''}:${url}`
 
@@ -874,7 +912,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
 
   // Pause video
   const pauseVideo = useCallback(() => {
-    console.log('[VideoPlayerContext] Pausing video')
+    debugPlayerLog('[VideoPlayerContext] Pausing video')
     if (Platform.OS === 'web') {
       try {
         getPlayerPort()?.pause?.()
@@ -884,7 +922,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
   }, [setDesiredPlaying])
 
   const resumeVideo = useCallback(() => {
-    console.log('[VideoPlayerContext] Resuming video')
+    debugPlayerLog('[VideoPlayerContext] Resuming video')
 
     // On iOS, do a seek while still paused to reinitialize audio, then resume
     // This avoids visible jitter since video isn't playing during the seek
@@ -911,12 +949,12 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
       const currentVideo = currentVideoRef.current
       const currentUrl = videoUrlRef.current
       if (!currentVideo || !currentUrl) {
-        console.log('[VideoPlayerContext] No active video to minimize on Android')
+        debugPlayerLog('[VideoPlayerContext] No active video to minimize on Android')
         return
       }
 
       // Using react-native-video native PiP - no longer using split PlayerActivity
-      console.log('[VideoPlayerContext] Minimizing to in-app mini player')
+      debugPlayerLog('[VideoPlayerContext] Minimizing to in-app mini player')
       dispatch({
         type: 'MINIMIZE',
         source: 'minimizePlayer',
@@ -925,7 +963,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
       return
     }
 
-    console.log('[VideoPlayerContext] Minimizing to in-app mini player')
+    debugPlayerLog('[VideoPlayerContext] Minimizing to in-app mini player')
     dispatch({
       type: 'MINIMIZE',
       source: 'minimizePlayer',
@@ -935,7 +973,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
 
   // Maximize from mini player
   const maximizePlayer = useCallback((source: string = 'unknown') => {
-    console.log('[VideoPlayerContext] Maximizing player from:', source)
+    debugPlayerLog('[VideoPlayerContext] Maximizing player from:', source)
     dispatch({ type: 'MAXIMIZE', source: 'maximizePlayer' })
   }, [dispatch, setDesiredPlaying])
 
@@ -1015,7 +1053,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
 
     if (!didImperativeSeek) {
       const seekValue = clampedTime / dur
-      console.log('[VideoPlayerContext] Fallback seekTo via seekPosition:', clampedTime, 'seconds, seek prop:', seekValue)
+      debugPlayerLog('[VideoPlayerContext] Fallback seekTo via seekPosition:', clampedTime, 'seconds, seek prop:', seekValue)
       setSeekPosition(seekValue)
     } else {
       setSeekPosition(undefined)
@@ -1041,7 +1079,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
 
     if (!didImperativeSeek) {
       const seekValue = newTime / dur
-      console.log('[VideoPlayerContext] Fallback seekBy via seekPosition:', delta, 'to:', newTime, 'seek prop:', seekValue)
+      debugPlayerLog('[VideoPlayerContext] Fallback seekBy via seekPosition:', delta, 'to:', newTime, 'seek prop:', seekValue)
       setSeekPosition(seekValue)
     } else {
       setSeekPosition(undefined)
@@ -1054,13 +1092,13 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
 
   // Set playback speed
   const setPlaybackRate = useCallback((rate: number) => {
-    console.log('[VideoPlayerContext] Setting playback rate:', rate)
+    debugPlayerLog('[VideoPlayerContext] Setting playback rate:', rate)
     setPlaybackRateState(rate)
   }, [])
 
   const onProgress = useCallback((data: { currentTime: number; duration: number }) => {
     if (Platform.OS === 'android' && pipExitExpectedPlayingRef.current && !isInPipModeRef.current) {
-      console.log('[VideoPlayerContext] PiP exit resume confirmed via progress')
+      debugPlayerLog('[VideoPlayerContext] PiP exit resume confirmed via progress')
       pipExitShouldResumeRef.current = false
       pipExitExpectedPlayingRef.current = false
       pipExitResumeUntilRef.current = 0
@@ -1114,13 +1152,13 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
   }, [])
 
   const onLoaded = useCallback(() => {
-    console.log('[VideoPlayerContext] Player loaded')
+    debugPlayerLog('[VideoPlayerContext] Player loaded')
     isBufferingRef.current = false
     setIsLoading(false)
   }, [])
 
   const onPlaying = useCallback(() => {
-    console.log('[VideoPlayerContext] Player playing')
+    debugPlayerLog('[VideoPlayerContext] Player playing')
     if (Platform.OS === 'ios') {
       iosIgnorePausedUntilRef.current = 0
     }
@@ -1135,7 +1173,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
 
   const onPaused = useCallback(() => {
     if (Platform.OS === 'ios' && Date.now() < iosIgnorePausedUntilRef.current) {
-      console.log('[VideoPlayerContext] Ignoring transient iOS paused event during source swap')
+      debugPlayerLog('[VideoPlayerContext] Ignoring transient iOS paused event during source swap')
       return
     }
     if (pipExitExpectedPlayingRef.current && !isInPipModeRef.current) {
@@ -1147,7 +1185,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
       pipExitShouldResumeRef.current = false
       pipExitExpectedPlayingRef.current = false
     }
-    console.log('[VideoPlayerContext] Player paused')
+    debugPlayerLog('[VideoPlayerContext] Player paused')
     // Sync JS state for deliberate external pauses (PiP button, notification
     // pause, audio focus loss). Skip if the player is buffering — that's a
     // transient pause (e.g. after notification seek on uncached content) and
@@ -1160,7 +1198,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
   }, [reassertNativePlayAfterPipExit])
 
   const onBuffering = useCallback((data: { isBuffering: boolean }) => {
-    console.log('[VideoPlayerContext] Player buffering:', data?.isBuffering)
+    debugPlayerLog('[VideoPlayerContext] Player buffering:', data?.isBuffering)
     if (data?.isBuffering === undefined) return
     isBufferingRef.current = Boolean(data.isBuffering)
 
@@ -1192,7 +1230,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
   }, [])
 
   const onEnded = useCallback(() => {
-    console.log('[VideoPlayerContext] Player ended')
+    debugPlayerLog('[VideoPlayerContext] Player ended')
     isBufferingRef.current = false
     setDesiredPlaying(false)
   }, [setDesiredPlaying])
@@ -1212,7 +1250,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
       data.mVideoHeight > 0
     ) {
       const aspectRatio = data.mVideoWidth / data.mVideoHeight
-      console.log('[VideoPlayerContext] Video dimensions:', data.mVideoWidth, 'x', data.mVideoHeight, '- aspect ratio:', aspectRatio.toFixed(3))
+      debugPlayerLog('[VideoPlayerContext] Video dimensions:', data.mVideoWidth, 'x', data.mVideoHeight, '- aspect ratio:', aspectRatio.toFixed(3))
       setVideoAspectRatio(aspectRatio)
       // PiP aspect ratio is handled natively by react-native-video
     }
@@ -1227,6 +1265,40 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
     if (isInPipMode) return false
     return true
   }, [currentVideo, playerMode, isInPipMode])
+
+  const actionsValue = useMemo<VideoPlayerActionsContextType>(() => ({
+    loadAndPlayVideo,
+    setAmbientVideoContext,
+    pauseVideo,
+    resumeVideo,
+    closeVideo,
+    enterBackgroundAudio,
+    suppressForegroundRestoreOnce,
+    suppressForegroundRestoreFor,
+    clearLastClosedVideo,
+    minimizePlayer,
+    maximizePlayer,
+    seekTo,
+    seekBy,
+    setPlaybackRate,
+    setVideoStats,
+    setIsLoading,
+  }), [
+    loadAndPlayVideo,
+    setAmbientVideoContext,
+    pauseVideo,
+    resumeVideo,
+    closeVideo,
+    enterBackgroundAudio,
+    suppressForegroundRestoreOnce,
+    suppressForegroundRestoreFor,
+    clearLastClosedVideo,
+    minimizePlayer,
+    maximizePlayer,
+    seekTo,
+    seekBy,
+    setPlaybackRate,
+  ])
 
   // PERFORMANCE: Memoize context value to prevent unnecessary re-renders
   // Components consuming this context will only re-render when these specific values change
@@ -1293,8 +1365,10 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
   ])
 
   return (
-    <VideoPlayerContext.Provider value={contextValue}>
-      {children}
-    </VideoPlayerContext.Provider>
+    <VideoPlayerActionsContext.Provider value={actionsValue}>
+      <VideoPlayerContext.Provider value={contextValue}>
+        {children}
+      </VideoPlayerContext.Provider>
+    </VideoPlayerActionsContext.Provider>
   )
 }

--- a/packages/app/tests/pear-inline-player-view.test.mjs
+++ b/packages/app/tests/pear-inline-player-view.test.mjs
@@ -35,10 +35,12 @@ test('PearInlineVideoView adapter controls the shared Expo Video player directly
 
   assert.match(source, /play:\s*async \(\)\s*=> \{\s*player\.play\(\)\s*}/)
   assert.match(source, /pause:\s*async \(\)\s*=> \{\s*player\.pause\(\)\s*}/)
-  assert.match(
-    source,
-    /stop:\s*async \(\)\s*=> \{[\s\S]*player\.pause\(\)[\s\S]*player\.currentTime = 0/,
-  )
+  const stopBody = source.match(/stop:\s*async \(\)\s*=> \{([\s\S]*?)\n\s*},/)?.[1] ?? ''
+  const destroyBody = source.match(/destroy:\s*async \(\)\s*=> \{([\s\S]*?)\n\s*},/)?.[1] ?? ''
+  assert.match(stopBody, /player\.pause\(\)/)
+  assert.match(destroyBody, /player\.pause\(\)/)
+  assert.doesNotMatch(stopBody, /currentTime = 0|seek\(0\)/, 'rapid Android open/close teardown should not seek the player before unmount')
+  assert.doesNotMatch(destroyBody, /currentTime = 0|seek\(0\)/, 'destroy should avoid a redundant seek when native resources are being torn down')
   assert.match(source, /seek:\s*async \(timeSeconds: number\) => \{[\s\S]*player\.currentTime = Math\.max\(0, timeSeconds\)/)
   assert.doesNotMatch(source, /controller\./)
 })

--- a/packages/app/tests/video-player-loading-clears-regression.test.mjs
+++ b/packages/app/tests/video-player-loading-clears-regression.test.mjs
@@ -5,6 +5,10 @@ import { test } from 'node:test'
 const contextPath = new URL('../lib/VideoPlayerContext.tsx', import.meta.url)
 const videoRoutePath = new URL('../app/video/[id].tsx', import.meta.url)
 const overlayPath = new URL('../components/VideoPlayerOverlayImpl.tsx', import.meta.url)
+const homePath = new URL('../app/(tabs)/index.tsx', import.meta.url)
+const searchTabPath = new URL('../app/(tabs)/search.tsx', import.meta.url)
+const searchPath = new URL('../app/search.tsx', import.meta.url)
+const studioPath = new URL('../app/(tabs)/studio.tsx', import.meta.url)
 
 async function source(url) {
   return readFile(url, 'utf8')
@@ -27,6 +31,33 @@ test('VideoPlayerContext also clears the connecting gate once backend stats show
   assert.match(statsHandler, /stats\.progress[^\n]+>\s*0/, 'stats handler must treat positive progress as media-ready')
   assert.match(statsHandler, /setIsLoading\(false\)/, 'stats handler must clear global player loading')
   assert.match(statsHandler, /isBufferingRef\.current\s*=\s*false/, 'stats handler must clear buffering ref')
+})
+
+test('VideoPlayerContext keeps player debug logging behind an explicit opt-in gate', async () => {
+  const src = await source(contextPath)
+
+  assert.match(src, /function debugPlayerLog\(\.\.\.args: unknown\[\]\)/, 'expected a dedicated player debug logger')
+  assert.match(src, /__PEARTUBE_DEBUG_VIDEO_PLAYER__/, 'debug logging should be controlled by an explicit global flag')
+  assert.doesNotMatch(src, /console\.log\(/, 'player hot paths should not write directly to console.log')
+})
+
+test('feed and picker screens use action-only player context to avoid progress-driven rerenders', async () => {
+  const contextSource = await source(contextPath)
+  const homeSource = await source(homePath)
+  const searchTabSource = await source(searchTabPath)
+  const searchSource = await source(searchPath)
+  const studioSource = await source(studioPath)
+
+  assert.match(contextSource, /export function useVideoPlayerActions\(\)/, 'VideoPlayerContext should expose an action-only hook')
+  for (const [name, src] of [
+    ['home tab', homeSource],
+    ['search tab', searchTabSource],
+    ['search route', searchSource],
+    ['studio tab', studioSource],
+  ]) {
+    assert.match(src, /useVideoPlayerActions/, `${name} should use the stable action-only hook`)
+    assert.doesNotMatch(src, /useVideoPlayerContext/, `${name} should not subscribe to high-frequency player state`)
+  }
 })
 
 test('mobile/native route uses the shared overlay player instead of an inline player shell', async () => {

--- a/packages/app/tests/video-player-loading-clears-regression.test.mjs
+++ b/packages/app/tests/video-player-loading-clears-regression.test.mjs
@@ -8,7 +8,7 @@ const overlayPath = new URL('../components/VideoPlayerOverlayImpl.tsx', import.m
 const homePath = new URL('../app/(tabs)/index.tsx', import.meta.url)
 const searchTabPath = new URL('../app/(tabs)/search.tsx', import.meta.url)
 const searchPath = new URL('../app/search.tsx', import.meta.url)
-const studioPath = new URL('../app/(tabs)/studio.tsx', import.meta.url)
+const socialPath = new URL('../lib/SocialContext.tsx', import.meta.url)
 
 async function source(url) {
   return readFile(url, 'utf8')
@@ -46,18 +46,25 @@ test('feed and picker screens use action-only player context to avoid progress-d
   const homeSource = await source(homePath)
   const searchTabSource = await source(searchTabPath)
   const searchSource = await source(searchPath)
-  const studioSource = await source(studioPath)
 
   assert.match(contextSource, /export function useVideoPlayerActions\(\)/, 'VideoPlayerContext should expose an action-only hook')
   for (const [name, src] of [
     ['home tab', homeSource],
     ['search tab', searchTabSource],
     ['search route', searchSource],
-    ['studio tab', studioSource],
   ]) {
     assert.match(src, /useVideoPlayerActions/, `${name} should use the stable action-only hook`)
     assert.doesNotMatch(src, /useVideoPlayerContext/, `${name} should not subscribe to high-frequency player state`)
   }
+})
+
+test('SocialProvider subscribes only to stable player session fields', async () => {
+  const contextSource = await source(contextPath)
+  const socialSource = await source(socialPath)
+
+  assert.match(contextSource, /export function useVideoPlayerSession\(\)/, 'VideoPlayerContext should expose a stable session-only hook')
+  assert.match(socialSource, /useVideoPlayerSession/, 'SocialProvider should use the session-only hook')
+  assert.doesNotMatch(socialSource, /useVideoPlayerContext/, 'SocialProvider should not rerender on playback progress or stats changes')
 })
 
 test('mobile/native route uses the shared overlay player instead of an inline player shell', async () => {


### PR DESCRIPTION
## Summary

- Avoid resetting the Expo Video player to `currentTime = 0` during `stop`/`destroy`, which removes unnecessary Android player work during rapid video open/close cycles.
- Put hot-path `VideoPlayerContext` logging behind the opt-in `__PEARTUBE_DEBUG_VIDEO_PLAYER__` dev flag.
- Add an action-only video player context and move feed/search/studio action consumers to it so progress updates do not rerender those screens.

## Validation

- `node --test packages/app/tests/pear-inline-player-view.test.mjs packages/app/tests/video-player-loading-clears-regression.test.mjs packages/app/tests/player-port-contract-regression.test.mjs packages/app/tests/mobile-player-page-layout-regression.test.mjs` passed: 27/27.
- `git diff --check --cached` passed.
- `./node_modules/.bin/tsc --noEmit --pretty false` still fails on existing app-wide TypeScript issues, including missing `@gluestack-ui/*` / `@tamagui/*` declarations and unrelated errors in discover/home/player styling/state files.