### PR TITLE
fix(mobile): pass relay peers into backend launch

### DIFF
--- a/packages/app/app/_layout.tsx
+++ b/packages/app/app/_layout.tsx
@@ -77,6 +77,12 @@ const BACKEND_SOURCE_CACHE_KEY = '__PEARTUBE_BACKEND_SOURCE__'
 const DOWNLOADER_SOURCE_CACHE_KEY = '__PEARTUBE_DOWNLOADER_WORKER_SOURCE__'
 const CAST_ACTIVE_GLOBAL_KEY = '__PEARTUBE_CAST_ACTIVE__'
 const PeartubeNetworkDiscovery = (NativeModules as any).PeartubeNetworkDiscovery
+const MOBILE_RELAY_PEERS = [
+  '9890785d1a1b5af8e4bfba0f585f54272b6951e3dc0fdc43a30ed73f1d740f13',
+  'd10f6fbdae2d8e439cf9b6e29cbb42199fff101a8e707345eb455faab92e7d7a',
+  '8cdc6bc7d9d1bfe99644d06dee042023c54d55af178cfa12bf778fe51f01152a',
+  '43f48db991cc40002ebd9661239b49e83c1d6b41c86b06b94a57925d00e5ab05',
+]
 
 function requirePeartubeNetworkDiscovery(): any {
   const mod = (NativeModules as any).PeartubeNetworkDiscovery
@@ -544,6 +550,11 @@ const BACKEND_STARTUP_TIMEOUT_MS = 30000
         ),
         loadBackendSource: async () => sources.backendSource,
         loadDownloaderWorkerSource: async () => sources.downloaderWorkerSource ?? null,
+        launchOptions: {
+          __peartubeLaunchOptions: true,
+          network: { relayPeers: MOBILE_RELAY_PEERS },
+          swarmOptions: { knownPeers: MOBILE_RELAY_PEERS },
+        },
       })
       startupLog('[Startup] initPlatformRPC returned ms=', Date.now() - t0)
 

--- a/packages/app/tests/native-relay-launch-options-regression.test.mjs
+++ b/packages/app/tests/native-relay-launch-options-regression.test.mjs
@@ -1,0 +1,28 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const appRoot = path.resolve(__dirname, '..')
+
+function readAppFile(relativePath) {
+  return fs.readFileSync(path.join(appRoot, relativePath), 'utf8')
+}
+
+test('native root passes relay peer launch options into the mobile backend worklet', () => {
+  const source = readAppFile('app/_layout.tsx')
+
+  assert.match(
+    source,
+    /const MOBILE_RELAY_PEERS = \[/,
+    'native root should define explicit mobile relay peers for launch options',
+  )
+  assert.match(
+    source,
+    /launchOptions:\s*{[\s\S]*network:\s*{\s*relayPeers:\s*MOBILE_RELAY_PEERS\s*}[\s\S]*swarmOptions:\s*{\s*knownPeers:\s*MOBILE_RELAY_PEERS\s*}[\s\S]*}/,
+    'initPlatformRPC should receive relay peer launch options so Android can direct-dial relays during startup',
+  )
+})

--- a/packages/platform/src/rpc.native.ts
+++ b/packages/platform/src/rpc.native.ts
@@ -168,7 +168,7 @@ const mainRunner = createNativeRunner({
   },
   workletId: BACKEND_WORKLET_ID,
   resolveLaunchArgs(options) {
-    return [options.storagePath, ...nativeRuntimeConfig.workerArgs];
+    return [options.storagePath, options.entrypoint, ...nativeRuntimeConfig.workerArgs];
   },
 });
 
