### PR TITLE
fix(p2p): remove app-level direct peer dialing

### DIFF
--- a/packages/app/app/_layout.tsx
+++ b/packages/app/app/_layout.tsx
@@ -77,12 +77,6 @@ const BACKEND_SOURCE_CACHE_KEY = '__PEARTUBE_BACKEND_SOURCE__'
 const DOWNLOADER_SOURCE_CACHE_KEY = '__PEARTUBE_DOWNLOADER_WORKER_SOURCE__'
 const CAST_ACTIVE_GLOBAL_KEY = '__PEARTUBE_CAST_ACTIVE__'
 const PeartubeNetworkDiscovery = (NativeModules as any).PeartubeNetworkDiscovery
-const MOBILE_RELAY_PEERS = [
-  '9890785d1a1b5af8e4bfba0f585f54272b6951e3dc0fdc43a30ed73f1d740f13',
-  'd10f6fbdae2d8e439cf9b6e29cbb42199fff101a8e707345eb455faab92e7d7a',
-  '8cdc6bc7d9d1bfe99644d06dee042023c54d55af178cfa12bf778fe51f01152a',
-  '43f48db991cc40002ebd9661239b49e83c1d6b41c86b06b94a57925d00e5ab05',
-]
 
 function requirePeartubeNetworkDiscovery(): any {
   const mod = (NativeModules as any).PeartubeNetworkDiscovery
@@ -550,11 +544,6 @@ const BACKEND_STARTUP_TIMEOUT_MS = 30000
         ),
         loadBackendSource: async () => sources.backendSource,
         loadDownloaderWorkerSource: async () => sources.downloaderWorkerSource ?? null,
-        launchOptions: {
-          __peartubeLaunchOptions: true,
-          network: { relayPeers: MOBILE_RELAY_PEERS },
-          swarmOptions: { knownPeers: MOBILE_RELAY_PEERS },
-        },
       })
       startupLog('[Startup] initPlatformRPC returned ms=', Date.now() - t0)
 

--- a/packages/app/tests/native-relay-launch-options-regression.test.mjs
+++ b/packages/app/tests/native-relay-launch-options-regression.test.mjs
@@ -12,17 +12,22 @@ function readAppFile(relativePath) {
   return fs.readFileSync(path.join(appRoot, relativePath), 'utf8')
 }
 
