### PR TITLE
fix(app): release shorts media sessions on teardown

### DIFF
--- a/packages/app/components/video-player/PearInlineVideoView.tsx
+++ b/packages/app/components/video-player/PearInlineVideoView.tsx
@@ -246,7 +246,14 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
         },
         destroy: async () => {
           player.pause()
+          player.showNowPlayingNotification = false
+          player.staysActiveInBackground = false
           player.currentTime = 0
+          if (typeof player.replaceAsync === 'function') {
+            await player.replaceAsync(null)
+          } else {
+            player.replace(null)
+          }
         },
         seek: async (timeSeconds: number) => {
           seekPlaybackRecoveryUntilRef.current = Date.now() + SEEK_PLAYBACK_RECOVERY_MS

--- a/packages/app/tests/vertical-discovery-regression.test.mjs
+++ b/packages/app/tests/vertical-discovery-regression.test.mjs
@@ -330,7 +330,7 @@ test('native inline player exposes explicit PiP exit and tears down its surface 
   assert.match(source, /allowsPictureInPicture=\{autoEnterPipOnLeave\}/, 'Expo Video should keep PiP gated by route-local policy')
   assert.match(source, /startsPictureInPictureAutomatically=\{autoEnterPipOnLeave\}/, 'Expo Video should retain automatic PiP when enabled')
   assert.match(source, /exitPictureInPicture:\s*\(\) => \{[\s\S]*Expo Video PiP is controlled through VideoView props/, 'native inline player should bridge explicit PiP exit without react-native-video refs')
-  assert.match(source, /destroy: async \(\) => \{[\s\S]*player\.pause\(\)[\s\S]*player\.currentTime = 0/, 'destroy should leave no playback surface running behind the route')
+  assert.match(source, /destroy: async \(\) => \{[\s\S]*player\.pause\(\)[\s\S]*player\.showNowPlayingNotification = false[\s\S]*player\.staysActiveInBackground = false[\s\S]*player\.currentTime = 0[\s\S]*replaceAsync\(null\)[\s\S]*player\.replace\(null\)/, 'destroy should disable notification/background state and detach the Expo Video source so Android media sessions are released')
 })
 
 test('bottom tab screens pad scrollable content by the measured pill tab bar height', () => {


### PR DESCRIPTION
## Summary
- disable Expo Video notification/background flags when the inline player is destroyed
- detach the Expo Video source on destroy so Shorts swipes, unmounts, and app backgrounding release native media-session resources
- tighten the vertical discovery regression test to require source detachment and notification cleanup

## Test plan
- `node --test packages/app/tests/vertical-discovery-regression.test.mjs`
- `./node_modules/.bin/eslint --quiet packages/app/components/video-player/PearInlineVideoView.tsx packages/app/tests/vertical-discovery-regression.test.mjs`
- `npm run lint:changed`
- `git diff --check`

Closes #250
