### PR TITLE
fix(app): preserve video stats across playback lifecycle

### DIFF
--- a/packages/app/app/video/[id].tsx
+++ b/packages/app/app/video/[id].tsx
@@ -456,6 +456,7 @@ function MobileVideoPlayerScreen() {
     const generation = loadGenerationRef.current + 1
     loadGenerationRef.current = generation
     clearStatsPolling()
+    setLocalStats(null)
     setIsLoading(true)
 
     try {
@@ -542,7 +543,8 @@ function MobileVideoPlayerScreen() {
     const isSameVideoAsCurrent = Boolean(currentRef && targetRef && currentRef === targetRef && sameChannel)
 
     if (!videoLoaded) {
-      if (fromMiniPlayer && isSameVideoAsCurrent && (Platform.OS !== 'web' || isPear)) {
+      if (isSameVideoAsCurrent && videoUrl && (Platform.OS !== 'web' || isPear)) {
+        setIsLoading(false)
         startStatsPolling()
       } else {
         loadVideo()
@@ -554,7 +556,7 @@ function MobileVideoPlayerScreen() {
       clearTimeout(channelInfoTimer)
       clearStatsPolling()
     }
-  }, [videoData, loadingMeta, fromMiniPlayer, isPear, videoLoaded, loadVideo, startStatsPolling, loadChannelInfo, currentVideo, clearStatsPolling])
+  }, [videoData, loadingMeta, isPear, videoLoaded, loadVideo, startStatsPolling, loadChannelInfo, currentVideo, videoUrl, setIsLoading, clearStatsPolling])
 
   // Back/minimize button - beforeRemove listener handles minimizePlayer()
   const goBack = () => {
@@ -577,6 +579,8 @@ function MobileVideoPlayerScreen() {
       </View>
     )
   }
+
+  const displayedStats = videoStats || localStats
 
   return (
     <View style={[styles.container, { paddingTop: insets.top }]}>
@@ -612,7 +616,7 @@ function MobileVideoPlayerScreen() {
             <View style={{ width: screenWidth, height: videoHeight }}>
               {/* Video is rendered by VideoPlayerOverlay on all platforms */}
               <P2PStatsOverlay
-                stats={localStats || videoStats}
+                stats={displayedStats}
                 showDetails={showStats}
                 onPress={() => setShowStats(!showStats)}
               />
@@ -631,7 +635,7 @@ function MobileVideoPlayerScreen() {
       {/* Video Info & Actions */}
       <ScrollView style={styles.content} showsVerticalScrollIndicator={false}>
         {/* P2P Stats Bar */}
-        {(Platform.OS !== 'web' || isPear) && <P2PStatsBar stats={localStats || videoStats} />}
+        {(Platform.OS !== 'web' || isPear) && <P2PStatsBar stats={displayedStats} />}
 
         {/* Video Title & Meta */}
         <View style={styles.videoInfo}>

--- a/packages/app/tests/mobile-video-stats-lifecycle-regression.test.mjs
+++ b/packages/app/tests/mobile-video-stats-lifecycle-regression.test.mjs
@@ -1,0 +1,61 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const appRoot = path.resolve(__dirname, '..')
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(appRoot, relativePath), 'utf8')
+}
+
+test('mobile watch page keeps live context stats ahead of stale polled stats', () => {
+  const source = read('app/video/[id].tsx')
+
+  assert.match(
+    source,
+    /const displayedStats = videoStats \|\| localStats/,
+    'event-driven VideoPlayerContext stats should win over older local polling snapshots',
+  )
+  assert.match(
+    source,
+    /<P2PStatsOverlay[\s\S]*stats=\{displayedStats\}/,
+    'inline overlay should use the same fresh stats source',
+  )
+  assert.match(
+    source,
+    /<P2PStatsBar stats=\{displayedStats\}/,
+    'detail stats bar should use the same fresh stats source',
+  )
+})
+
+test('mobile watch page reattaches stats when returning to an already playing video', () => {
+  const source = read('app/video/[id].tsx')
+
+  assert.match(
+    source,
+    /if \(isSameVideoAsCurrent && videoUrl && \(Platform\.OS !== 'web' \|\| isPear\)\) \{[\s\S]*setIsLoading\(false\)[\s\S]*startStatsPolling\(\)/,
+    'returning to the active video should poll stats instead of replaying preparePlayback and showing the loading gate',
+  )
+  assert.doesNotMatch(
+    source,
+    /fromMiniPlayer && isSameVideoAsCurrent/,
+    'same-video lifecycle handling must not depend only on fromMiniPlayer route params',
+  )
+})
+
+test('mobile watch page clears stale local stats only when starting a different load', () => {
+  const source = read('app/video/[id].tsx')
+  const loadStart = source.indexOf('const loadVideo = useCallback(async () =>')
+  assert.notEqual(loadStart, -1, 'expected loadVideo callback')
+  const loadBlock = source.slice(loadStart, source.indexOf('  // Load video when videoData is available', loadStart))
+
+  assert.match(
+    loadBlock,
+    /clearStatsPolling\(\)[\s\S]*setLocalStats\(null\)[\s\S]*setIsLoading\(true\)/,
+    'new playback loads should drop stale local snapshots before showing a loading state',
+  )
+})


### PR DESCRIPTION
## Summary
- keep live `VideoPlayerContext` stats ahead of stale route-local polling snapshots
- reattach stats polling when returning to the same already-playing video instead of showing the prepare/playback loading gate
- clear stale local stats only when a new playback load actually starts
- add regression coverage for app background/return and same-video navigation lifecycle gaps

## Test plan
- `node --test packages/app/tests/mobile-video-stats-lifecycle-regression.test.mjs packages/app/tests/p2p-stats-bar-data-truth-regression.test.mjs packages/app/tests/video-player-loading-clears-regression.test.mjs`
- `./node_modules/.bin/eslint --quiet packages/app/app/video/[id].tsx packages/app/tests/mobile-video-stats-lifecycle-regression.test.mjs`
- Android release APK build with increased Gradle heap: `./gradlew :app:assembleRelease -PtargetAbis=x86_64 -PreactNativeArchitectures=x86_64 --no-daemon --stacktrace -Dorg.gradle.jvmargs='-Xmx6144m -XX:MaxMetaspaceSize=1536m -XX:+HeapDumpOnOutOfMemoryError'`
- `apksigner verify --print-certs packages/app/android/app/build/outputs/apk/release/app-x86_64-release.apk`
- installed `app-x86_64-release.apk` on `emulator-5554` and launched `com.peartube.app/.MainActivity`

## Notes
- The original `npm run build:android:apk:x86_64` reached dex merge and failed with `D8: java.lang.OutOfMemoryError: Java heap space`; rerunning Gradle directly with a larger heap completed successfully.
- Emulator launch exposed a separate stale-local-data/system ANR state (`SESSION_CLOSED` from Hypercore/autobase after reinstall over prior app data). `pm clear com.peartube.app` removed the stale app data, but the emulator itself still showed system/permission ANR overlays, so the UI lifecycle fix is verified by source regressions + install/launch smoke rather than a full Maestro navigation loop.
