### PR TITLE
fix(p2p): rely on Hyperswarm topic discovery

### DIFF
--- a/packages/app/app/_layout.tsx
+++ b/packages/app/app/_layout.tsx
@@ -77,12 +77,6 @@ const BACKEND_SOURCE_CACHE_KEY = '__PEARTUBE_BACKEND_SOURCE__'
 const DOWNLOADER_SOURCE_CACHE_KEY = '__PEARTUBE_DOWNLOADER_WORKER_SOURCE__'
 const CAST_ACTIVE_GLOBAL_KEY = '__PEARTUBE_CAST_ACTIVE__'
 const PeartubeNetworkDiscovery = (NativeModules as any).PeartubeNetworkDiscovery
-const MOBILE_RELAY_PEERS = [
-  'e405808fe789b4807f264ed88ea8b2643ae031f0ffb83435a895e0b775963333',
-  'c41caf08c970f335583e9d1b37888940c93c136764ecb0b1358bff86fdd64aa4',
-  '146cca33794aa29bcecf90a02600945fafabde3a57d745fe8d1e16ada5520760',
-  '76e6525250aa442d7c1913ef1ecc4087b03a8e2eba9c76781950a0622a482f8c',
-]
 
 function requirePeartubeNetworkDiscovery(): any {
   const mod = (NativeModules as any).PeartubeNetworkDiscovery
@@ -550,10 +544,6 @@ const BACKEND_STARTUP_TIMEOUT_MS = 30000
         ),
         loadBackendSource: async () => sources.backendSource,
         loadDownloaderWorkerSource: async () => sources.downloaderWorkerSource ?? null,
-        launchOptions: {
-          __peartubeLaunchOptions: true,
-          network: { relayPeers: MOBILE_RELAY_PEERS },
-        },
       })
       startupLog('[Startup] initPlatformRPC returned ms=', Date.now() - t0)
 

--- a/packages/app/tests/native-relay-launch-options-regression.test.mjs
+++ b/packages/app/tests/native-relay-launch-options-regression.test.mjs
@@ -12,18 +12,11 @@ function readAppFile(relativePath) {
   return fs.readFileSync(path.join(appRoot, relativePath), 'utf8')
 }
 
