### PR TITLE
[codex] Improve Expo video playback performance

### DIFF
--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -61,6 +61,13 @@
           "enableNotificationControls": true
         }
       ],
+      [
+        "expo-video",
+        {
+          "supportsBackgroundPlayback": true,
+          "supportsPictureInPicture": true
+        }
+      ],
       "./plugins/withEnsureBackendBundles.js",
       [
         "expo-build-properties",

--- a/packages/app/app/(tabs)/index.tsx
+++ b/packages/app/app/(tabs)/index.tsx
@@ -10,7 +10,7 @@ import { useApp, colors } from '../_layout'
 import { VideoCard } from '../../components/video'
 import type { VideoData } from '@peartube/core'
 import { CastHeaderButton } from '@/components/cast'
-import { useVideoPlayerContext } from '@/lib/VideoPlayerContext'
+import { useVideoPlayerActions } from '@/lib/VideoPlayerContext'
 import { usePlatform } from '@/lib/PlatformProvider'
 import { fetchThumbnailUrlWithRetry } from '@/lib/thumbnail'
 import { formatTimeAgo } from '@/lib/formatters'
@@ -116,7 +116,7 @@ export default function HomeScreen() {
   const insets = useSafeAreaInsets()
   const router = useRouter()
   const { ready, identity, videos, loading, loadVideos, rpc, backendError, startupStatus, retryBackend, platformEvents, blobServerPort, androidDiscoveryPermissionStatus } = useApp()
-  const { loadAndPlayVideo } = useVideoPlayerContext()
+  const { loadAndPlayVideo } = useVideoPlayerActions()
   const { isDesktop } = usePlatform()
   const { width: screenWidth } = useWindowDimensions()
   const tabBarMetrics = useTabBarMetrics()
@@ -278,7 +278,7 @@ export default function HomeScreen() {
       const result = await Promise.race([feedPromise, timeoutPromise])
 
       if (result?.entries) {
-        const mergedEntries = (Array.isArray(result.entries) ? result.entries : []).filter((entry, index, all) => {
+        const mergedEntries = (Array.isArray(result.entries) ? result.entries : []).filter((entry: any, index: number, all: any[]) => {
           const key = entry?.channelKey || entry?.driveKey
           return key && all.findIndex((candidate) => (candidate?.channelKey || candidate?.driveKey) === key) === index
         }) as FeedEntry[]

--- a/packages/app/app/(tabs)/search.tsx
+++ b/packages/app/app/(tabs)/search.tsx
@@ -7,7 +7,7 @@ import { useApp, colors } from '../_layout'
 import { VideoCard, type VideoData } from '../../components/video'
 import type { VideoData as CoreVideoData } from '@peartube/core'
 import { CastHeaderButton } from '@/components/cast'
-import { useVideoPlayerContext } from '@/lib/VideoPlayerContext'
+import { useVideoPlayerActions } from '@/lib/VideoPlayerContext'
 import { usePlatform } from '@/lib/PlatformProvider'
 import { useTabBarMetrics } from '@/lib/tabBarHeight'
 import { fetchThumbnailUrlWithRetry } from '@/lib/thumbnail'
@@ -71,7 +71,7 @@ export default function SearchTab() {
   const [query, setQuery] = useState('')
 
   const { ready, rpc, blobServerPort } = useApp()
-  const { loadAndPlayVideo, closeVideo } = useVideoPlayerContext()
+  const { loadAndPlayVideo, closeVideo } = useVideoPlayerActions()
   const { isDesktop } = usePlatform()
   const { width: screenWidth } = useWindowDimensions()
 

--- a/packages/app/app/(tabs)/studio.tsx
+++ b/packages/app/app/(tabs)/studio.tsx
@@ -11,7 +11,7 @@ import * as ImagePicker from 'expo-image-picker'
 import * as VideoThumbnails from 'expo-video-thumbnails'
 import { useApp, colors } from '../_layout'
 import { CastHeaderButton } from '@/components/cast'
-import { useVideoPlayerContext } from '@/lib/VideoPlayerContext'
+import { useVideoPlayerActions } from '@/lib/VideoPlayerContext'
 import { VideoEditModal } from '@/components/VideoEditModal'
 import { formatBytes } from '@/lib/formatters'
 import { useTabBarMetrics } from '@/lib/tabBarHeight'
@@ -40,7 +40,7 @@ export default function StudioScreen() {
   const insets = useSafeAreaInsets()
   const router = useRouter()
   const { identity, videos, rpc, uploadVideo, pickVideoFile, pickImageFile, loadVideos, removeVideo } = useApp()
-  const { pauseVideo, closeVideo, suppressForegroundRestoreOnce, suppressForegroundRestoreFor, clearLastClosedVideo } = useVideoPlayerContext()
+  const { pauseVideo, closeVideo, suppressForegroundRestoreOnce, suppressForegroundRestoreFor, clearLastClosedVideo } = useVideoPlayerActions()
   const [uploading, setUploading] = useState(false)
   const [uploadProgress, setUploadProgress] = useState(0)
   const [uploadSpeed, setUploadSpeed] = useState(0)  // bytes/sec

--- a/packages/app/app/search.tsx
+++ b/packages/app/app/search.tsx
@@ -10,7 +10,7 @@ import { useApp, colors } from './_layout'
 import { VideoCard, VideoData } from '../components/video'
 import type { VideoData as CoreVideoData } from '@peartube/core'
 import { CastHeaderButton } from '@/components/cast'
-import { useVideoPlayerContext } from '@/lib/VideoPlayerContext'
+import { useVideoPlayerActions } from '@/lib/VideoPlayerContext'
 import { usePlatform } from '@/lib/PlatformProvider'
 import { fetchThumbnailUrlWithRetry } from '@/lib/thumbnail'
 import { getDesktopVideoGridColumns } from '@/lib/video-layout'
@@ -101,7 +101,7 @@ export default function SearchScreen() {
   const query = typeof params.q === 'string' ? params.q : ''
 
   const { ready, rpc, platformEvents, blobServerPort } = useApp()
-  const { loadAndPlayVideo, closeVideo } = useVideoPlayerContext()
+  const { loadAndPlayVideo, closeVideo } = useVideoPlayerActions()
   const { isDesktop } = usePlatform()
   const { width: screenWidth } = useWindowDimensions()
 

--- a/packages/app/app/video/[id].tsx
+++ b/packages/app/app/video/[id].tsx
@@ -7,14 +7,13 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { View, Text, Pressable, ActivityIndicator, Platform, ScrollView, useWindowDimensions, StyleSheet, Alert } from 'react-native'
 import { useLocalSearchParams, useRouter, useNavigation } from 'expo-router'
-import { useIsFocused } from 'expo-router/react-navigation'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { Feather } from '@expo/vector-icons'
 import { useApp, colors } from '../_layout'
 import { usePlatform } from '@/lib/PlatformProvider'
 import { formatBytes as formatSize, formatTimeAgo, formatViews } from '@/lib/formatters'
 import { getPlayerPageVideoHeight } from '@/lib/video-layout'
-import { useVideoPlayerContext, VideoStats } from '@/lib/VideoPlayerContext'
+import { useVideoPlayerActions, useVideoPlayerSession, VideoStats } from '@/lib/VideoPlayerContext'
 import { useCast } from '@/lib/cast'
 import { DevicePickerModal, CastRemoteModal } from '@/components/cast'
 import { VideoEditModal } from '@/components/VideoEditModal'
@@ -123,7 +122,9 @@ function P2PStatsBar({ stats }: { stats: VideoStats | null }) {
     }
   }, [stats, appRpc])
 
-  console.log('[P2PStatsBar] Rendering, stats:', stats ? 'present' : 'null', 'globalConnections:', globalConnections)
+  if (__DEV__) {
+    console.log('[P2PStatsBar] Rendering, stats:', stats ? 'present' : 'null', 'globalConnections:', globalConnections)
+  }
 
   // Format bytes to human readable
   const formatBytes = (bytes: number): string => {
@@ -277,30 +278,15 @@ function MobileVideoPlayerScreen() {
   const { width: screenWidth } = useWindowDimensions()
   const videoHeight = getPlayerPageVideoHeight(screenWidth)
   const { rpc, identity } = useApp()
-  const isFocused = useIsFocused()
-
   // VideoPlayerContext - SHARED player for continuous playback
   // Stats come via EVENT_VIDEO_STATS events from backend -> videoStatsEventEmitter -> context
   const {
     currentVideo,
     videoUrl,
-    isPlaying,
     isLoading: loadingVideo,
     videoStats,
-    playbackSession,
-    playerRef,
-    playbackRate,
-    minimizePlayer,
-    loadAndPlayVideo,
-    setIsLoading,
-    isInPipMode,
-    onProgress,
-    onPlaying,
-    onPaused,
-    onBuffering,
-    onEnded,
-    onError,
-  } = useVideoPlayerContext()
+  } = useVideoPlayerSession()
+  const { minimizePlayer, loadAndPlayVideo, setIsLoading } = useVideoPlayerActions()
 
   // Parse video data from params (JSON encoded or URL params)
   const params = useLocalSearchParams()
@@ -318,6 +304,9 @@ function MobileVideoPlayerScreen() {
   const [videoData, setVideoData] = useState<any>(videoDataParam)
   const [loadingMeta, setLoadingMeta] = useState(!videoDataParam && !!channelKeyParam)
   const statsPollingRef = useRef<NodeJS.Timeout | null>(null)
+  const statsPollingDelayRef = useRef<NodeJS.Timeout | null>(null)
+  const mountedRef = useRef(true)
+  const loadGenerationRef = useRef(0)
 
   // Video editing
   const [editingVideo, setEditingVideo] = useState<any>(null)
@@ -329,12 +318,35 @@ function MobileVideoPlayerScreen() {
   const [connectingCastDeviceId, setConnectingCastDeviceId] = useState<string | null>(null)
   const [recentCastDeviceId, setRecentCastDeviceId] = useState<string | null>(null)
 
+  const clearStatsPolling = useCallback(() => {
+    if (statsPollingDelayRef.current) {
+      clearTimeout(statsPollingDelayRef.current)
+      statsPollingDelayRef.current = null
+    }
+    if (statsPollingRef.current) {
+      clearInterval(statsPollingRef.current)
+      statsPollingRef.current = null
+    }
+  }, [])
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+      loadGenerationRef.current += 1
+      clearStatsPolling()
+    }
+  }, [clearStatsPolling])
+
   // Fetch video metadata if not provided (YouTube-style: load from ID)
   useEffect(() => {
     if (videoDataParam || !channelKeyParam || !id || !rpc) return
 
+    let cancelled = false
     const fetchVideoData = async () => {
-      console.log('[VideoPlayer] Fetching video data for:', id, 'from channel:', channelKeyParam)
+      if (__DEV__) {
+        console.log('[VideoPlayer] Fetching video data for:', id, 'from channel:', channelKeyParam)
+      }
       setLoadingMeta(true)
       try {
         const result = await rpc.getVideoData({
@@ -343,8 +355,10 @@ function MobileVideoPlayerScreen() {
           publicBeeKey: publicBeeParam || undefined
         })
         const fetchedVideoData = result?.video || result
-        if (fetchedVideoData) {
-          console.log('[VideoPlayer] Got video data:', fetchedVideoData.title)
+        if (!cancelled && mountedRef.current && fetchedVideoData) {
+          if (__DEV__) {
+            console.log('[VideoPlayer] Got video data:', fetchedVideoData.title)
+          }
           setVideoData({
             id,
             channelKey: channelKeyParam,
@@ -355,11 +369,16 @@ function MobileVideoPlayerScreen() {
       } catch (err) {
         console.error('[VideoPlayer] Failed to fetch video data:', err)
       } finally {
-        setLoadingMeta(false)
+        if (!cancelled && mountedRef.current) {
+          setLoadingMeta(false)
+        }
       }
     }
 
     fetchVideoData()
+    return () => {
+      cancelled = true
+    }
   }, [id, channelKeyParam, publicBeeParam, videoDataParam, rpc])
 
   // Intercept back navigation (swipe gesture, back button) to minimize instead of close
@@ -386,11 +405,14 @@ function MobileVideoPlayerScreen() {
 
   const startStatsPolling = useCallback(() => {
     if (!videoData || !rpc) return
-    if (statsPollingRef.current) clearInterval(statsPollingRef.current)
+    if (!mountedRef.current) return
+    clearStatsPolling()
     const videoRef = (videoData.path && typeof videoData.path === 'string' && videoData.path.startsWith('/'))
       ? videoData.path
       : videoData.id
-    console.log('[VideoPlayer] Starting stats polling for', videoRef)
+    if (__DEV__) {
+      console.log('[VideoPlayer] Starting stats polling for', videoRef)
+    }
 
     const pollStats = async () => {
       try {
@@ -399,8 +421,10 @@ function MobileVideoPlayerScreen() {
           videoId: videoRef
         })
         const stats = result?.stats
-        console.log('[VideoPlayer] Got stats:', stats ? `${stats.progress}%` : 'null')
-        if (stats) {
+        if (__DEV__) {
+          console.log('[VideoPlayer] Got stats:', stats ? `${stats.progress}%` : 'null')
+        }
+        if (mountedRef.current && stats) {
           setLocalStats(stats as VideoStats)
           if (isStatsComplete(stats as VideoStats) && statsPollingRef.current) {
             clearInterval(statsPollingRef.current)
@@ -414,10 +438,24 @@ function MobileVideoPlayerScreen() {
 
     pollStats()
     statsPollingRef.current = setInterval(pollStats, 1000)
-  }, [rpc, videoData])
+  }, [clearStatsPolling, rpc, videoData])
+
+  const scheduleStatsPolling = useCallback((delayMs = 500) => {
+    if (statsPollingDelayRef.current) {
+      clearTimeout(statsPollingDelayRef.current)
+    }
+    statsPollingDelayRef.current = setTimeout(() => {
+      statsPollingDelayRef.current = null
+      if (!mountedRef.current) return
+      startStatsPolling()
+    }, delayMs)
+  }, [startStatsPolling])
 
   const loadVideo = useCallback(async () => {
     if (!videoData || !rpc) return
+    const generation = loadGenerationRef.current + 1
+    loadGenerationRef.current = generation
+    clearStatsPolling()
     setIsLoading(true)
 
     try {
@@ -442,23 +480,27 @@ function MobileVideoPlayerScreen() {
       )
       const cachedUrl = cacheKey ? getCachedVideoUrl(cacheKey) : null
       if (cachedUrl) {
+        if (!mountedRef.current || loadGenerationRef.current !== generation) return
         loadAndPlayVideo(videoData, cachedUrl)
         if (Platform.OS !== 'web' || isPear) {
-          void rpc.preparePlayback(playbackRequest).then((result) => {
+          void rpc.preparePlayback(playbackRequest).then((result: any) => {
+            if (!mountedRef.current || loadGenerationRef.current !== generation) return
             if (result?.stats) {
               setLocalStats(result.stats as VideoStats)
             }
             if (!isStatsComplete(result?.stats as VideoStats | null | undefined)) {
-              setTimeout(() => startStatsPolling(), 500)
+              scheduleStatsPolling(500)
             }
-          }).catch((err) => {
+          }).catch((err: any) => {
             console.error('[VideoPlayer] preparePlayback failed:', err)
-            setTimeout(() => startStatsPolling(), 500)
+            if (!mountedRef.current || loadGenerationRef.current !== generation) return
+            scheduleStatsPolling(500)
           })
         }
         return
       }
       const result = await rpc.preparePlayback(playbackRequest)
+      if (!mountedRef.current || loadGenerationRef.current !== generation) return
 
       if (result?.url) {
         if (cacheKey) setCachedVideoUrl(cacheKey, result.url)
@@ -471,15 +513,17 @@ function MobileVideoPlayerScreen() {
 
         if (Platform.OS !== 'web' || isPear) {
           if (!isStatsComplete(result?.stats as VideoStats | null | undefined)) {
-            setTimeout(() => startStatsPolling(), 500)
+            scheduleStatsPolling(500)
           }
         }
       }
     } catch (err) {
       console.error('[VideoPlayer] Failed to load video:', err)
-      setIsLoading(false)
+      if (mountedRef.current && loadGenerationRef.current === generation) {
+        setIsLoading(false)
+      }
     }
-  }, [isPear, loadAndPlayVideo, rpc, setIsLoading, startStatsPolling, videoData])
+  }, [clearStatsPolling, isPear, loadAndPlayVideo, rpc, scheduleStatsPolling, setIsLoading, videoData])
 
   // Load video when videoData is available (either from params or fetched)
   useEffect(() => {
@@ -508,12 +552,9 @@ function MobileVideoPlayerScreen() {
 
     return () => {
       clearTimeout(channelInfoTimer)
-      if (statsPollingRef.current) {
-        clearInterval(statsPollingRef.current)
-        statsPollingRef.current = null
-      }
+      clearStatsPolling()
     }
-  }, [videoData, loadingMeta, fromMiniPlayer, isPear, videoLoaded, loadVideo, startStatsPolling, loadChannelInfo, currentVideo])
+  }, [videoData, loadingMeta, fromMiniPlayer, isPear, videoLoaded, loadVideo, startStatsPolling, loadChannelInfo, currentVideo, clearStatsPolling])
 
   // Back/minimize button - beforeRemove listener handles minimizePlayer()
   const goBack = () => {
@@ -907,7 +948,6 @@ const styles = StyleSheet.create({
     marginTop: 4,
     maxWidth: '100%',
     textAlign: 'center',
-    numberOfLines: 1,
   },
   actionLabelActive: {
     color: colors.primary,

--- a/packages/app/components/PillTabBar.tsx
+++ b/packages/app/components/PillTabBar.tsx
@@ -12,7 +12,7 @@ import Animated, {
   interpolate,
   Extrapolation,
 } from 'react-native-reanimated'
-import { useVideoPlayerContext } from '@/lib/VideoPlayerContext'
+import { useVideoPlayerSession } from '@/lib/VideoPlayerContext'
 import { setTabBarMetrics } from '@/lib/tabBarHeight'
 import { usePlatform } from '@/lib/PlatformProvider'
 import { colors } from '@/lib/colors'
@@ -65,7 +65,7 @@ export function PillTabBar() {
   const pathname = usePathname()
   const router = useRouter()
   const { isDesktop } = usePlatform()
-  const { playerMode, isInPipMode, androidSplitPlayerEnabled } = useVideoPlayerContext()
+  const { playerMode, isInPipMode, androidSplitPlayerEnabled } = useVideoPlayerSession()
   const isAndroidWatchPathActive = Platform.OS === 'android' && pathname.startsWith('/video/')
 
   const barVisible = useSharedValue(1)

--- a/packages/app/components/VideoPlayerOverlayImpl.tsx
+++ b/packages/app/components/VideoPlayerOverlayImpl.tsx
@@ -631,7 +631,9 @@ export function VideoPlayerOverlay() {
   }, [isInPipMode, playerMode, showControlsTemporarily])
 
   const handlePipStatusChanged = useCallback((event: { isInPictureInPicture: boolean; width: number; height: number }) => {
-    console.log('[VideoPlayerOverlay] PiP status changed:', event.isInPictureInPicture, event.width, event.height)
+    if (__DEV__) {
+      console.log('[VideoPlayerOverlay] PiP status changed:', event.isInPictureInPicture, event.width, event.height)
+    }
     setIsInPipMode(event.isInPictureInPicture)
     if (event.isInPictureInPicture && event.width > 0 && event.height > 0) {
       setPipWindowSize({ width: event.width, height: event.height })
@@ -649,7 +651,9 @@ export function VideoPlayerOverlay() {
     onLoaded()
     const width = info?.videoSize?.width
     const height = info?.videoSize?.height
-    console.log('[VideoPlayerOverlay] Video loaded with dimensions:', width, 'x', height)
+    if (__DEV__) {
+      console.log('[VideoPlayerOverlay] Video loaded with dimensions:', width, 'x', height)
+    }
     // PiP aspect ratio is handled natively by react-native-video
   }, [onLoaded])
 
@@ -2768,7 +2772,7 @@ export function VideoPlayerOverlay() {
 
       {/* Cast button moved into time display row below */}
 
-      {!isInPipMode && Platform.OS !== 'web' && playerMode !== 'mini' && playerMode !== 'hidden' && showControls && (
+      {!isInPipMode && Platform.OS !== 'web' && playerMode !== 'mini' && showControls && (
         <Scrubber
           containerStyle={progressBarStyle}
           duration={effectiveDuration}

--- a/packages/app/components/video-player/PearInlineVideoView.tsx
+++ b/packages/app/components/video-player/PearInlineVideoView.tsx
@@ -1,5 +1,5 @@
 import { useEventListener } from 'expo'
-import { VideoPlayer, VideoView, useVideoPlayer } from 'expo-video'
+import { VideoView, useVideoPlayer, type VideoPlayer, type VideoSource } from 'expo-video'
 import { memo, ReactNode, RefObject, useCallback, useEffect, useMemo, useRef } from 'react'
 import { AppState, AppStateStatus, Platform, StyleProp, StyleSheet, View, ViewStyle } from 'react-native'
 import { createPlayerPort, type PlayerPort } from '@/lib/video-player'
@@ -104,12 +104,21 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
   const previousStatusRef = useRef<string | null>(null)
   const seekPlaybackRecoveryUntilRef = useRef(0)
   const isPlayingRef = useRef(isPlaying)
+  const playbackRateRef = useRef(playbackRate)
+  const notificationControlsRef = useRef(showNotificationControls)
+  const onErrorRef = useRef(onError)
+  const sourceReplaceGenerationRef = useRef(0)
 
-  const player = useVideoPlayer({ uri: videoUrl, metadata: {
-    title: videoTitle || undefined,
-    artist: channelName || undefined,
-    artwork: thumbnailUrl || undefined,
-  } }, (nextPlayer) => {
+  const videoSource = useMemo<VideoSource>(() => ({
+    uri: videoUrl,
+    metadata: {
+      title: videoTitle || undefined,
+      artist: channelName || undefined,
+      artwork: thumbnailUrl || undefined,
+    },
+  }), [channelName, thumbnailUrl, videoTitle, videoUrl])
+
+  const player = useVideoPlayer(null, (nextPlayer) => {
     playerRefForCallbacks.current = nextPlayer
     nextPlayer.timeUpdateEventInterval = 0.5
     nextPlayer.loop = false
@@ -123,7 +132,6 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
         // Some Expo Video versions expose bufferOptions as read-only before source load.
       }
     }
-    if (isPlaying) nextPlayer.play()
   })
 
   playerRefForCallbacks.current = player
@@ -142,6 +150,60 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
   useEffect(() => {
     isPlayingRef.current = isPlaying
   }, [isPlaying])
+
+  useEffect(() => {
+    playbackRateRef.current = playbackRate
+  }, [playbackRate])
+
+  useEffect(() => {
+    notificationControlsRef.current = showNotificationControls
+  }, [showNotificationControls])
+
+  useEffect(() => {
+    onErrorRef.current = onError
+  }, [onError])
+
+  useEffect(() => {
+    let cancelled = false
+    const generation = sourceReplaceGenerationRef.current + 1
+    sourceReplaceGenerationRef.current = generation
+
+    const applySource = async () => {
+      try {
+        if (typeof player.replaceAsync === 'function') {
+          await player.replaceAsync(videoSource)
+        } else {
+          player.replace(videoSource)
+        }
+
+        if (cancelled || sourceReplaceGenerationRef.current !== generation) return
+
+        player.playbackRate = playbackRateRef.current
+        player.showNowPlayingNotification = notificationControlsRef.current
+        player.staysActiveInBackground = notificationControlsRef.current
+        if (isPlayingRef.current) {
+          player.play()
+        }
+      } catch (error) {
+        if (cancelled || sourceReplaceGenerationRef.current !== generation) return
+        const message = error instanceof Error ? error.message : 'Failed to load video source'
+        const code = typeof error === 'object' && error !== null && 'code' in error
+          ? (error as { code?: unknown }).code
+          : undefined
+        onErrorRef.current?.({
+          message,
+          code,
+          engine: 'expo-video',
+        })
+      }
+    }
+
+    void applySource()
+
+    return () => {
+      cancelled = true
+    }
+  }, [player, videoSource])
 
   const shouldSuppressStuckPlaybackRecovery = useCallback(() => {
     if (Platform.OS !== 'android') return false
@@ -389,7 +451,6 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
   return (
     <View testID={testID} style={[styles.container, style]}>
       <VideoView
-        key={`expo-video-${playbackSession}:${currentVideoKey || ''}`}
         player={player}
         style={StyleSheet.absoluteFill}
         contentFit="contain"

--- a/packages/app/lib/SocialContext.tsx
+++ b/packages/app/lib/SocialContext.tsx
@@ -2,7 +2,7 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useRef, use
 import { Alert } from 'react-native'
 import { rpc } from '@peartube/platform/rpc'
 import { useApp } from '@/lib/AppContext'
-import { useVideoPlayerContext } from '@/lib/VideoPlayerContext'
+import { useVideoPlayerSession } from '@/lib/VideoPlayerContext'
 import { COMMENTS_PER_PAGE } from '@/components/video-player'
 
 const SOCIAL_RPC_TIMEOUT_MS = 8000
@@ -58,9 +58,7 @@ export function useSocial() {
 
 export function SocialProvider({ children }: { children: React.ReactNode }) {
   const { identity } = useApp()
-  const player = useVideoPlayerContext()
-  const currentVideo = player.currentVideo
-  const playerMode = player.playerMode
+  const { currentVideo, playerMode } = useVideoPlayerSession()
 
   const commentsLengthRef = useRef(0)
 

--- a/packages/app/lib/VideoPlayerContext.tsx
+++ b/packages/app/lib/VideoPlayerContext.tsx
@@ -105,12 +105,84 @@ interface VideoPlayerContextType {
   onVideoStateChange: (data: { type?: string; mVideoWidth?: number; mVideoHeight?: number }) => void
 }
 
+type VideoPlayerSessionContextType = Pick<VideoPlayerContextType,
+  | 'currentVideo'
+  | 'videoUrl'
+  | 'isPlaying'
+  | 'isLoading'
+  | 'playerMode'
+  | 'videoStats'
+  | 'playbackSession'
+  | 'isInPipMode'
+  | 'setIsInPipMode'
+  | 'pipWindowSize'
+  | 'setPipWindowSize'
+  | 'shouldEnablePip'
+  | 'androidSplitPlayerEnabled'
+  | 'videoAspectRatio'
+  | 'playerRef'
+>
+
+type VideoPlayerProgressContextType = Pick<VideoPlayerContextType,
+  | 'currentTime'
+  | 'duration'
+  | 'progress'
+  | 'playbackRate'
+  | 'seekPosition'
+>
+
+type VideoPlayerActionsContextType = Pick<VideoPlayerContextType,
+  | 'loadAndPlayVideo'
+  | 'setAmbientVideoContext'
+  | 'pauseVideo'
+  | 'resumeVideo'
+  | 'closeVideo'
+  | 'enterBackgroundAudio'
+  | 'suppressForegroundRestoreOnce'
+  | 'suppressForegroundRestoreFor'
+  | 'clearLastClosedVideo'
+  | 'minimizePlayer'
+  | 'maximizePlayer'
+  | 'maximizedForPipRef'
+  | 'seekTo'
+  | 'seekBy'
+  | 'setPlaybackRate'
+  | 'setVideoStats'
+  | 'setIsLoading'
+  | 'onProgress'
+  | 'onLoaded'
+  | 'onPlaying'
+  | 'onPaused'
+  | 'onBuffering'
+  | 'onEnded'
+  | 'onError'
+  | 'onVideoStateChange'
+>
+
 const VideoPlayerContext = createContext<VideoPlayerContextType | null>(null)
+const VideoPlayerSessionContext = createContext<VideoPlayerSessionContextType | null>(null)
+const VideoPlayerProgressContext = createContext<VideoPlayerProgressContextType | null>(null)
+const VideoPlayerActionsContext = createContext<VideoPlayerActionsContextType | null>(null)
+
+function useRequiredVideoContext<T>(ctx: T | null, hookName: string): T {
+  if (!ctx) throw new Error(`${hookName} must be used within VideoPlayerProvider`)
+  return ctx
+}
 
 export function useVideoPlayerContext() {
-  const ctx = useContext(VideoPlayerContext)
-  if (!ctx) throw new Error('useVideoPlayerContext must be used within VideoPlayerProvider')
-  return ctx
+  return useRequiredVideoContext(useContext(VideoPlayerContext), 'useVideoPlayerContext')
+}
+
+export function useVideoPlayerSession() {
+  return useRequiredVideoContext(useContext(VideoPlayerSessionContext), 'useVideoPlayerSession')
+}
+
+export function useVideoPlayerProgress() {
+  return useRequiredVideoContext(useContext(VideoPlayerProgressContext), 'useVideoPlayerProgress')
+}
+
+export function useVideoPlayerActions() {
+  return useRequiredVideoContext(useContext(VideoPlayerActionsContext), 'useVideoPlayerActions')
 }
 
 interface VideoPlayerProviderProps {
@@ -310,7 +382,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
 
   const restoreLastClosedVideo = useCallback((reason: string) => {
     if (!lastClosedVideoRef.current || !lastClosedUrlRef.current) return false
-    console.log('[VideoPlayerContext] Restoring last closed video:', reason)
+    if (__DEV__) console.log('[VideoPlayerContext] Restoring last closed video:', reason)
     currentVideoRef.current = lastClosedVideoRef.current
     videoUrlRef.current = lastClosedUrlRef.current
     setPlaybackSession((prev) => prev + 1)
@@ -333,7 +405,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
     const video = currentVideoRef.current
     const url = videoUrlRef.current
     if (!video || !url) return false
-    console.log('[VideoPlayerContext] Forcing playback reload:', reason)
+    if (__DEV__) console.log('[VideoPlayerContext] Forcing playback reload:', reason)
     setPlaybackSession((prev) => prev + 1)
     dispatch({
       type: 'FORCE_RELOAD_PLAYBACK',
@@ -364,7 +436,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
     reason: 'user' | 'remote-stop' | 'android-minimize-close' | 'pip-close' | 'background-audio' = 'user',
     opts?: { preserveLastClosed?: boolean },
   ) => {
-    console.log('[VideoPlayerContext] Closing session:', reason)
+    if (__DEV__) console.log('[VideoPlayerContext] Closing session:', reason)
 
     const preserveNativeSession =
       reason === 'android-minimize-close' &&
@@ -453,7 +525,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
 
   const enterBackgroundAudio = useCallback(() => {
     if (!currentVideoRef.current || !videoUrlRef.current) return
-    console.log('[VideoPlayerContext] Entering background audio mode')
+    if (__DEV__) console.log('[VideoPlayerContext] Entering background audio mode')
     // Transition to background_audio mode WITHOUT unmounting the Video component.
     // This keeps state.video and state.url intact so ExoPlayer continues playing
     // via VideoPlaybackService. When the app returns to foreground, the state machine
@@ -567,14 +639,16 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
             isPlaying: wasPlaying,
           })
         }
-        console.log(
-          '[VideoPlayerContext] Going to background, wasPlaying:',
-          wasPlaying,
-          'playerMode:',
-          playerModeRef.current,
-          'rawMode:',
-          modeBeforeBackground,
-        )
+        if (__DEV__) {
+          console.log(
+            '[VideoPlayerContext] Going to background, wasPlaying:',
+            wasPlaying,
+            'playerMode:',
+            playerModeRef.current,
+            'rawMode:',
+            modeBeforeBackground,
+          )
+        }
        } else if (comingToForeground && isBackgroundedRef.current) {
          isBackgroundedRef.current = false
          maximizedForPipRef.current = false
@@ -583,7 +657,9 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
           // The player was already running — any buffering is surface reattach, not a real stall.
           suppressTransientBufferingRef.current = true
           setIsLoading(false)
-          console.log('[VideoPlayerContext] Coming to foreground, wasPlaying:', wasPlayingWhenBackgroundedRef.current, 'wasInPiP:', wasInPip, 'pipInFlight:', pipTransitionInFlightRef.current)
+          if (__DEV__) {
+            console.log('[VideoPlayerContext] Coming to foreground, wasPlaying:', wasPlayingWhenBackgroundedRef.current, 'wasInPiP:', wasInPip, 'pipInFlight:', pipTransitionInFlightRef.current)
+          }
 
          // IMPORTANT: Don't clear PiP state on foreground if we were in PiP.
          // When returning from PiP, Android can deliver the AppState "active" event
@@ -591,7 +667,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
          // makes the PiP exit handler think we were never in PiP, so it won't
          // restore playback state (leading to unintended pauses).
           if (!wasInPip) {
-            console.log('[VideoPlayerContext] Clearing PiP state on foreground')
+            if (__DEV__) console.log('[VideoPlayerContext] Clearing PiP state on foreground')
             isInPipModeRef.current = false
             setPipWindowSize(null)
             if (pipTransitionTimeoutRef.current) {
@@ -661,7 +737,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
   useEffect(() => {
     if (Platform.OS !== 'android') return
     const closeSub = DeviceEventEmitter.addListener('onPipClosed', () => {
-      console.log('[VideoPlayerContext] PiP closed (X button) — pausing')
+      if (__DEV__) console.log('[VideoPlayerContext] PiP closed (X button) — pausing')
       setDesiredPlaying(false)
     })
     return () => closeSub.remove()
@@ -675,12 +751,14 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
      const unsubscribe = _videoStatsEventEmitter.subscribe((driveKey, videoPath, stats) => {
        // Use ref for synchronous access (state may not be updated yet)
        const video = currentVideoRef.current
-       console.log('[VideoPlayerContext] Stats event received, checking match:', {
-         videoPath,
-         driveKey,
-         currentPath: video?.path,
-         currentKey: video?.channelKey
-       })
+       if (__DEV__) {
+         console.log('[VideoPlayerContext] Stats event received, checking match:', {
+           videoPath,
+           driveKey,
+           currentPath: video?.path,
+           currentKey: video?.channelKey
+         })
+       }
        // Only update if this is for the current video.
        // Some layers identify a video by id while others may still use legacy path formats.
        // Normalize both before comparison so mobile/desktop stay consistent.
@@ -709,7 +787,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
       const sameVideo = Boolean(video) && (samePath || sameId) && (keysCompatible || sameId)
 
        if (sameVideo) {
-         console.log('[VideoPlayerContext] Received stats event:', stats.progress + '%')
+         if (__DEV__) console.log('[VideoPlayerContext] Received stats event:', stats.progress + '%')
         setVideoStats(stats)
         if (typeof stats.progress === 'number' && stats.progress > 0) {
           // Once the backend is serving bytes, stop showing the generic
@@ -828,7 +906,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
 
   // Load and play a new video (triggers overlay to fullscreen)
   const loadAndPlayVideo = useCallback((video: VideoData, url: string) => {
-    console.log('[VideoPlayerContext] Loading video:', video.title, 'URL:', url)
+    if (__DEV__) console.log('[VideoPlayerContext] Loading video:', video.title, 'URL:', url)
 
     const requestKey = `${video.channelKey || ''}:${video.id || video.path || ''}:${url}`
 
@@ -875,7 +953,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
 
   // Pause video
   const pauseVideo = useCallback(() => {
-    console.log('[VideoPlayerContext] Pausing video')
+    if (__DEV__) console.log('[VideoPlayerContext] Pausing video')
     if (Platform.OS === 'web') {
       try {
         getPlayerPort()?.pause?.()
@@ -885,7 +963,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
   }, [setDesiredPlaying])
 
   const resumeVideo = useCallback(() => {
-    console.log('[VideoPlayerContext] Resuming video')
+    if (__DEV__) console.log('[VideoPlayerContext] Resuming video')
 
     // On iOS, do a seek while still paused to reinitialize audio, then resume
     // This avoids visible jitter since video isn't playing during the seek
@@ -912,12 +990,12 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
       const currentVideo = currentVideoRef.current
       const currentUrl = videoUrlRef.current
       if (!currentVideo || !currentUrl) {
-        console.log('[VideoPlayerContext] No active video to minimize on Android')
+        if (__DEV__) console.log('[VideoPlayerContext] No active video to minimize on Android')
         return
       }
 
       // Using react-native-video native PiP - no longer using split PlayerActivity
-      console.log('[VideoPlayerContext] Minimizing to in-app mini player')
+      if (__DEV__) console.log('[VideoPlayerContext] Minimizing to in-app mini player')
       dispatch({
         type: 'MINIMIZE',
         source: 'minimizePlayer',
@@ -926,17 +1004,17 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
       return
     }
 
-    console.log('[VideoPlayerContext] Minimizing to in-app mini player')
+    if (__DEV__) console.log('[VideoPlayerContext] Minimizing to in-app mini player')
     dispatch({
       type: 'MINIMIZE',
       source: 'minimizePlayer',
-      platform: Platform.OS === 'web' ? 'web' : Platform.OS === 'android' ? 'android' : 'ios',
+      platform: Platform.OS === 'web' ? 'web' : 'ios',
     })
   }, [dispatch, setDesiredPlaying])
 
   // Maximize from mini player
   const maximizePlayer = useCallback((source: string = 'unknown') => {
-    console.log('[VideoPlayerContext] Maximizing player from:', source)
+    if (__DEV__) console.log('[VideoPlayerContext] Maximizing player from:', source)
     dispatch({ type: 'MAXIMIZE', source: 'maximizePlayer' })
   }, [dispatch, setDesiredPlaying])
 
@@ -1016,7 +1094,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
 
     if (!didImperativeSeek) {
       const seekValue = clampedTime / dur
-      console.log('[VideoPlayerContext] Fallback seekTo via seekPosition:', clampedTime, 'seconds, seek prop:', seekValue)
+      if (__DEV__) console.log('[VideoPlayerContext] Fallback seekTo via seekPosition:', clampedTime, 'seconds, seek prop:', seekValue)
       setSeekPosition(seekValue)
     } else {
       setSeekPosition(undefined)
@@ -1042,7 +1120,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
 
     if (!didImperativeSeek) {
       const seekValue = newTime / dur
-      console.log('[VideoPlayerContext] Fallback seekBy via seekPosition:', delta, 'to:', newTime, 'seek prop:', seekValue)
+      if (__DEV__) console.log('[VideoPlayerContext] Fallback seekBy via seekPosition:', delta, 'to:', newTime, 'seek prop:', seekValue)
       setSeekPosition(seekValue)
     } else {
       setSeekPosition(undefined)
@@ -1055,13 +1133,13 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
 
   // Set playback speed
   const setPlaybackRate = useCallback((rate: number) => {
-    console.log('[VideoPlayerContext] Setting playback rate:', rate)
+    if (__DEV__) console.log('[VideoPlayerContext] Setting playback rate:', rate)
     setPlaybackRateState(rate)
   }, [])
 
   const onProgress = useCallback((data: { currentTime: number; duration: number }) => {
     if (Platform.OS === 'android' && pipExitExpectedPlayingRef.current && !isInPipModeRef.current) {
-      console.log('[VideoPlayerContext] PiP exit resume confirmed via progress')
+      if (__DEV__) console.log('[VideoPlayerContext] PiP exit resume confirmed via progress')
       pipExitShouldResumeRef.current = false
       pipExitExpectedPlayingRef.current = false
       pipExitResumeUntilRef.current = 0
@@ -1115,13 +1193,13 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
   }, [])
 
   const onLoaded = useCallback(() => {
-    console.log('[VideoPlayerContext] Player loaded')
+    if (__DEV__) console.log('[VideoPlayerContext] Player loaded')
     isBufferingRef.current = false
     setIsLoading(false)
   }, [])
 
   const onPlaying = useCallback(() => {
-    console.log('[VideoPlayerContext] Player playing')
+    if (__DEV__) console.log('[VideoPlayerContext] Player playing')
     if (Platform.OS === 'ios') {
       iosIgnorePausedUntilRef.current = 0
     }
@@ -1136,7 +1214,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
 
   const onPaused = useCallback(() => {
     if (Platform.OS === 'ios' && Date.now() < iosIgnorePausedUntilRef.current) {
-      console.log('[VideoPlayerContext] Ignoring transient iOS paused event during source swap')
+      if (__DEV__) console.log('[VideoPlayerContext] Ignoring transient iOS paused event during source swap')
       return
     }
     if (pipExitExpectedPlayingRef.current && !isInPipModeRef.current) {
@@ -1149,14 +1227,14 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
       pipExitExpectedPlayingRef.current = false
     }
     if (seekConfirmRef.current && isPlayingRef.current) {
-      console.log('[VideoPlayerContext] Ignoring transient paused event during seek')
+      if (__DEV__) console.log('[VideoPlayerContext] Ignoring transient paused event during seek')
       isBufferingRef.current = true
       try {
         getPlayerPort()?.play?.()
       } catch {}
       return
     }
-    console.log('[VideoPlayerContext] Player paused')
+    if (__DEV__) console.log('[VideoPlayerContext] Player paused')
     // Sync JS state for deliberate external pauses (PiP button, notification
     // pause, audio focus loss). Skip if the player is buffering — that's a
     // transient pause (e.g. after notification seek on uncached content) and
@@ -1169,7 +1247,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
   }, [getPlayerPort, reassertNativePlayAfterPipExit])
 
   const onBuffering = useCallback((data: { isBuffering: boolean }) => {
-    console.log('[VideoPlayerContext] Player buffering:', data?.isBuffering)
+    if (__DEV__) console.log('[VideoPlayerContext] Player buffering:', data?.isBuffering)
     if (data?.isBuffering === undefined) return
     isBufferingRef.current = Boolean(data.isBuffering)
 
@@ -1201,7 +1279,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
   }, [])
 
   const onEnded = useCallback(() => {
-    console.log('[VideoPlayerContext] Player ended')
+    if (__DEV__) console.log('[VideoPlayerContext] Player ended')
     isBufferingRef.current = false
     setDesiredPlaying(false)
   }, [setDesiredPlaying])
@@ -1221,7 +1299,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
       data.mVideoHeight > 0
     ) {
       const aspectRatio = data.mVideoWidth / data.mVideoHeight
-      console.log('[VideoPlayerContext] Video dimensions:', data.mVideoWidth, 'x', data.mVideoHeight, '- aspect ratio:', aspectRatio.toFixed(3))
+      if (__DEV__) console.log('[VideoPlayerContext] Video dimensions:', data.mVideoWidth, 'x', data.mVideoHeight, '- aspect ratio:', aspectRatio.toFixed(3))
       setVideoAspectRatio(aspectRatio)
       // PiP aspect ratio is handled natively by react-native-video
     }
@@ -1237,19 +1315,13 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
     return true
   }, [currentVideo, playerMode, isInPipMode])
 
-  // PERFORMANCE: Memoize context value to prevent unnecessary re-renders
-  // Components consuming this context will only re-render when these specific values change
-  const contextValue = useMemo<VideoPlayerContextType>(() => ({
+  const sessionValue = useMemo<VideoPlayerSessionContextType>(() => ({
     currentVideo,
     videoUrl,
     isPlaying,
     isLoading,
     playerMode,
     videoStats,
-    currentTime,
-    duration,
-    progress,
-    playbackRate,
     playbackSession,
     isInPipMode,
     setIsInPipMode,
@@ -1258,8 +1330,32 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
     shouldEnablePip,
     androidSplitPlayerEnabled,
     videoAspectRatio,
-    seekPosition,
     playerRef,
+  }), [
+    currentVideo,
+    videoUrl,
+    isPlaying,
+    isLoading,
+    playerMode,
+    videoStats,
+    playbackSession,
+    isInPipMode,
+    setIsInPipMode,
+    pipWindowSize,
+    shouldEnablePip,
+    androidSplitPlayerEnabled,
+    videoAspectRatio,
+  ])
+
+  const progressValue = useMemo<VideoPlayerProgressContextType>(() => ({
+    currentTime,
+    duration,
+    progress,
+    playbackRate,
+    seekPosition,
+  }), [currentTime, duration, progress, playbackRate, seekPosition])
+
+  const actionsValue = useMemo<VideoPlayerActionsContextType>(() => ({
     loadAndPlayVideo,
     setAmbientVideoContext,
     pauseVideo,
@@ -1286,24 +1382,27 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
     onError,
     onVideoStateChange,
   }), [
-    // Low-frequency dependencies (video changes)
-    currentVideo, videoUrl, videoStats,
-    // Medium-frequency dependencies (control state)
-    isPlaying, isLoading, playerMode, playbackRate, playbackSession,
-    isInPipMode, pipWindowSize, shouldEnablePip, androidSplitPlayerEnabled, videoAspectRatio, seekPosition,
-    // High-frequency dependencies (progress - NOTE: this still causes re-renders at 4Hz)
-    currentTime, duration, progress,
-    // Callbacks (stable references via useCallback)
     loadAndPlayVideo, setAmbientVideoContext, pauseVideo, resumeVideo,
     closeVideo, enterBackgroundAudio, suppressForegroundRestoreOnce, suppressForegroundRestoreFor, clearLastClosedVideo, minimizePlayer, maximizePlayer, seekTo, seekBy, setPlaybackRate,
-    setIsInPipMode,
     onProgress, onLoaded, onPlaying, onPaused, onBuffering,
     onEnded, onError, onVideoStateChange,
   ])
 
+  const contextValue = useMemo<VideoPlayerContextType>(() => ({
+    ...sessionValue,
+    ...progressValue,
+    ...actionsValue,
+  }), [actionsValue, progressValue, sessionValue])
+
   return (
-    <VideoPlayerContext.Provider value={contextValue}>
-      {children}
-    </VideoPlayerContext.Provider>
+    <VideoPlayerActionsContext.Provider value={actionsValue}>
+      <VideoPlayerSessionContext.Provider value={sessionValue}>
+        <VideoPlayerProgressContext.Provider value={progressValue}>
+          <VideoPlayerContext.Provider value={contextValue}>
+            {children}
+          </VideoPlayerContext.Provider>
+        </VideoPlayerProgressContext.Provider>
+      </VideoPlayerSessionContext.Provider>
+    </VideoPlayerActionsContext.Provider>
   )
 }

--- a/packages/app/lib/android-discovery-diagnostics.d.ts
+++ b/packages/app/lib/android-discovery-diagnostics.d.ts
@@ -1,0 +1,26 @@
+export function getAndroidDiscoveryPermissionRequests(options?: {
+  platformOS?: string
+  platformVersion?: string | number
+  permissions?: Record<string, string>
+}): string[]
+
+export function classifyFeedDiscoveryState(options?: {
+  ready?: boolean
+  entries?: any[]
+  videos?: any[]
+  peerCount?: number
+  swarmStatus?: any
+  permissionStatus?: any
+  hasCachedSnapshot?: boolean
+}): {
+  state:
+    | 'backend-starting'
+    | 'permission-degraded'
+    | 'content-ready'
+    | 'hydrating'
+    | 'cached-fallback'
+    | 'discovery-waiting'
+    | 'network-degraded'
+  recoverable: boolean
+  reason?: string
+}

--- a/packages/app/lib/feed-hydration.d.ts
+++ b/packages/app/lib/feed-hydration.d.ts
@@ -15,6 +15,7 @@ export function mergeHydratedFeedVideos(options: {
   previousVideos?: any[]
   incomingVideos?: any[]
   refreshedChannelKeys?: string[]
+  feedEntries?: any[]
   identityDriveKey?: string | null
   limit?: number
 }): any[]

--- a/packages/app/lib/playerStateMachine.ts
+++ b/packages/app/lib/playerStateMachine.ts
@@ -51,6 +51,9 @@ export type TransitionSource =
   | 'androidPipExitRestorePreviousMode'
   | 'loadAndPlayVideo'
   | 'closeVideo'
+  | 'remoteStopClose'
+  | 'androidMinimizeClose'
+  | 'pipClose'
   | 'minimizePlayer'
   | 'maximizePlayer'
   | 'enterBackgroundAudio'
@@ -86,7 +89,7 @@ export type PlayerEvent =
     }
   | {
       type: 'CLOSE_VIDEO'
-      source: 'closeVideo'
+      source: 'closeVideo' | 'remoteStopClose' | 'androidMinimizeClose' | 'pipClose'
     }
   | {
       type: 'MINIMIZE'
@@ -471,10 +474,13 @@ function playerReducerInternal(state: PlayerState, event: PlayerEvent): PlayerSt
               url: event.url || null,
             }
           }
+          if (!event.video || !event.url) {
+            return toHiddenState(state)
+          }
           return {
             ...state,
             video: event.video,
-            url: event.url || null,
+            url: event.url,
           }
         case 'RESTORE_FROM_LAST_CLOSED':
           return invalidTransition(state, event)
@@ -539,10 +545,13 @@ function playerReducerInternal(state: PlayerState, event: PlayerEvent): PlayerSt
               url: event.url || null,
             }
           }
+          if (!event.video || !event.url) {
+            return toHiddenState(state)
+          }
           return {
             ...state,
             video: event.video,
-            url: event.url || null,
+            url: event.url,
           }
         case 'RESTORE_FROM_LAST_CLOSED':
           return invalidTransition(state, event)

--- a/packages/app/tests/expo-sdk-56-navigation-regression.test.mjs
+++ b/packages/app/tests/expo-sdk-56-navigation-regression.test.mjs
@@ -31,3 +31,13 @@ test('SDK 56 app code does not directly import React Navigation packages', () =>
     assert.doesNotMatch(readFile(file), /from ['"]@react-navigation\//, `${file} should import navigation shims from expo-router`)
   }
 })
+
+test('SDK 56 native video config uses the Expo Video plugin', () => {
+  const appConfig = readJson('packages/app/app.json')
+  const plugins = appConfig.expo?.plugins || []
+  const expoVideoPlugin = plugins.find((plugin) => Array.isArray(plugin) && plugin[0] === 'expo-video')
+
+  assert.ok(expoVideoPlugin, 'expo-video should own native player background/PiP configuration on SDK 56')
+  assert.equal(expoVideoPlugin[1]?.supportsBackgroundPlayback, true)
+  assert.equal(expoVideoPlugin[1]?.supportsPictureInPicture, true)
+})

--- a/packages/app/tests/pear-inline-player-view.test.mjs
+++ b/packages/app/tests/pear-inline-player-view.test.mjs
@@ -66,6 +66,15 @@ test('PearInlineVideoView uses Expo Video on native SDK 56 to avoid react-native
   assert.doesNotMatch(source, /from 'react-native-video'/)
 })
 
+test('PearInlineVideoView keeps one Expo Video player and replaces sources without remounting the VideoView', () => {
+  const source = readAppFile('components/video-player/PearInlineVideoView.tsx')
+
+  assert.match(source, /useVideoPlayer\(null,/)
+  assert.match(source, /replaceAsync/)
+  assert.match(source, /\.replace\(videoSource\)/)
+  assert.doesNotMatch(source, /key=\{`expo-video-/)
+})
+
 test('legacy MpvMobileVideoView implementation stays removed or only exists as a shim', () => {
   const shimPath = path.join(appRoot, 'components/video-player/MpvMobileVideoView.tsx')
   if (!fs.existsSync(shimPath)) {

--- a/packages/app/tests/video-player-context-split-regression.test.mjs
+++ b/packages/app/tests/video-player-context-split-regression.test.mjs
@@ -1,0 +1,61 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const appRoot = path.resolve(__dirname, '..')
+
+function readAppFile(relativePath) {
+  return fs.readFileSync(path.join(appRoot, relativePath), 'utf8')
+}
+
+test('VideoPlayerContext exposes focused session, progress, and action hooks', () => {
+  const source = readAppFile('lib/VideoPlayerContext.tsx')
+
+  assert.match(source, /const VideoPlayerSessionContext = createContext/)
+  assert.match(source, /const VideoPlayerProgressContext = createContext/)
+  assert.match(source, /const VideoPlayerActionsContext = createContext/)
+  assert.match(source, /export function useVideoPlayerSession\(\)/)
+  assert.match(source, /export function useVideoPlayerProgress\(\)/)
+  assert.match(source, /export function useVideoPlayerActions\(\)/)
+})
+
+test('low-frequency UI consumers avoid the combined high-frequency player context', () => {
+  for (const relativePath of ['lib/SocialContext.tsx', 'components/PillTabBar.tsx']) {
+    const source = readAppFile(relativePath)
+
+    assert.match(source, /useVideoPlayerSession/)
+    assert.doesNotMatch(source, /useVideoPlayerContext\(/)
+  }
+})
+
+test('command-only screens use the action context instead of progress-carrying context', () => {
+  for (const relativePath of [
+    'app/search.tsx',
+    'app/(tabs)/search.tsx',
+    'app/(tabs)/index.tsx',
+    'app/(tabs)/studio.tsx',
+  ]) {
+    const source = readAppFile(relativePath)
+
+    assert.match(source, /useVideoPlayerActions/)
+    assert.doesNotMatch(source, /useVideoPlayerContext\(/)
+  }
+})
+
+test('watch page composes focused player hooks without subscribing to progress ticks', () => {
+  const source = readAppFile('app/video/[id].tsx')
+
+  assert.match(source, /useVideoPlayerSession\(\)/)
+  assert.match(source, /useVideoPlayerActions\(\)/)
+  assert.doesNotMatch(source, /useVideoPlayerContext\(/)
+  assert.doesNotMatch(source, /\bonProgress\b/)
+  assert.doesNotMatch(source, /\bonPlaying\b/)
+  assert.doesNotMatch(source, /\bonPaused\b/)
+  assert.doesNotMatch(source, /\bonBuffering\b/)
+  assert.doesNotMatch(source, /\bonEnded\b/)
+  assert.doesNotMatch(source, /\bonError\b/)
+})

--- a/packages/app/tests/video-player-loading-clears-regression.test.mjs
+++ b/packages/app/tests/video-player-loading-clears-regression.test.mjs
@@ -35,6 +35,16 @@ test('mobile/native route uses the shared overlay player instead of an inline pl
   assert.doesNotMatch(src, /onLoad=\{onLoaded\}/, 'route should not try to wire a nonexistent inline player load handler')
 })
 
+test('mobile/native route cancels delayed stats polling when closed quickly', async () => {
+  const src = await source(videoRoutePath)
+
+  assert.match(src, /const statsPollingDelayRef = useRef/, 'watch route should track delayed stats polling timers')
+  assert.match(src, /const mountedRef = useRef\(true\)/, 'watch route should guard async work after unmount')
+  assert.match(src, /const clearStatsPolling = useCallback/, 'watch route should centralize stats polling cleanup')
+  assert.match(src, /const scheduleStatsPolling = useCallback/, 'watch route should schedule stats polling through a cancellable helper')
+  assert.doesNotMatch(src, /setTimeout\(\(\) => startStatsPolling\(\), 500\)/, 'stats polling should not be started by uncancellable delayed callbacks')
+})
+
 test('desktop/native overlay forwards load events into shared player context before local handling', async () => {
   const src = await source(overlayPath)
   assert.match(src, /onLoaded,/, 'overlay must read onLoaded from useVideoPlayerContext')


### PR DESCRIPTION
## Summary

- Keep a stable Expo Video player instance and replace sources with `replaceAsync` instead of remounting `VideoView` during rapid video open/close cycles.
- Split video player state into focused session, progress, and action contexts so command-only and low-frequency UI consumers avoid progress tick re-renders.
- Add regression coverage for the Expo Video source replacement path, SDK 56 navigation constraints, loading clear behavior, and the context split.

## Validation

- `node packages/app/tests/video-player-context-split-regression.test.mjs`
- `node packages/app/tests/pear-inline-player-view.test.mjs`
- `node packages/app/tests/video-player-loading-clears-regression.test.mjs`
- `node packages/app/tests/expo-sdk-56-navigation-regression.test.mjs`
- `npm run typecheck`

## Notes

- Full `tsc -p packages/app/tsconfig.json --noEmit` still fails on existing app-wide type debt, mostly missing Gluestack/Tamagui module declarations and older UI typing errors.