### PR TITLE
fix(relay): seed discovered channels and clear unavailable previews

### DIFF
--- a/packages/cli/src/admission.js
+++ b/packages/cli/src/admission.js
@@ -45,13 +45,13 @@ export function evaluateCandidate({ candidate, config, acceptedChannels = new Se
     return { accepted: false, reason: 'discovery-disabled', retentionClass: null }
   }
 
-  if (acceptedChannels.size >= config.discovery.maxChannels) {
+  if (Number(config.discovery.maxChannels || 0) > 0 && acceptedChannels.size >= config.discovery.maxChannels) {
     return { accepted: false, reason: 'channel-limit', retentionClass: null }
   }
 
   if (candidate.ownerKey) {
     const ownerChannelCount = ownerCounts.get(candidate.ownerKey) || 0
-    if (ownerChannelCount >= config.discovery.maxChannelsPerOwner) {
+    if (Number(config.discovery.maxChannelsPerOwner || 0) > 0 && ownerChannelCount >= config.discovery.maxChannelsPerOwner) {
       return { accepted: false, reason: 'owner-limit', retentionClass: null }
     }
   }

--- a/packages/cli/src/blob-downloader.js
+++ b/packages/cli/src/blob-downloader.js
@@ -111,6 +111,31 @@ function addSuccessfulPreviewVideo(previews, ref) {
   return addPreviewVideo(previews, ref.sourceVideo)
 }
 
+function addUnavailableVideo(unavailableVideos, ref, err) {
+  if (ref?.kind !== 'video') return false
+  const video = ref.sourceVideo
+  if (!video?.id || !video?.blobId || !video?.blobsCoreKey) return false
+  const id = getVideoKey(video)
+  if (unavailableVideos.some((existing) => getVideoKey(existing) === id)) return false
+  unavailableVideos.push({
+    id: String(video.id),
+    title: video?.title ? String(video.title) : 'Untitled',
+    uploadedAt: Number(video?.uploadedAt || 0) || 0,
+    duration: Number(video?.duration || 0) || 0,
+    thumbnail: video?.thumbnail || null,
+    blobId: String(video.blobId),
+    blobsCoreKey: String(video.blobsCoreKey),
+    mimeType: video?.mimeType || 'video/mp4',
+    availability: 'unavailable',
+    byteAvailability: 'unavailable',
+    unavailableReason: err?.message || (err ? String(err) : 'Blob unavailable'),
+    thumbnailBlobId: video?.thumbnailBlobId || null,
+    thumbnailBlobsCoreKey: video?.thumbnailBlobsCoreKey || null,
+    thumbnailMimeType: video?.thumbnailMimeType || null
+  })
+  return true
+}
+
 function addPreviewVideo(previews, video) {
   if (!video?.id || !video?.blobId || !video?.blobsCoreKey) return false
   const id = getVideoKey(video)
@@ -209,6 +234,7 @@ export async function downloadChannelBlobs(ctx, publicBeeKey, driveKey, logger =
     thumbnailsDownloaded: 0,
     bytesDownloaded: 0,
     previewVideos: [],
+    unavailableVideos: [],
     videoCount: 0,
     lastError: null
   }
@@ -258,20 +284,21 @@ export async function downloadChannelBlobs(ctx, publicBeeKey, driveKey, logger =
       } catch (err) {
         stats.blobsFailed += 1
         stats.lastError = err?.message || String(err)
+        if (ref.kind === 'video') addUnavailableVideo(stats.unavailableVideos, ref, err)
         const logUnavailable = isDiscoveryMirror(options) && isBlobDownloadTimeout(err)
         const logFailure = logUnavailable && typeof logger.warn === 'function'
           ? logger.warn.bind(logger)
           : logError
         logFailure(logUnavailable ? '[blob-downloader] Blob download unavailable' : '[blob-downloader] Blob download failed', {
           driveKey,
-          videoId: ref.videoId || '<unknown-video>',
+          videoId: ref.videoId || ref.sourceVideo?.id || '<unknown-video>',
           kind: ref.kind,
           error: stats.lastError
         })
       }
     }
 
-    stats.videoCount = Math.max(stats.videoCount, stats.previewVideos.length, stats.videosDownloaded)
+    stats.videoCount = Math.max(stats.videoCount, stats.previewVideos.length, stats.unavailableVideos.length, stats.videosDownloaded)
 
     logInfo('[blob-downloader] Channel blob download complete', {
       driveKey,

--- a/packages/cli/src/cache-manager.js
+++ b/packages/cli/src/cache-manager.js
@@ -70,7 +70,7 @@ export class CacheManager {
         existing.source = 'pinned'
         changed = true
       }
-      if (Array.isArray(options.previewVideos)) {
+      if (Array.isArray(options.previewVideos) || options.clearPreviewVideos === true) {
         const nextSignature = JSON.stringify(previewVideos)
         const currentSignature = JSON.stringify(existing.previewVideos || [])
         if (nextSignature !== currentSignature) {

--- a/packages/cli/src/config.js
+++ b/packages/cli/src/config.js
@@ -248,9 +248,10 @@ function configFromEnv(env = {}) {
     if (env.PEARTUBE_ADMISSION_CHANNELS) config.admission.channels = splitCommaList(env.PEARTUBE_ADMISSION_CHANNELS)
     if (env.PEARTUBE_ADMISSION_OWNERS) config.admission.owners = splitCommaList(env.PEARTUBE_ADMISSION_OWNERS)
   }
-  if (env.PEARTUBE_DISCOVERY_ENABLED || env.PEARTUBE_DISCOVERY_MAX_CHANNELS || env.PEARTUBE_DISCOVERY_MAX_CHANNELS_PER_OWNER) {
+  if (env.PEARTUBE_DISCOVERY_ENABLED || env.PEARTUBE_DISCOVERY_SEED_DISCOVERED || env.PEARTUBE_DISCOVERY_MAX_CHANNELS || env.PEARTUBE_DISCOVERY_MAX_CHANNELS_PER_OWNER) {
     config.discovery = {}
     if (env.PEARTUBE_DISCOVERY_ENABLED) config.discovery.enabled = parseBoolean(env.PEARTUBE_DISCOVERY_ENABLED)
+    if (env.PEARTUBE_DISCOVERY_SEED_DISCOVERED) config.discovery.seedDiscovered = parseBoolean(env.PEARTUBE_DISCOVERY_SEED_DISCOVERED)
     if (env.PEARTUBE_DISCOVERY_MAX_CHANNELS) config.discovery.maxChannels = Number(env.PEARTUBE_DISCOVERY_MAX_CHANNELS)
     if (env.PEARTUBE_DISCOVERY_MAX_CHANNELS_PER_OWNER) {
       config.discovery.maxChannelsPerOwner = Number(env.PEARTUBE_DISCOVERY_MAX_CHANNELS_PER_OWNER)
@@ -589,6 +590,7 @@ export function resolveRelayConfig(input = {}, { env = process.env || {} } = {})
   config.discovery.enabled = config.mode === RELAY_MODE_PUBLIC && config.policy === RELAY_POLICY_DISCOVERY
     ? config.discovery.enabled !== false
     : false
+  config.discovery.seedDiscovered = config.discovery.seedDiscovered !== false
   config.discovery.maxChannels = Number(config.discovery.maxChannels)
   config.discovery.maxChannelsPerOwner = Number(config.discovery.maxChannelsPerOwner)
 
@@ -667,6 +669,7 @@ export function renderExampleConfig(config = DEFAULT_RELAY_CONFIG) {
   lines.push(
     'discovery:',
     `  enabled: ${config.discovery.enabled}`,
+    `  seedDiscovered: ${config.discovery.seedDiscovered !== false}`,
     `  maxChannels: ${config.discovery.maxChannels}`,
     `  maxChannelsPerOwner: ${config.discovery.maxChannelsPerOwner}`
   )

--- a/packages/cli/src/constants.js
+++ b/packages/cli/src/constants.js
@@ -13,8 +13,8 @@ export const VALID_POLICIES = [RELAY_POLICY_ALLOWLIST, RELAY_POLICY_DISCOVERY]
 export const DEFAULT_STORAGE_PATH = './peartube-relay'
 export const DEFAULT_MAX_BYTES = 100000 * 1024 * 1024
 
-export const DEFAULT_DISCOVERY_MAX_CHANNELS = 500
-export const DEFAULT_DISCOVERY_MAX_CHANNELS_PER_OWNER = 20
+export const DEFAULT_DISCOVERY_MAX_CHANNELS = 0
+export const DEFAULT_DISCOVERY_MAX_CHANNELS_PER_OWNER = 0
 
 export const RELAY_CATALOG_FILENAME = 'relay-catalog.json'
 export const RELAY_STATUS_FILENAME = 'relay-status.json'
@@ -82,6 +82,7 @@ export const DEFAULT_RELAY_CONFIG = {
   },
   discovery: {
     enabled: true,
+    seedDiscovered: true,
     maxChannels: DEFAULT_DISCOVERY_MAX_CHANNELS,
     maxChannelsPerOwner: DEFAULT_DISCOVERY_MAX_CHANNELS_PER_OWNER
   },

--- a/packages/cli/src/runtime.js
+++ b/packages/cli/src/runtime.js
@@ -45,7 +45,7 @@ function buildNetworkDoctor({
   return doctor
 }
 
-export async function createRelayRuntime({ config, logger }) {
+export async function createRelayRuntime({ config, logger } = {}) {
   const [
     { initializeStorage, loadChannel, loadPublicBee, getNetworkStats },
     { PublicFeedManager },
@@ -121,8 +121,16 @@ export async function createRelayRuntime({ config, logger }) {
   })
   let candidateHandler = null
 
+  function discoveryAcceptsCandidates() {
+    if (config?.policy === 'allowlist') return false
+    if (config?.discovery?.enabled === false) return false
+    if (config?.discovery?.seedDiscovered === false) return false
+    return true
+  }
+
   function emitFeedEntries() {
     if (typeof candidateHandler !== 'function') return
+    if (!discoveryAcceptsCandidates()) return
 
     for (const entry of publicFeed.getFeed?.() || publicFeed.entries.values()) {
       if (!entry?.driveKey || !entry?.publicBeeKey) continue

--- a/packages/cli/src/service.js
+++ b/packages/cli/src/service.js
@@ -246,6 +246,17 @@ export async function createRelayService({
         decision
       })
 
+      const mirrorUnavailableVideos = Array.isArray(mirrorStats?.unavailableVideos) ? mirrorStats.unavailableVideos : []
+      const hasUnavailableVideos = mirrorUnavailableVideos.length > 0
+      const mirrorReturnedPreviewVideos = Array.isArray(mirrorStats?.previewVideos)
+      const refreshedPreviewVideos = mirrorReturnedPreviewVideos
+        ? mirrorStats.previewVideos
+        : (hasUnavailableVideos
+            ? []
+            : (Array.isArray(existingChannel?.previewVideos) && existingChannel.previewVideos.length > 0
+                ? existingChannel.previewVideos
+                : undefined))
+
       await relayCatalog.upsertChannel({
         ...baseRecord,
         ...mirrorAttemptRecord,
@@ -254,9 +265,8 @@ export async function createRelayService({
         videosDownloaded: mirrorStats?.videosDownloaded || 0,
         mirroredAt: now,
         lastError: mirrorStats?.lastError || null,
-        previewVideos: Array.isArray(mirrorStats?.previewVideos)
-          ? mirrorStats.previewVideos
-          : undefined,
+        previewVideos: refreshedPreviewVideos,
+        unavailableVideos: hasUnavailableVideos ? mirrorUnavailableVideos : [],
         videoCount: Number(mirrorStats?.videoCount || mirrorStats?.videosDownloaded || mirrorStats?.videosFound || 0) || 0,
         manifestUpdatedAt: now
       })
@@ -273,9 +283,13 @@ export async function createRelayService({
       if (resolved.publicBeeKey) {
         const seedPreviewVideos = Array.isArray(mirrorStats?.previewVideos)
           ? mirrorStats.previewVideos
-          : []
+          : (hasUnavailableVideos ? [] : (Array.isArray(resolved.previewVideos) ? resolved.previewVideos : []))
+        const persistedPreviewVideos = seedPreviewVideos.length > 0
+          ? seedPreviewVideos
+          : (hasUnavailableVideos || mirrorReturnedPreviewVideos ? [] : (Array.isArray(existingChannel?.previewVideos) ? existingChannel.previewVideos : []))
         await runtime.cacheManager?.addChannel?.(resolved.channelKey, resolved.publicBeeKey, 'discovered', {
-          previewVideos: seedPreviewVideos
+          previewVideos: seedPreviewVideos,
+          clearPreviewVideos: hasUnavailableVideos
         }).catch(() => {})
         const seedStats = await runtime.seeder?.seedChannel?.({
           driveKey: resolved.channelKey,
@@ -290,8 +304,9 @@ export async function createRelayService({
           source: 'relay-cache',
           relayRole: 'cache',
           relayServing: true,
-          previewVideos: seedPreviewVideos,
-          videoCount: Number(mirrorStats?.videoCount || mirrorStats?.videosDownloaded || mirrorStats?.videosFound || seedPreviewVideos.length || 0) || 0,
+          previewVideos: persistedPreviewVideos,
+          unavailableVideos: mirrorUnavailableVideos,
+          videoCount: Number(mirrorStats?.videoCount || mirrorStats?.videosDownloaded || mirrorStats?.videosFound || persistedPreviewVideos.length || 0) || 0,
           manifestUpdatedAt: now
         }
         await runtime.publishRelayCatalogEntry?.(catalogEntry).catch(() => {})

--- a/packages/cli/test/blob-downloader.test.mjs
+++ b/packages/cli/test/blob-downloader.test.mjs
@@ -341,3 +341,63 @@ test('downloadChannelBlobs abandons a stalled blob download after idle timeout',
     globalThis.clearTimeout = realClearTimeout
   }
 })
+
+test('downloadChannelBlobs reports unavailable refs after timeout without republishing them', async (t) => {
+  const timeoutCore = {
+    length: 4,
+    byteLength: 400,
+    discoveryKey: 'timeout-discovery',
+    downloads: [],
+    async ready() {},
+    download(range) {
+      this.downloads.push(range)
+      return {
+        async done() { throw new Error('Blob download timeout (60000ms)') }
+      }
+    }
+  }
+  const errors = []
+  const ctx = {
+    swarm: { join() {} },
+    store: {
+      get(key) {
+        const keyHex = Buffer.isBuffer(key) ? key.toString('hex') : String(key)
+        if (keyHex.startsWith('dd')) return timeoutCore
+        throw new Error()
+      }
+    }
+  }
+
+  const stats = await downloadChannelBlobs(
+    ctx,
+    'ee'.repeat(32),
+    'chan-timeout',
+    { info() {}, debug() {}, error(...args) { errors.push(args) } },
+    {
+      previewVideos: [{
+        id: 'timeout-video',
+        title: 'Timeout Video',
+        blobId: '1:2:100:200',
+        blobsCoreKey: 'dd'.repeat(32)
+      }]
+    },
+    {
+      async loadPublicBee() {
+        return {
+          async listVideos() { return [] }
+        }
+      }
+    }
+  )
+
+  t.is(stats.blobsFound, 1)
+  t.is(stats.blobsDownloaded, 0)
+  t.is(stats.videosDownloaded, 0)
+  t.is(stats.previewVideos.length, 0)
+  t.is(stats.unavailableVideos.length, 1)
+  t.is(stats.unavailableVideos[0].id, 'timeout-video')
+  t.is(stats.unavailableVideos[0].availability, 'unavailable')
+  t.is(stats.unavailableVideos[0].byteAvailability, 'unavailable')
+  t.ok(stats.unavailableVideos[0].unavailableReason.includes('Blob download timeout'))
+  t.is(errors.length, 1)
+})

--- a/packages/cli/test/config.test.mjs
+++ b/packages/cli/test/config.test.mjs
@@ -19,6 +19,18 @@ test('resolveRelayConfig defaults to public discovery mode', async (t) => {
   t.is(config.paths.corestore, 'peartube-relay/corestore')
 })
 
+
+test('resolveRelayConfig defaults public discovery relays to seed every discovered channel', async (t) => {
+  const config = resolveRelayConfig({}, { env: {} })
+
+  t.is(config.mode, 'public')
+  t.is(config.policy, 'discovery')
+  t.is(config.discovery.enabled, true)
+  t.is(config.discovery.seedDiscovered, true)
+  t.is(config.discovery.maxChannels, 0)
+  t.is(config.discovery.maxChannelsPerOwner, 0)
+})
+
 test('resolveRelayConfig forces private mode to allowlist policy', async (t) => {
   const config = resolveRelayConfig({ mode: 'private' }, { env: {} })
 
@@ -98,6 +110,7 @@ test('loadRelayConfig supports env-only relay configuration', async (t) => {
       PEARTUBE_ADMISSION_CHANNELS: 'chan-a,chan-b',
       PEARTUBE_ADMISSION_OWNERS: 'owner-a',
       PEARTUBE_DISCOVERY_ENABLED: 'false',
+      PEARTUBE_DISCOVERY_SEED_DISCOVERED: 'false',
       PEARTUBE_DISCOVERY_MAX_CHANNELS: '12',
       PEARTUBE_DISCOVERY_MAX_CHANNELS_PER_OWNER: '3',
       PEARTUBE_NETWORK_ANNOUNCE: 'false',
@@ -118,6 +131,7 @@ test('loadRelayConfig supports env-only relay configuration', async (t) => {
   t.alike(config.admission.channels, ['chan-a', 'chan-b'])
   t.alike(config.admission.owners, ['owner-a'])
   t.is(config.discovery.enabled, false)
+  t.is(config.discovery.seedDiscovered, false)
   t.is(config.discovery.maxChannels, 12)
   t.is(config.discovery.maxChannelsPerOwner, 3)
   t.is(config.network.announce, false)

--- a/packages/cli/test/service.test.mjs
+++ b/packages/cli/test/service.test.mjs
@@ -264,6 +264,50 @@ test('createRelayService publishes discovered relay inventory as relay catalog f
   }
 })
 
+
+test('createRelayService accepts discovered channels by default without discovery caps', async (t) => {
+  const dir = makeTempDir('peartube-relay-service-default-discovery-')
+  const runtime = createFakeRuntime()
+  const mirrored = []
+
+  try {
+    const service = await createRelayService({
+      config: {
+        mode: 'public',
+        policy: 'discovery',
+        storage: { path: dir, maxBytes: 10_000 },
+        paths: {
+          catalog: join(dir, 'relay-catalog.json'),
+          status: join(dir, 'relay-status.json')
+        },
+        admission: { channels: [], owners: [] },
+        discovery: {
+          enabled: true,
+          seedDiscovered: true,
+          maxChannels: 0,
+          maxChannelsPerOwner: 0
+        }
+      },
+      logger: createFakeLogger(),
+      runtimeFactory: async () => runtime,
+      mirrorChannel: async (candidate) => {
+        mirrored.push(candidate.channelKey)
+        return { bytesDownloaded: 1024, videosFound: 1, videosDownloaded: 1 }
+      },
+      writeStatusFile: async () => {}
+    })
+
+    await service.start()
+    await runtime.emit({ channelKey: 'chan-open-default', publicBeeKey: 'bee-open-default' })
+
+    t.alike(mirrored, ['chan-open-default'])
+    t.is(service.catalog.getChannel('chan-open-default').retentionClass, 'discovery')
+    await service.close()
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('createRelayService starts without forcing an eager feed sync', async (t) => {
   const dir = makeTempDir('peartube-relay-service-logs-')
   const runtime = createFakeRuntime()
@@ -1011,6 +1055,69 @@ test('createRelayService clears playable previews when accepted refresh mirror t
     t.is(channel.videosDownloaded, 0)
     t.is(channel.bytes, 0)
     t.is(channel.lastError, 'mirror unavailable')
+    await service.close()
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+
+test('createRelayService marks timed-out preview refs unavailable instead of preserving them', async (t) => {
+  const dir = makeTempDir('peartube-relay-service-unavailable-refresh-')
+  const runtime = createFakeRuntime()
+  const previewVideos = [{
+    id: 'preview-timeout',
+    blobId: '0:2:0:20',
+    blobsCoreKey: 'aa'.repeat(32),
+    availability: 'playable'
+  }]
+  const unavailableVideos = [{
+    id: 'preview-timeout',
+    blobId: '0:2:0:20',
+    blobsCoreKey: 'aa'.repeat(32),
+    availability: 'unavailable',
+    byteAvailability: 'unavailable',
+    unavailableReason: 'Blob download timeout (60000ms)'
+  }]
+  const published = []
+
+  try {
+    const service = await createRelayService({
+      config: {
+        mode: 'public',
+        policy: 'discovery',
+        storage: { path: dir, maxBytes: 10_000 },
+        paths: {
+          catalog: join(dir, 'relay-catalog.json'),
+          status: join(dir, 'relay-status.json')
+        },
+        admission: { channels: [], owners: [] },
+        discovery: { enabled: true, maxChannels: 5, maxChannelsPerOwner: 2 }
+      },
+      logger: createFakeLogger(),
+      runtimeFactory: async () => runtime,
+      mirrorChannel: async () => ({
+        bytesDownloaded: 0,
+        videosFound: 1,
+        videosDownloaded: 0,
+        previewVideos: [],
+        unavailableVideos,
+        videoCount: 1
+      }),
+      writeStatusFile: async () => {}
+    })
+    runtime.publishRelayCatalogEntry = async (entry) => { published.push(entry) }
+
+    await service.start()
+    await runtime.emit({ channelKey: 'chan-unavailable-refresh', publicBeeKey: 'bee-unavailable-refresh', source: 'discovered', previewVideos })
+
+    const channel = service.catalog.getChannel('chan-unavailable-refresh')
+    t.alike(channel.previewVideos, [])
+    t.is(channel.unavailableVideos.length, 1)
+    t.is(channel.unavailableVideos[0].availability, 'unavailable')
+    t.is(channel.videosDownloaded, 0)
+    t.is(published[published.length - 1].previewVideos.length, 0)
+    t.is(published[published.length - 1].unavailableVideos.length, 1)
     await service.close()
   } finally {
     rmSync(dir, { recursive: true, force: true })


### PR DESCRIPTION
## Summary

- Default public discovery relays to seed every discovered channel unless `discovery.seedDiscovered` is explicitly false.
- Treat `discovery.maxChannels: 0` and `maxChannelsPerOwner: 0` as unlimited instead of blocking discovery admission.
- Track timed-out preview refs as `unavailableVideos`, clear stale playable preview refs from cache/catalog publication, and keep presence-only/snare relays explicit.

## Validation

- `npm test --prefix packages/cli -- test/blob-downloader.test.mjs test/config.test.mjs test/service.test.mjs` passed: 103/103.
- `git diff --check` passed.
