### PR TITLE
fix(desktop-native): clean up native sidecar shutdown

### DIFF
--- a/packages/desktop-native/Bridge/native-host-sidecar-cleanup.test.mjs
+++ b/packages/desktop-native/Bridge/native-host-sidecar-cleanup.test.mjs
@@ -1,0 +1,21 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const sidecarPath = path.resolve(import.meta.dirname, 'native-host-sidecar.mjs')
+const source = fs.readFileSync(sidecarPath, 'utf8')
+
+test('native sidecar uses lazy transcoder adapter instead of dead unavailable stub', () => {
+  assert.doesNotMatch(source, /Transcoding is not wired in the native sidecar yet\./)
+  assert.match(source, /async startTranscode\(\.\.\.args\)/)
+  assert.match(source, /ensureTranscoderModule\(\)/)
+})
+
+test('native sidecar clears keepalive timer through idempotent shutdown cleanup', () => {
+  assert.match(source, /function createKeepAliveCleanup\(\)/)
+  assert.match(source, /let keepAliveCleanup = createKeepAliveCleanup\(\)/)
+  assert.match(source, /await shutdownBridge\(state, cleanupKeepAlive\)/)
+  assert.match(source, /void shutdownBridge\(state, cleanup\)/)
+  assert.match(source, /cleanupKeepAlive\?\.\(\)/)
+})

--- a/packages/desktop-native/Bridge/native-host-sidecar.mjs
+++ b/packages/desktop-native/Bridge/native-host-sidecar.mjs
@@ -1,3 +1,4 @@
+/* eslint-disable no-empty, no-undef, @typescript-eslint/no-require-imports */
 import bareProcess from 'bare-process'
 import os from 'bare-os'
 import HRPC from '../../spec/spec/hrpc/index.js'
@@ -40,6 +41,8 @@ let mpvFrameServerPort = 0
 let mpvFrameServerReady = null
 let bareHttp1Promise = null
 let platformPromise = null
+let transcoderModule = null
+let transcoderModulePromise = null
 
 async function loadBareHTTP1() {
   if (bareHttp1Promise) return bareHttp1Promise
@@ -131,6 +134,50 @@ async function loadBareFFmpeg() {
   })()
 
   return ffmpegLoadPromise
+}
+
+async function ensureTranscoderModule() {
+  if (transcoderModule) return transcoderModule
+  if (!transcoderModulePromise) {
+    transcoderModulePromise = import('../../app/backend/transcoder.mjs')
+      .then((module) => {
+        transcoderModule = module?.default ?? module
+        return transcoderModule
+      })
+      .catch((error) => {
+        transcoderModulePromise = null
+        throw error
+      })
+  }
+
+  return transcoderModulePromise
+}
+
+function createLazyTranscoder() {
+  return {
+    async startTranscode(...args) {
+      const module = await ensureTranscoderModule()
+      return module.startTranscode(...args)
+    },
+    async stopTranscode(...args) {
+      const module = await ensureTranscoderModule()
+      return module.stopTranscode(...args)
+    },
+    async getStatus(...args) {
+      const module = await ensureTranscoderModule()
+      return module.getStatus(...args)
+    },
+  }
+}
+
+function createKeepAliveCleanup() {
+  let keepAliveTimer = setInterval(() => {}, 1 << 30)
+
+  return function cleanupKeepAlive() {
+    if (!keepAliveTimer) return
+    clearInterval(keepAliveTimer)
+    keepAliveTimer = null
+  }
 }
 
 function handleMpvFrameRequest(req, res) {
@@ -433,11 +480,7 @@ async function createNativeSidecarBackend(options = {}) {
     const path = pathModule?.default ?? pathModule
     const fs = fsModule?.default ?? fsModule
     const generateAndStoreThumbnail = thumbnailModule?.generateAndStoreThumbnail
-    const transcoder = {
-      startTranscode: async () => ({ success: false, error: 'Transcoding is not wired in the native sidecar yet.' }),
-      stopTranscode: () => ({ success: false, error: 'Transcoding is not wired in the native sidecar yet.' }),
-      getStatus: () => ({ status: 'unavailable', progress: 0, bytesWritten: 0, error: 'Transcoding is not wired in the native sidecar yet.' }),
-    }
+    const transcoder = createLazyTranscoder()
 
     attachMobileHandlers(backend, {
       api: backend.api,
@@ -634,7 +677,8 @@ function createChannelDataFetcher(client) {
   }
 }
 
-async function shutdownBridge(state) {
+async function shutdownBridge(state, cleanupKeepAlive = null) {
+  cleanupKeepAlive?.()
   await destroyAllMpvPlayers()
   await state.hostSession?.terminate?.()
   state.hostSession = null
@@ -753,7 +797,7 @@ function toSchemaSnapshot(snapshot) {
   }
 }
 
-function registerHandlers(hrpcInstance, state, reportFatal) {
+function registerHandlers(hrpcInstance, state, reportFatal, cleanupKeepAlive = null) {
   hrpcInstance.onDesktopBootstrap(async (req) => {
     const ready = await ensureHostBooted(
       state,
@@ -776,7 +820,7 @@ function registerHandlers(hrpcInstance, state, reportFatal) {
   })
 
   hrpcInstance.onDesktopShutdown(async () => {
-    await shutdownBridge(state)
+    await shutdownBridge(state, cleanupKeepAlive)
     return { success: true }
   })
 
@@ -1279,7 +1323,7 @@ function registerHandlers(hrpcInstance, state, reportFatal) {
 
 async function main() {
   const state = createBridgeState()
-  const keepAliveTimer = setInterval(() => {}, 1 << 30)
+  let keepAliveCleanup = createKeepAliveCleanup()
 
   // bare-rpc expects a duplex stream with on('data'), on('error'), on('drain'), write(), destroy()
   const stream = {
@@ -1334,13 +1378,14 @@ async function main() {
     })
   }
 
-  registerHandlers(hrpc, state, reportFatal)
+  registerHandlers(hrpc, state, reportFatal, keepAliveCleanup)
 
   process.stdin?.resume?.()
 
   process.stdin?.on?.('end', () => {
-    clearInterval(keepAliveTimer)
-    void shutdownBridge(state).finally(() => {
+    const cleanup = keepAliveCleanup
+    keepAliveCleanup = null
+    void shutdownBridge(state, cleanup).finally(() => {
       try {
         Bare.exit(0)
       } catch {}


### PR DESCRIPTION
## Summary
- remove the native sidecar's dead transcoder stub and route transcode calls through the same lazy adapter used by the app backend
- make native sidecar keepAlive timer cleanup idempotent and run it from both explicit shutdown and stdin EOF shutdown
- add source-level regression coverage for the sidecar cleanup contract

Closes #227

## Test plan
- `node --test packages/desktop-native/Bridge/native-host-sidecar-cleanup.test.mjs packages/desktop-native/Bridge/native-rpc.test.mjs packages/desktop-native/Bridge/playback-resolution.test.mjs packages/desktop-native/Bridge/bridge-core.test.mjs`
- `npx eslint --quiet packages/desktop-native/Bridge/native-host-sidecar.mjs packages/desktop-native/Bridge/native-host-sidecar-cleanup.test.mjs`
- `npm run lint:changed`
- `git diff --check`
