### PR TITLE
fix(p2p): propagate signed feed descriptors

### DIFF
--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -1730,6 +1730,7 @@ export function createApi({
             videoCount: Array.isArray(rawVideos) ? rawVideos.length : 0,
             manifestUpdatedAt: getStableManifestUpdatedAt(meta, rawVideos, publicBee),
             previewVideos,
+            signedDescriptor: meta?.signedDescriptor || null,
           }
         } catch {
           return null

--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -437,6 +437,7 @@ export class PublicFeed {
           previewVideos: Array.isArray(snapshot.previewVideos)
             ? this._sanitizePreviewVideos(snapshot.previewVideos)
             : this._sanitizePreviewVideos(byKey.get(driveKey)?.previewVideos),
+          signedDescriptor: snapshot.signedDescriptor || byKey.get(driveKey)?.signedDescriptor || null,
         }
         byKey.set(driveKey, merged)
         this._applyEntrySnapshot(driveKey, merged)

--- a/packages/backend/test/api-feed-snapshot-descriptor-regression.test.mjs
+++ b/packages/backend/test/api-feed-snapshot-descriptor-regression.test.mjs
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import b4a from 'b4a'
+import crypto from 'hypercore-crypto'
+import IdentityKey from 'keet-identity-key'
+
+import { createApi } from '../src/api.js'
+import { PublicFeedManager } from '../src/public-feed.js'
+import {
+  createChannelRootDescriptor,
+  signChannelRootDescriptor,
+  verifySignedChannelRootDescriptor,
+} from '../src/channel-descriptor.js'
+
+const key = (byte) => Buffer.alloc(32, byte).toString('hex')
+
+function createMetaDb () {
+  const store = new Map()
+  return {
+    async get (k) {
+      return store.has(k) ? store.get(k) : null
+    },
+    async put (k, v) {
+      store.set(k, { value: v })
+    },
+  }
+}
+
+function createCtx () {
+  return {
+    metaDb: createMetaDb(),
+    swarm: {
+      keyPair: crypto.keyPair(),
+      connections: new Set(),
+      peers: new Map(),
+    },
+  }
+}
+
+async function signedDescriptor ({ deviceKeyPair, channelId = key(1), metadataKey = key(2), mediaKey = key(3), seq = 1 } = {}) {
+  const identity = await IdentityKey.from({ mnemonic: IdentityKey.generateMnemonic() })
+  const proof = await identity.bootstrap(deviceKeyPair.publicKey)
+  const descriptor = createChannelRootDescriptor({
+    identityPublicKey: b4a.toString(identity.identityPublicKey, 'hex'),
+    channelId,
+    metadataKey,
+    mediaKey,
+    seq,
+    createdAt: 1,
+    updatedAt: 1,
+  })
+  return signChannelRootDescriptor({ descriptor, deviceKeyPair, deviceProof: proof })
+}
+
+function createPublicBee ({ signed, videos = [] } = {}) {
+  return {
+    core: { length: 10 },
+    async getMetadata () {
+      return {
+        name: 'Signed Feed Channel',
+        signedDescriptor: signed,
+      }
+    },
+    async listVideos () {
+      return videos
+    },
+    async getVideo (id) {
+      return videos.find((video) => video.id === id) || null
+    },
+  }
+}
+
+test('feed snapshots include signed channel descriptor so signed public feed ingress accepts them', async () => {
+  const ctx = createCtx()
+  const publicFeed = new PublicFeedManager(ctx.swarm, ctx.metaDb)
+  const signed = await signedDescriptor({ deviceKeyPair: ctx.swarm.keyPair, channelId: key(1), metadataKey: key(2), mediaKey: key(3) })
+  const api = createApi({
+    ctx,
+    publicFeed,
+    loadPublicBee: async () => createPublicBee({ signed }),
+  })
+
+  const [snapshot] = await api.getFeedSnapshotEntries([{ driveKey: key(1), publicBeeKey: key(2) }])
+
+  assert.ok(snapshot?.signedDescriptor, 'snapshot should carry channel root descriptor')
+  assert.equal(snapshot.signedDescriptor.descriptor.channelId, key(1))
+  assert.equal(snapshot.signedDescriptor.descriptor.metadataKey, key(2))
+  assert.equal(snapshot.signedDescriptor.descriptor.mediaKey, key(3))
+  assert.equal((await verifySignedChannelRootDescriptor(snapshot.signedDescriptor)).valid, true)
+
+  const receivingFeed = new PublicFeedManager(ctx.swarm, createMetaDb())
+  try {
+    receivingFeed.handleMessage({ type: 'HAVE_FEED', entries: [snapshot] }, {})
+    await new Promise((resolve) => setImmediate(resolve))
+
+    assert.equal(receivingFeed.entries.has(key(1)), true)
+    assert.equal(receivingFeed.entries.get(key(1)).publicBeeKey, key(2))
+  } finally {
+    receivingFeed.stop()
+    publicFeed.stop()
+  }
+})


### PR DESCRIPTION
## Summary
- include signed channel root descriptors in API feed snapshot entries
- preserve descriptors when PublicFeed merges feed snapshots into HAVE_FEED gossip
- add regression proving a signed-ingress receiver accepts the gossiped snapshot

## Evidence
- Physical phone connected to peer 0f683c866d10caa8 and opened the feed Protomux channel.
- Phone sent NEED_FEED repeatedly but returned 0 feed entries.
- Relays were sending HAVE_FEED with entries, so the failure boundary was not DHT discovery or socket open; it was feed-entry acceptance after signed ingress.

## Tests
- node --test packages/backend/test/api-feed-snapshot-descriptor-regression.test.mjs packages/backend/test/public-feed-signed-ingress.test.mjs packages/backend/test/public-feed-descriptor.test.mjs
- npx eslint --quiet packages/backend/src/api.js packages/backend/src/public-feed.js packages/backend/test/api-feed-snapshot-descriptor-regression.test.mjs
- git diff --check