### PR TITLE
fix(backend): speed up peer connection startup

### DIFF
--- a/packages/backend/src/known-peers.js
+++ b/packages/backend/src/known-peers.js
@@ -86,11 +86,13 @@ export async function loadKnownPeers(metaDb) {
   }
 }
 
-export function dialKnownPeers(swarm, knownList) {
+export function dialKnownPeers(swarm, knownList, options = {}) {
   if (!swarm || typeof swarm.joinPeer !== 'function' || swarm._peartubeOffline) return 0
+  const limit = Number.isFinite(options.limit) && options.limit > 0 ? Math.floor(options.limit) : Infinity
   let dialed = 0
   const seen = new Set()
   for (const entry of knownList) {
+    if (dialed >= limit) break
     try {
       const key = typeof entry?.key === 'string' ? entry.key.toLowerCase() : null
       if (!key || !/^[0-9a-f]{64}$/.test(key) || seen.has(key)) continue

--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -690,6 +690,15 @@ export class PublicFeed {
       this._ownsFeedDiscovery = false
     }
 
+    // Set up feed protocol on any existing connections before cache restore. If
+    // storage already connected to a peer during backend warm-up, the Protomux
+    // feed channel should not wait behind disk/cache reads.
+    const existingConns = this.swarm.connections?.size || 0;
+    console.log('[PublicFeed] Setting up feed protocol on', existingConns, 'existing connections before cache restore');
+    for (const conn of this.swarm.connections) {
+      this.handleConnection(conn, {});
+    }
+
     // Load persisted published channels from database
     // Try new format first (with publicBeeKey), fall back to legacy format
     if (this.metaDb) {
@@ -789,12 +798,6 @@ export class PublicFeed {
       try { this.onFeedUpdate?.(); } catch {}
     }
 
-    // Set up feed protocol on any existing connections.
-    const existingConns = this.swarm.connections?.size || 0;
-    console.log('[PublicFeed] Setting up feed protocol on', existingConns, 'existing connections');
-    for (const conn of this.swarm.connections) {
-      this.handleConnection(conn, {});
-    }
     this._startGossipLoop()
     console.log('[PublicFeed] ===== PUBLIC FEED STARTED =====');
   }

--- a/packages/backend/src/storage.js
+++ b/packages/backend/src/storage.js
@@ -26,9 +26,11 @@ import {
 } from './runtime-modules.js'
 import { NETWORK_TOPIC_STRING } from './types.js'
 import { normalizeBlobRefInput } from './blob-ref.js'
-import { createKnownPeerCache, loadKnownPeers, dialKnownPeers, getDialableKnownPeers } from './known-peers.js'
+import { createKnownPeerCache, loadKnownPeers, dialKnownPeers, getDialableKnownPeers, getExplicitPeerList } from './known-peers.js'
 
 const DEFAULT_BLOBS_CORE_UPDATE_TIMEOUT_MS = 15000
+const DEFAULT_STARTUP_KNOWN_PEER_DIAL_LIMIT = 8
+const DEFAULT_RESUME_KNOWN_PEER_DIAL_LIMIT = 8
 
 function resolveDebugLogPath() {
   return globalThis?.process?.env?.PEARTUBE_NATIVE_WORKLET_DEBUG_LOG || null
@@ -235,7 +237,12 @@ function copyDefinedOption(target, source, key) {
 }
 
 export function createHyperswarmOptions({ keyPair, network = {}, swarmOptions = {} } = {}) {
-  const options = { ...swarmOptions, keyPair }
+  const options = {
+    maxParallel: 8,
+    maxPeers: 96,
+    ...swarmOptions,
+    keyPair
+  }
   const envBootstrap = readEnv('PEARTUBE_NETWORK_BOOTSTRAP') || readEnv('PEARTUBE_HYPERSWARM_BOOTSTRAP')
   const envRelayThrough = readEnv('PEARTUBE_NETWORK_RELAY_THROUGH') || readEnv('PEARTUBE_RELAY_THROUGH')
   const bootstrap = normalizeBootstrap(network.bootstrap ?? swarmOptions.bootstrap ?? envBootstrap)
@@ -773,7 +780,7 @@ export function retainSwarmDiscovery(ctx, discoveryKey, options = {}) {
   if (!ctx.swarm._peartubeOffline) {
     getDialableKnownPeers(ctx)
       .then((known) => {
-        const dialed = dialKnownPeers(ctx.swarm, known)
+        const dialed = dialKnownPeers(ctx.swarm, known, { limit: ctx.swarm?._peartubeStartupDialLimit || DEFAULT_STARTUP_KNOWN_PEER_DIAL_LIMIT })
         if (dialed > 0) {
           const label = options.label || discoveryKeyHex.slice(0, 16)
           console.log(`[Storage] Direct-dialed ${dialed} known peer(s) for ${label}`)
@@ -1229,7 +1236,18 @@ export async function initializeStorage(config) {
     swarm = createOfflineSwarm(keyPair, 'module-unavailable')
   } else {
     try {
-      swarm = new LoadedHyperswarm(createHyperswarmOptions({ keyPair, network, swarmOptions }));
+      const hyperswarmOptions = createHyperswarmOptions({ keyPair, network, swarmOptions })
+      swarm = new LoadedHyperswarm(hyperswarmOptions);
+      swarm._peartubeStartupDialLimit = Math.max(1, Number(
+        network.startupKnownPeerDialLimit ??
+        swarmOptions.startupKnownPeerDialLimit ??
+        DEFAULT_STARTUP_KNOWN_PEER_DIAL_LIMIT
+      ) || DEFAULT_STARTUP_KNOWN_PEER_DIAL_LIMIT)
+      swarm._peartubeResumeDialLimit = Math.max(1, Number(
+        network.resumeKnownPeerDialLimit ??
+        swarmOptions.resumeKnownPeerDialLimit ??
+        DEFAULT_RESUME_KNOWN_PEER_DIAL_LIMIT
+      ) || DEFAULT_RESUME_KNOWN_PEER_DIAL_LIMIT)
     } catch (err) {
       if (requireNetwork) {
         throw new Error(`Hyperswarm failed to start for required network startup: ${err?.message || String(err)}`)
@@ -1347,13 +1365,55 @@ export async function initializeStorage(config) {
     log.debug('Swarm update event', { connections: swarm.connections?.size || 0, peers: swarm.peers?.size || 0 })
   });
 
-  // Warm dial: re-connect to recently-seen peers. swarm.joinPeer is idempotent
-  // against any topic-based discovery that follows.
   if (!swarm._peartubeOffline) {
+    // Start listening before direct dials and topic joins. This overlaps DHT/server
+    // readiness with outbound connection attempts instead of waiting until after
+    // warm-dial and peer-pool join setup.
+    console.log('[Storage] Starting swarm.listen() early (non-blocking)...');
+    await appendDebugLine('[storage] swarm.listen start early')
+    const listenPromise = swarm.listen()
+    globalNetworkStartupTiming?.record('swarm-listen-called')
+
+    // Track listen state for debugging
+    swarm._peartubeListenResolved = false
+    if (listenPromise && typeof listenPromise.then === 'function') {
+      listenPromise
+        .then(() => {
+          swarm._peartubeListenResolved = true
+          globalNetworkStartupTiming?.record('swarm-listen-resolved', { firewalled: swarm.dht?.firewalled, bootstrapped: swarm.dht?.bootstrapped })
+          console.log('[Storage] listen() resolved, dht.firewalled:', swarm.dht?.firewalled, 'dht.bootstrapped:', swarm.dht?.bootstrapped)
+          void appendDebugLine(
+            `[storage] swarm.listen resolved firewalled=${swarm.dht?.firewalled} bootstrapped=${swarm.dht?.bootstrapped}`
+          )
+        })
+        .catch((e) => {
+          globalNetworkStartupTiming?.record('swarm-listen-failed', { error: e?.message || String(e) })
+          console.log('[Storage] listen() failed:', e?.message)
+          void appendDebugLine(`[storage] swarm.listen failed ${e?.message || String(e)}`)
+        })
+    }
+  }
+
+  // Direct-dial explicitly configured relay/known peers before any persisted DB
+  // read. These are the highest-signal peers on Android cold starts.
+  if (!swarm._peartubeOffline) {
+    const explicitPeers = getExplicitPeerList({ network, swarmOptions })
+    const explicitDialed = dialKnownPeers(swarm, explicitPeers)
+    if (explicitDialed > 0) {
+      globalNetworkStartupTiming?.record('explicit-peer-dialed', { dialed: explicitDialed, candidates: explicitPeers.length })
+      console.log('[Storage] Direct-dialed', explicitDialed, 'explicit peer(s) before known-peer cache load')
+      void appendDebugLine(`[storage] explicit warm-dialed ${explicitDialed} of ${explicitPeers.length} peers`)
+    }
+  }
+
+  // Warm dial: re-connect to recently-seen peers. Limit startup fanout so stale
+  // cached peers do not occupy all client dial slots ahead of configured relays.
+  if (!swarm._peartubeOffline) {
+    const startupDialLimit = swarm._peartubeStartupDialLimit || DEFAULT_STARTUP_KNOWN_PEER_DIAL_LIMIT
     loadKnownPeers(metaDb).then((known) => {
       if (!known.length) return
-      const dialed = dialKnownPeers(swarm, known)
-      if (dialed > 0) console.log('[Storage] Warm-dialed', dialed, 'of', known.length, 'known peers')
+      const dialed = dialKnownPeers(swarm, known, { limit: startupDialLimit })
+      if (dialed > 0) console.log('[Storage] Warm-dialed', dialed, 'of', known.length, 'known peers (limit:', startupDialLimit + ')')
     }).catch((err) => {
       console.log('[Storage] Warm-dial skipped:', err?.message)
     })
@@ -1387,31 +1447,6 @@ export async function initializeStorage(config) {
     globalPeerPoolDiscovery = null
   }
 
-  // Start listening - DON'T block on it since it may hang on mobile
-  // The listen() call starts the server but we don't need to wait for it
-  console.log('[Storage] Starting swarm.listen() (non-blocking)...');
-  await appendDebugLine('[storage] swarm.listen start')
-  const listenPromise = swarm.listen()
-  globalNetworkStartupTiming?.record('swarm-listen-called')
-
-  // Track listen state for debugging
-  swarm._peartubeListenResolved = false
-  if (listenPromise && typeof listenPromise.then === 'function') {
-    listenPromise
-      .then(() => {
-        swarm._peartubeListenResolved = true
-        globalNetworkStartupTiming?.record('swarm-listen-resolved', { firewalled: swarm.dht?.firewalled, bootstrapped: swarm.dht?.bootstrapped })
-        console.log('[Storage] listen() resolved, dht.firewalled:', swarm.dht?.firewalled, 'dht.bootstrapped:', swarm.dht?.bootstrapped)
-        void appendDebugLine(
-          `[storage] swarm.listen resolved firewalled=${swarm.dht?.firewalled} bootstrapped=${swarm.dht?.bootstrapped}`
-        )
-      })
-      .catch((e) => {
-        globalNetworkStartupTiming?.record('swarm-listen-failed', { error: e?.message || String(e) })
-        console.log('[Storage] listen() failed:', e?.message)
-        void appendDebugLine(`[storage] swarm.listen failed ${e?.message || String(e)}`)
-      })
-  }
 
   // Log DHT state for debugging
   const logDhtState = () => {
@@ -2500,7 +2535,7 @@ export async function resumeNetworking() {
 
     if (globalKnownPeerCache && globalSwarm) {
       loadKnownPeers(globalSwarm._peartubeMetaDb).then((known) => {
-        const dialed = dialKnownPeers(globalSwarm, known)
+        const dialed = dialKnownPeers(globalSwarm, known, { limit: globalSwarm._peartubeResumeDialLimit || DEFAULT_RESUME_KNOWN_PEER_DIAL_LIMIT })
         if (dialed > 0) console.log('[Network] Resume warm-dialed', dialed, 'known peers')
       }).catch((err) => {
         console.log('[Network] Resume warm-dial skipped:', err?.message)

--- a/packages/backend/test/known-peers.test.mjs
+++ b/packages/backend/test/known-peers.test.mjs
@@ -33,3 +33,22 @@ test('getExplicitPeerList accepts relayPeers and knownPeers from network and swa
 
   assert.deepEqual(peers, [keyA, keyB, keyA, keyB])
 })
+
+test('dialKnownPeers respects a startup dial limit after dedupe', () => {
+  const calls = []
+  const swarm = {
+    joinPeer(publicKey) {
+      calls.push(Buffer.from(publicKey).toString('hex'))
+    }
+  }
+
+  const count = dialKnownPeers(swarm, [
+    { key: keyA },
+    { key: keyA.toUpperCase() },
+    { key: keyB },
+    { key: 'cc'.repeat(32) },
+  ], { limit: 2 })
+
+  assert.equal(count, 2)
+  assert.deepEqual(calls, [keyA, keyB])
+})

--- a/packages/backend/test/public-feed-manager.test.mjs
+++ b/packages/backend/test/public-feed-manager.test.mjs
@@ -1,4 +1,10 @@
 import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
 import { Duplex } from 'node:stream'
 import { EventEmitter } from 'node:events'
 import test from 'node:test'
@@ -1333,4 +1339,14 @@ test('feed snapshot provider propagates explicit empty previews', async () => {
     Protomux.from = originalFrom
     manager.stop()
   }
+})
+
+
+test('PublicFeedManager wires existing swarm sockets before cache restore reads', () => {
+  const source = fs.readFileSync(path.join(__dirname, '..', 'src', 'public-feed.js'), 'utf8')
+  const existingIndex = source.indexOf('existing connections before cache restore')
+  const cacheRestoreIndex = source.indexOf('discovered-channels-v2')
+
+  assert.ok(existingIndex > 0, 'existing connection wiring should be explicitly before cache restore')
+  assert.ok(cacheRestoreIndex > existingIndex, 'cache restore should happen after existing socket wiring')
 })

--- a/packages/backend/test/storage-startup-regression.test.mjs
+++ b/packages/backend/test/storage-startup-regression.test.mjs
@@ -148,10 +148,31 @@ test('storage plumbs explicit Hyperswarm network options into swarm construction
   )
   assert.match(
     storageSource,
-    /new LoadedHyperswarm\(createHyperswarmOptions\(\{ keyPair, network, swarmOptions \}\)\)/,
+    /const hyperswarmOptions = createHyperswarmOptions\(\{ keyPair, network, swarmOptions \}\)/,
     'Hyperswarm should receive configured bootstrap and relay options'
   )
+  assert.match(storageSource, /new LoadedHyperswarm\(hyperswarmOptions\)/)
 })
+
+test('storage uses faster Hyperswarm defaults and limits startup known-peer fanout', () => {
+  assert.match(storageSource, /maxParallel:\s*8/)
+  assert.match(storageSource, /maxPeers:\s*96/)
+  assert.match(storageSource, /DEFAULT_STARTUP_KNOWN_PEER_DIAL_LIMIT\s*=\s*8/)
+  assert.match(storageSource, /getExplicitPeerList\(\{ network, swarmOptions \}\)/)
+  assert.match(storageSource, /Direct-dialed[\s\S]*explicit peer\(s\) before known-peer cache load/)
+  assert.match(storageSource, /dialKnownPeers\(swarm, known, \{ limit: startupDialLimit \}\)/)
+})
+
+test('storage starts swarm listen before direct dial and peer-pool topic join', () => {
+  const listenIndex = storageSource.indexOf('Starting swarm.listen() early')
+  const explicitDialIndex = storageSource.indexOf('explicit peer(s) before known-peer cache load')
+  const topicJoinIndex = storageSource.indexOf('Joined peartube-network topic for peer pool building')
+
+  assert.ok(listenIndex > 0, 'early listen block should exist')
+  assert.ok(explicitDialIndex > listenIndex, 'explicit peer dial should happen after listen starts')
+  assert.ok(topicJoinIndex > explicitDialIndex, 'topic join should happen after explicit peer dial')
+})
+
 
 test('network suspend is guarded by backend playback activity, not only cast state', () => {
   assert.match(storageSource, /export function setPlaybackActive\(/)
@@ -177,7 +198,7 @@ test('storage captures Hyperswarm connection lifecycle diagnostics', () => {
 
 test('retained content discovery direct-dials configured or cached peers for blob topics', () => {
   assert.match(storageSource, /getDialableKnownPeers\(ctx\)/)
-  assert.match(storageSource, /dialKnownPeers\(ctx\.swarm, known\)/)
+  assert.match(storageSource, /dialKnownPeers\(ctx\.swarm, known, \{ limit: ctx\.swarm\?\._peartubeStartupDialLimit \|\| DEFAULT_STARTUP_KNOWN_PEER_DIAL_LIMIT \}\)/)
   assert.match(storageSource, /network,/)
   assert.match(storageSource, /swarmOptions,/)
 })


### PR DESCRIPTION
## Summary
- start Hyperswarm listen before direct dials/topic joins so DHT readiness overlaps backend warm-up
- direct-dial explicitly configured relay/known peers before reading the persisted known-peer cache
- cap startup/resume known-peer fanout so stale cached peers do not occupy all dial slots
- tune Hyperswarm defaults to higher parallelism and peer capacity while keeping overrides intact
- wire PublicFeed existing sockets before cache restore so already-connected peers open feed channels immediately

## Verification
- packages/backend/node_modules/.bin/brittle packages/backend/test/known-peers.test.mjs packages/backend/test/storage-startup-regression.test.mjs packages/backend/test/public-feed-manager.test.mjs
- ./node_modules/.bin/eslint --quiet packages/backend/src/storage.js packages/backend/src/known-peers.js packages/backend/src/public-feed.js packages/backend/test/known-peers.test.mjs packages/backend/test/storage-startup-regression.test.mjs packages/backend/test/public-feed-manager.test.mjs
- npm run lint:changed
- git diff --check