### PR TITLE
fix(feed): preserve live preview availability for mobile fallback

### DIFF
--- a/packages/app/tests/feed-hydration.test.mjs
+++ b/packages/app/tests/feed-hydration.test.mjs
@@ -272,14 +272,14 @@ test('backend preview fallback preserves live-peer preview availability for Home
     source.indexOf('function getPreviewVideoFromFeed'),
   )
   const availabilityBlock = source.slice(
-    source.indexOf('const attachVideoAvailability'),
+    source.indexOf('const resolveExplicitVideoAvailability'),
     source.indexOf('const cached = listVideosCache.get'),
   )
 
   assert.match(previewHelper, /const feedEntryHasLivePeer = Number\(entry\?\.peerCount \|\| 0\) > 0/, 'backend preview fallback should treat live-peer feed previews as renderable')
   assert.match(previewHelper, /const videoAvailability = video\.availability \|\| video\.byteAvailability \|\| \(feedEntryHasLivePeer \? 'playable' : null\)/, 'preview videos should carry playable availability when the feed entry has live peers')
   assert.match(availabilityBlock, /const explicitAvailability = video\?\.byteAvailability \|\| video\?\.availability \|\| null/, 'availability revalidation should preserve explicit playable preview availability')
-  assert.match(availabilityBlock, /explicitAvailability === 'playable'[\s\S]*\? 'playable'/, 'explicit playable preview refs must not be downgraded to unavailable during fallback')
+  assert.match(availabilityBlock, /explicitAvailability === 'playable'[\s\S]*return 'playable'/, 'explicit playable preview refs must not be downgraded to unavailable during fallback')
 })
 
 test('mergeHydratedFeedVideos replaces stale channel cards when a refreshed channel no longer has watchable videos', () => {

--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -332,10 +332,12 @@ export function createApi({
     const previews = Array.isArray(entry?.previewVideos) ? entry.previewVideos : []
     if (previews.length === 0) return []
     const resolvedPublicBeeKey = publicBeeKey || entry?.publicBeeKey || null
+    const feedEntryHasLivePeer = Number(entry?.peerCount || 0) > 0
     return previews
       .filter((video) => video?.id || video?.path)
       .map((video) => {
         const id = normalizeVideoId(video.id || video.path)
+        const videoAvailability = video.availability || video.byteAvailability || (feedEntryHasLivePeer ? 'playable' : null)
         return {
           ...video,
           id,
@@ -343,6 +345,8 @@ export function createApi({
           channelKey: driveKey,
           publicBeeKey: resolvedPublicBeeKey,
           relayBacked: Boolean(entry?.relayServing || entry?.relayRole === 'cache' || entry?.source === 'relay-cache'),
+          availability: videoAvailability || video.availability,
+          byteAvailability: video.byteAvailability || videoAvailability || undefined,
           mimeType: video.mimeType || 'video/mp4',
         }
       })
@@ -931,12 +935,20 @@ export function createApi({
 
         const isPlayableAvailabilityHint = (hint) => hint?.availability === 'playable'
 
-        const resolveExplicitVideoAvailability = ({ localHint, peerHint }) => {
+        const resolveExplicitVideoAvailability = ({ video, localHint, peerHint }) => {
+          const explicitAvailability = video?.byteAvailability || video?.availability || null
+
           // Fast path: if our local store already has the opening blocks, the
           // video is immediately watchable without waiting on remote proof.
           if (isPlayableAvailabilityHint(localHint)) return 'playable'
 
-          // Remote playability must be explicitly proven by a peer serving hint.
+          // Preserve explicit playable preview refs emitted by the public-feed
+          // fallback. Those refs came from a live peer/relay manifest; without
+          // this, Android zero-peer states can downgrade renderable preview
+          // cards to unavailable before the blob hint round-trip completes.
+          if (explicitAvailability === 'playable') return 'playable'
+
+          // Remote playability must otherwise be explicitly proven by a peer serving hint.
           if (peerHint?.availability === 'playable') return 'playable'
           if (peerHint?.availability && peerHint.availability !== 'unknown') {
             return peerHint.availability
@@ -989,7 +1001,7 @@ export function createApi({
             const localHint = id ? localHintsById.get(id) : null
             const peerHint = id ? peerHintsById.get(id) : null
             const availability = id
-              ? resolveExplicitVideoAvailability({ localHint, peerHint })
+              ? resolveExplicitVideoAvailability({ video, localHint, peerHint })
               : 'unavailable'
 
             return {


### PR DESCRIPTION
## Summary
- preserves playable availability on public-feed preview fallback videos when a live peer/relay advertises the feed entry
- prevents `listVideos` availability revalidation from downgrading those explicit playable preview refs to unavailable before blob hint responses arrive
- tightens the regression covering Home/mobile fallback rendering from feed previews

## Root cause
Live relays were sending non-empty `HAVE_FEED` and relay status shows playable preview refs, but Android can still show zero/use no cards when the backend fallback path downgrades preview refs to `unavailable` during availability revalidation. That makes the UI/filter layer drop otherwise renderable relay-backed previews.

## Test Plan
- [x] `node --test packages/app/tests/feed-hydration.test.mjs packages/backend/test/public-feed-manager.test.mjs`
- [x] `./node_modules/.bin/eslint --quiet packages/backend/src/api.js packages/app/tests/feed-hydration.test.mjs`
- [x] `npm run lint:changed`
- [x] `git diff --check`
