### PR TITLE
fix(app): consume mobile launch options in backend startup

### DIFF
--- a/packages/app/backend/index.mjs
+++ b/packages/app/backend/index.mjs
@@ -284,6 +284,22 @@ function resolveMobileStoragePath(providedStoragePath) {
   return Bare?.argv?.[0] || bareStorageDir || ''
 }
 
+function parseMobileLaunchArgs(args = []) {
+  const first = args[0]
+  if (typeof first !== 'string' || !first.trim().startsWith('{')) {
+    return { launchOptions: null, workerArgs: args }
+  }
+
+  try {
+    const parsed = JSON.parse(first)
+    if (parsed?.__peartubeLaunchOptions === true) {
+      return { launchOptions: parsed, workerArgs: args.slice(1) }
+    }
+  } catch {}
+
+  return { launchOptions: null, workerArgs: args }
+}
+
 export async function startMobileBackend(options = {}) {
   const {
     storagePath: providedStoragePath,
@@ -338,7 +354,8 @@ export async function createMobileRuntimeBackend(options = {}) {
   if (!storagePath) throw new Error('createMobileRuntimeBackend requires a storagePath')
 
   const IPC = stream
-  const workerBundlePath = args[0] || ''
+  const { launchOptions, workerArgs } = parseMobileLaunchArgs(args)
+  const workerBundlePath = workerArgs[0] || ''
   if (workerBundlePath) globalThis.__PEARTUBE_WORKER_PATH__ = workerBundlePath
 
   let rpc = null
@@ -510,6 +527,8 @@ function removeStaleLocks(storageDir) {
     backend = await createBackendContext({
       storagePath: storageDir,
       corestoreWaitForLock: false,
+      network: launchOptions?.network,
+      swarmOptions: launchOptions?.swarmOptions,
       ipcLog,
       onFeedUpdate: () => {
         try {

--- a/packages/app/tests/native-backend-startup-regression.test.mjs
+++ b/packages/app/tests/native-backend-startup-regression.test.mjs
@@ -64,6 +64,36 @@ test('mobile backend startup lock cleanup removes db LOCK files before orchestra
   assert.match(removeLocksBody, /path\.join\(storageDir, 'db', 'LOCK'\)/)
 })
 
+test('mobile backend consumes launch options before downloader worker args', () => {
+  const source = readAppFile('backend/index.mjs')
+
+  assert.match(
+    source,
+    /function parseMobileLaunchArgs\(args = \[\]\) \{[\s\S]*__peartubeLaunchOptions[\s\S]*return \{ launchOptions: parsed, workerArgs: args\.slice\(1\) \}[\s\S]*return \{ launchOptions: null, workerArgs: args \}/,
+    'mobile backend entry should peel launchOptions off argv before reading downloader worker args',
+  )
+  assert.match(
+    source,
+    /const \{ launchOptions, workerArgs \} = parseMobileLaunchArgs\(args\)/,
+    'createMobileRuntimeBackend should parse launchOptions from BareKit worker args',
+  )
+  assert.match(
+    source,
+    /network: launchOptions\?\.network/,
+    'createBackendContext should receive launchOptions.network',
+  )
+  assert.match(
+    source,
+    /swarmOptions: launchOptions\?\.swarmOptions/,
+    'createBackendContext should receive launchOptions.swarmOptions',
+  )
+  assert.match(
+    source,
+    /const workerBundlePath = workerArgs\[0\] \|\| ''/,
+    'downloader worker path should be read after launchOptions are removed',
+  )
+})
+
 test('native root layout clears startup timeout and releases loading on explicit startup errors', () => {
   const source = readAppFile('app/_layout.tsx')
   const onErrorBlock = source.match(/platformRPC\.events\.onError\(\(data: any\) => \{([\s\S]*?)\n\s*\}\)/)?.[1] ?? ''

--- a/packages/host/test/mobile-entry.test.mjs
+++ b/packages/host/test/mobile-entry.test.mjs
@@ -15,6 +15,7 @@ function createFakeStream() {
 test('startMobileBackend delegates startup through the shared host contract', async (t) => {
   let destroyCalls = 0
   let attachedBackend = null
+  let capturedBackendOptions = null
 
   const session = await startMobileBackend({
     storagePath: '/tmp/peartube-mobile',
@@ -22,7 +23,8 @@ test('startMobileBackend delegates startup through the shared host contract', as
     entrypoint: 'mobile-entry',
     args: ['backend.bundle.js'],
     startHostImpl: startHost,
-    createBackendImpl: async ({ onReady }) => {
+    createBackendImpl: async ({ onReady, ...backendOptions }) => {
+      capturedBackendOptions = backendOptions
       const backend = {}
       onReady({ blobServerPort: 6123 })
       return {
@@ -46,11 +48,47 @@ test('startMobileBackend delegates startup through the shared host contract', as
     }
   })
 
-  t.alike(await session.waitUntilReady(), { blobServerPort: 6123, protocolVersion: 2 })
+  const ready = await session.waitUntilReady()
+  t.is(ready.blobServerPort, 6123)
+  t.is(ready.protocolVersion, 2)
   t.is(attachedBackend?.mobileHandlersAttached, true)
   t.is(attachedBackend?.castHandlersAttached, true)
+  t.alike(capturedBackendOptions.args, ['backend.bundle.js'])
 
   await session.terminate()
 
   t.is(destroyCalls, 1)
+})
+
+test('startMobileBackend preserves serialized launch options for runtime backend startup', async (t) => {
+  const launchOptions = {
+    __peartubeLaunchOptions: true,
+    network: { relayPeers: ['relay-a'] },
+    swarmOptions: { knownPeers: ['relay-a'] },
+  }
+  let capturedBackendOptions = null
+
+  const session = await startMobileBackend({
+    storagePath: '/tmp/peartube-mobile',
+    stream: createFakeStream(),
+    entrypoint: 'mobile-entry',
+    args: [JSON.stringify(launchOptions), 'downloader-worker.bundle.js'],
+    startHostImpl: startHost,
+    createBackendImpl: async ({ onReady, ...backendOptions }) => {
+      capturedBackendOptions = backendOptions
+      onReady({ blobServerPort: 6123 })
+      return {
+        backend: {},
+        handlerDeps: { storagePath: '/tmp/peartube-mobile' },
+        destroy: async () => {},
+      }
+    },
+  })
+
+  const ready = await session.waitUntilReady()
+  t.is(ready.blobServerPort, 6123)
+  t.is(ready.protocolVersion, 2)
+  t.alike(capturedBackendOptions.args, [JSON.stringify(launchOptions), 'downloader-worker.bundle.js'])
+
+  await session.terminate()
 })


### PR DESCRIPTION
## Summary
- Parse serialized Android launch options inside the mobile backend entry before treating remaining argv as downloader worker args.
- Forward launchOptions.network and launchOptions.swarmOptions into createBackendContext so explicit relay peers reach storage/Hyperswarm startup.
- Add regressions for the native launch-options path and the shared host contract preserving argv through startup.

## Test plan
- node --test --test-name-pattern='mobile backend consumes launch options before downloader worker args' packages/app/tests/native-backend-startup-regression.test.mjs
- packages/host/node_modules/.bin/brittle packages/host/test/mobile-entry.test.mjs
- node --test packages/app/tests/native-relay-launch-options-regression.test.mjs
- npx eslint --quiet packages/app/backend/index.mjs packages/app/tests/native-backend-startup-regression.test.mjs packages/host/test/mobile-entry.test.mjs
- git diff --check
- npm run lint:changed
