### PR TITLE
fix(desktop-native): harden thumbnails and playback sessions

### DIFF
--- a/packages/desktop-native/Sources/Models/NativeVideo.swift
+++ b/packages/desktop-native/Sources/Models/NativeVideo.swift
@@ -80,6 +80,16 @@ struct NativeVideo: Identifiable, Hashable, Codable {
     return backendVideoID
   }
 
+  var thumbnailCacheKey: String {
+    [
+      channelKey,
+      publicBeeKey ?? "",
+      thumbnailReference,
+      blobId ?? "",
+      blobsCoreKey ?? ""
+    ].joined(separator: "|")
+  }
+
   var intrinsicAspectRatio: Double? {
     guard let width, let height, width > 0, height > 0 else {
       return nil

--- a/packages/desktop-native/Sources/Services/HostBridgeService.swift
+++ b/packages/desktop-native/Sources/Services/HostBridgeService.swift
@@ -59,8 +59,8 @@ final class HostBridgeService {
   private(set) var isResolvingPlayback = false
   private(set) var lastPlaybackErrorMessage: String?
   private(set) var playbackStats: NativeVideoStats?
-  private(set) var thumbnailURLs: [NativeVideo.ID: URL] = [:]
-  private(set) var thumbnailRefreshTokens: [NativeVideo.ID: Int] = [:]
+  private(set) var thumbnailURLs: [String: URL] = [:]
+  private(set) var thumbnailRefreshTokens: [String: Int] = [:]
   private(set) var activeAVPlayer: AVPlayer?
   private(set) var activeMpvPlayerID: String?
   private(set) var activeMpvFrameServerPort: Int?
@@ -75,7 +75,7 @@ final class HostBridgeService {
   // RPCGate retired — RPC is now an actor, so concurrency is handled inside
   // BareRPC itself. `gatedRPC` remains a thin passthrough so its ~30 call
   // sites don't need updating.
-  @ObservationIgnored private var inFlightThumbnailIDs = Set<NativeVideo.ID>()
+  @ObservationIgnored private var inFlightThumbnailIDs = Set<String>()
   @ObservationIgnored private let logLimit = 120
   @ObservationIgnored private(set) var selectedStoragePath: String?
   @ObservationIgnored private var lastPlaybackRenderSize = CGSize(width: 1280, height: 720)
@@ -951,11 +951,6 @@ final class HostBridgeService {
       return nil
     }
 
-    guard await waitForAVPlayerReadiness(for: video) != nil else {
-      appendLog("AVPlayer source did not become ready for \(video.title).")
-      return nil
-    }
-
     startPlaybackStatsPolling(for: video)
     return url
   }
@@ -1118,8 +1113,30 @@ final class HostBridgeService {
     }
   }
 
-  func pauseActivePlayback() async {
+  static func shouldAcceptPlaybackCommand(
+    activeVideoID: NativeVideo.ID?,
+    activePlayerID: String?,
+    requestedVideoID: NativeVideo.ID,
+    requestedPlayerID: String
+  ) -> Bool {
+    activeVideoID == requestedVideoID && activePlayerID == requestedPlayerID
+  }
+
+  private func shouldAcceptActivePlaybackCommand(for videoID: NativeVideo.ID, playerId: String) -> Bool {
+    Self.shouldAcceptPlaybackCommand(
+      activeVideoID: activePlaybackVideoID,
+      activePlayerID: activeMpvPlayerID,
+      requestedVideoID: videoID,
+      requestedPlayerID: playerId
+    )
+  }
+
+  func pauseActivePlayback(for video: NativeVideo) async {
     guard let playerId = activeMpvPlayerID else { return }
+    guard shouldAcceptActivePlaybackCommand(for: video.id, playerId: playerId) else {
+      appendLog("Ignoring stale bare-mpv pause for \(video.title).")
+      return
+    }
 
     do {
       _ = try await gatedRPC { hrpc in
@@ -1130,8 +1147,12 @@ final class HostBridgeService {
     }
   }
 
-  func resumeActivePlayback() async {
+  func resumeActivePlayback(for video: NativeVideo) async {
     guard let playerId = activeMpvPlayerID else { return }
+    guard shouldAcceptActivePlaybackCommand(for: video.id, playerId: playerId) else {
+      appendLog("Ignoring stale bare-mpv resume for \(video.title).")
+      return
+    }
 
     do {
       _ = try await gatedRPC { hrpc in
@@ -1142,8 +1163,12 @@ final class HostBridgeService {
     }
   }
 
-  func seekActivePlayback(to time: Double) async {
+  func seekActivePlayback(for video: NativeVideo, to time: Double) async {
     guard let playerId = activeMpvPlayerID else { return }
+    guard shouldAcceptActivePlaybackCommand(for: video.id, playerId: playerId) else {
+      appendLog("Ignoring stale bare-mpv seek for \(video.title).")
+      return
+    }
 
     do {
       _ = try await gatedRPC { hrpc in
@@ -1154,8 +1179,9 @@ final class HostBridgeService {
     }
   }
 
-  func activePlaybackState() async -> NativeMpvState? {
+  func activePlaybackState(for video: NativeVideo) async -> NativeMpvState? {
     guard let playerId = activeMpvPlayerID else { return nil }
+    guard shouldAcceptActivePlaybackCommand(for: video.id, playerId: playerId) else { return nil }
 
     do {
       return try await gatedRPC { hrpc in
@@ -1168,8 +1194,9 @@ final class HostBridgeService {
     }
   }
 
-  func activePlaybackFrame() async -> NativeMpvRenderFrame? {
+  func activePlaybackFrame(for video: NativeVideo) async -> NativeMpvRenderFrame? {
     guard let playerId = activeMpvPlayerID else { return nil }
+    guard shouldAcceptActivePlaybackCommand(for: video.id, playerId: playerId) else { return nil }
 
     do {
       return try await gatedRPC { hrpc in
@@ -1196,11 +1223,11 @@ final class HostBridgeService {
   }
 
   func thumbnailURL(for video: NativeVideo) -> URL? {
-    guard let baseURL = thumbnailURLs[video.id] ?? video.thumbnailURL else {
+    guard let baseURL = thumbnailURLs[video.thumbnailCacheKey] ?? video.thumbnailURL else {
       return nil
     }
 
-    guard let revision = thumbnailRefreshTokens[video.id], revision > 0 else {
+    guard let revision = thumbnailRefreshTokens[video.thumbnailCacheKey], revision > 0 else {
       return baseURL
     }
 
@@ -1217,8 +1244,8 @@ final class HostBridgeService {
   }
 
   func refreshThumbnail(for video: NativeVideo) async {
-    thumbnailRefreshTokens[video.id] = (thumbnailRefreshTokens[video.id] ?? 0) + 1
-    thumbnailURLs.removeValue(forKey: video.id)
+    thumbnailRefreshTokens[video.thumbnailCacheKey] = (thumbnailRefreshTokens[video.thumbnailCacheKey] ?? 0) + 1
+    thumbnailURLs.removeValue(forKey: video.thumbnailCacheKey)
     await resolveThumbnail(for: video, force: true)
   }
 
@@ -1257,23 +1284,26 @@ final class HostBridgeService {
   private func resolveThumbnail(for video: NativeVideo, force: Bool) async {
     if !force, thumbnailURL(for: video) != nil { return }
     guard isReady else { return }
-    guard !inFlightThumbnailIDs.contains(video.id) else { return }
+    let thumbnailKey = video.thumbnailCacheKey
+    guard !inFlightThumbnailIDs.contains(thumbnailKey) else { return }
 
-    inFlightThumbnailIDs.insert(video.id)
-    defer { inFlightThumbnailIDs.remove(video.id) }
+    inFlightThumbnailIDs.insert(thumbnailKey)
+    defer { inFlightThumbnailIDs.remove(thumbnailKey) }
 
     do {
       let response = try await gatedRPC { hrpc in
         try await hrpc.getVideoThumbnail(
           GetVideoThumbnailRequest(
             channelKey: video.channelKey,
-            videoId: video.backendVideoID
+            videoId: video.thumbnailReference,
+            thumbnailBlobId: video.blobId ?? "",
+            thumbnailBlobsCoreKey: video.blobsCoreKey ?? ""
           )
         )
       }
 
       if response.exists, let urlString = response.url, !urlString.isEmpty, let url = URL(string: urlString) {
-        thumbnailURLs[video.id] = url
+        thumbnailURLs[video.thumbnailCacheKey] = url
       }
     } catch {
       appendLog("Thumbnail resolution failed for \(video.title): \(error.localizedDescription)")
@@ -1820,7 +1850,7 @@ final class HostBridgeService {
   private func primeThumbnailCache(with videos: [NativeVideo]) {
     for video in videos {
       if let url = video.thumbnailURL {
-        thumbnailURLs[video.id] = url
+        thumbnailURLs[video.thumbnailCacheKey] = url
       }
     }
   }
@@ -2500,6 +2530,7 @@ final class HostBridgeService {
   static func isAVPlayerReadyForPlayback(_ stats: NativeVideoStats) -> Bool {
     guard stats.success else { return false }
     if stats.isComplete { return true }
+    if stats.progress > 0 { return true }
     if stats.downloadedBlocks > 0 || stats.downloadedBytes > 0 { return true }
 
     guard let status = stats.status?
@@ -2514,7 +2545,7 @@ final class HostBridgeService {
     }
 
     if ["buffering", "downloading"].contains(status) {
-      return stats.peerCount > 0 || stats.downloadedBlocks > 0 || stats.downloadedBytes > 0
+      return stats.peerCount > 0 || stats.progress > 0 || stats.downloadedBlocks > 0 || stats.downloadedBytes > 0
     }
 
     return false

--- a/packages/desktop-native/Sources/Views/ContentView.swift
+++ b/packages/desktop-native/Sources/Views/ContentView.swift
@@ -376,7 +376,7 @@ private struct FloatingMiniPlayer: View {
     if appState.isPlayingPreview {
       if hostBridge.activeMpvPlayerID != nil {
         Task {
-          await hostBridge.pauseActivePlayback()
+          await hostBridge.pauseActivePlayback(for: video)
         }
       } else {
         hostBridge.pauseActiveAVPlayer()
@@ -387,7 +387,7 @@ private struct FloatingMiniPlayer: View {
 
     if hostBridge.activeMpvPlayerID != nil {
       Task {
-        await hostBridge.resumeActivePlayback()
+        await hostBridge.resumeActivePlayback(for: video)
       }
     } else {
       hostBridge.resumeActiveAVPlayer()

--- a/packages/desktop-native/Sources/Views/MpvPlayerView.swift
+++ b/packages/desktop-native/Sources/Views/MpvPlayerView.swift
@@ -100,7 +100,7 @@ final class MpvFrameRenderer: ObservableObject {
     renderTask = Task { [weak self] in
       await self?.runRenderLoop(
         hostBridge: hostBridge,
-        videoID: video.id,
+        video: video,
         playerId: playerId,
         frameURL: frameURL
       )
@@ -114,20 +114,20 @@ final class MpvFrameRenderer: ObservableObject {
 
   private func runRenderLoop(
     hostBridge: HostBridgeService,
-    videoID: NativeVideo.ID,
+    video: NativeVideo,
     playerId: String,
     frameURL: URL?
   ) async {
     var iteration = 0
 
     while !Task.isCancelled {
-      guard hostBridge.activePlaybackVideoID == videoID,
+      guard hostBridge.activePlaybackVideoID == video.id,
             hostBridge.activeMpvPlayerID == playerId else {
         break
       }
 
       if iteration.isMultiple(of: 3),
-         let state = await hostBridge.activePlaybackState() {
+         let state = await hostBridge.activePlaybackState(for: video) {
         currentTime = state.currentTime
         duration = state.duration
         paused = state.paused
@@ -141,7 +141,7 @@ final class MpvFrameRenderer: ObservableObject {
         image = frameImage
         isLoading = false
         errorMessage = nil
-      } else if let frame = await hostBridge.activePlaybackFrame(),
+      } else if let frame = await hostBridge.activePlaybackFrame(for: video),
                 frame.success,
                 frame.hasFrame,
                 let frameImage = Self.makeImage(

--- a/packages/desktop-native/Sources/Views/VideoDetailView.swift
+++ b/packages/desktop-native/Sources/Views/VideoDetailView.swift
@@ -339,7 +339,7 @@ struct VideoDetailView: View {
          hostBridge.activeMpvPlayerID != nil {
         hostBridge.recordPlaybackUIEvent("Pausing active bare-mpv session for \(video.id).")
         Task {
-          await hostBridge.pauseActivePlayback()
+          await hostBridge.pauseActivePlayback(for: video)
         }
       } else {
         hostBridge.recordPlaybackUIEvent("Pausing active AVPlayer session for \(video.id).")
@@ -363,7 +363,7 @@ struct VideoDetailView: View {
       if hostBridge.activePlaybackVideoID == video.id,
          hostBridge.activeMpvPlayerID != nil {
         hostBridge.recordPlaybackUIEvent("Resuming existing bare-mpv session for \(video.id).")
-        await hostBridge.resumeActivePlayback()
+        await hostBridge.resumeActivePlayback(for: video)
         appState.resumePlayback()
         appState.setError(nil)
         return

--- a/packages/desktop-native/Tests/PearTubeDesktopTests.swift
+++ b/packages/desktop-native/Tests/PearTubeDesktopTests.swift
@@ -2516,6 +2516,71 @@ final class PearTubeDesktopTests: XCTestCase {
     XCTAssertTrue(HostBridgeService.isAVPlayerReadyForPlayback(downloadingStats))
   }
 
+  func testThumbnailCacheKeyUsesPlaybackRefsWhenBackendIDsCollide() {
+    let first = NativeVideo(
+      id: "channel-a::video",
+      backendVideoID: "video",
+      channelKey: "channel-a",
+      title: "First",
+      channelName: "A",
+      durationText: "1:00",
+      summary: "",
+      tags: [],
+      accentHex: "#000000",
+      sections: [.home],
+      thumbnailURL: URL(string: "https://example.com/a.jpg"),
+      path: "/videos/shared-name.mp4",
+      blobId: "0:1:0:10",
+      blobsCoreKey: "aa"
+    )
+    let second = NativeVideo(
+      id: "channel-b::video",
+      backendVideoID: "video",
+      channelKey: "channel-b",
+      title: "Second",
+      channelName: "B",
+      durationText: "1:00",
+      summary: "",
+      tags: [],
+      accentHex: "#000000",
+      sections: [.home],
+      thumbnailURL: URL(string: "https://example.com/b.jpg"),
+      path: "/videos/shared-name.mp4",
+      blobId: "0:2:0:10",
+      blobsCoreKey: "bb"
+    )
+
+    XCTAssertNotEqual(first.thumbnailCacheKey, second.thumbnailCacheKey)
+  }
+
+  func testMpvCommandGuardsRejectStalePlaybackSessions() {
+    XCTAssertTrue(HostBridgeService.shouldAcceptPlaybackCommand(activeVideoID: "video-a", activePlayerID: "player-a", requestedVideoID: "video-a", requestedPlayerID: "player-a"))
+    XCTAssertFalse(HostBridgeService.shouldAcceptPlaybackCommand(activeVideoID: "video-b", activePlayerID: "player-a", requestedVideoID: "video-a", requestedPlayerID: "player-a"))
+    XCTAssertFalse(HostBridgeService.shouldAcceptPlaybackCommand(activeVideoID: "video-a", activePlayerID: "player-b", requestedVideoID: "video-a", requestedPlayerID: "player-a"))
+    XCTAssertFalse(HostBridgeService.shouldAcceptPlaybackCommand(activeVideoID: nil, activePlayerID: "player-a", requestedVideoID: "video-a", requestedPlayerID: "player-a"))
+  }
+
+  func testAVPlayerReadinessAcceptsProgressOnlyStartupStats() {
+    let progressOnlyStats = NativeBridgeVideoStatsResponse(
+      success: true,
+      status: "downloading",
+      progress: 1,
+      totalBlocks: 128,
+      downloadedBlocks: 0,
+      totalBytes: 1024,
+      downloadedBytes: 0,
+      peerCount: 0,
+      swarmConnections: 0,
+      speedMBps: "0.00",
+      uploadSpeedMBps: nil,
+      elapsed: 1,
+      isComplete: false,
+      error: nil
+    )
+
+    XCTAssertTrue(HostBridgeService.isAVPlayerReadyForPlayback(progressOnlyStats))
+  }
+
   func testFeedUpdatedEventCodecRoundTrips() throws {
     let payload = NativeBridgeFeedUpdatedEvent(channelKey: "feed", action: "update")
     let encoded = try NativeBridgePayload.encode(NativeBridgeFeedUpdatedEventCodec(), value: payload)


### PR DESCRIPTION
## Summary
- key desktop thumbnail cache/refresh state by channel + thumbnail/playback refs instead of only the video id
- resolve thumbnails with the same `/videos/...` reference and blob refs used by playback
- harden bare-mpv pause/resume/seek/state/frame calls so stale UI tasks cannot control a newer active session
- keep desktop AVPlayer startup from waiting on lagging stats readiness, while accepting progress-only startup stats for diagnostics

## Test plan
- [x] `node --test Bridge/bridge-core.test.mjs Bridge/native-rpc.test.mjs Bridge/playback-resolution.test.mjs Bridge/sidecar-addon-roots.test.mjs scripts/bare-pack-host-flags.test.mjs`
- [x] `git diff --check`
- [x] `npm run lint:changed`
- [ ] Swift/macOS desktop tests in CI (`swift` is unavailable on this Linux host)

## Local notes
- Initialized `packages/bare-mpv` and `packages/bare-ffmpeg` submodules to unblock local desktop bridge generation.
- Full `npm run test:bridge` still exposes pre-existing local/native environment failures outside this patch:
  - sidecar runtime cannot load Linux linked addon `libbare-abort.2.0.13.so`
  - media-extension plist contract test fails against existing placeholder extension Info.plist metadata
