### PR TITLE
fix(relay): stop stalled blob downloads

### DIFF
--- a/packages/cli/src/blob-downloader.js
+++ b/packages/cli/src/blob-downloader.js
@@ -3,6 +3,7 @@ import { loadPublicBee } from '@peartube/backend/storage'
 import { normalizeBlobRefInput } from '@peartube/backend/blob-ref'
 
 const VIDEO_DOWNLOAD_TIMEOUT_MS = 60_000
+const DOWNLOAD_PROGRESS_IDLE_MS = 10_000
 const BLOB_DOWNLOAD_TIMEOUT = 'BLOB_DOWNLOAD_TIMEOUT'
 
 function parseBlobId(blobId) {
@@ -23,7 +24,47 @@ function timeoutPromise(timeoutMs) {
 }
 
 function isBlobDownloadTimeout(err) {
-  return err?.code === BLOB_DOWNLOAD_TIMEOUT || /^Blob download timeout \(\d+ms\)$/.test(err?.message || '')
+  return err?.code === BLOB_DOWNLOAD_TIMEOUT || /^Blob download (?:idle )?timeout \(.*\)$/.test(err?.message || '')
+}
+
+
+function createIdleProgressGuard({ timeoutMs, onTimeout }) {
+  let timer = null
+  let settled = false
+  let rejectGuard = null
+
+  const promise = new Promise((_, reject) => {
+    rejectGuard = reject
+  })
+
+  const clear = () => {
+    if (timer) clearTimeout(timer)
+    timer = null
+  }
+
+  const bump = () => {
+    if (settled) return
+    clear()
+    timer = setTimeout(() => {
+      if (settled) return
+      settled = true
+      try { onTimeout?.() } catch {
+        // Best effort cleanup only.
+      }
+      const err = new Error(`Blob download idle timeout (${timeoutMs}ms without progress)`)
+      err.code = BLOB_DOWNLOAD_TIMEOUT
+      rejectGuard(err)
+    }, timeoutMs)
+    timer?.unref?.()
+  }
+
+  const stop = () => {
+    settled = true
+    clear()
+  }
+
+  bump()
+  return { promise, bump, stop }
 }
 
 function isDiscoveryMirror(options) {
@@ -101,8 +142,8 @@ async function downloadBlobRef(ctx, ref) {
   if (ctx.swarm && !ctx.swarm.destroyed && blobsCore.discoveryKey) {
     try {
       discoveryHandle = ctx.swarm.join(blobsCore.discoveryKey, { server: true, client: true })
-    } catch (err) {
-      void err
+    } catch {
+      // Discovery joins are opportunistic for relay prefetching.
     }
   }
 
@@ -111,17 +152,40 @@ async function downloadBlobRef(ctx, ref) {
     end: blockOffset + blockLength
   })
 
+  const idleGuard = createIdleProgressGuard({
+    timeoutMs: DOWNLOAD_PROGRESS_IDLE_MS,
+    onTimeout: () => {
+      try { download.destroy?.() } catch {
+      // Best effort cleanup only.
+    }
+    }
+  })
+  const onDownload = () => idleGuard.bump()
+  const onAppend = () => idleGuard.bump()
+  blobsCore.on?.('download', onDownload)
+  blobsCore.on?.('append', onAppend)
+
   try {
     await Promise.race([
       download.done(),
-      timeoutPromise(VIDEO_DOWNLOAD_TIMEOUT_MS)
+      timeoutPromise(VIDEO_DOWNLOAD_TIMEOUT_MS),
+      idleGuard.promise
     ])
   } catch (err) {
-    try { download.destroy?.() } catch {}
+    try { download.destroy?.() } catch {
+      // Best effort cleanup only.
+    }
     throw err
   } finally {
-    try { await discoveryHandle?.destroy?.() } catch {}
-    try { await discoveryHandle?.close?.() } catch {}
+    idleGuard.stop()
+    blobsCore.off?.('download', onDownload)
+    blobsCore.off?.('append', onAppend)
+    try { await discoveryHandle?.destroy?.() } catch {
+      // Best effort cleanup only.
+    }
+    try { await discoveryHandle?.close?.() } catch {
+      // Best effort cleanup only.
+    }
   }
 
   if (Number.isFinite(ref.blobId?.byteLength)) return Number(ref.blobId.byteLength)

--- a/packages/cli/test/blob-downloader.test.mjs
+++ b/packages/cli/test/blob-downloader.test.mjs
@@ -1,8 +1,10 @@
 import test from 'brittle'
+import { EventEmitter } from 'node:events'
 import { downloadChannelBlobs, addVideoDownloadRefs } from '../src/blob-downloader.js'
 
 function createCore({ length = 10, byteLength = 100 } = {}) {
-  return {
+  const core = new EventEmitter()
+  Object.assign(core, {
     length,
     byteLength,
     readyCalls: 0,
@@ -17,7 +19,8 @@ function createCore({ length = 10, byteLength = 100 } = {}) {
         async done() {}
       }
     }
-  }
+  })
+  return core
 }
 
 test('addVideoDownloadRefs collects video and thumbnail blob refs without duplicates', (t) => {
@@ -109,7 +112,8 @@ test('downloadChannelBlobs downloads feed preview refs when PublicBee has no vid
 
 test('downloadChannelBlobs only republishes successfully cached video previews', async (t) => {
   const playableCore = createCore({ length: 4, byteLength: 400 })
-  const missingCore = {
+  const missingCore = new EventEmitter()
+  Object.assign(missingCore, {
     discoveryKey: 'missing-discovery',
     async ready() {},
     download() {
@@ -117,7 +121,7 @@ test('downloadChannelBlobs only republishes successfully cached video previews',
         async done() { throw new Error('remote blocks unavailable') }
       }
     }
-  }
+  })
   const ctx = {
     swarm: { join() {} },
     store: {
@@ -248,5 +252,92 @@ test('downloadChannelBlobs treats discovered blob timeouts as unavailable warnin
       kind: 'video',
       error: 'Blob download timeout (60000ms)'
     })
+  }
+})
+
+
+test('downloadChannelBlobs abandons a stalled blob download after idle timeout', async (t) => {
+  const realSetTimeout = globalThis.setTimeout
+  const realClearTimeout = globalThis.clearTimeout
+  const timers = []
+  globalThis.setTimeout = (fn, ms) => {
+    const timer = {
+      fn,
+      ms,
+      cleared: false,
+      unref() {}
+    }
+    timers.push(timer)
+    return timer
+  }
+  globalThis.clearTimeout = (timer) => {
+    if (timer) timer.cleared = true
+  }
+
+  const stalledCore = createCore({ length: 4, byteLength: 400 })
+  let destroyed = false
+  stalledCore.download = function download(range) {
+    this.downloads.push(range)
+    return {
+      destroy() { destroyed = true },
+      done() { return new Promise(() => {}) }
+    }
+  }
+
+  try {
+    const ctx = {
+      swarm: { join() {} },
+      store: {
+        get() { return stalledCore }
+      }
+    }
+    const warnings = []
+
+    const promise = downloadChannelBlobs(
+      ctx,
+      'ee'.repeat(32),
+      'chan-stalled',
+      { info() {}, debug() {}, warn(...args) { warnings.push(args) }, error() {} },
+      {
+        source: 'discovered',
+        previewVideos: [{
+          id: 'stalled',
+          title: 'Stalled',
+          blobId: '1:2:100:200',
+          blobsCoreKey: 'aa'.repeat(32)
+        }]
+      },
+      {
+        async loadPublicBee() {
+          return {
+            async listVideos() {
+              return []
+            }
+          }
+        }
+      }
+    )
+
+    for (let i = 0; i < 20 && stalledCore.downloads.length === 0; i += 1) {
+      await Promise.resolve()
+    }
+    t.is(stalledCore.downloads.length, 1, 'stalled download should have started')
+    const idleTimer = timers.find((timer) => !timer.cleared && timer.ms === 10_000)
+    t.ok(idleTimer, 'idle timer should be armed')
+    idleTimer.fn()
+
+    const stats = await promise
+    t.ok(destroyed, 'stalled download should be destroyed after idle timeout')
+    t.is(stats.blobsFound, 1)
+    t.is(stats.blobsDownloaded, 0)
+    t.is(stats.blobsFailed, 1)
+    t.is(stats.videosDownloaded, 0)
+    t.alike(stats.previewVideos, [])
+    t.is(warnings.length, 1)
+    t.is(warnings[0][0], '[blob-downloader] Blob download unavailable')
+    t.is(warnings[0][1].error, 'Blob download idle timeout (10000ms without progress)')
+  } finally {
+    globalThis.setTimeout = realSetTimeout
+    globalThis.clearTimeout = realClearTimeout
   }
 })


### PR DESCRIPTION
## Summary
- add an idle-progress guard for relay blob prefetch downloads
- destroy stalled downloads after 10s without `download`/`append` progress instead of waiting for the 60s hard timeout
- classify idle timeouts as unavailable for discovered relay mirrors so stale preview refs are not republished as playable

## Test Plan
- `./packages/cli/node_modules/.bin/brittle packages/cli/test/blob-downloader.test.mjs`
- `./node_modules/.bin/eslint --quiet packages/cli/src/blob-downloader.js packages/cli/test/blob-downloader.test.mjs`
- `git diff --check`
