### PR TITLE
fix: require signed public feed ingress

### DIFF
--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -23,7 +23,8 @@ import { logger } from './logger.js'
 import { hashFeedEntries, hashPreviewVideos } from './hash-utils.js'
 import {
   SIGNED_CHANNEL_ROOT_DESCRIPTOR_SCHEMA,
-  CHANNEL_ROOT_DESCRIPTOR_SCHEMA
+  CHANNEL_ROOT_DESCRIPTOR_SCHEMA,
+  verifySignedChannelRootDescriptor
 } from './channel-descriptor.js'
 
 const log = logger('PublicFeed')
@@ -92,6 +93,8 @@ export class PublicFeed {
     this._gossipInterval = null;
     /** @type {number} */
     this._gossipIntervalMs = 30000;
+    /** @type {boolean} */
+    this.requireSignedPeerEntries = options.requireSignedPeerEntries !== false;
     /** @type {Array<{name: string, at: number, sinceStartMs: number, [key: string]: any}>} */
     this._startupEvents = [];
     /** @type {number} */
@@ -267,6 +270,25 @@ export class PublicFeed {
       proof: typeof signed.proof === 'string' ? signed.proof : null,
       attestation: typeof signed.attestation === 'string' ? signed.attestation : null,
     }
+  }
+
+  _normalizedDescriptorMatchesEntry(signedDescriptor, driveKey, publicBeeKey) {
+    const descriptor = signedDescriptor?.descriptor
+    if (!descriptor) return false
+    const lowerDriveKey = typeof driveKey === 'string' ? driveKey.toLowerCase() : null
+    const lowerPublicBeeKey = typeof publicBeeKey === 'string' ? publicBeeKey.toLowerCase() : null
+    if (!lowerDriveKey || descriptor.channelId !== lowerDriveKey) return false
+    if (lowerPublicBeeKey && descriptor.metadataKey !== lowerPublicBeeKey) return false
+    return true
+  }
+
+  async _verifyPeerEntrySnapshot(snapshot, driveKey, publicBeeKey) {
+    if (!this.requireSignedPeerEntries) return true
+    const signedDescriptor = this._normalizeSignedDescriptor(snapshot?.signedDescriptor)
+    if (!signedDescriptor) return false
+    if (!this._normalizedDescriptorMatchesEntry(signedDescriptor, driveKey, publicBeeKey)) return false
+    const verified = await verifySignedChannelRootDescriptor(signedDescriptor)
+    return Boolean(verified?.valid)
   }
 
   _shouldApplySignedDescriptor(current, next) {
@@ -1258,11 +1280,27 @@ export class PublicFeed {
         for (const entry of msg.entries) {
           if (!entry?.driveKey || !isValidKey(entry.publicBeeKey)) continue
           announcedKeys.push(entry.driveKey)
-          if (this.addEntry(entry.driveKey, 'peer', entry.publicBeeKey, entry)) {
-            added++;
-          } else if (this._applyEntrySnapshot(entry.driveKey, entry)) {
-            updated++;
+          if (!this.requireSignedPeerEntries) {
+            if (this.addEntry(entry.driveKey, 'peer', entry.publicBeeKey, entry)) {
+              added++;
+            } else if (this._applyEntrySnapshot(entry.driveKey, entry)) {
+              updated++;
+            }
+            continue
           }
+          this._verifyPeerEntrySnapshot(entry, entry.driveKey, entry.publicBeeKey)
+            .then((verified) => {
+              if (!verified) return
+              let changed = false
+              if (this.addEntry(entry.driveKey, 'peer', entry.publicBeeKey, entry)) changed = true
+              else if (this._applyEntrySnapshot(entry.driveKey, entry)) changed = true
+              if (changed) {
+                this._setPeerFeedKeys(conn, [entry.driveKey])
+                try { this.onFeedUpdate?.() } catch {}
+                this._schedulePersistDiscovered()
+              }
+            })
+            .catch(() => {})
         }
       }
       // Fallback to legacy keys array
@@ -1272,6 +1310,7 @@ export class PublicFeed {
         for (const key of msg.keys) {
           if (!key) continue
           announcedKeys.push(key)
+          if (this.requireSignedPeerEntries) continue
           if (this.addEntry(key, 'peer')) {
             added++;
           }
@@ -1298,15 +1337,31 @@ export class PublicFeed {
       const isValidKey = (k) => typeof k === 'string' && /^[a-f0-9]{64}$/i.test(k)
       if (!isValidKey(msg.publicBeeKey)) return
       const entrySource = msg.source === 'relay-cache' ? 'relay-cache' : 'peer'
-      if (this.addEntry(msg.key, entrySource, msg.publicBeeKey, msg)) {
-        this.onFeedUpdate?.();
-        this._schedulePersistDiscovered()
-        // Re-gossip to other peers (exclude sender, include publicBeeKey)
-        this.broadcastSubmitChannel(msg.key, conn, msg.publicBeeKey, msg);
-      } else if (this._applyEntrySnapshot(msg.key, msg)) {
-        this.onFeedUpdate?.()
-        this._schedulePersistDiscovered()
+      if (!this.requireSignedPeerEntries) {
+        if (this.addEntry(msg.key, entrySource, msg.publicBeeKey, msg)) {
+          this.onFeedUpdate?.();
+          this._schedulePersistDiscovered()
+          this.broadcastSubmitChannel(msg.key, conn, msg.publicBeeKey, msg);
+        } else if (this._applyEntrySnapshot(msg.key, msg)) {
+          this.onFeedUpdate?.()
+          this._schedulePersistDiscovered()
+        }
+        return
       }
+      this._verifyPeerEntrySnapshot(msg, msg.key, msg.publicBeeKey)
+        .then((verified) => {
+          if (!verified) return
+          if (this.addEntry(msg.key, entrySource, msg.publicBeeKey, msg)) {
+            this.onFeedUpdate?.();
+            this._schedulePersistDiscovered()
+            // Re-gossip to other peers (exclude sender, include publicBeeKey)
+            this.broadcastSubmitChannel(msg.key, conn, msg.publicBeeKey, msg);
+          } else if (this._applyEntrySnapshot(msg.key, msg)) {
+            this.onFeedUpdate?.()
+            this._schedulePersistDiscovered()
+          }
+        })
+        .catch(() => {})
     }
     // Handle legacy NEED_FEED/FEED_RESPONSE for backwards compat
     else if (msg.type === 'NEED_FEED') {
@@ -1316,6 +1371,7 @@ export class PublicFeed {
     else if (msg.type === 'FEED_RESPONSE' && msg.keys) {
       console.log('[PublicFeed] FEED_RESPONSE received with', msg.keys?.length || 0, 'keys');
       let added = 0;
+      if (this.requireSignedPeerEntries) return
       for (const key of msg.keys) {
         if (this.addEntry(key, 'peer')) {
           added++;

--- a/packages/backend/test/public-feed-manager.test.mjs
+++ b/packages/backend/test/public-feed-manager.test.mjs
@@ -214,7 +214,7 @@ test('PublicFeedManager bounds remembered discovered peers for long-running desk
 
 test('PublicFeedManager bounds retained peer feed entries from HAVE_FEED gossip', () => {
   const swarm = createSwarm()
-  const manager = new PublicFeedManager(swarm, createMetaDb(), { maxFeedEntries: 3 })
+  const manager = new PublicFeedManager(swarm, createMetaDb(), { maxFeedEntries: 3, requireSignedPeerEntries: false })
   const conn = createConnection()
 
   try {
@@ -571,8 +571,8 @@ test('handleConnection immediately opens Protomux feed channel for connected dis
 })
 
 test('real Protomux feed channel exchanges local feed entries between two managers', async () => {
-  const managerA = new PublicFeedManager(createSwarm(), createMetaDb())
-  const managerB = new PublicFeedManager(createSwarm(), createMetaDb())
+  const managerA = new PublicFeedManager(createSwarm(), createMetaDb(), { requireSignedPeerEntries: false })
+  const managerB = new PublicFeedManager(createSwarm(), createMetaDb(), { requireSignedPeerEntries: false })
   const [connA, connB] = createMemoryConnectionPair()
   let updatesB = 0
 
@@ -1101,7 +1101,7 @@ test('peer disconnect notifies listeners when a cached keyed entry loses live an
 
 test('handle HAVE_FEED stores serving manifest data on the entry', () => {
   const swarm = createSwarm()
-  const manager = new PublicFeedManager(swarm, createMetaDb())
+  const manager = new PublicFeedManager(swarm, createMetaDb(), { requireSignedPeerEntries: false })
   const conn = createConnection()
 
   try {

--- a/packages/backend/test/public-feed-signed-ingress.test.mjs
+++ b/packages/backend/test/public-feed-signed-ingress.test.mjs
@@ -1,0 +1,118 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import b4a from 'b4a'
+import crypto from 'hypercore-crypto'
+import IdentityKey from 'keet-identity-key'
+
+import { PublicFeedManager } from '../src/public-feed.js'
+import {
+  createChannelRootDescriptor,
+  signChannelRootDescriptor,
+} from '../src/channel-descriptor.js'
+
+const key = (byte) => Buffer.alloc(32, byte).toString('hex')
+
+function createSwarm() {
+  return {
+    keyPair: { publicKey: b4a.alloc(32, 0) },
+    connections: new Set(),
+    peers: new Map(),
+    join() {
+      return { flushed: async () => {} }
+    },
+    status() {
+      return null
+    },
+  }
+}
+
+function createMetaDb() {
+  const store = new Map()
+  return {
+    async get(k) {
+      return store.has(k) ? store.get(k) : null
+    },
+    async put(k, v) {
+      store.set(k, v)
+    },
+  }
+}
+
+async function signedDescriptor({ identityMnemonic = IdentityKey.generateMnemonic(), deviceKeyPair = crypto.keyPair(), channelId = key(1), metadataKey = key(2), mediaKey = key(3), seq = 1 } = {}) {
+  const identity = await IdentityKey.from({ mnemonic: identityMnemonic })
+  const proof = await identity.bootstrap(deviceKeyPair.publicKey)
+  const descriptor = createChannelRootDescriptor({
+    identityPublicKey: b4a.toString(identity.identityPublicKey, 'hex'),
+    channelId,
+    metadataKey,
+    mediaKey,
+    seq,
+    createdAt: 1,
+    updatedAt: 1,
+  })
+  return signChannelRootDescriptor({ descriptor, deviceKeyPair, deviceProof: proof })
+}
+
+test('public feed rejects peer HAVE_FEED entries without a verified signed descriptor', () => {
+  const manager = new PublicFeedManager(createSwarm(), createMetaDb())
+  try {
+    manager.handleMessage({
+      type: 'HAVE_FEED',
+      entries: [{
+        driveKey: key(1),
+        publicBeeKey: key(2),
+        channelName: 'spoofed unsigned channel',
+      }],
+    }, {})
+
+    assert.equal(manager.entries.has(key(1)), false)
+    assert.equal(manager.getFeed().length, 0)
+  } finally {
+    manager.stop()
+  }
+})
+
+test('public feed accepts peer HAVE_FEED entries with matching verified descriptor', async () => {
+  const manager = new PublicFeedManager(createSwarm(), createMetaDb())
+  const signed = await signedDescriptor({ channelId: key(1), metadataKey: key(2), mediaKey: key(3) })
+
+  try {
+    manager.handleMessage({
+      type: 'HAVE_FEED',
+      entries: [{
+        driveKey: key(1),
+        publicBeeKey: key(2),
+        channelName: 'verified channel',
+        signedDescriptor: signed,
+      }],
+    }, {})
+    await new Promise((resolve) => setImmediate(resolve))
+
+    const entry = manager.entries.get(key(1))
+    assert.ok(entry)
+    assert.equal(entry.publicBeeKey, key(2))
+    assert.equal(entry.signedDescriptor.descriptor.channelId, key(1))
+  } finally {
+    manager.stop()
+  }
+})
+
+test('public feed rejects signed peer entries whose descriptor does not bind advertised keys', async () => {
+  const manager = new PublicFeedManager(createSwarm(), createMetaDb())
+  const signed = await signedDescriptor({ channelId: key(9), metadataKey: key(2), mediaKey: key(3) })
+
+  try {
+    manager.handleMessage({
+      type: 'SUBMIT_CHANNEL',
+      key: key(1),
+      publicBeeKey: key(2),
+      signedDescriptor: signed,
+    }, {})
+    await new Promise((resolve) => setImmediate(resolve))
+
+    assert.equal(manager.entries.has(key(1)), false)
+  } finally {
+    manager.stop()
+  }
+})


### PR DESCRIPTION
## Summary
- Require peer-discovered public-feed entries to carry a verified signed channel-root descriptor by default.
- Bind the descriptor to the advertised channel/public-bee keys before accepting HAVE_FEED or SUBMIT_CHANNEL ingress.
- Keep legacy unsigned behavior only in explicit regression-test opt-out paths.

Closes #233

## Test Plan
- `node --check packages/backend/src/public-feed.js`
- `node --check packages/backend/test/public-feed-manager.test.mjs`
- `packages/backend/node_modules/.bin/brittle packages/backend/test/public-feed-manager.test.mjs packages/backend/test/public-feed-descriptor.test.mjs packages/backend/test/channel-descriptor.test.mjs packages/backend/test/public-feed-signed-ingress.test.mjs`
- `git diff --check`
- `npm run lint:changed`