-test('native root passes relay peer launch options into the mobile backend worklet', () => {
+test('native root does not ship hardcoded relay peers into the mobile backend worklet', () => {
   const source = readAppFile('app/_layout.tsx')
 
-  assert.match(
+  assert.doesNotMatch(
     source,
     /const MOBILE_RELAY_PEERS = \[/,
-    'native root should define explicit mobile relay peers for launch options',
+    'mobile app should not ship a static relay public-key allowlist',
   )
-  assert.match(
+  assert.doesNotMatch(
     source,
-    /launchOptions:\s*{[\s\S]*network:\s*{\s*relayPeers:\s*MOBILE_RELAY_PEERS\s*}[\s\S]*swarmOptions:\s*{\s*knownPeers:\s*MOBILE_RELAY_PEERS\s*}[\s\S]*}/,
-    'initPlatformRPC should receive relay peer launch options so Android can direct-dial relays during startup',
+    /relayPeers:\s*MOBILE_RELAY_PEERS/,
+    'mobile backend launch should not direct-dial baked-in relay peers',
+  )
+  assert.doesNotMatch(
+    source,
+    /knownPeers:\s*MOBILE_RELAY_PEERS/,
+    'mobile backend launch should not direct-dial baked-in known peers',
   )
 })

--- a/packages/backend/src/known-peers.js
+++ b/packages/backend/src/known-peers.js
@@ -1,10 +1,9 @@
 /**
  * Known-Peer Cache
  *
- * Persists noise public keys of peers we've connected to so subsequent cold
- * starts can call `swarm.joinPeer(pk)` directly. This short-circuits the
- * topic-based DHT lookup that would otherwise have to complete before any
- * peer connection can occur.
+ * Persists noise public keys of peers we've connected to so diagnostics and
+ * future policy can inspect recent neighbors without bypassing topic-based
+ * Hyperswarm discovery.
  */
 
 import b4a from 'b4a'
@@ -86,26 +85,6 @@ export async function loadKnownPeers(metaDb) {
   }
 }
 
-export function dialKnownPeers(swarm, knownList, options = {}) {
-  if (!swarm || typeof swarm.joinPeer !== 'function' || swarm._peartubeOffline) return 0
-  const limit = Number.isFinite(options.limit) && options.limit > 0 ? Math.floor(options.limit) : Infinity
-  let dialed = 0
-  const seen = new Set()
-  for (const entry of knownList) {
-    if (dialed >= limit) break
-    try {
-      const key = typeof entry?.key === 'string' ? entry.key.toLowerCase() : null
-      if (!key || !/^[0-9a-f]{64}$/.test(key) || seen.has(key)) continue
-      seen.add(key)
-      const pk = b4a.from(key, 'hex')
-      if (pk.length !== 32) continue
-      swarm.joinPeer(pk)
-      dialed++
-    } catch { /* best effort */ }
-  }
-  return dialed
-}
-
 function normalizeExplicitPeerKey(value) {
   const keyHex = toKeyHex(value?.key || value?.publicKey || value)
   return keyHex ? { key: keyHex, lastSeen: Date.now(), source: value?.source || 'explicit' } : null
@@ -129,8 +108,6 @@ export function getExplicitPeerList(ctx) {
   return out
 }
 
-export async function getDialableKnownPeers(ctx) {
-  const explicit = getExplicitPeerList(ctx)
-  const persisted = await loadKnownPeers(ctx?._peartubeMetaDb || ctx?.metaDb)
-  return [...explicit, ...persisted]
+export async function getCachedPeerList(ctx) {
+  return loadKnownPeers(ctx?._peartubeMetaDb || ctx?.metaDb)
 }

--- a/packages/backend/src/storage.js
+++ b/packages/backend/src/storage.js
@@ -26,11 +26,9 @@ import {
 } from './runtime-modules.js'
 import { NETWORK_TOPIC_STRING } from './types.js'
 import { normalizeBlobRefInput } from './blob-ref.js'
-import { createKnownPeerCache, loadKnownPeers, dialKnownPeers, getDialableKnownPeers, getExplicitPeerList } from './known-peers.js'
+import { createKnownPeerCache } from './known-peers.js'
 
 const DEFAULT_BLOBS_CORE_UPDATE_TIMEOUT_MS = 15000
-const DEFAULT_STARTUP_KNOWN_PEER_DIAL_LIMIT = 8
-const DEFAULT_RESUME_KNOWN_PEER_DIAL_LIMIT = 8
 
 function resolveDebugLogPath() {
   return globalThis?.process?.env?.PEARTUBE_NATIVE_WORKLET_DEBUG_LOG || null
@@ -777,20 +775,6 @@ export function retainSwarmDiscovery(ctx, discoveryKey, options = {}) {
   const handle = ctx.swarm.join(discoveryKey, { server: true, client: true })
   handles.set(discoveryKeyHex, handle)
 
-  if (!ctx.swarm._peartubeOffline) {
-    getDialableKnownPeers(ctx)
-      .then((known) => {
-        const dialed = dialKnownPeers(ctx.swarm, known, { limit: ctx.swarm?._peartubeStartupDialLimit || DEFAULT_STARTUP_KNOWN_PEER_DIAL_LIMIT })
-        if (dialed > 0) {
-          const label = options.label || discoveryKeyHex.slice(0, 16)
-          console.log(`[Storage] Direct-dialed ${dialed} known peer(s) for ${label}`)
-        }
-      })
-      .catch((err) => {
-        console.log('[Storage] Direct peer dial skipped:', err?.message)
-      })
-  }
-
   try {
     const flushed = handle?.flushed?.()
     if (flushed && typeof flushed.then === 'function') {
@@ -1238,16 +1222,6 @@ export async function initializeStorage(config) {
     try {
       const hyperswarmOptions = createHyperswarmOptions({ keyPair, network, swarmOptions })
       swarm = new LoadedHyperswarm(hyperswarmOptions);
-      swarm._peartubeStartupDialLimit = Math.max(1, Number(
-        network.startupKnownPeerDialLimit ??
-        swarmOptions.startupKnownPeerDialLimit ??
-        DEFAULT_STARTUP_KNOWN_PEER_DIAL_LIMIT
-      ) || DEFAULT_STARTUP_KNOWN_PEER_DIAL_LIMIT)
-      swarm._peartubeResumeDialLimit = Math.max(1, Number(
-        network.resumeKnownPeerDialLimit ??
-        swarmOptions.resumeKnownPeerDialLimit ??
-        DEFAULT_RESUME_KNOWN_PEER_DIAL_LIMIT
-      ) || DEFAULT_RESUME_KNOWN_PEER_DIAL_LIMIT)
     } catch (err) {
       if (requireNetwork) {
         throw new Error(`Hyperswarm failed to start for required network startup: ${err?.message || String(err)}`)
@@ -1293,8 +1267,9 @@ export async function initializeStorage(config) {
     }
   }
 
-  // Known-peer cache: persist remote pubkeys so the next cold start can
-  // `swarm.joinPeer(pk)` them directly without waiting for a topic DHT lookup.
+  // Known-peer cache: persist remote pubkeys for diagnostics and future policy.
+  // Do not use this cache for app-level direct dialing; Hyperswarm owns peer
+  // selection through joined topics.
   const selfKeyHex = swarm.keyPair?.publicKey ? b4a.toString(swarm.keyPair.publicKey, 'hex') : null
   const knownPeerCache = createKnownPeerCache(metaDb, { selfKeyHex })
   swarm._peartubeMetaDb = metaDb
@@ -1392,31 +1367,6 @@ export async function initializeStorage(config) {
           void appendDebugLine(`[storage] swarm.listen failed ${e?.message || String(e)}`)
         })
     }
-  }
-
-  // Direct-dial explicitly configured relay/known peers before any persisted DB
-  // read. These are the highest-signal peers on Android cold starts.
-  if (!swarm._peartubeOffline) {
-    const explicitPeers = getExplicitPeerList({ network, swarmOptions })
-    const explicitDialed = dialKnownPeers(swarm, explicitPeers)
-    if (explicitDialed > 0) {
-      globalNetworkStartupTiming?.record('explicit-peer-dialed', { dialed: explicitDialed, candidates: explicitPeers.length })
-      console.log('[Storage] Direct-dialed', explicitDialed, 'explicit peer(s) before known-peer cache load')
-      void appendDebugLine(`[storage] explicit warm-dialed ${explicitDialed} of ${explicitPeers.length} peers`)
-    }
-  }
-
-  // Warm dial: re-connect to recently-seen peers. Limit startup fanout so stale
-  // cached peers do not occupy all client dial slots ahead of configured relays.
-  if (!swarm._peartubeOffline) {
-    const startupDialLimit = swarm._peartubeStartupDialLimit || DEFAULT_STARTUP_KNOWN_PEER_DIAL_LIMIT
-    loadKnownPeers(metaDb).then((known) => {
-      if (!known.length) return
-      const dialed = dialKnownPeers(swarm, known, { limit: startupDialLimit })
-      if (dialed > 0) console.log('[Storage] Warm-dialed', dialed, 'of', known.length, 'known peers (limit:', startupDialLimit + ')')
-    }).catch((err) => {
-      console.log('[Storage] Warm-dial skipped:', err?.message)
-    })
   }
 
   // Join the PearTube network topic for peer pool building
@@ -2531,15 +2481,6 @@ export async function resumeNetworking() {
         }
       }
       console.log('[Network] Wakeup sessions marked active');
-    }
-
-    if (globalKnownPeerCache && globalSwarm) {
-      loadKnownPeers(globalSwarm._peartubeMetaDb).then((known) => {
-        const dialed = dialKnownPeers(globalSwarm, known, { limit: globalSwarm._peartubeResumeDialLimit || DEFAULT_RESUME_KNOWN_PEER_DIAL_LIMIT })
-        if (dialed > 0) console.log('[Network] Resume warm-dialed', dialed, 'known peers')
-      }).catch((err) => {
-        console.log('[Network] Resume warm-dial skipped:', err?.message)
-      })
     }
 
     console.log('[Network] Resumed successfully');

--- a/packages/backend/test/blob-playback-service-peer-warmup.test.mjs
+++ b/packages/backend/test/blob-playback-service-peer-warmup.test.mjs
@@ -7,7 +7,7 @@ const VALID_KEY = 'a'.repeat(64)
 const VALID_BLOB = '1:2:3:4'
 const VALID_URL = 'http://127.0.0.1:4321/blob.mp4?token=***'
 
-function createCtx({ peers = [], joinPeer } = {}) {
+function createCtx({ peers = [] } = {}) {
   const calls = []
   const core = {
     discoveryKey: Buffer.from('discovery-key'),
@@ -49,23 +49,14 @@ function createCtx({ peers = [], joinPeer } = {}) {
         },
         joinPeer(publicKey) {
           calls.push(['joinPeer', publicKey.toString('hex')])
-          if (joinPeer) joinPeer(publicKey)
         },
       },
     },
   }
 }
 
-test('preparePlayback starts configured relay peer attachment without blocking the player URL', async () => {
-  let joinedPeerCount = 0
-  const { ctx, core, calls } = createCtx({
-    joinPeer: () => {
-      joinedPeerCount++
-      if (joinedPeerCount === 2) {
-        core.peers.push({ remotePublicKey: Buffer.from('d'.repeat(64), 'hex') })
-      }
-    },
-  })
+test('preparePlayback joins the blob topic and leaves peer selection to Hyperswarm', async () => {
+  const { ctx, core, calls } = createCtx()
   const service = new BlobPlaybackService({ ctx })
 
   let statsCalls = 0
@@ -84,15 +75,10 @@ test('preparePlayback starts configured relay peer attachment without blocking t
 
   assert.equal(result.url, VALID_URL)
   assert.equal(result.warmupStarted, true)
-  assert.equal(result.peerWarmupStarted, true)
   assert.equal(result.stats.peerCount, 0)
   assert.ok(statsCalls >= 1)
 
   await new Promise((resolve) => setImmediate(resolve))
-  assert.equal(core.peers.length, 1)
-  assert.deepEqual(
-    calls.filter((call) => call[0] === 'joinPeer').map((call) => call[1]),
-    ['b'.repeat(64), 'c'.repeat(64)]
-  )
   assert.ok(calls.some((call) => call[0] === 'join'))
+  assert.deepEqual(calls.filter((call) => call[0] === 'joinPeer'), [])
 })

--- a/packages/backend/test/known-peers.test.mjs
+++ b/packages/backend/test/known-peers.test.mjs
@@ -1,29 +1,10 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import { dialKnownPeers, getExplicitPeerList } from '../src/known-peers.js'
+import { getExplicitPeerList, getCachedPeerList } from '../src/known-peers.js'
 
 const keyA = 'aa'.repeat(32)
 const keyB = 'bb'.repeat(32)
-
-test('dialKnownPeers dedupes repeated keys and ignores invalid entries', () => {
-  const calls = []
-  const swarm = {
-    joinPeer(publicKey) {
-      calls.push(Buffer.from(publicKey).toString('hex'))
-    }
-  }
-
-  const count = dialKnownPeers(swarm, [
-    { key: keyA },
-    { key: keyA.toUpperCase() },
-    { key: 'not-a-key' },
-    { key: keyB },
-  ])
-
-  assert.equal(count, 2)
-  assert.deepEqual(calls, [keyA, keyB])
-})
 
 test('getExplicitPeerList accepts relayPeers and knownPeers from network and swarmOptions', () => {
   const peers = getExplicitPeerList({
@@ -34,21 +15,16 @@ test('getExplicitPeerList accepts relayPeers and knownPeers from network and swa
   assert.deepEqual(peers, [keyA, keyB, keyA, keyB])
 })
 
-test('dialKnownPeers respects a startup dial limit after dedupe', () => {
-  const calls = []
-  const swarm = {
-    joinPeer(publicKey) {
-      calls.push(Buffer.from(publicKey).toString('hex'))
-    }
+test('getCachedPeerList loads persisted peers for diagnostics without joining them directly', async () => {
+  const cached = [{ key: keyA, lastSeen: 2 }, { key: keyB, lastSeen: 1 }]
+  const ctx = {
+    metaDb: {
+      async get(key) {
+        assert.equal(key, 'known-peers-v1')
+        return { value: cached }
+      },
+    },
   }
 
-  const count = dialKnownPeers(swarm, [
-    { key: keyA },
-    { key: keyA.toUpperCase() },
-    { key: keyB },
-    { key: 'cc'.repeat(32) },
-  ], { limit: 2 })
-
-  assert.equal(count, 2)
-  assert.deepEqual(calls, [keyA, keyB])
+  assert.deepEqual(await getCachedPeerList(ctx), cached)
 })

--- a/packages/backend/test/storage-startup-regression.test.mjs
+++ b/packages/backend/test/storage-startup-regression.test.mjs
@@ -154,23 +154,21 @@ test('storage plumbs explicit Hyperswarm network options into swarm construction
   assert.match(storageSource, /new LoadedHyperswarm\(hyperswarmOptions\)/)
 })
 
-test('storage uses faster Hyperswarm defaults and limits startup known-peer fanout', () => {
+test('storage uses faster Hyperswarm defaults without app-level direct dialing', () => {
   assert.match(storageSource, /maxParallel:\s*8/)
   assert.match(storageSource, /maxPeers:\s*96/)
-  assert.match(storageSource, /DEFAULT_STARTUP_KNOWN_PEER_DIAL_LIMIT\s*=\s*8/)
-  assert.match(storageSource, /getExplicitPeerList\(\{ network, swarmOptions \}\)/)
-  assert.match(storageSource, /Direct-dialed[\s\S]*explicit peer\(s\) before known-peer cache load/)
-  assert.match(storageSource, /dialKnownPeers\(swarm, known, \{ limit: startupDialLimit \}\)/)
+  assert.doesNotMatch(storageSource, /Direct-dialed[\s\S]*explicit peer\(s\) before known-peer cache load/)
+  assert.doesNotMatch(storageSource, /dialKnownPeers\(/)
+  assert.doesNotMatch(storageSource, /getDialableKnownPeers\(/)
+  assert.match(storageSource, /swarm\.join\(PEARTUBE_NETWORK_TOPIC, \{ server: true, client: true \}\)/)
 })
 
-test('storage starts swarm listen before direct dial and peer-pool topic join', () => {
+test('storage starts swarm listen before peer-pool topic join', () => {
   const listenIndex = storageSource.indexOf('Starting swarm.listen() early')
-  const explicitDialIndex = storageSource.indexOf('explicit peer(s) before known-peer cache load')
   const topicJoinIndex = storageSource.indexOf('Joined peartube-network topic for peer pool building')
 
   assert.ok(listenIndex > 0, 'early listen block should exist')
-  assert.ok(explicitDialIndex > listenIndex, 'explicit peer dial should happen after listen starts')
-  assert.ok(topicJoinIndex > explicitDialIndex, 'topic join should happen after explicit peer dial')
+  assert.ok(topicJoinIndex > listenIndex, 'topic join should happen after listen starts')
 })
 
 
@@ -196,11 +194,10 @@ test('storage captures Hyperswarm connection lifecycle diagnostics', () => {
   assert.match(storageSource, /hyperswarm: diagnostics/)
 })
 
-test('retained content discovery direct-dials configured or cached peers for blob topics', () => {
-  assert.match(storageSource, /getDialableKnownPeers\(ctx\)/)
-  assert.match(storageSource, /dialKnownPeers\(ctx\.swarm, known, \{ limit: ctx\.swarm\?\._peartubeStartupDialLimit \|\| DEFAULT_STARTUP_KNOWN_PEER_DIAL_LIMIT \}\)/)
-  assert.match(storageSource, /network,/)
-  assert.match(storageSource, /swarmOptions,/)
+test('retained content discovery relies on the joined blob topics instead of app-level direct dialing', () => {
+  assert.match(storageSource, /retainSwarmDiscovery\(ctx, blobsCore\.discoveryKey/)
+  assert.doesNotMatch(storageSource, /getDialableKnownPeers\(ctx\)/)
+  assert.doesNotMatch(storageSource, /dialKnownPeers\(ctx\.swarm/)
 })
 
 test('storage captures pre-open DHT connect close diagnostics', () => {


### PR DESCRIPTION
## Summary
- Removes app-shipped `MOBILE_RELAY_PEERS` and stops passing baked relay keys into mobile backend startup
- Removes backend app-level direct dialing / warm-dialing of explicit or cached peer public keys
- Keeps Hyperswarm topic joins as the peer-selection mechanism for network, feed, and blob discovery
- Leaves persisted known peers as diagnostics/future policy data instead of `joinPeer` input

## Rationale
Hyperswarm should own peer selection through joined topics. Hardcoded relay public keys and cached-peer `joinPeer` warmups can bypass the swarm's discovery/backoff behavior and make Android show stale discovered hints rather than real socket/blob peer state.

## Test Plan
- `node --test packages/app/tests/native-relay-launch-options-regression.test.mjs`
- `node --test packages/backend/test/known-peers.test.mjs packages/backend/test/blob-playback-service-peer-warmup.test.mjs packages/backend/test/storage-startup-regression.test.mjs`
- `./node_modules/.bin/eslint --quiet packages/app/app/_layout.tsx packages/app/tests/native-relay-launch-options-regression.test.mjs packages/backend/src/known-peers.js packages/backend/src/storage.js packages/backend/test/known-peers.test.mjs packages/backend/test/blob-playback-service-peer-warmup.test.mjs packages/backend/test/storage-startup-regression.test.mjs`
- `git diff --check`
