### PR TITLE
fix(app): keep stats visible during playback buffering

### DIFF
--- a/packages/app/components/video-player/P2PStatsBar.tsx
+++ b/packages/app/components/video-player/P2PStatsBar.tsx
@@ -25,6 +25,9 @@ export const P2PStatsBar = memo(function P2PStatsBar({ stats }: P2PStatsBarProps
   const totalBlocks = Number(stats?.totalBlocks ?? 0)
   const hasBytes = totalBytes > 0
   const hasBlocks = totalBlocks > 0
+  const hasDownloadedBytes = downloadedBytes > 0
+  const hasDownloadedBlocks = downloadedBlocks > 0
+  const hasPlayableProgress = hasDownloadedBytes || hasDownloadedBlocks || Number(stats?.progress ?? 0) > 0
   const hasProgressDetails = hasBytes || hasBlocks || Boolean(stats?.isComplete)
 
   const getStatusInfo = () => {
@@ -32,6 +35,7 @@ export const P2PStatsBar = memo(function P2PStatsBar({ stats }: P2PStatsBarProps
     if (stats.isComplete) return { color: '#4ade80', label: 'Cached' }
     if (stats.status === 'downloading') return { color: '#fbbf24', label: 'Downloading' }
     if (downloadSpeed > 0) return { color: '#fbbf24', label: 'Downloading' }
+    if (hasPlayableProgress) return { color: '#60a5fa', label: 'Streaming' }
     if (stats.status === 'connecting') return { color: '#60a5fa', label: 'Finding video peers' }
     if (stats.status === 'resolving') return { color: '#a78bfa', label: 'Resolving video' }
     if (stats.status === 'error') return { color: '#f87171', label: 'Playback error' }

--- a/packages/app/lib/VideoPlayerContext.tsx
+++ b/packages/app/lib/VideoPlayerContext.tsx
@@ -1259,6 +1259,13 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
       return
     }
 
+    // If the player is already advancing, a native buffering=true event means a
+    // transient refill, not a new playback preparation. Keep the stats/details
+    // visible instead of flipping the whole watch UI back to the loading gate.
+    if (data.isBuffering && currentTimeRef.current > 0) {
+      return
+    }
+
     // Suppress transient buffering after returning from PiP or background audio.
     // ExoPlayer re-attaches its surface and fires brief buffering events.
     // Cleared by the next onPlaying event confirming real playback resumed.

--- a/packages/app/tests/p2p-stats-bar-regression.test.mjs
+++ b/packages/app/tests/p2p-stats-bar-regression.test.mjs
@@ -1,10 +1,17 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
-import { resolve } from 'node:path'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
-const source = readFileSync(resolve('components/video-player/P2PStatsBar.tsx'), 'utf8')
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const source = readFileSync(resolve(__dirname, '../components/video-player/P2PStatsBar.tsx'), 'utf8')
 
 test('P2P stats bar does not claim preparing when bytes are actively transferring', () => {
   assert.match(source, /if \(downloadSpeed > 0\) return \{ color: '#fbbf24', label: 'Downloading' \}/)
+})
+
+test('P2P stats bar treats an actively loaded video as ready even when transfer speeds are momentarily idle', () => {
+  assert.match(source, /const hasPlayableProgress =/, 'stats bar should classify playable byte or block progress separately from transfer speed')
+  assert.match(source, /if \(hasPlayableProgress\) return \{ color: '#60a5fa', label: 'Streaming' \}/, 'loaded playable progress should stay in streaming state instead of falling through to preparing')
 })

--- a/packages/app/tests/video-player-loading-clears-regression.test.mjs
+++ b/packages/app/tests/video-player-loading-clears-regression.test.mjs
@@ -45,6 +45,17 @@ test('mobile/native route cancels delayed stats polling when closed quickly', as
   assert.doesNotMatch(src, /setTimeout\(\(\) => startStatsPolling\(\), 500\)/, 'stats polling should not be started by uncancellable delayed callbacks')
 })
 
+test('VideoPlayerContext suppresses the loading gate for mid-playback buffering events', async () => {
+  const src = await source(contextPath)
+  const bufferingStart = src.indexOf('const onBuffering = useCallback')
+  assert.notEqual(bufferingStart, -1, 'expected VideoPlayerContext onBuffering callback')
+  const bufferingHandler = src.slice(bufferingStart, src.indexOf('const onEnded', bufferingStart))
+
+  assert.match(bufferingHandler, /data\.isBuffering && currentTimeRef\.current > 0/, 'buffering while playback has advanced should be treated as transient')
+  assert.match(bufferingHandler, /Keep the stats\/details[\s\S]*visible/, 'transient mid-playback buffering should keep stats/details visible')
+  assert.match(bufferingHandler, /setIsLoading\(data\.isBuffering\)/, 'initial buffering should still show loading before playback starts')
+})
+
 test('desktop/native overlay forwards load events into shared player context before local handling', async () => {
   const src = await source(overlayPath)
   assert.match(src, /onLoaded,/, 'overlay must read onLoaded from useVideoPlayerContext')


### PR DESCRIPTION
## Summary
- keep the stats/details UI visible when native playback emits a transient buffering=true event after the video has already advanced
- classify already-playable P2P stats as Streaming when transfer speed is momentarily idle, instead of falling through to Preparing video
- make the P2P stats-bar regression test path-independent so it runs correctly from repo root

## Verification
- node --test packages/app/tests/p2p-stats-bar-regression.test.mjs packages/app/tests/video-player-loading-clears-regression.test.mjs packages/app/tests/mobile-video-stats-lifecycle-regression.test.mjs
- npx eslint --quiet packages/app/components/video-player/P2PStatsBar.tsx packages/app/lib/VideoPlayerContext.tsx packages/app/tests/p2p-stats-bar-regression.test.mjs packages/app/tests/video-player-loading-clears-regression.test.mjs
- git diff --check

## Notes
This targets the reported Android symptom where the video keeps playing but the peer stats bar/overlay flips back to a preparing/loading state mid-playback. Initial startup buffering still shows the loading gate; only buffering after currentTime has advanced is suppressed.
