### PR TITLE
fix(p2p): bind submit-channel senders to feed entries

### DIFF
--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -1546,14 +1546,17 @@ export class PublicFeed {
       const isValidKey = (k) => typeof k === 'string' && /^[a-f0-9]{64}$/i.test(k)
       if (!isValidKey(msg.publicBeeKey)) return
       const entrySource = msg.source === 'relay-cache' ? 'relay-cache' : 'peer'
-      if (this.addEntry(msg.key, entrySource, msg.publicBeeKey, msg)) {
-        this.onFeedUpdate?.();
-        this._schedulePersistDiscovered()
-        // Re-gossip to other peers (exclude sender, include publicBeeKey)
-        this.broadcastSubmitChannel(msg.key, conn, msg.publicBeeKey, msg);
-      } else if (this._applyEntrySnapshot(msg.key, msg)) {
+      const added = this.addEntry(msg.key, entrySource, msg.publicBeeKey, msg)
+      const updated = !added && this._applyEntrySnapshot(msg.key, msg)
+      const peerSetChanged = this._setPeerFeedKeys(conn, [msg.key])
+
+      if (added || updated || peerSetChanged) {
         this.onFeedUpdate?.()
         this._schedulePersistDiscovered()
+      }
+      if (added) {
+        // Re-gossip to other peers (exclude sender, include publicBeeKey)
+        this.broadcastSubmitChannel(msg.key, conn, msg.publicBeeKey, msg);
       }
     }
     // Handle legacy NEED_FEED/FEED_RESPONSE for backwards compat

--- a/packages/backend/test/public-feed-manager.test.mjs
+++ b/packages/backend/test/public-feed-manager.test.mjs
@@ -1239,3 +1239,41 @@ test('relay catalog entries stay visible and do not become published channels', 
   assert.equal(entries[0].relayServing, true)
   assert.equal(entries[0].peerCount, 0)
 })
+
+test('SUBMIT_CHANNEL binds the sender as a live peer even when the entry already exists', () => {
+  const manager = new PublicFeedManager(createSwarm(), createMetaDb())
+  const conn = createConnection()
+
+  try {
+    manager.addEntry(DRIVE_KEY, 'relay-cache', PUBLIC_BEE_KEY, {
+      previewVideos: [{
+        id: 'existing-preview',
+        blobId: '0:4:0:512',
+        blobsCoreKey: 'cc'.repeat(32),
+        availability: 'playable',
+      }],
+    })
+
+    manager.handleMessage({
+      type: 'SUBMIT_CHANNEL',
+      key: DRIVE_KEY,
+      publicBeeKey: PUBLIC_BEE_KEY,
+      source: 'relay-cache',
+      relayServing: true,
+      previewVideos: [{
+        id: 'existing-preview',
+        blobId: '0:4:0:512',
+        blobsCoreKey: 'cc'.repeat(32),
+        availability: 'playable',
+      }],
+    }, conn)
+
+    assert.equal(manager.peerFeedKeys.get(conn)?.has(DRIVE_KEY), true)
+    assert.equal(manager.entryPeerCounts.get(DRIVE_KEY), 1)
+    const entries = manager.getFeed()
+    assert.equal(entries.length, 1)
+    assert.equal(entries[0].peerCount, 1)
+  } finally {
+    manager.stop()
+  }
+})


### PR DESCRIPTION
## Summary
- bind accepted `SUBMIT_CHANNEL` gossip to the sender connection via `peerFeedKeys` / `entryPeerCounts`
- keep `getFeed()` from behaving as if no live peer advertised an already-known relay catalog entry
- add a regression for the exact existing-entry case that can leave Android at `Feed: 0 / Channels: 0`

## Test Plan
- `node --test packages/backend/test/public-feed-manager.test.mjs`
- `git diff --check -- HEAD~1..HEAD`

## Notes
The live relay mesh currently has non-empty feed/catalog state, so the phone screenshot boundary is client ingestion/accounting, not empty relays.
