### PR TITLE
[codex] fix playback seeking for uncached streams

### DIFF
--- a/packages/app/components/video-player/PearInlineVideoView.tsx
+++ b/packages/app/components/video-player/PearInlineVideoView.tsx
@@ -43,6 +43,7 @@ const ANDROID_BUFFER_OPTIONS = {
   preferredForwardBufferDuration: 20,
   waitsToMinimizeStalling: true,
 }
+const SEEK_PLAYBACK_RECOVERY_MS = 6000
 
 function getExpoEventDurationMs(data: any, player?: VideoPlayer | null) {
   const rawDurationSeconds = Number(data?.duration ?? player?.duration ?? 0)
@@ -101,6 +102,8 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
   const wasInPipRef = useRef(isInPipMode)
   const playerRefForCallbacks = useRef<VideoPlayer | null>(null)
   const previousStatusRef = useRef<string | null>(null)
+  const seekPlaybackRecoveryUntilRef = useRef(0)
+  const isPlayingRef = useRef(isPlaying)
 
   const player = useVideoPlayer({ uri: videoUrl, metadata: {
     title: videoTitle || undefined,
@@ -132,8 +135,13 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
     playbackStartedAtRef.current = null
     lastAppliedSeekRef.current = null
     previousStatusRef.current = null
+    seekPlaybackRecoveryUntilRef.current = 0
     playerRefForCallbacks.current = player
   }, [player, videoUrl, playbackSession, currentVideoKey])
+
+  useEffect(() => {
+    isPlayingRef.current = isPlaying
+  }, [isPlaying])
 
   const shouldSuppressStuckPlaybackRecovery = useCallback(() => {
     if (Platform.OS !== 'android') return false
@@ -157,6 +165,7 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
     if (lastAppliedSeekRef.current === Math.round(targetSeconds * 1000)) return
 
     lastAppliedSeekRef.current = Math.round(targetSeconds * 1000)
+    seekPlaybackRecoveryUntilRef.current = Date.now() + SEEK_PLAYBACK_RECOVERY_MS
     player.currentTime = Math.max(0, targetSeconds)
   }, [player])
 
@@ -178,6 +187,7 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
           player.currentTime = 0
         },
         seek: async (timeSeconds: number) => {
+          seekPlaybackRecoveryUntilRef.current = Date.now() + SEEK_PLAYBACK_RECOVERY_MS
           player.currentTime = Math.max(0, timeSeconds)
         },
         resume: async (playing: boolean) => {
@@ -216,6 +226,7 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
   }, [player, showNotificationControls])
 
   useEffect(() => {
+    isPlayingRef.current = isPlaying
     if (isPlaying) {
       player.play()
     } else {
@@ -330,12 +341,17 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
     if (nativePlaying) {
       hasReceivedPlayEventRef.current = true
       pipExitPlayingRef.current = false
+      seekPlaybackRecoveryUntilRef.current = 0
       onPlaying?.()
       return
     }
 
     if (Platform.OS === 'web' && !hasReceivedPlayEventRef.current) return
     if (pipExitPlayingRef.current) return
+    if (Date.now() <= seekPlaybackRecoveryUntilRef.current && isPlayingRef.current) {
+      onBuffering?.({ isBuffering: true })
+      return
+    }
     onPaused?.()
   })
 
@@ -346,13 +362,16 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
         onBuffering?.({ isBuffering: true })
       } else if (status === 'readyToPlay') {
         onBuffering?.({ isBuffering: false })
+        if (Date.now() <= seekPlaybackRecoveryUntilRef.current && isPlayingRef.current) {
+          player.play()
+        }
       }
     }
     if (status === 'error') {
       console.error('[PearInlineVideoView] error:', error)
       onError?.({
         message: error?.message || 'Unknown error',
-        code: error?.code,
+        code: (error as any)?.code,
         engine: 'expo-video',
       })
     }

