### PR TITLE
fix(mobile): report feed counts to Discover

### DIFF
--- a/packages/backend/src/mobile-handlers.js
+++ b/packages/backend/src/mobile-handlers.js
@@ -147,8 +147,12 @@ export function attachMobileHandlers(B, deps) {
 
   B.getPublicFeed = async () => {
     const r = await api.getPublicFeed()
+    const entries = Array.isArray(r?.entries) ? r.entries : []
+    const stats = r?.stats && typeof r.stats === 'object' ? r.stats : {}
+    const visibleEntries = entries.length
+    const feedConnections = Number(stats.feedConnections ?? stats.peerCount ?? 0) || 0
     return {
-      entries: r.entries.map(e => ({
+      entries: entries.map(e => ({
         channelKey: e.driveKey || e.channelKey,
         driveKey: e.driveKey || e.channelKey,
         source: e.source || 'peer',
@@ -160,7 +164,14 @@ export function attachMobileHandlers(B, deps) {
         manifestUpdatedAt: e.manifestUpdatedAt || 0,
         previewVideos: Array.isArray(e.previewVideos) ? e.previewVideos : [],
       })),
-      stats: r.stats || { totalEntries: 0, hiddenCount: 0, peerCount: 0 },
+      stats: {
+        ...stats,
+        peerCount: feedConnections,
+        feedConnections,
+        feedEntries: Number(stats.feedEntries ?? stats.totalEntries ?? visibleEntries) || visibleEntries,
+        totalEntries: Number(stats.totalEntries ?? visibleEntries) || visibleEntries,
+        channelsLoaded: Number(stats.channelsLoaded ?? visibleEntries) || visibleEntries,
+      },
     }
   }
   B.getCanonicalFeed = B.getPublicFeed

--- a/packages/backend/test/mobile-handlers-feed-stats.test.mjs
+++ b/packages/backend/test/mobile-handlers-feed-stats.test.mjs
@@ -1,0 +1,75 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { attachMobileHandlers } from '../src/mobile-handlers.js'
+
+function makeDeps(api) {
+  return {
+    api,
+    identityManager: {
+      getActiveIdentity() { return null },
+      getIdentities() { return [] },
+    },
+    uploadManager: {},
+    ctx: {},
+    initializeIdentityFromMnemonic: async () => ({}),
+    rpc: {},
+    fs: {},
+    path: {},
+    generateAndStoreThumbnail: async () => null,
+    transcoder: {},
+  }
+}
+
+test('mobile getPublicFeed forwards visible feed counts into stats for Discover chips', async () => {
+  const backend = {}
+  attachMobileHandlers(backend, makeDeps({
+    async getPublicFeed() {
+      return {
+        entries: [
+          { driveKey: 'a'.repeat(64), publicBeeKey: 'b'.repeat(64), previewVideos: [{ id: 'v1' }] },
+          { driveKey: 'c'.repeat(64), publicBeeKey: 'd'.repeat(64), previewVideos: [{ id: 'v2' }] },
+        ],
+        stats: {
+          peerCount: 1,
+          feedConnections: 1,
+        },
+      }
+    },
+  }))
+
+  const result = await backend.getPublicFeed()
+
+  assert.equal(result.entries.length, 2)
+  assert.equal(result.stats.peerCount, 1)
+  assert.equal(result.stats.feedConnections, 1)
+  assert.equal(result.stats.feedEntries, 2)
+  assert.equal(result.stats.totalEntries, 2)
+  assert.equal(result.stats.channelsLoaded, 2)
+})
+
+test('mobile getPublicFeed preserves explicit backend feed stats when present', async () => {
+  const backend = {}
+  attachMobileHandlers(backend, makeDeps({
+    async getPublicFeed() {
+      return {
+        entries: [{ driveKey: 'a'.repeat(64), publicBeeKey: 'b'.repeat(64) }],
+        stats: {
+          peerCount: 3,
+          feedConnections: 3,
+          feedEntries: 99,
+          totalEntries: 100,
+          channelsLoaded: 42,
+        },
+      }
+    },
+  }))
+
+  const result = await backend.getPublicFeed()
+
+  assert.equal(result.stats.peerCount, 3)
+  assert.equal(result.stats.feedConnections, 3)
+  assert.equal(result.stats.feedEntries, 99)
+  assert.equal(result.stats.totalEntries, 100)
+  assert.equal(result.stats.channelsLoaded, 42)
+})


### PR DESCRIPTION
## Summary
- fixes the mobile RPC adapter so `getCanonicalFeed` / `getPublicFeed` returns `feedEntries`, `totalEntries`, and `channelsLoaded` from the visible feed entries when backend stats omit them
- keeps explicit backend stats intact when present
- adds a focused regression for the Android/mobile feed-stats contract

## Evidence
- Live v0.1.163 relays are gossiping: local relay status showed 359 feed entries and 17,557 playable previews on the main relay, with recent `HAVE_FEED with 359 entries` logs.
- The physical Android device was not visible over ADB in this session, so the missing layer I could prove locally is the mobile adapter/UI stats boundary.

## Test plan
- `node --test packages/backend/test/mobile-handlers-feed-stats.test.mjs`
- `node --check packages/backend/src/mobile-handlers.js`
- `git diff --check`
- `npm run lint:changed -- --quiet` (reported no changed JS/TS files to lint)
