### PR TITLE
fix(app): keep cached stats above streaming

### DIFF
--- a/packages/app/components/video-player/P2PStatsBar.tsx
+++ b/packages/app/components/video-player/P2PStatsBar.tsx
@@ -27,12 +27,19 @@ export const P2PStatsBar = memo(function P2PStatsBar({ stats }: P2PStatsBarProps
   const hasBlocks = totalBlocks > 0
   const hasDownloadedBytes = downloadedBytes > 0
   const hasDownloadedBlocks = downloadedBlocks > 0
+  const isCached = Boolean(
+    stats?.isComplete ||
+    stats?.status === 'complete' ||
+    Number(stats?.progress ?? 0) >= 100 ||
+    (totalBlocks > 0 && downloadedBlocks >= totalBlocks) ||
+    (totalBytes > 0 && downloadedBytes >= totalBytes)
+  )
   const hasPlayableProgress = hasDownloadedBytes || hasDownloadedBlocks || Number(stats?.progress ?? 0) > 0
-  const hasProgressDetails = hasBytes || hasBlocks || Boolean(stats?.isComplete)
+  const hasProgressDetails = hasBytes || hasBlocks || isCached
 
   const getStatusInfo = () => {
     if (!stats) return { color: '#6b7280', label: 'Starting player' }
-    if (stats.isComplete) return { color: '#4ade80', label: 'Cached' }
+    if (isCached) return { color: '#4ade80', label: 'Cached' }
     if (stats.status === 'downloading') return { color: '#fbbf24', label: 'Downloading' }
     if (downloadSpeed > 0) return { color: '#fbbf24', label: 'Downloading' }
     if (hasPlayableProgress) return { color: '#60a5fa', label: 'Streaming' }
@@ -66,7 +73,7 @@ export const P2PStatsBar = memo(function P2PStatsBar({ stats }: P2PStatsBarProps
       </View>
 
       {/* Progress bar */}
-      {stats && !stats.isComplete && hasProgressDetails && (
+      {stats && !isCached && hasProgressDetails && (
         <View style={styles.progressBarBg}>
           <View style={[styles.progressBarFill, { width: `${stats.progress || 0}%` }]} />
         </View>
@@ -85,7 +92,7 @@ export const P2PStatsBar = memo(function P2PStatsBar({ stats }: P2PStatsBarProps
               {downloadedBlocks} / {totalBlocks} blocks
             </Text>
           )}
-          <Text style={[styles.statProgress, stats.isComplete && styles.statProgressComplete]}>
+          <Text style={[styles.statProgress, isCached && styles.statProgressComplete]}>
             {stats.progress || 0}%
           </Text>
         </View>

--- a/packages/app/tests/p2p-stats-bar-regression.test.mjs
+++ b/packages/app/tests/p2p-stats-bar-regression.test.mjs
@@ -15,3 +15,17 @@ test('P2P stats bar treats an actively loaded video as ready even when transfer 
   assert.match(source, /const hasPlayableProgress =/, 'stats bar should classify playable byte or block progress separately from transfer speed')
   assert.match(source, /if \(hasPlayableProgress\) return \{ color: '#60a5fa', label: 'Streaming' \}/, 'loaded playable progress should stay in streaming state instead of falling through to preparing')
 })
+
+test('P2P stats bar treats fully loaded videos as cached before streaming', () => {
+  const cachedCheckIndex = source.indexOf("if (isCached) return { color: '#4ade80', label: 'Cached' }")
+  const streamingCheckIndex = source.indexOf("if (hasPlayableProgress) return { color: '#60a5fa', label: 'Streaming' }")
+
+  assert.notEqual(cachedCheckIndex, -1, 'stats bar should normalize fully loaded videos to Cached')
+  assert.notEqual(streamingCheckIndex, -1, 'stats bar should still show Streaming for partial playable progress')
+  assert.ok(cachedCheckIndex < streamingCheckIndex, 'Cached must win over Streaming for fully cached videos')
+  assert.match(source, /stats\?\.status === 'complete'/, 'complete status should count as cached')
+  assert.match(source, /Number\(stats\?\.progress \?\? 0\) >= 100/, '100% progress should count as cached')
+  assert.match(source, /totalBlocks > 0 && downloadedBlocks >= totalBlocks/, 'all blocks downloaded should count as cached')
+  assert.match(source, /totalBytes > 0 && downloadedBytes >= totalBytes/, 'all bytes downloaded should count as cached')
+  assert.match(source, /stats && !isCached && hasProgressDetails/, 'progress bar should not render as an active transfer once cached')
+})


### PR DESCRIPTION
## Summary
- Normalize fully loaded P2P stats to a cached state before checking partial playable progress
- Treat `status: complete`, 100% progress, all downloaded blocks, or all downloaded bytes as cached
- Hide the active transfer progress bar once the stats represent a cached video

## Test Plan
- `node --test packages/app/tests/p2p-stats-bar-regression.test.mjs`
- `node --test packages/app/tests/mobile-video-stats-lifecycle-regression.test.mjs packages/app/tests/video-player-loading-clears-regression.test.mjs`
- `./node_modules/.bin/eslint --quiet packages/app/components/video-player/P2PStatsBar.tsx packages/app/tests/p2p-stats-bar-regression.test.mjs`
- `git diff --check`