--- a/packages/app/lib/VideoPlayerContext.tsx
+++ b/packages/app/lib/VideoPlayerContext.tsx
@@ -304,6 +304,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
   }, [])
 
   const setDesiredPlaying = useCallback((nextIsPlaying: boolean) => {
+    isPlayingRef.current = nextIsPlaying
     setIsPlaying(nextIsPlaying)
   }, [])
 
@@ -1147,6 +1148,14 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
       pipExitShouldResumeRef.current = false
       pipExitExpectedPlayingRef.current = false
     }
+    if (seekConfirmRef.current && isPlayingRef.current) {
+      console.log('[VideoPlayerContext] Ignoring transient paused event during seek')
+      isBufferingRef.current = true
+      try {
+        getPlayerPort()?.play?.()
+      } catch {}
+      return
+    }
     console.log('[VideoPlayerContext] Player paused')
     // Sync JS state for deliberate external pauses (PiP button, notification
     // pause, audio focus loss). Skip if the player is buffering — that's a
@@ -1157,7 +1166,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
     if (!isBufferingRef.current) {
       setIsPlaying(false)
     }
-  }, [reassertNativePlayAfterPipExit])
+  }, [getPlayerPort, reassertNativePlayAfterPipExit])
 
   const onBuffering = useCallback((data: { isBuffering: boolean }) => {
     console.log('[VideoPlayerContext] Player buffering:', data?.isBuffering)

--- a/packages/app/tests/video-player-streaming-seek-regression.test.mjs
+++ b/packages/app/tests/video-player-streaming-seek-regression.test.mjs
@@ -1,0 +1,52 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const appRoot = path.resolve(__dirname, '..')
+
+function readAppFile(relativePath) {
+  return fs.readFileSync(path.join(appRoot, relativePath), 'utf8')
+}
+
+test('VideoPlayerContext treats seek-time native pauses as buffering, not user pauses', () => {
+  const source = readAppFile('lib/VideoPlayerContext.tsx')
+  const pausedStart = source.indexOf('const onPaused = useCallback')
+  assert.notEqual(pausedStart, -1, 'expected onPaused callback')
+  const pausedHandler = source.slice(pausedStart, source.indexOf('const onBuffering', pausedStart))
+
+  assert.match(
+    pausedHandler,
+    /seekConfirmRef\.current[\s\S]*isPlayingRef\.current[\s\S]*getPlayerPort\(\)\?\.play\?\.\(\)[\s\S]*return/,
+    'seek-induced pause events should be ignored and playback reasserted before JS flips isPlaying=false',
+  )
+})
+
+test('PearInlineVideoView reasserts desired playback after seek buffering resolves', () => {
+  const source = readAppFile('components/video-player/PearInlineVideoView.tsx')
+  const adapterStart = source.indexOf('const adapter = useMemo')
+  assert.notEqual(adapterStart, -1, 'expected PlayerPort adapter')
+  const adapterBlock = source.slice(adapterStart, source.indexOf('useEffect(() => {\n    player.playbackRate', adapterStart))
+  const statusStart = source.indexOf("useEventListener(player, 'statusChange'")
+  assert.notEqual(statusStart, -1, 'expected statusChange listener')
+  const statusBlock = source.slice(statusStart, source.indexOf("useEventListener(player, 'playToEnd'", statusStart))
+
+  assert.match(
+    source,
+    /const SEEK_PLAYBACK_RECOVERY_MS = \d+/,
+    'native player should have a bounded seek recovery window',
+  )
+  assert.match(
+    adapterBlock,
+    /seekPlaybackRecoveryUntilRef\.current = Date\.now\(\) \+ SEEK_PLAYBACK_RECOVERY_MS[\s\S]*player\.currentTime = Math\.max\(0, timeSeconds\)/,
+    'imperative seeks should mark a recovery window before moving the native currentTime',
+  )
+  assert.match(
+    statusBlock,
+    /status === 'readyToPlay'[\s\S]*Date\.now\(\) <= seekPlaybackRecoveryUntilRef\.current[\s\S]*isPlayingRef\.current[\s\S]*player\.play\(\)/,
+    'readyToPlay after a seek should reassert the desired playing state',
+  )
+})

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -75,6 +75,7 @@
     "hypercore": "^11.28.1",
     "hypercore-blob-server": "^1.12.0",
     "hypercore-crypto": "^3.6.1",
+    "hypercore-id-encoding": "^1.3.0",
     "hyperdispatch": "^1.5.1",
     "hyperswarm": "^4.17.0",
     "hyperswarm-stats": "^1.3.0",

--- a/packages/backend/src/blob-range-priority.js
+++ b/packages/backend/src/blob-range-priority.js
@@ -1,0 +1,187 @@
+import c from 'compact-encoding'
+import HypercoreID from 'hypercore-id-encoding'
+import z32 from 'z32'
+
+const DEFAULT_BLOB_RANGE_READ_AHEAD_BYTES = 2 * 1024 * 1024
+const DEFAULT_BLOB_RANGE_PRIORITY_TIMEOUT_MS = 15000
+
+const blobIdEncoding = {
+  preencode(state, blob) {
+    c.uint.preencode(state, blob.blockOffset)
+    c.uint.preencode(state, blob.blockLength)
+    c.uint.preencode(state, blob.byteOffset)
+    c.uint.preencode(state, blob.byteLength)
+  },
+  encode(state, blob) {
+    c.uint.encode(state, blob.blockOffset)
+    c.uint.encode(state, blob.blockLength)
+    c.uint.encode(state, blob.byteOffset)
+    c.uint.encode(state, blob.byteLength)
+  },
+  decode(state) {
+    return {
+      blockOffset: c.uint.decode(state),
+      blockLength: c.uint.decode(state),
+      byteOffset: c.uint.decode(state),
+      byteLength: c.uint.decode(state)
+    }
+  }
+}
+
+function isFiniteNonNegativeInteger(value) {
+  return Number.isInteger(value) && value >= 0
+}
+
+export function parseHttpByteRange(rangeHeader, byteLength) {
+  if (typeof rangeHeader !== 'string' || !rangeHeader.startsWith('bytes=')) return null
+  const totalBytes = Number(byteLength)
+  if (!Number.isFinite(totalBytes) || totalBytes <= 0) return null
+
+  const match = rangeHeader.match(/^bytes=(\d*)-(\d*)$/)
+  if (!match) return null
+
+  const [, rawStart, rawEnd] = match
+  if (!rawStart && !rawEnd) return null
+
+  let start
+  let end
+
+  if (!rawStart) {
+    const suffixLength = Number(rawEnd)
+    if (!Number.isInteger(suffixLength) || suffixLength <= 0) return null
+    start = Math.max(0, totalBytes - suffixLength)
+    end = totalBytes - 1
+  } else {
+    start = Number(rawStart)
+    end = rawEnd ? Number(rawEnd) : totalBytes - 1
+  }
+
+  if (!isFiniteNonNegativeInteger(start) || !isFiniteNonNegativeInteger(end)) return null
+  if (start >= totalBytes) return null
+  end = Math.min(end, totalBytes - 1)
+  if (end < start) return null
+
+  return { start, end }
+}
+
+export function getPrioritizedBlobDownloadRange(blob, byteRange, options = {}) {
+  if (!blob || !byteRange) return null
+
+  const blockOffset = Number(blob.blockOffset)
+  const blockLength = Number(blob.blockLength)
+  const byteLength = Number(blob.byteLength)
+  const rangeStart = Number(byteRange.start)
+  const rangeEnd = Number(byteRange.end)
+
+  if (!isFiniteNonNegativeInteger(blockOffset)) return null
+  if (!Number.isInteger(blockLength) || blockLength <= 0) return null
+  if (!Number.isFinite(byteLength) || byteLength <= 0) return null
+  if (!isFiniteNonNegativeInteger(rangeStart) || !isFiniteNonNegativeInteger(rangeEnd)) return null
+  if (rangeEnd < rangeStart || rangeStart >= byteLength) return null
+
+  const readAheadBytes = Math.max(0, Number(options.readAheadBytes ?? DEFAULT_BLOB_RANGE_READ_AHEAD_BYTES) || 0)
+  const bytesPerBlock = Math.max(1, byteLength / blockLength)
+  const prioritizedEndByte = Math.min(byteLength - 1, rangeEnd + readAheadBytes)
+  const relativeStartBlock = Math.max(0, Math.min(blockLength - 1, Math.floor(rangeStart / bytesPerBlock)))
+  const relativeEndBlock = Math.max(
+    relativeStartBlock + 1,
+    Math.min(blockLength, Math.ceil((prioritizedEndByte + 1) / bytesPerBlock))
+  )
+  const start = blockOffset + relativeStartBlock
+  const end = blockOffset + relativeEndBlock
+
+  return { start, end, blocks: end - start }
+}
+
+function decodeBlobParam(value) {
+  if (typeof value !== 'string' || value.length === 0) return null
+  try {
+    return c.decode(blobIdEncoding, z32.decode(value))
+  } catch {
+    return null
+  }
+}
+
+function decodeBlobRangeRequest(blobServer, req) {
+  const rangeHeader = req?.headers?.range
+  if (!rangeHeader) return null
+
+  let url
+  try {
+    url = new URL(req.url, 'http://127.0.0.1')
+  } catch {
+    return null
+  }
+
+  const token = url.searchParams.get('token') || ''
+  if (blobServer?.token && token !== blobServer.token) return null
+
+  const encodedKey = url.searchParams.get('key')
+  const encodedBlob = url.searchParams.get('blob')
+  if (!encodedKey || !encodedBlob) return null
+
+  let key
+  try {
+    key = HypercoreID.decode(encodedKey)
+  } catch {
+    return null
+  }
+
+  const blob = decodeBlobParam(encodedBlob)
+  const byteRange = parseHttpByteRange(rangeHeader, blob?.byteLength)
+  if (!key || !blob || !byteRange) return null
+
+  return { key, blob, byteRange }
+}
+
+export async function prioritizeBlobServerRangeRequest(blobServer, req, options = {}) {
+  if (!blobServer || typeof blobServer._getCore !== 'function') return null
+
+  const request = decodeBlobRangeRequest(blobServer, req)
+  if (!request) return null
+
+  const downloadRange = getPrioritizedBlobDownloadRange(request.blob, request.byteRange, options)
+  if (!downloadRange) return null
+
+  const core = await blobServer._getCore(request.key, {
+    key: request.key,
+    blob: request.blob,
+    range: request.byteRange
+  }, true)
+  if (!core || typeof core.download !== 'function') return null
+
+  const range = core.download({
+    start: downloadRange.start,
+    end: downloadRange.end,
+    linear: false
+  })
+  const timeoutMs = Math.max(
+    1000,
+    Number(options.timeoutMs ?? DEFAULT_BLOB_RANGE_PRIORITY_TIMEOUT_MS) || DEFAULT_BLOB_RANGE_PRIORITY_TIMEOUT_MS
+  )
+  let cleanedUp = false
+  const cleanup = () => {
+    if (cleanedUp) return
+    cleanedUp = true
+    try { range?.destroy?.() } catch { /* best effort */ }
+    try {
+      const closeResult = core.close?.()
+      if (closeResult && typeof closeResult.catch === 'function') closeResult.catch(() => {})
+    } catch { /* best effort */ }
+  }
+  const timer = setTimeout(cleanup, timeoutMs)
+  const done = typeof range?.done === 'function'
+    ? range.done()
+    : typeof range?.downloaded === 'function'
+      ? range.downloaded()
+      : Promise.resolve()
+
+  Promise.resolve(done)
+    .catch(() => {})
+    .finally(() => {
+      clearTimeout(timer)
+      cleanup()
+    })
+
+  return downloadRange
+}

--- a/packages/backend/src/storage.js
+++ b/packages/backend/src/storage.js
@@ -11,6 +11,7 @@ import b4a from 'b4a';
 import crypto from 'hypercore-crypto';
 import { MultiWriterChannel, ChannelPairer } from './channel/index.js'
 import { PublicChannelBee } from './channel/public-channel-bee.js'
+import { prioritizeBlobServerRangeRequest } from './blob-range-priority.js'
 import { loadPublicBeeFromCache } from './public-bee-loader.js'
 import { logger } from './logger.js'
 import { relocateLegacyBlindPeerDir, relocateLegacyCorestoreDir, relocateLegacyLogsDir } from './storage-layout.js'
@@ -1106,6 +1107,9 @@ export async function initializeStorage(config) {
       res.setHeader('Access-Control-Allow-Headers', 'Range')
       res.setHeader('Access-Control-Expose-Headers', 'Content-Length, Content-Range, Accept-Ranges')
       if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return }
+      if (req.method === 'GET' && req.headers?.range) {
+        prioritizeBlobServerRangeRequest(blobServer, req).catch(() => {})
+      }
       return origOnRequest(req, res)
     }
 

--- a/packages/backend/test/blob-range-priority.test.mjs
+++ b/packages/backend/test/blob-range-priority.test.mjs
@@ -1,0 +1,105 @@
+import test from 'brittle'
+import c from 'compact-encoding'
+import HypercoreID from 'hypercore-id-encoding'
+import z32 from 'z32'
+
+import {
+  getPrioritizedBlobDownloadRange,
+  parseHttpByteRange,
+  prioritizeBlobServerRangeRequest,
+} from '../src/blob-range-priority.js'
+
+const blobIdEncoding = {
+  preencode(state, blob) {
+    c.uint.preencode(state, blob.blockOffset)
+    c.uint.preencode(state, blob.blockLength)
+    c.uint.preencode(state, blob.byteOffset)
+    c.uint.preencode(state, blob.byteLength)
+  },
+  encode(state, blob) {
+    c.uint.encode(state, blob.blockOffset)
+    c.uint.encode(state, blob.blockLength)
+    c.uint.encode(state, blob.byteOffset)
+    c.uint.encode(state, blob.byteLength)
+  },
+  decode(state) {
+    return {
+      blockOffset: c.uint.decode(state),
+      blockLength: c.uint.decode(state),
+      byteOffset: c.uint.decode(state),
+      byteLength: c.uint.decode(state),
+    }
+  },
+}
+
+test('parseHttpByteRange normalizes closed and open HTTP byte ranges', (t) => {
+  t.alike(parseHttpByteRange('bytes=65536-131071', 1048576), { start: 65536, end: 131071 })
+  t.alike(parseHttpByteRange('bytes=983040-', 1048576), { start: 983040, end: 1048575 })
+  t.alike(parseHttpByteRange('bytes=-65536', 1048576), { start: 983040, end: 1048575 })
+  t.is(parseHttpByteRange('bytes=131071-65536', 1048576), null)
+  t.is(parseHttpByteRange('items=0-10', 1048576), null)
+})
+
+test('getPrioritizedBlobDownloadRange maps a seek byte range to the matching blob core blocks', (t) => {
+  const blob = {
+    blockOffset: 10,
+    blockLength: 100,
+    byteOffset: 4096,
+    byteLength: 100 * 65536,
+  }
+
+  t.alike(
+    getPrioritizedBlobDownloadRange(blob, { start: 4 * 65536, end: (5 * 65536) - 1 }, { readAheadBytes: 0 }),
+    { start: 14, end: 15, blocks: 1 },
+  )
+
+  t.alike(
+    getPrioritizedBlobDownloadRange(blob, { start: 98 * 65536, end: (99 * 65536) - 1 }, { readAheadBytes: 4 * 65536 }),
+    { start: 108, end: 110, blocks: 2 },
+  )
+})
+
+test('prioritizeBlobServerRangeRequest starts a non-linear core download for the requested HTTP range', async (t) => {
+  const calls = []
+  const key = Buffer.from('b'.repeat(64), 'hex')
+  const blob = {
+    blockOffset: 10,
+    blockLength: 100,
+    byteOffset: 4096,
+    byteLength: 100 * 65536,
+  }
+  const encodedBlob = z32.encode(c.encode(blobIdEncoding, blob))
+  const req = {
+    url: `/?key=${HypercoreID.encode(key)}&blob=${encodedBlob}&type=video%2Fmp4&token=test-token`,
+    headers: {
+      range: `bytes=${4 * 65536}-${(5 * 65536) - 1}`,
+    },
+  }
+  const blobServer = {
+    token: 'test-token',
+    async _getCore(requestKey, info, active) {
+      calls.push(['_getCore', requestKey.toString('hex'), info.blob, active])
+      return {
+        download(options) {
+          calls.push(['download', options])
+          return {
+            done: () => Promise.resolve(),
+            destroy: () => calls.push(['destroy']),
+          }
+        },
+        close() {
+          calls.push(['close'])
+        },
+      }
+    },
+  }
+
+  const result = await prioritizeBlobServerRangeRequest(blobServer, req, { readAheadBytes: 0 })
+  await Promise.resolve()
+  await Promise.resolve()
+
+  t.alike(result, { start: 14, end: 15, blocks: 1 })
+  t.alike(calls[0], ['_getCore', key.toString('hex'), blob, true])
+  t.alike(calls[1], ['download', { start: 14, end: 15, linear: false }])
+  t.ok(calls.some((call) => call[0] === 'close'))
+})

--- a/packages/backend/test/playback-api.test.mjs
+++ b/packages/backend/test/playback-api.test.mjs
@@ -58,6 +58,12 @@ test('preparePlayback returns a playable URL before warmup settles or fails', as
       isComplete: false,
     },
     warmupStarted: true,
+    peerWarmupStarted: true,
+    peerWarmup: {
+      peerCount: 0,
+      retained: false,
+      timedOut: false,
+    },
   })
 
   t.alike(calls, [


### PR DESCRIPTION
## Summary
- Suppress transient native pause events while an active seek is recovering on uncached streamed video, and reassert playback once the player reports `readyToPlay`.
- Keep desired playback state in sync during seek recovery so a buffering seek does not flip the UI into paused state.
- Prioritize Hypercore blob block downloads for HTTP range requests so arbitrary seek targets are fetched ahead of the normal streaming path.

## Verification
- `node --test packages/app/tests/pear-inline-player-view.test.mjs packages/app/tests/video-player-loading-clears-regression.test.mjs packages/app/tests/player-port-contract-regression.test.mjs packages/app/tests/video-player-streaming-seek-regression.test.mjs`
- `/Users/jd/.nvm/versions/node/v22.19.0/bin/node packages/backend/node_modules/brittle/cmd.js packages/backend/test/blob-range-priority.test.mjs packages/backend/test/playback-service.test.mjs packages/backend/test/playback-api.test.mjs packages/backend/test/blob-playback-service-peer-warmup.test.mjs`
- `packages/backend/node_modules/.bin/brittle packages/backend/test/storage-startup-regression.test.mjs`
- `git diff --check`

Note: full `./node_modules/.bin/tsc --noEmit --pretty false -p packages/app/tsconfig.json` still fails on existing project-wide type issues unrelated to this change, including missing UI packages and pre-existing app type errors.