### PR TITLE
fix(app): clean studio copy lint

### DIFF
--- a/packages/app/app/(tabs)/studio.tsx
+++ b/packages/app/app/(tabs)/studio.tsx
@@ -516,7 +516,7 @@ export default function StudioScreen() {
               {!isPear && thumbnailError ? (
                 <View className="bg-pear-bg-elevated border border-pear-border rounded-lg p-4">
                   <Text className="text-caption text-pear-text-muted">
-                    Thumbnail generation failed. Tap "Add Thumbnail" to pick an image.
+                    Thumbnail generation failed. Tap Add Thumbnail to pick an image.
                   </Text>
                 </View>
               ) : null}


### PR DESCRIPTION
## Summary
- Fixes the changed-file lint failure left on main by removing quoted JSX copy in Studio.

## Validation
- ./node_modules/.bin/eslint --quiet packages/app/app/\(tabs\)/studio.tsx
- npm run lint:changed
- node packages/app/tests/video-player-context-split-regression.test.mjs
- node packages/app/tests/pear-inline-player-view.test.mjs
- node packages/app/tests/video-player-loading-clears-regression.test.mjs
- node packages/app/tests/expo-sdk-56-navigation-regression.test.mjs
- git diff --check