### PR TITLE
fix(p2p): count submit-channel relay gossip peers

### DIFF
--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -1382,10 +1382,15 @@ export class PublicFeed {
       const entrySource = msg.source === 'relay-cache' ? 'relay-cache' : 'peer'
       if (!this.requireSignedPeerEntries) {
         if (this.addEntry(msg.key, entrySource, publicBeeKey, normalizedMsg)) {
+          this._setPeerFeedKeys(conn, [msg.key])
           this.onFeedUpdate?.();
           this._schedulePersistDiscovered()
           this.broadcastSubmitChannel(msg.key, conn, publicBeeKey, normalizedMsg);
         } else if (this._applyEntrySnapshot(msg.key, normalizedMsg)) {
+          this._setPeerFeedKeys(conn, [msg.key])
+          this.onFeedUpdate?.()
+          this._schedulePersistDiscovered()
+        } else if (this._setPeerFeedKeys(conn, [msg.key])) {
           this.onFeedUpdate?.()
           this._schedulePersistDiscovered()
         }
@@ -1395,11 +1400,16 @@ export class PublicFeed {
         .then((verified) => {
           if (!verified) return
           if (this.addEntry(msg.key, entrySource, publicBeeKey, normalizedMsg)) {
+            this._setPeerFeedKeys(conn, [msg.key])
             this.onFeedUpdate?.();
             this._schedulePersistDiscovered()
             // Re-gossip to other peers (exclude sender, include publicBeeKey)
             this.broadcastSubmitChannel(msg.key, conn, publicBeeKey, normalizedMsg);
           } else if (this._applyEntrySnapshot(msg.key, normalizedMsg)) {
+            this._setPeerFeedKeys(conn, [msg.key])
+            this.onFeedUpdate?.()
+            this._schedulePersistDiscovered()
+          } else if (this._setPeerFeedKeys(conn, [msg.key])) {
             this.onFeedUpdate?.()
             this._schedulePersistDiscovered()
           }

--- a/packages/backend/test/public-feed-signed-ingress.test.mjs
+++ b/packages/backend/test/public-feed-signed-ingress.test.mjs
@@ -120,6 +120,7 @@ test('public feed rejects signed peer entries whose descriptor does not bind adv
 
 test('public feed accepts relay-cache catalog entries without signed descriptors', async () => {
   const manager = new PublicFeedManager(createSwarm(), createMetaDb())
+  const conn = {}
   try {
     manager.handleMessage({
       type: 'SUBMIT_CHANNEL',
@@ -136,7 +137,7 @@ test('public feed accepts relay-cache catalog entries without signed descriptors
         blobsCoreKey: key(3),
         availability: 'playable',
       }],
-    }, {})
+    }, conn)
     await new Promise((resolve) => setImmediate(resolve))
 
     const entry = manager.entries.get(key(1))
@@ -145,6 +146,8 @@ test('public feed accepts relay-cache catalog entries without signed descriptors
     assert.equal(entry.relayServing, true)
     assert.equal(entry.publicBeeKey, key(2))
     assert.equal(entry.previewVideos[0].availability, 'playable')
+    assert.equal(manager.peerFeedKeys.get(conn)?.has(key(1)), true)
+    assert.equal(manager.entryPeerCounts.get(key(1)), 1)
     assert.equal(manager.getFeed().length, 1)
   } finally {
     manager.stop()


### PR DESCRIPTION
## Summary
- count `SUBMIT_CHANNEL` advertisements against the sender connection after accepting/refreshing the entry
- covers both unsigned relay-cache catalog gossip and signed peer submit-channel gossip
- adds a regression proving relay-cache `SUBMIT_CHANNEL` updates `peerFeedKeys` / `entryPeerCounts`

## Root cause
Android/emulator had live feed sockets and received many `SUBMIT_CHANNEL` messages from relays, but API still returned `raw=0` because `SUBMIT_CHANNEL` acceptance added/updated entries without binding the advertised key to the connection. The previous async accounting fix only covered `HAVE_FEED`.

## Test Plan
- `packages/backend/node_modules/.bin/brittle packages/backend/test/public-feed-signed-ingress.test.mjs`
- `npx eslint --quiet packages/backend/src/public-feed.js packages/backend/test/public-feed-signed-ingress.test.mjs`
- `npm run lint:changed`
- `git diff --check -- packages/backend/src/public-feed.js packages/backend/test/public-feed-signed-ingress.test.mjs`

Closes #331
