### PR TITLE
fix(app): preserve android autoplay during source load

### DIFF
--- a/packages/app/components/video-player/PearInlineVideoView.tsx
+++ b/packages/app/components/video-player/PearInlineVideoView.tsx
@@ -408,7 +408,15 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
       return
     }
 
-    if (Platform.OS === 'web' && !hasReceivedPlayEventRef.current) return
+    if (!hasReceivedPlayEventRef.current && isPlayingRef.current) {
+      try {
+        player.play()
+      } catch {
+        // Best effort: keep JS desired playback state from being cancelled by
+        // an expo-video paused event emitted before the first native play event.
+      }
+      return
+    }
     if (pipExitPlayingRef.current) return
     if (Date.now() <= seekPlaybackRecoveryUntilRef.current && isPlayingRef.current) {
       onBuffering?.({ isBuffering: true })

--- a/packages/app/tests/android-video-opens-playing-regression.test.mjs
+++ b/packages/app/tests/android-video-opens-playing-regression.test.mjs
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { test } from 'node:test'
+
+const inlineViewPath = new URL('../components/video-player/PearInlineVideoView.tsx', import.meta.url)
+
+async function source(url) {
+  return readFile(url, 'utf8')
+}
+
+test('Android keeps initial desired play state when expo-video emits a pre-play paused event', async () => {
+  const src = await source(inlineViewPath)
+  const handlerStart = src.indexOf("useEventListener(player, 'playingChange'")
+  assert.notEqual(handlerStart, -1, 'expected expo-video playingChange handler')
+  const handler = src.slice(handlerStart, src.indexOf("useEventListener(player, 'statusChange'", handlerStart))
+
+  assert.match(handler, /!hasReceivedPlayEventRef\.current && isPlayingRef\.current/, 'pre-play paused events while desired playback is true should be ignored')
+  assert.match(handler, /player\.play\(\)/, 'ignored pre-play paused events should reassert native play')
+  assert.doesNotMatch(handler, /Platform\.OS === 'web' && !hasReceivedPlayEventRef\.current/, 'the pre-play paused guard must not be web-only')
+})


### PR DESCRIPTION
## Summary
- ignore expo-video's pre-play `playingChange(false)` event when JS has just requested playback
- reassert `player.play()` in that pre-play race so Android video opens in playing state instead of immediately flipping paused
- add regression coverage for the initial Android paused-event race

## Verification
- node --test packages/app/tests/android-video-opens-playing-regression.test.mjs packages/app/tests/video-player-loading-clears-regression.test.mjs packages/app/tests/mobile-video-stats-lifecycle-regression.test.mjs
- npx eslint --quiet packages/app/components/video-player/PearInlineVideoView.tsx packages/app/tests/android-video-opens-playing-regression.test.mjs
- npm run lint:changed
- git diff --check

## Notes
`npx tsc --noEmit --project packages/app/tsconfig.json` still reports pre-existing app-wide type errors unrelated to this change, including missing gluestack/native diagnostics declarations and existing StyleSheet.absoluteFillObject issues in other files.
