### PR TITLE
fix(p2p): count async verified feed entries

### DIFF
--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -1303,6 +1303,22 @@ export class PublicFeed {
       let announcedKeys = []
       let receivedCount = 0
 
+      const applyVerifiedEntry = (entry, publicBeeKey, normalizedEntry) => {
+        let changed = false
+        if (this.addEntry(entry.driveKey, 'peer', publicBeeKey, normalizedEntry)) changed = true
+        else if (this._applyEntrySnapshot(entry.driveKey, normalizedEntry)) changed = true
+
+        // The advertised key was real feed state even if the entry already
+        // existed locally. Keep the connection -> key mapping in sync inside
+        // the async signed-ingress path; otherwise UI/API stats stay at
+        // keyed=0/raw=0 until another synchronous message happens.
+        const peerSetChanged = this._setPeerFeedKeys(conn, [entry.driveKey])
+        if (changed || peerSetChanged) {
+          try { this.onFeedUpdate?.() } catch {}
+          this._schedulePersistDiscovered()
+        }
+      }
+
       // Prefer new entries format (with publicBeeKey)
       if (msg.entries && Array.isArray(msg.entries)) {
       log.debug('HAVE_FEED received (entries)', { count: msg.entries.length })
@@ -1323,14 +1339,7 @@ export class PublicFeed {
           this._verifyPeerEntrySnapshot(normalizedEntry, entry.driveKey, publicBeeKey)
             .then((verified) => {
               if (!verified) return
-              let changed = false
-              if (this.addEntry(entry.driveKey, 'peer', publicBeeKey, normalizedEntry)) changed = true
-              else if (this._applyEntrySnapshot(entry.driveKey, normalizedEntry)) changed = true
-              if (changed) {
-                this._setPeerFeedKeys(conn, [entry.driveKey])
-                try { this.onFeedUpdate?.() } catch {}
-                this._schedulePersistDiscovered()
-              }
+              applyVerifiedEntry(entry, publicBeeKey, normalizedEntry)
             })
             .catch(() => {})
         }

--- a/packages/backend/test/public-feed-signed-ingress.test.mjs
+++ b/packages/backend/test/public-feed-signed-ingress.test.mjs
@@ -187,3 +187,46 @@ test('public feed accepts relay-cache HAVE_FEED catalog entries without signed d
     manager.stop()
   }
 })
+
+test('public feed counts already-known async verified HAVE_FEED entries for the peer connection', async () => {
+  const manager = new PublicFeedManager(createSwarm(), createMetaDb())
+  const signed = await signedDescriptor({ channelId: key(7), metadataKey: key(8), mediaKey: key(9) })
+  const conn = {}
+
+  try {
+    manager.addEntry(key(7), 'peer', key(8), {
+      driveKey: key(7),
+      publicBeeKey: key(8),
+      signedDescriptor: signed,
+      previewVideos: [{
+        id: 'cached-video',
+        blobId: '0:1:0:128',
+        blobsCoreKey: key(10),
+        availability: 'playable',
+      }],
+    })
+
+    manager.handleMessage({
+      type: 'HAVE_FEED',
+      entries: [{
+        driveKey: key(7),
+        publicBeeKey: key(8),
+        signedDescriptor: signed,
+        previewVideos: [{
+          id: 'cached-video',
+          blobId: '0:1:0:128',
+          blobsCoreKey: key(10),
+          availability: 'playable',
+        }],
+      }],
+    }, conn)
+    await new Promise((resolve) => setImmediate(resolve))
+
+    assert.equal(manager.peerFeedKeys.get(conn)?.has(key(7)), true)
+    assert.equal(manager.entryPeerCounts.get(key(7)), 1)
+    assert.equal(manager.getStats().totalEntries, 1)
+    assert.equal(manager.getFeed().length, 1)
+  } finally {
+    manager.stop()
+  }
+})


### PR DESCRIPTION
## Summary
- update signed HAVE_FEED ingress so async-verified entries always attach the advertised key to that peer connection
- preserve feed update notifications even when the entry was already cached locally
- add regression for the exact zero-feed state: entry exists, peer advertises it, but peerFeedKeys/entryPeerCounts stayed empty

## Evidence
- v0.1.159 app connected to 7 feed peers and received repeated SUBMIT_CHANNEL gossip, but Home still showed Feed: 0 / Channels: 0.
- Live relays were still on v0.1.158; after rolling them to v0.1.159 they sent non-empty HAVE_FEED snapshots: local=80 entries, relay-2=54, relay-3=1, relay-4=54.
- App still returned `[API] Returning 0 feed entries (7 peers, keyed=0, fallback=0, raw=0)`.
- Boundary is now local public-feed state accounting after async signed ingress, not relay runtime freshness or socket discovery.

## Tests
- node --test packages/backend/test/public-feed-signed-ingress.test.mjs
- npx eslint --quiet packages/backend/src/public-feed.js packages/backend/test/public-feed-signed-ingress.test.mjs
- node --test packages/backend/test/api-feed-snapshot-descriptor-regression.test.mjs packages/backend/test/public-feed-signed-ingress.test.mjs packages/backend/test/public-feed-manager.test.mjs
- npm run lint:changed
- git diff --check

Closes #327