### PR TITLE
fix(android): restore relay bootstrap warm dials

### DIFF
--- a/packages/app/app/_layout.tsx
+++ b/packages/app/app/_layout.tsx
@@ -77,6 +77,12 @@ const BACKEND_SOURCE_CACHE_KEY = '__PEARTUBE_BACKEND_SOURCE__'
 const DOWNLOADER_SOURCE_CACHE_KEY = '__PEARTUBE_DOWNLOADER_WORKER_SOURCE__'
 const CAST_ACTIVE_GLOBAL_KEY = '__PEARTUBE_CAST_ACTIVE__'
 const PeartubeNetworkDiscovery = (NativeModules as any).PeartubeNetworkDiscovery
+const MOBILE_RELAY_PEERS = [
+  '9890785d1a1b5af8e4bfba0f585f54272b6951e3dc0fdc43a30ed73f1d740f13',
+  'd10f6fbdae2d8e439cf9b6e29cbb42199fff101a8e707345eb455faab92e7d7a',
+  '8cdc6bc7d9d1bfe99644d06dee042023c54d55af178cfa12bf778fe51f01152a',
+  '43f48db991cc40002ebd9661239b49e83c1d6b41c86b06b94a57925d00e5ab05',
+]
 
 function requirePeartubeNetworkDiscovery(): any {
   const mod = (NativeModules as any).PeartubeNetworkDiscovery
@@ -544,6 +550,11 @@ const BACKEND_STARTUP_TIMEOUT_MS = 30000
         ),
         loadBackendSource: async () => sources.backendSource,
         loadDownloaderWorkerSource: async () => sources.downloaderWorkerSource ?? null,
+        launchOptions: {
+          __peartubeLaunchOptions: true,
+          network: { relayPeers: MOBILE_RELAY_PEERS },
+          swarmOptions: { knownPeers: MOBILE_RELAY_PEERS },
+        },
       })
       startupLog('[Startup] initPlatformRPC returned ms=', Date.now() - t0)
 

--- a/packages/app/tests/native-relay-launch-options-regression.test.mjs
+++ b/packages/app/tests/native-relay-launch-options-regression.test.mjs
@@ -12,22 +12,17 @@ function readAppFile(relativePath) {
   return fs.readFileSync(path.join(appRoot, relativePath), 'utf8')
 }
 