@@ -505,7 +505,11 @@ export async function initPlatformRPC(config: {
   loadBackendSource?: () => Promise<string>;
   loadDownloaderWorkerSource?: () => Promise<string | null | undefined>;
   storagePath?: string;
-}): Promise<void> {
+  launchOptions?: {
+    network?: Record<string, unknown>;
+    swarmOptions?: Record<string, unknown>;
+  };
+} = {}): Promise<void> {
   if (_isInitialized && mainBridge.isInitialized()) {
     _startupState = 'ready';
     console.log('[Platform RPC] Already initialized');
@@ -591,7 +595,17 @@ export async function initPlatformRPC(config: {
 
     nativeRuntimeConfig.backendPath = backendPath;
     nativeRuntimeConfig.backendSource = backendPath ? '' : backendSource;
-    nativeRuntimeConfig.workerArgs = downloaderWorkerPath ? [downloaderWorkerPath] : [];
+    const launchOptionsArg = config.launchOptions
+      ? JSON.stringify({
+        __peartubeLaunchOptions: true,
+        network: config.launchOptions.network,
+        swarmOptions: config.launchOptions.swarmOptions,
+      })
+      : null;
+    nativeRuntimeConfig.workerArgs = [
+      ...(launchOptionsArg ? [launchOptionsArg] : []),
+      ...(downloaderWorkerPath ? [downloaderWorkerPath] : []),
+    ];
 
     if (backendPath) {
       console.log('[Platform RPC] Backend worklet will launch from file:', backendPath);

--- a/packages/platform/test/native-runner-launch-args.test.mjs
+++ b/packages/platform/test/native-runner-launch-args.test.mjs
@@ -1,0 +1,38 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const platformRoot = path.resolve(__dirname, '..')
+
+function readPlatformFile(relativePath) {
+  return fs.readFileSync(path.join(platformRoot, relativePath), 'utf8')
+}
+
+test('native RPC launch args preserve the mobile entrypoint before trailing worker args', () => {
+  const source = readPlatformFile('src/rpc.native.ts')
+
+  assert.match(
+    source,
+    /resolveLaunchArgs\(options\) \{\s*return \[options\.storagePath, options\.entrypoint, \.\.\.nativeRuntimeConfig\.workerArgs\];\s*\}/,
+    'mobile backend worklet argv must be storagePath, entrypoint, then launch/worker args',
+  )
+})
+
+test('native RPC serializes launch options before downloader worker args', () => {
+  const source = readPlatformFile('src/rpc.native.ts')
+
+  assert.match(
+    source,
+    /const launchOptionsArg = config\.launchOptions[\s\S]*__peartubeLaunchOptions: true[\s\S]*network: config\.launchOptions\.network[\s\S]*swarmOptions: config\.launchOptions\.swarmOptions/,
+    'initPlatformRPC should serialize backend launch options',
+  )
+  assert.match(
+    source,
+    /nativeRuntimeConfig\.workerArgs = \[[\s\S]*\.\.\.\(launchOptionsArg \? \[launchOptionsArg\] : \[\]\),[\s\S]*\.\.\.\(downloaderWorkerPath \? \[downloaderWorkerPath\] : \[\]\),[\s\S]*\]/,
+    'launch options must be the first trailing arg so sidecar parsing consumes them before downloader worker path',
+  )
+})


### PR DESCRIPTION
## Summary
- Preserve the mobile backend entrypoint in BareKit worklet argv before trailing worker args.
- Pass explicit relay peer launch options from native root startup into the backend sidecar.
- Add source regressions covering the native launch argv and Android relay launch options.

## Why
Android was only reliably showing one connected relay and many videos were failing to start even while the local relay mesh itself was healthy. Live relay status showed 5-6 feed connections per relay and DHT online, so the broken boundary was phone startup/direct-dial seeding rather than relay process health. The backend already knows how to consume `network.relayPeers` / `swarmOptions.knownPeers`; mobile startup was not getting those options through the worklet argv.

## Test Plan
- `npx eslint --quiet packages/platform/src/rpc.native.ts packages/app/app/_layout.tsx packages/platform/test/native-runner-launch-args.test.mjs packages/app/tests/native-relay-launch-options-regression.test.mjs`
- `git diff --check`
- `node --test packages/app/tests/native-relay-launch-options-regression.test.mjs`
- `node --test packages/platform/test/native-runner-launch-args.test.mjs`
- `node --test packages/backend/test/known-peers.test.mjs`
- `node --test packages/backend/test/blob-playback-service-peer-warmup.test.mjs`

## Live diagnostics
- `peartube-relay`: connections=6 feedConnections=6 feedEntries=89 playable=33 unavailable=277
- `peartube-relay-2`: connections=6 feedConnections=6 feedEntries=89 playable=9 unavailable=169
- `peartube-relay-3`: connections=6 feedConnections=6 feedEntries=89 playable=7 unavailable=136
- `peartube-relay-4`: connections=5 feedConnections=5 feedEntries=89 playable=6 unavailable=58
- ADB only saw emulator; no physical phone was attached for phone-side proof.