-test('native root passes explicit relay peers into the mobile backend worklet', () => {
+test('native root does not ship app-level relay peers into the mobile backend worklet', () => {
   const source = readAppFile('app/_layout.tsx')
 
-  assert.match(
-    source,
-    /const MOBILE_RELAY_PEERS = \[[\s\S]*e405808fe789b4807f264ed88ea8b2643ae031f0ffb83435a895e0b775963333[\s\S]*c41caf08c970f335583e9d1b37888940c93c136764ecb0b1358bff86fdd64aa4[\s\S]*146cca33794aa29bcecf90a02600945fafabde3a57d745fe8d1e16ada5520760[\s\S]*76e6525250aa442d7c1913ef1ecc4087b03a8e2eba9c76781950a0622a482f8c[\s\S]*\]/,
-    'mobile app should ship the current relay public keys used for Android bootstrap',
-  )
-  assert.match(
-    source,
-    /launchOptions:\s*\{[\s\S]*__peartubeLaunchOptions:\s*true[\s\S]*network:\s*\{\s*relayPeers:\s*MOBILE_RELAY_PEERS\s*\}[\s\S]*\}/,
-    'mobile backend launch should direct-dial the configured relays before relying on topic discovery',
-  )
-  assert.doesNotMatch(source, /swarmOptions:\s*\{\s*knownPeers:\s*MOBILE_RELAY_PEERS\s*\}/)
+  assert.doesNotMatch(source, /MOBILE_RELAY_PEERS/)
+  assert.doesNotMatch(source, /network:\s*\{\s*relayPeers:/)
+  assert.doesNotMatch(source, /swarmOptions:\s*\{\s*knownPeers:/)
+  assert.match(source, /initPlatformRPC\(\{[\s\S]*loadBackendSource:[\s\S]*loadDownloaderWorkerSource:/)
 })

--- a/packages/backend/src/known-peers.js
+++ b/packages/backend/src/known-peers.js
@@ -1,10 +1,9 @@
 /**
  * Known-Peer Cache
  *
- * Persists noise public keys of peers we've connected to so subsequent cold
- * starts can call `swarm.joinPeer(pk)` them directly. This short-circuits the
- * topic-based DHT lookup that would otherwise have to complete before any
- * peer connection can occur.
+ * Persists noise public keys of peers we've connected to for diagnostics and
+ * future operator policy. Default PearTube peer discovery is topic-owned by
+ * Hyperswarm; cached peers are not dialed during normal startup/resume.
  */
 
 import b4a from 'b4a'
@@ -84,53 +83,4 @@ export async function loadKnownPeers(metaDb) {
     console.log('[KnownPeers] load failed:', err?.message)
     return []
   }
-}
-
-export function dialKnownPeers(swarm, knownList, options = {}) {
-  if (!swarm || typeof swarm.joinPeer !== 'function' || swarm._peartubeOffline) return 0
-  const limit = Number.isFinite(options.limit) && options.limit > 0 ? Math.floor(options.limit) : Infinity
-  let dialed = 0
-  const seen = new Set()
-  for (const entry of knownList) {
-    if (dialed >= limit) break
-    try {
-      const key = typeof entry?.key === 'string' ? entry.key.toLowerCase() : null
-      if (!key || !/^[0-9a-f]{64}$/.test(key) || seen.has(key)) continue
-      seen.add(key)
-      const pk = b4a.from(key, 'hex')
-      if (pk.length !== 32) continue
-      swarm.joinPeer(pk)
-      dialed++
-    } catch { /* best effort */ }
-  }
-  return dialed
-}
-
-function normalizeExplicitPeerKey(value) {
-  const keyHex = toKeyHex(value?.key || value?.publicKey || value)
-  return keyHex ? { key: keyHex, lastSeen: Date.now(), source: value?.source || 'explicit' } : null
-}
-
-export function getExplicitPeerList(ctx) {
-  const configured = [
-    ctx?.network?.relayPeers,
-    ctx?.network?.knownPeers,
-    ctx?.swarmOptions?.relayPeers,
-    ctx?.swarmOptions?.knownPeers,
-  ]
-  const out = []
-  for (const value of configured) {
-    const list = Array.isArray(value) ? value : (value ? String(value).split(/[\s,]+/) : [])
-    for (const item of list) {
-      const normalized = normalizeExplicitPeerKey(item)
-      if (normalized) out.push(normalized)
-    }
-  }
-  return out
-}
-
-export async function getDialableKnownPeers(ctx) {
-  const explicit = getExplicitPeerList(ctx)
-  const persisted = await loadKnownPeers(ctx?._peartubeMetaDb || ctx?.metaDb)
-  return [...explicit, ...persisted]
 }

--- a/packages/backend/src/storage.js
+++ b/packages/backend/src/storage.js
@@ -26,11 +26,9 @@ import {
 } from './runtime-modules.js'
 import { NETWORK_TOPIC_STRING } from './types.js'
 import { normalizeBlobRefInput } from './blob-ref.js'
-import { createKnownPeerCache, loadKnownPeers, dialKnownPeers, getDialableKnownPeers, getExplicitPeerList } from './known-peers.js'
+import { createKnownPeerCache } from './known-peers.js'
 
 const DEFAULT_BLOBS_CORE_UPDATE_TIMEOUT_MS = 15000
-const DEFAULT_STARTUP_KNOWN_PEER_DIAL_LIMIT = 8
-const DEFAULT_RESUME_KNOWN_PEER_DIAL_LIMIT = 8
 
 function resolveDebugLogPath() {
   return globalThis?.process?.env?.PEARTUBE_NATIVE_WORKLET_DEBUG_LOG || null
@@ -777,19 +775,6 @@ export function retainSwarmDiscovery(ctx, discoveryKey, options = {}) {
   const handle = ctx.swarm.join(discoveryKey, { server: true, client: true })
   handles.set(discoveryKeyHex, handle)
 
-  if (!ctx.swarm._peartubeOffline) {
-    getDialableKnownPeers(ctx)
-      .then((known) => {
-        const dialed = dialKnownPeers(ctx.swarm, known, { limit: ctx.swarm?._peartubeStartupDialLimit || DEFAULT_STARTUP_KNOWN_PEER_DIAL_LIMIT })
-        if (dialed > 0) {
-          const label = options.label || discoveryKeyHex.slice(0, 16)
-          console.log(`[Storage] Direct-dialed ${dialed} known peer(s) for ${label}`)
-        }
-      })
-      .catch((err) => {
-        console.log('[Storage] Direct peer dial skipped:', err?.message)
-      })
-  }
 
   try {
     const flushed = handle?.flushed?.()
@@ -1240,16 +1225,6 @@ export async function initializeStorage(config) {
     try {
       const hyperswarmOptions = createHyperswarmOptions({ keyPair, network, swarmOptions })
       swarm = new LoadedHyperswarm(hyperswarmOptions);
-      swarm._peartubeStartupDialLimit = Math.max(1, Number(
-        network.startupKnownPeerDialLimit ??
-        swarmOptions.startupKnownPeerDialLimit ??
-        DEFAULT_STARTUP_KNOWN_PEER_DIAL_LIMIT
-      ) || DEFAULT_STARTUP_KNOWN_PEER_DIAL_LIMIT)
-      swarm._peartubeResumeDialLimit = Math.max(1, Number(
-        network.resumeKnownPeerDialLimit ??
-        swarmOptions.resumeKnownPeerDialLimit ??
-        DEFAULT_RESUME_KNOWN_PEER_DIAL_LIMIT
-      ) || DEFAULT_RESUME_KNOWN_PEER_DIAL_LIMIT)
     } catch (err) {
       if (requireNetwork) {
         throw new Error(`Hyperswarm failed to start for required network startup: ${err?.message || String(err)}`)
@@ -1295,8 +1270,8 @@ export async function initializeStorage(config) {
     }
   }
 
-  // Known-peer cache: persist remote pubkeys so the next cold start can
-  // `swarm.joinPeer(pk)` them directly without waiting for a topic DHT lookup.
+  // Known-peer cache: persist remote pubkeys for diagnostics and possible
+  // operator policy. Default discovery stays topic-owned by Hyperswarm.
   const selfKeyHex = swarm.keyPair?.publicKey ? b4a.toString(swarm.keyPair.publicKey, 'hex') : null
   const knownPeerCache = createKnownPeerCache(metaDb, { selfKeyHex })
   swarm._peartubeMetaDb = metaDb
@@ -1396,30 +1371,6 @@ export async function initializeStorage(config) {
     }
   }
 
-  // Direct-dial explicitly configured relay/known peers before any persisted DB
-  // read. These are the highest-signal peers on Android cold starts.
-  if (!swarm._peartubeOffline) {
-    const explicitPeers = getExplicitPeerList({ network, swarmOptions })
-    const explicitDialed = dialKnownPeers(swarm, explicitPeers)
-    if (explicitDialed > 0) {
-      globalNetworkStartupTiming?.record('explicit-peer-dialed', { dialed: explicitDialed, candidates: explicitPeers.length })
-      console.log('[Storage] Direct-dialed', explicitDialed, 'explicit peer(s) before known-peer cache load')
-      void appendDebugLine(`[storage] explicit warm-dialed ${explicitDialed} of ${explicitPeers.length} peers`)
-    }
-  }
-
-  // Warm dial: re-connect to recently-seen peers. Limit startup fanout so stale
-  // cached peers do not occupy all client dial slots ahead of configured relays.
-  if (!swarm._peartubeOffline) {
-    const startupDialLimit = swarm._peartubeStartupDialLimit || DEFAULT_STARTUP_KNOWN_PEER_DIAL_LIMIT
-    loadKnownPeers(metaDb).then((known) => {
-      if (!known.length) return
-      const dialed = dialKnownPeers(swarm, known, { limit: startupDialLimit })
-      if (dialed > 0) console.log('[Storage] Warm-dialed', dialed, 'of', known.length, 'known peers (limit:', startupDialLimit + ')')
-    }).catch((err) => {
-      console.log('[Storage] Warm-dial skipped:', err?.message)
-    })
-  }
 
   // Join the PearTube network topic for peer pool building
   // More connected peers = better relay options for symmetric NAT holepunching
@@ -2535,14 +2486,6 @@ export async function resumeNetworking() {
       console.log('[Network] Wakeup sessions marked active');
     }
 
-    if (globalKnownPeerCache && globalSwarm) {
-      loadKnownPeers(globalSwarm._peartubeMetaDb).then((known) => {
-        const dialed = dialKnownPeers(globalSwarm, known, { limit: globalSwarm._peartubeResumeDialLimit || DEFAULT_RESUME_KNOWN_PEER_DIAL_LIMIT })
-        if (dialed > 0) console.log('[Network] Resume warm-dialed', dialed, 'known peers')
-      }).catch((err) => {
-        console.log('[Network] Resume warm-dial skipped:', err?.message)
-      })
-    }
 
     console.log('[Network] Resumed successfully');
   } catch (err) {

--- a/packages/backend/test/known-peers.test.mjs
+++ b/packages/backend/test/known-peers.test.mjs
@@ -1,55 +1,42 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import { getExplicitPeerList, getDialableKnownPeers, dialKnownPeers } from '../src/known-peers.js'
+import { createKnownPeerCache, loadKnownPeers } from '../src/known-peers.js'
 
 const keyA = 'aa'.repeat(32)
 const keyB = 'bb'.repeat(32)
 
-test('getExplicitPeerList accepts relayPeers and knownPeers from network and swarmOptions', () => {
-  const peers = getExplicitPeerList({
-    network: { relayPeers: [keyA], knownPeers: keyB },
-    swarmOptions: { relayPeers: `${keyA},${keyB}` },
-  }).map((entry) => entry.key)
+test('known peer cache records connected peers for diagnostics only', async () => {
+  const writes = []
+  const cache = createKnownPeerCache({
+    async put(key, value) {
+      writes.push({ key, value })
+    },
+  }, { selfKeyHex: keyB })
 
-  assert.deepEqual(peers, [keyA, keyB, keyA, keyB])
+  cache.record(Buffer.from(keyA, 'hex'))
+  cache.record(Buffer.from(keyB, 'hex'))
+  await cache.flush()
+
+  assert.equal(writes.length, 1)
+  assert.equal(writes[0].key, 'known-peers-v1')
+  assert.equal(writes[0].value.length, 1)
+  assert.equal(writes[0].value[0].key, keyA)
 })
 
-test('getDialableKnownPeers returns explicit relays before persisted peers', async () => {
-  const cached = [{ key: keyB, lastSeen: 1 }]
-  const ctx = {
-    network: { relayPeers: [keyA] },
-    metaDb: {
-      async get(key) {
-        assert.equal(key, 'known-peers-v1')
-        return { value: cached }
-      },
+test('loadKnownPeers returns sorted persisted diagnostics without dialing policy', async () => {
+  const cached = [
+    { key: keyA, lastSeen: 1 },
+    { key: 'not-a-key', lastSeen: 999 },
+    { key: keyB, lastSeen: 2 },
+  ]
+
+  const peers = await loadKnownPeers({
+    async get(key) {
+      assert.equal(key, 'known-peers-v1')
+      return { value: cached }
     },
-  }
+  })
 
-  const peers = await getDialableKnownPeers(ctx)
-  assert.equal(peers.length, 2)
-  assert.equal(peers[0].key, keyA)
-  assert.equal(peers[0].source, 'explicit')
-  assert.equal(typeof peers[0].lastSeen, 'number')
-  assert.deepEqual(peers[1], cached[0])
-})
-
-test('dialKnownPeers direct-dials valid unique public keys with a bounded fanout', () => {
-  const calls = []
-  const swarm = {
-    joinPeer(publicKey) {
-      calls.push(Buffer.from(publicKey).toString('hex'))
-    },
-  }
-
-  const dialed = dialKnownPeers(swarm, [
-    { key: keyA },
-    { key: keyA },
-    { key: 'not-a-key' },
-    { key: keyB },
-  ], { limit: 1 })
-
-  assert.equal(dialed, 1)
-  assert.deepEqual(calls, [keyA])
+  assert.deepEqual(peers, [cached[2], cached[0]])
 })

--- a/packages/backend/test/storage-startup-regression.test.mjs
+++ b/packages/backend/test/storage-startup-regression.test.mjs
@@ -155,12 +155,12 @@ test('storage plumbs explicit Hyperswarm network options into swarm construction
   assert.match(storageSource, /new LoadedHyperswarm\(hyperswarmOptions\)/)
 })
 
-test('storage direct-dials explicit relay peers before relying on topic discovery', () => {
+test('storage lets Hyperswarm topic discovery own default peer selection', () => {
   assert.match(storageSource, /maxParallel:\s*8/)
   assert.match(storageSource, /maxPeers:\s*96/)
-  assert.match(storageSource, /Direct-dialed[\s\S]*explicit peer\(s\) before known-peer cache load/)
-  assert.match(storageSource, /const explicitPeers = getExplicitPeerList\(\{ network, swarmOptions \}\)/)
-  assert.match(storageSource, /dialKnownPeers\(swarm, explicitPeers\)/)
+  assert.doesNotMatch(storageSource, /Direct-dialed[\s\S]*explicit peer\(s\) before known-peer cache load/)
+  assert.doesNotMatch(storageSource, /const explicitPeers = getExplicitPeerList\(\{ network, swarmOptions \}\)/)
+  assert.doesNotMatch(storageSource, /dialKnownPeers\(swarm, explicitPeers\)/)
   assert.match(storageSource, /swarm\.join\(PEARTUBE_NETWORK_TOPIC, \{ server: true, client: true \}\)/)
 })
 
@@ -195,10 +195,10 @@ test('storage captures Hyperswarm connection lifecycle diagnostics', () => {
   assert.match(storageSource, /hyperswarm: diagnostics/)
 })
 
-test('retained content discovery joins blob topics and warm-dials known peers', () => {
+test('retained content discovery joins blob topics without app-level peer dials', () => {
   assert.match(storageSource, /retainSwarmDiscovery\(ctx, blobsCore\.discoveryKey/)
-  assert.match(storageSource, /getDialableKnownPeers\(ctx\)/)
-  assert.match(storageSource, /dialKnownPeers\(ctx\.swarm, known/)
+  assert.doesNotMatch(storageSource, /getDialableKnownPeers\(ctx\)/)
+  assert.doesNotMatch(storageSource, /dialKnownPeers\(ctx\.swarm, known/)
 })
 
 test('storage captures pre-open DHT connect close diagnostics', () => {


### PR DESCRIPTION
## Summary
- remove app-shipped mobile relay public keys from native backend launch options
- remove default startup/resume/content warm-dial paths that call joinPeer from cached or configured peers
- keep known peer persistence as diagnostics only while the default path joins the shared peartube-network and blob topics

## Verification
- node --test packages/app/tests/native-relay-launch-options-regression.test.mjs packages/backend/test/storage-startup-regression.test.mjs packages/backend/test/known-peers.test.mjs
- npx eslint --quiet packages/app/app/_layout.tsx packages/app/tests/native-relay-launch-options-regression.test.mjs packages/backend/src/storage.js packages/backend/src/known-peers.js packages/backend/test/known-peers.test.mjs packages/backend/test/storage-startup-regression.test.mjs
- git diff --check

## Notes
- Phone and relays already derive the same peartube-network topic: 660317ae9e952274c923999437d2d5827ba1e6ef646ae1ccb4b148b65102db1d.
- This PR removes the bootstrap-peer/direct-dial rabbit hole and restores Hyperswarm-owned topic discovery as the default architecture.