-test('native root does not ship hardcoded relay peers into the mobile backend worklet', () => {
+test('native root passes explicit relay peers into the mobile backend worklet', () => {
   const source = readAppFile('app/_layout.tsx')
 
-  assert.doesNotMatch(
+  assert.match(
     source,
-    /const MOBILE_RELAY_PEERS = \[/,
-    'mobile app should not ship a static relay public-key allowlist',
+    /const MOBILE_RELAY_PEERS = \[[\s\S]*9890785d1a1b5af8e4bfba0f585f54272b6951e3dc0fdc43a30ed73f1d740f13[\s\S]*d10f6fbdae2d8e439cf9b6e29cbb42199fff101a8e707345eb455faab92e7d7a[\s\S]*8cdc6bc7d9d1bfe99644d06dee042023c54d55af178cfa12bf778fe51f01152a[\s\S]*43f48db991cc40002ebd9661239b49e83c1d6b41c86b06b94a57925d00e5ab05[\s\S]*\]/,
+    'mobile app should ship the known relay public keys used for Android bootstrap',
   )
-  assert.doesNotMatch(
+  assert.match(
     source,
-    /relayPeers:\s*MOBILE_RELAY_PEERS/,
-    'mobile backend launch should not direct-dial baked-in relay peers',
-  )
-  assert.doesNotMatch(
-    source,
-    /knownPeers:\s*MOBILE_RELAY_PEERS/,
-    'mobile backend launch should not direct-dial baked-in known peers',
+    /launchOptions:\s*\{[\s\S]*__peartubeLaunchOptions:\s*true[\s\S]*network:\s*\{\s*relayPeers:\s*MOBILE_RELAY_PEERS\s*\}[\s\S]*swarmOptions:\s*\{\s*knownPeers:\s*MOBILE_RELAY_PEERS\s*\}[\s\S]*\}/,
+    'mobile backend launch should direct-dial the configured relays before relying on topic discovery',
   )
 })

--- a/packages/backend/src/known-peers.js
+++ b/packages/backend/src/known-peers.js
@@ -1,9 +1,10 @@
 /**
  * Known-Peer Cache
  *
- * Persists noise public keys of peers we've connected to so diagnostics and
- * future policy can inspect recent neighbors without bypassing topic-based
- * Hyperswarm discovery.
+ * Persists noise public keys of peers we've connected to so subsequent cold
+ * starts can call `swarm.joinPeer(pk)` them directly. This short-circuits the
+ * topic-based DHT lookup that would otherwise have to complete before any
+ * peer connection can occur.
  */
 
 import b4a from 'b4a'
@@ -85,6 +86,26 @@ export async function loadKnownPeers(metaDb) {
   }
 }
 
+export function dialKnownPeers(swarm, knownList, options = {}) {
+  if (!swarm || typeof swarm.joinPeer !== 'function' || swarm._peartubeOffline) return 0
+  const limit = Number.isFinite(options.limit) && options.limit > 0 ? Math.floor(options.limit) : Infinity
+  let dialed = 0
+  const seen = new Set()
+  for (const entry of knownList) {
+    if (dialed >= limit) break
+    try {
+      const key = typeof entry?.key === 'string' ? entry.key.toLowerCase() : null
+      if (!key || !/^[0-9a-f]{64}$/.test(key) || seen.has(key)) continue
+      seen.add(key)
+      const pk = b4a.from(key, 'hex')
+      if (pk.length !== 32) continue
+      swarm.joinPeer(pk)
+      dialed++
+    } catch { /* best effort */ }
+  }
+  return dialed
+}
+
 function normalizeExplicitPeerKey(value) {
   const keyHex = toKeyHex(value?.key || value?.publicKey || value)
   return keyHex ? { key: keyHex, lastSeen: Date.now(), source: value?.source || 'explicit' } : null
@@ -108,6 +129,8 @@ export function getExplicitPeerList(ctx) {
   return out
 }
 
-export async function getCachedPeerList(ctx) {
-  return loadKnownPeers(ctx?._peartubeMetaDb || ctx?.metaDb)
+export async function getDialableKnownPeers(ctx) {
+  const explicit = getExplicitPeerList(ctx)
+  const persisted = await loadKnownPeers(ctx?._peartubeMetaDb || ctx?.metaDb)
+  return [...explicit, ...persisted]
 }

--- a/packages/backend/src/storage.js
+++ b/packages/backend/src/storage.js
@@ -26,9 +26,11 @@ import {
 } from './runtime-modules.js'
 import { NETWORK_TOPIC_STRING } from './types.js'
 import { normalizeBlobRefInput } from './blob-ref.js'
-import { createKnownPeerCache } from './known-peers.js'
+import { createKnownPeerCache, loadKnownPeers, dialKnownPeers, getDialableKnownPeers, getExplicitPeerList } from './known-peers.js'
 
 const DEFAULT_BLOBS_CORE_UPDATE_TIMEOUT_MS = 15000
+const DEFAULT_STARTUP_KNOWN_PEER_DIAL_LIMIT = 8
+const DEFAULT_RESUME_KNOWN_PEER_DIAL_LIMIT = 8
 
 function resolveDebugLogPath() {
   return globalThis?.process?.env?.PEARTUBE_NATIVE_WORKLET_DEBUG_LOG || null
@@ -775,6 +777,20 @@ export function retainSwarmDiscovery(ctx, discoveryKey, options = {}) {
   const handle = ctx.swarm.join(discoveryKey, { server: true, client: true })
   handles.set(discoveryKeyHex, handle)
 
+  if (!ctx.swarm._peartubeOffline) {
+    getDialableKnownPeers(ctx)
+      .then((known) => {
+        const dialed = dialKnownPeers(ctx.swarm, known, { limit: ctx.swarm?._peartubeStartupDialLimit || DEFAULT_STARTUP_KNOWN_PEER_DIAL_LIMIT })
+        if (dialed > 0) {
+          const label = options.label || discoveryKeyHex.slice(0, 16)
+          console.log(`[Storage] Direct-dialed ${dialed} known peer(s) for ${label}`)
+        }
+      })
+      .catch((err) => {
+        console.log('[Storage] Direct peer dial skipped:', err?.message)
+      })
+  }
+
   try {
     const flushed = handle?.flushed?.()
     if (flushed && typeof flushed.then === 'function') {
@@ -1222,6 +1238,16 @@ export async function initializeStorage(config) {
     try {
       const hyperswarmOptions = createHyperswarmOptions({ keyPair, network, swarmOptions })
       swarm = new LoadedHyperswarm(hyperswarmOptions);
+      swarm._peartubeStartupDialLimit = Math.max(1, Number(
+        network.startupKnownPeerDialLimit ??
+        swarmOptions.startupKnownPeerDialLimit ??
+        DEFAULT_STARTUP_KNOWN_PEER_DIAL_LIMIT
+      ) || DEFAULT_STARTUP_KNOWN_PEER_DIAL_LIMIT)
+      swarm._peartubeResumeDialLimit = Math.max(1, Number(
+        network.resumeKnownPeerDialLimit ??
+        swarmOptions.resumeKnownPeerDialLimit ??
+        DEFAULT_RESUME_KNOWN_PEER_DIAL_LIMIT
+      ) || DEFAULT_RESUME_KNOWN_PEER_DIAL_LIMIT)
     } catch (err) {
       if (requireNetwork) {
         throw new Error(`Hyperswarm failed to start for required network startup: ${err?.message || String(err)}`)
@@ -1267,9 +1293,8 @@ export async function initializeStorage(config) {
     }
   }
 
-  // Known-peer cache: persist remote pubkeys for diagnostics and future policy.
-  // Do not use this cache for app-level direct dialing; Hyperswarm owns peer
-  // selection through joined topics.
+  // Known-peer cache: persist remote pubkeys so the next cold start can
+  // `swarm.joinPeer(pk)` them directly without waiting for a topic DHT lookup.
   const selfKeyHex = swarm.keyPair?.publicKey ? b4a.toString(swarm.keyPair.publicKey, 'hex') : null
   const knownPeerCache = createKnownPeerCache(metaDb, { selfKeyHex })
   swarm._peartubeMetaDb = metaDb
@@ -1367,6 +1392,31 @@ export async function initializeStorage(config) {
           void appendDebugLine(`[storage] swarm.listen failed ${e?.message || String(e)}`)
         })
     }
+  }
+
+  // Direct-dial explicitly configured relay/known peers before any persisted DB
+  // read. These are the highest-signal peers on Android cold starts.
+  if (!swarm._peartubeOffline) {
+    const explicitPeers = getExplicitPeerList({ network, swarmOptions })
+    const explicitDialed = dialKnownPeers(swarm, explicitPeers)
+    if (explicitDialed > 0) {
+      globalNetworkStartupTiming?.record('explicit-peer-dialed', { dialed: explicitDialed, candidates: explicitPeers.length })
+      console.log('[Storage] Direct-dialed', explicitDialed, 'explicit peer(s) before known-peer cache load')
+      void appendDebugLine(`[storage] explicit warm-dialed ${explicitDialed} of ${explicitPeers.length} peers`)
+    }
+  }
+
+  // Warm dial: re-connect to recently-seen peers. Limit startup fanout so stale
+  // cached peers do not occupy all client dial slots ahead of configured relays.
+  if (!swarm._peartubeOffline) {
+    const startupDialLimit = swarm._peartubeStartupDialLimit || DEFAULT_STARTUP_KNOWN_PEER_DIAL_LIMIT
+    loadKnownPeers(metaDb).then((known) => {
+      if (!known.length) return
+      const dialed = dialKnownPeers(swarm, known, { limit: startupDialLimit })
+      if (dialed > 0) console.log('[Storage] Warm-dialed', dialed, 'of', known.length, 'known peers (limit:', startupDialLimit + ')')
+    }).catch((err) => {
+      console.log('[Storage] Warm-dial skipped:', err?.message)
+    })
   }
 
   // Join the PearTube network topic for peer pool building
@@ -2481,6 +2531,15 @@ export async function resumeNetworking() {
         }
       }
       console.log('[Network] Wakeup sessions marked active');
+    }
+
+    if (globalKnownPeerCache && globalSwarm) {
+      loadKnownPeers(globalSwarm._peartubeMetaDb).then((known) => {
+        const dialed = dialKnownPeers(globalSwarm, known, { limit: globalSwarm._peartubeResumeDialLimit || DEFAULT_RESUME_KNOWN_PEER_DIAL_LIMIT })
+        if (dialed > 0) console.log('[Network] Resume warm-dialed', dialed, 'known peers')
+      }).catch((err) => {
+        console.log('[Network] Resume warm-dial skipped:', err?.message)
+      })
     }
 
     console.log('[Network] Resumed successfully');

--- a/packages/backend/test/known-peers.test.mjs
+++ b/packages/backend/test/known-peers.test.mjs
@@ -1,7 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import { getExplicitPeerList, getCachedPeerList } from '../src/known-peers.js'
+import { getExplicitPeerList, getDialableKnownPeers, dialKnownPeers } from '../src/known-peers.js'
 
 const keyA = 'aa'.repeat(32)
 const keyB = 'bb'.repeat(32)
@@ -15,9 +15,10 @@ test('getExplicitPeerList accepts relayPeers and knownPeers from network and swa
   assert.deepEqual(peers, [keyA, keyB, keyA, keyB])
 })
 
-test('getCachedPeerList loads persisted peers for diagnostics without joining them directly', async () => {
-  const cached = [{ key: keyA, lastSeen: 2 }, { key: keyB, lastSeen: 1 }]
+test('getDialableKnownPeers returns explicit relays before persisted peers', async () => {
+  const cached = [{ key: keyB, lastSeen: 1 }]
   const ctx = {
+    network: { relayPeers: [keyA] },
     metaDb: {
       async get(key) {
         assert.equal(key, 'known-peers-v1')
@@ -26,5 +27,29 @@ test('getCachedPeerList loads persisted peers for diagnostics without joining th
     },
   }
 
-  assert.deepEqual(await getCachedPeerList(ctx), cached)
+  const peers = await getDialableKnownPeers(ctx)
+  assert.equal(peers.length, 2)
+  assert.equal(peers[0].key, keyA)
+  assert.equal(peers[0].source, 'explicit')
+  assert.equal(typeof peers[0].lastSeen, 'number')
+  assert.deepEqual(peers[1], cached[0])
+})
+
+test('dialKnownPeers direct-dials valid unique public keys with a bounded fanout', () => {
+  const calls = []
+  const swarm = {
+    joinPeer(publicKey) {
+      calls.push(Buffer.from(publicKey).toString('hex'))
+    },
+  }
+
+  const dialed = dialKnownPeers(swarm, [
+    { key: keyA },
+    { key: keyA },
+    { key: 'not-a-key' },
+    { key: keyB },
+  ], { limit: 1 })
+
+  assert.equal(dialed, 1)
+  assert.deepEqual(calls, [keyA])
 })

--- a/packages/backend/test/storage-startup-regression.test.mjs
+++ b/packages/backend/test/storage-startup-regression.test.mjs
@@ -154,12 +154,12 @@ test('storage plumbs explicit Hyperswarm network options into swarm construction
   assert.match(storageSource, /new LoadedHyperswarm\(hyperswarmOptions\)/)
 })
 
-test('storage uses faster Hyperswarm defaults without app-level direct dialing', () => {
+test('storage direct-dials explicit relay peers before relying on topic discovery', () => {
   assert.match(storageSource, /maxParallel:\s*8/)
   assert.match(storageSource, /maxPeers:\s*96/)
-  assert.doesNotMatch(storageSource, /Direct-dialed[\s\S]*explicit peer\(s\) before known-peer cache load/)
-  assert.doesNotMatch(storageSource, /dialKnownPeers\(/)
-  assert.doesNotMatch(storageSource, /getDialableKnownPeers\(/)
+  assert.match(storageSource, /Direct-dialed[\s\S]*explicit peer\(s\) before known-peer cache load/)
+  assert.match(storageSource, /const explicitPeers = getExplicitPeerList\(\{ network, swarmOptions \}\)/)
+  assert.match(storageSource, /dialKnownPeers\(swarm, explicitPeers\)/)
   assert.match(storageSource, /swarm\.join\(PEARTUBE_NETWORK_TOPIC, \{ server: true, client: true \}\)/)
 })
 
@@ -194,10 +194,10 @@ test('storage captures Hyperswarm connection lifecycle diagnostics', () => {
   assert.match(storageSource, /hyperswarm: diagnostics/)
 })
 
-test('retained content discovery relies on the joined blob topics instead of app-level direct dialing', () => {
+test('retained content discovery joins blob topics and warm-dials known peers', () => {
   assert.match(storageSource, /retainSwarmDiscovery\(ctx, blobsCore\.discoveryKey/)
-  assert.doesNotMatch(storageSource, /getDialableKnownPeers\(ctx\)/)
-  assert.doesNotMatch(storageSource, /dialKnownPeers\(ctx\.swarm/)
+  assert.match(storageSource, /getDialableKnownPeers\(ctx\)/)
+  assert.match(storageSource, /dialKnownPeers\(ctx\.swarm, known/)
 })
 
 test('storage captures pre-open DHT connect close diagnostics', () => {


### PR DESCRIPTION
## Summary
- restore the Android relay bootstrap path that passed known relay public keys into the mobile backend launch options
- restore bounded `joinPeer` warm dials for explicit relay peers and recently connected peers before relying on topic discovery alone
- warm-dial known peers again when retaining blob discovery and when returning from background
- update regressions so the Android app keeps the peer bootstrap path that previously showed 6+ peers

## Why
Android regressed from seeing multiple connected peers to staying at zero peers even while the relay mesh itself stayed healthy. The last known working path was PR #309. PR #311 removed the app-level relay bootstrap/direct-dial path on the theory that Hyperswarm topic discovery alone should be enough, but the physical Android symptom shows that assumption is wrong for the current relay topology/NAT conditions.

## Verification
- `node --check packages/backend/src/known-peers.js`
- `node --check packages/backend/src/storage.js`
- `node --test packages/app/tests/native-relay-launch-options-regression.test.mjs packages/backend/test/known-peers.test.mjs packages/backend/test/storage-startup-regression.test.mjs`
- `npx eslint --quiet packages/app/app/_layout.tsx packages/app/tests/native-relay-launch-options-regression.test.mjs packages/backend/src/known-peers.js packages/backend/src/storage.js packages/backend/test/known-peers.test.mjs packages/backend/test/storage-startup-regression.test.mjs`
- `npm run lint:changed`
- `git diff --check`

## Live evidence before patch
- local relay mesh healthy: 6-7 connections, 6-7 feed connections, 89 feed entries
- ADB only saw emulator locally; no physical phone attached for direct phone-side logcat proof
