### PR TITLE
fix(p2p): align discovery lifecycle with durable routing

### DIFF
--- a/packages/app/android/app/src/main/java/com/peartube/app/MainApplication.kt
+++ b/packages/app/android/app/src/main/java/com/peartube/app/MainApplication.kt
@@ -42,6 +42,11 @@ class MainApplication : Application(), ReactApplication {
     } catch (e: IllegalArgumentException) {
       ReleaseLevel.STABLE
     }
+    try {
+      networkDiscovery.start()
+    } catch (t: Throwable) {
+      networkDiscovery.logException("startup", t)
+    }
     loadReactNative(this)
     registerActivityLifecycleCallbacks(object : ActivityLifecycleCallbacks {
       override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) = Unit

--- a/packages/app/app/_layout.tsx
+++ b/packages/app/app/_layout.tsx
@@ -839,13 +839,13 @@ const BACKEND_STARTUP_TIMEOUT_MS = 30000
 
     try {
       const discoveryModule = requirePeartubeNetworkDiscovery()
-      const discoveryStatus = await discoveryModule.acquireMulticastLock()
+      const discoveryStatus = await discoveryModule.getDiscoveryNetworkStatus()
       status.multicastLockHeld = discoveryStatus?.multicastLockHeld === true
       status.lastError = discoveryStatus?.lastError ?? status.lastError ?? null
     } catch (err: any) {
       status.multicastLockHeld = false
       status.lastError = err?.message || String(err)
-      console.warn('[App] Android network discovery setup failed:', status.lastError)
+      console.warn('[App] Android network discovery status failed:', status.lastError)
     }
 
     console.log('[App] Android discovery permission status:', JSON.stringify(status))
@@ -866,16 +866,6 @@ const BACKEND_STARTUP_TIMEOUT_MS = 30000
         cancelled = true
         subscription.remove()
         castPlaybackStateUnsubRef.current?.()
-        if (Platform.OS === 'android') {
-          try {
-            const discoveryModule = requirePeartubeNetworkDiscovery()
-            discoveryModule.releaseMulticastLock().catch((err: any) => {
-              console.log('[App] Android discovery multicast release failed:', err?.message)
-            })
-          } catch (err: any) {
-            console.log('[App] Android discovery multicast release failed:', err?.message)
-          }
-        }
         clearCastSuspendGraceTimer()
         if (startupTimerRef.current) {
           clearTimeout(startupTimerRef.current)

--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -130,10 +130,10 @@ export class PublicFeed {
     /** @type {number} */
     this._persistDebounceMs = 1500
     /** @type {number} */
-    this._persistMaxEntries = 500
+    this._persistMaxEntries = Math.max(1, Number(options.maxFeedEntries || 500) || 500)
 
     /** @type {number} */
-    this.maxPeers = Math.max(1, Number(options.maxPeers || this.swarm?.maxPeers || 48) || 48)
+    this.maxPeers = Math.max(1, Number(options.maxDiscoveredPeers || options.maxPeers || this.swarm?.maxPeers || 48) || 48)
     /** @type {Map<string, {publicKey: any, score: number, firstSeenAt: number, lastSeenAt: number, joined: boolean, demoted: boolean, joinAttempts: number, lastJoinedAt: number | null, lastConnectionAt: number | null, relayHints: number, topics?: Set<string>, lastJoinError?: string | null}>} */
     this._peerDirectory = new Map()
     /** @type {Map<any, any>} */
@@ -654,7 +654,13 @@ export class PublicFeed {
     const keyHex = b4a.toString(publicKey, 'hex')
     if (!keyHex || keyHex === b4a.toString(this.swarm?.keyPair?.publicKey || [], 'hex')) return null
     this._discoveredPeers.set(keyHex, publicKey)
-    if (peer && typeof peer === 'object') {
+    while (this._discoveredPeers.size > this.maxPeers) {
+      const oldestKey = this._discoveredPeers.keys().next().value
+      if (!oldestKey) break
+      this._discoveredPeers.delete(oldestKey)
+      this._discoveredPeerHints.delete(oldestKey)
+    }
+    if (peer && typeof peer === 'object' && this._discoveredPeers.has(keyHex)) {
       const relayAddresses = Array.isArray(peer.relayAddresses) ? peer.relayAddresses : []
       const existing = this._discoveredPeerHints.get(keyHex) || {}
       this._discoveredPeerHints.set(keyHex, {
@@ -666,7 +672,7 @@ export class PublicFeed {
         lastSeenAt: this._now(),
       })
     }
-    return { keyHex, publicKey }
+    return this._discoveredPeers.has(keyHex) ? { keyHex, publicKey } : null
   }
 
   _peerKeyHex(publicKey) {
@@ -693,6 +699,20 @@ export class PublicFeed {
       }
     }
     return lowest
+  }
+
+  _enforceFeedEntryLimit() {
+    while (this.entries.size > this._persistMaxEntries) {
+      const oldestKey = this.entries.keys().next().value
+      if (!oldestKey) break
+      const entry = this.entries.get(oldestKey)
+      if (entry?.source === 'local') break
+      this.entries.delete(oldestKey)
+      this.entryPeerCounts.delete(oldestKey)
+      for (const peerKeys of this.peerFeedKeys.values()) {
+        peerKeys.delete(oldestKey)
+      }
+    }
   }
 
   _enforcePeerDirectoryLimit() {
@@ -844,7 +864,8 @@ export class PublicFeed {
       return false
     }
 
-    this._queuePublicJoinPeer(record, peer, topic)
+    this._directPeerDialStats.skipped++
+    this._directPeerDialStats.lastReason = 'hyperswarm-owned-dialing'
     this._rememberDiscoveredPeerInSwarm(peer, topic, remembered.keyHex)
     if (this._hasActivePeerConnection(remembered.keyHex, remembered.publicKey)) {
       this._directPeerDialStats.skipped++
@@ -862,21 +883,6 @@ export class PublicFeed {
       if (err?.stack) this._directPeerLastDialErrorStack.set(keyHex, err.stack)
       return null
     }
-  }
-
-  runBoundedPeerRecovery(reason = 'heartbeat') {
-    const event = {
-      at: this._now(),
-      action: 'observed-peers-without-sockets',
-      reason: 'hyperswarm-owned-dialing',
-      requestedReason: reason,
-      discoveredPeers: this._discoveredPeers.size,
-      connections: this.swarm?.connections?.size || 0,
-      queued: 0,
-    }
-    this._recoveryEvents.push(event)
-    while (this._recoveryEvents.length > 10) this._recoveryEvents.shift()
-    return event
   }
 
   _swarmDialState(keyHex, publicKey = null) {
@@ -956,21 +962,37 @@ export class PublicFeed {
     this._recordStartupEvent('public-feed-start-called')
     console.log('[PublicFeed] ===== STARTING PUBLIC FEED =====');
 
-    // Issue the topic join up front so DHT announce/lookup overlaps with the
-    // metaDb cache restoration below. (Matches the hyperdrive README pattern:
-    // attach handlers → join → do other work; never await flush() on the
-    // hot path.)
-    try {
-      this.feedDiscovery = this.swarm.join(NETWORK_TOPIC, { server: true, client: true })
-      this._recordStartupEvent('public-feed-topic-join-called', { topicHex: NETWORK_TOPIC_HEX })
-      this.feedDiscovery?.flushed?.().then(() => {
-        this._recordStartupEvent('public-feed-topic-flushed', { peers: this.swarm.peers?.size || 0, connections: this.swarm.connections?.size || 0 })
-        console.log('[PublicFeed] Shared network feed discovery flushed, connections:', this.swarm.connections?.size || 0)
-      }).catch(() => {})
-      console.log('[PublicFeed] Joined shared network feed topic:', NETWORK_TOPIC_HEX.slice(0, 16))
-    } catch (err) {
-      console.log('[PublicFeed] Shared network feed topic join failed:', err?.message)
-      this.feedDiscovery = null
+    // Reuse the storage-owned peartube-network discovery handle when present.
+    // Storage joins the topic immediately at startup/resume; the feed catalog
+    // layer should not create a second app-level join path.
+    if (this.swarm.peerPoolDiscovery) {
+      this.feedDiscovery = this.swarm.peerPoolDiscovery
+      this._ownsFeedDiscovery = false
+      this._recordStartupEvent('public-feed-topic-owned-by-storage', { topicHex: NETWORK_TOPIC_HEX })
+      try { this.swarm.status?.(NETWORK_TOPIC) } catch { /* diagnostic only */ }
+    } else {
+      try {
+        this.feedDiscovery = this.swarm.join(NETWORK_TOPIC, { server: true, client: true })
+        this._ownsFeedDiscovery = true
+        this._recordStartupEvent('public-feed-topic-owned-by-storage', { topicHex: NETWORK_TOPIC_HEX, fallbackJoin: true })
+        this._recordStartupEvent('public-feed-topic-join-called', { topicHex: NETWORK_TOPIC_HEX })
+        this.feedDiscovery?.flushed?.().then(() => {
+          this._recordStartupEvent('public-feed-topic-flushed', { peers: this.swarm.peers?.size || 0, connections: this.swarm.connections?.size || 0 })
+          console.log('[PublicFeed] Shared network feed discovery flushed, connections:', this.swarm.connections?.size || 0)
+        }).catch(() => {})
+        console.log('[PublicFeed] Joined shared network feed topic:', NETWORK_TOPIC_HEX.slice(0, 16))
+      } catch (err) {
+        console.log('[PublicFeed] Shared network feed topic join failed:', err?.message)
+        this.feedDiscovery = null
+      }
+    }
+
+    // Wire existing connections before cache restore reads.
+    // Set up feed protocol on any existing connections.
+    const existingConns = this.swarm.connections?.size || 0;
+    console.log('[PublicFeed] Setting up feed protocol on', existingConns, 'existing connections');
+    for (const conn of this.swarm.connections) {
+      this.handleConnection(conn, {});
     }
 
     // Load persisted published channels from database
@@ -1072,12 +1094,6 @@ export class PublicFeed {
       try { this.onFeedUpdate?.(); } catch {}
     }
 
-    // Set up feed protocol on any existing connections.
-    const existingConns = this.swarm.connections?.size || 0;
-    console.log('[PublicFeed] Setting up feed protocol on', existingConns, 'existing connections');
-    for (const conn of this.swarm.connections) {
-      this.handleConnection(conn, {});
-    }
     this._startGossipLoop()
     console.log('[PublicFeed] ===== PUBLIC FEED STARTED =====');
   }
@@ -1456,6 +1472,21 @@ export class PublicFeed {
     return changed
   }
 
+
+  _prunePeerFeedKeysToEntries(conn) {
+    const peerKeys = this.peerFeedKeys.get(conn)
+    if (!peerKeys) return false
+    let changed = false
+    for (const key of Array.from(peerKeys)) {
+      if (this.entries.has(key)) continue
+      peerKeys.delete(key)
+      this.entryPeerCounts.delete(key)
+      changed = true
+    }
+    if (peerKeys.size === 0) this.peerFeedKeys.delete(conn)
+    return changed
+  }
+
   _clearPeerFeedKeys(conn) {
     const prevKeys = this.peerFeedKeys.get(conn)
     if (!prevKeys) return false
@@ -1537,7 +1568,9 @@ export class PublicFeed {
         }
       }
 
-      const peerSetChanged = this._applyPeerFeedKeys(conn, announcedKeys)
+      let peerSetChanged = this._applyPeerFeedKeys(conn, announcedKeys)
+      this._enforceFeedEntryLimit()
+      peerSetChanged = this._prunePeerFeedKeysToEntries(conn) || peerSetChanged
       if (!this._startupEvents.some((event) => event.name === 'first-have-feed-received')) {
         this._recordStartupEvent('first-have-feed-received', { keys: announcedKeys.length, entries: receivedCount })
       }
@@ -1558,6 +1591,7 @@ export class PublicFeed {
       const resolvedPublicBeeKey = this._resolvePublicBeeKey(msg)
       if (!resolvedPublicBeeKey && !msg?.signedDescriptor && !isValidKey(msg?.metadataKey)) return
       const entrySource = msg.source === 'relay-cache' ? 'relay-cache' : 'peer'
+      const peerSetChanged = this._applyPeerFeedKeys(conn, [msg.key])
       if (this.addEntry(msg.key, entrySource, resolvedPublicBeeKey, msg)) {
         this.onFeedUpdate?.();
         this._schedulePersistDiscovered()
@@ -1566,6 +1600,8 @@ export class PublicFeed {
       } else if (this._applyEntrySnapshot(msg.key, msg)) {
         this.onFeedUpdate?.()
         this._schedulePersistDiscovered()
+      } else if (peerSetChanged) {
+        this.onFeedUpdate?.()
       }
     }
     // Handle legacy NEED_FEED/FEED_RESPONSE for backwards compat

--- a/packages/backend/src/storage.js
+++ b/packages/backend/src/storage.js
@@ -25,7 +25,7 @@ import {
 } from './runtime-modules.js'
 import { NETWORK_TOPIC_STRING } from './types.js'
 import { normalizeBlobRefInput } from './blob-ref.js'
-import { createKnownPeerCache } from './known-peers.js'
+import { createKnownPeerCache, loadKnownPeers } from './known-peers.js'
 
 function resolveDebugLogPath() {
   return globalThis?.process?.env?.PEARTUBE_NATIVE_WORKLET_DEBUG_LOG || null
@@ -212,62 +212,36 @@ function decodePersistedValue(value) {
   return value
 }
 
-function isSwarmDiscoveryReady(swarm) {
-  return Boolean(
-    swarm &&
-    !swarm._peartubeOffline &&
-    swarm._peartubeListenResolved &&
-    swarm.dht?.bootstrapped
-  )
-}
-
-async function waitForSwarmDiscoveryReady(swarm) {
-  if (!swarm || swarm._peartubeOffline) return false
-  if (isSwarmDiscoveryReady(swarm)) return true
-
-  if (swarm._peartubeDiscoveryReadyPromise) {
-    return swarm._peartubeDiscoveryReadyPromise
+async function warmDialKnownPeers(swarm, metaDb, { reason = 'startup', limit = 5 } = {}) {
+  if (!swarm || swarm._peartubeOffline || typeof swarm.joinPeer !== 'function' || !metaDb) {
+    return { dialed: 0, skipped: true }
   }
 
-  swarm._peartubeDiscoveryReadyPromise = new Promise((resolve) => {
-    let settled = false
-    let onNetworkUpdate = null
+  let peers = []
+  try {
+    peers = await loadKnownPeers(metaDb)
+  } catch (err) {
+    console.log('[Storage] Known-peer warm dial load failed:', err?.message)
+    return { dialed: 0, error: err?.message || String(err) }
+  }
 
-    const cleanup = (ready) => {
-      if (settled) return
-      settled = true
-      try {
-        if (onNetworkUpdate && typeof swarm.dht?.off === 'function') {
-          swarm.dht.off('network-update', onNetworkUpdate)
-        }
-      } catch { /* best effort */ }
-      resolve(Boolean(ready))
-    }
-
-    onNetworkUpdate = () => {
-      if (isSwarmDiscoveryReady(swarm)) cleanup(true)
-    }
-
+  let dialed = 0
+  for (const peer of peers.slice(0, Math.max(0, Math.min(5, Number(limit) || 5)))) {
+    if (!peer?.key || !/^[a-f0-9]{64}$/i.test(peer.key)) continue
     try {
-      if (typeof swarm.dht?.on === 'function') {
-        swarm.dht.on('network-update', onNetworkUpdate)
-      }
-    } catch { /* best effort */ }
-
-    const listenPromise = swarm._peartubeListenPromise
-    if (listenPromise && typeof listenPromise.then === 'function') {
-      listenPromise.then(() => {
-        swarm._peartubeListenResolved = true
-        if (isSwarmDiscoveryReady(swarm)) cleanup(true)
-      }).catch(() => {
-        cleanup(false)
-      })
+      swarm.joinPeer(b4a.from(peer.key, 'hex'))
+      dialed++
+    } catch (err) {
+      console.log('[Storage] Known-peer warm dial failed:', peer.key.slice(0, 16), err?.message)
     }
+  }
 
-    if (isSwarmDiscoveryReady(swarm)) cleanup(true)
-  })
+  if (dialed > 0) {
+    globalNetworkStartupTiming?.record('known-peer-warm-dial', { reason, dialed })
+    console.log('[Storage] Warm-dialed known peers:', dialed, 'reason:', reason)
+  }
 
-  return swarm._peartubeDiscoveryReadyPromise
+  return { dialed }
 }
 
 function collectPersistedDhtRoutingEntries(swarm) {
@@ -974,47 +948,26 @@ function scheduleDeferredDiscoveryJoin(ctx, discoveryKey, handle, options = {}) 
 
   const swarm = ctx.swarm
   const discoveryKeyHex = b4a.toString(discoveryKey, 'hex')
-  let onNetworkUpdate = null
 
   const start = () => {
-    if (handle._peartubeStarted || handle._peartubeDestroyed || !isSwarmDiscoveryReady(swarm)) return null
+    if (handle._peartubeStarted || handle._peartubeDestroyed || swarm._peartubeOffline) return null
     handle._peartubeStarted = true
     try {
       const realHandle = swarm.join(discoveryKey, { server: true, client: true })
       handle._setRealHandle(realHandle)
       if (options?.label) {
-        console.log(`[Storage] Swarm discovery joined for ${options.label}`)
+        console.log(`[Storage] Swarm discovery joined immediately for ${options.label}`)
       } else {
-        console.log('[Storage] Swarm discovery joined:', discoveryKeyHex.slice(0, 16))
+        console.log('[Storage] Swarm discovery joined immediately:', discoveryKeyHex.slice(0, 16))
       }
       return realHandle
     } catch (err) {
-      console.log('[Storage] Deferred swarm discovery join failed:', err?.message)
+      console.log('[Storage] Immediate swarm discovery join failed:', err?.message)
       handle._setRealHandle(null)
       return null
     }
   }
 
-  const listenPromise = swarm._peartubeListenPromise
-  if (listenPromise && typeof listenPromise.then === 'function') {
-    listenPromise.then(() => start()).catch(() => {})
-  }
-
-  try {
-    if (typeof swarm.dht?.on === 'function') {
-      onNetworkUpdate = () => { start() }
-      swarm.dht.on('network-update', onNetworkUpdate)
-    }
-  } catch { /* best effort */ }
-
-  const originalDestroy = handle.destroy.bind(handle)
-  handle.destroy = () => {
-    try { if (onNetworkUpdate && typeof swarm.dht?.off === 'function') swarm.dht.off('network-update', onNetworkUpdate) } catch { /* best effort */ }
-    originalDestroy()
-  }
-  handle.close = handle.destroy
-
-  void Promise.resolve().then(() => start())
   return start() || handle
 }
 
@@ -1564,23 +1517,23 @@ export async function initializeStorage(config) {
 
   await restorePersistedDhtRoutingTable(swarm, metaDb, { reason: 'startup' })
 
-  // Join the PearTube network topic only after the DHT is bootstrapped and listen() has resolved.
-  // More connected peers = better relay options for symmetric NAT holepunching.
+  // Join the PearTube network topic immediately. Do not wait for DHT bootstrap
+  // or listen() resolution; HyperDHT/Hyperswarm can use the announcement to wake
+  // routing state while startup continues.
   const PEARTUBE_NETWORK_TOPIC = crypto.data(b4a.from(NETWORK_TOPIC_STRING, 'utf-8'));
   globalPeerPoolTopicHex = b4a.toString(PEARTUBE_NETWORK_TOPIC, 'hex')
   let peerPoolDiscoveryStarted = false
 
-  const maybeStartPeerPoolDiscovery = async (reason = 'ready') => {
+  const joinPeerPoolDiscoveryImmediately = (reason = 'startup') => {
     if (peerPoolDiscoveryStarted || swarm._peartubeOffline) return globalPeerPoolDiscovery
-    if (!isSwarmDiscoveryReady(swarm)) return null
 
     peerPoolDiscoveryStarted = true
     try {
       const poolDiscovery = swarm.join(PEARTUBE_NETWORK_TOPIC, { server: true, client: true });
       globalNetworkStartupTiming?.record('topic-join-called', { topic: 'peer-pool', topicHex: globalPeerPoolTopicHex, reason })
       globalPeerPoolDiscovery = poolDiscovery;
-      console.log('[Storage] Joined peartube-network topic for peer pool building after', reason)
-      // Don't await flushed() - it can hang on mobile
+      console.log('[Storage] Joined peartube-network topic for peer pool building immediately:', reason)
+      // Do not await flushed(); mobile DHT bootstrapping can lag behind the join.
       poolDiscovery.flushed().then(() => {
         console.log('[Storage] Peer pool topic discovery flushed, connections:', swarm.connections?.size || 0);
         globalNetworkStartupTiming?.record('topic-flushed', { topic: 'peer-pool', connections: swarm.connections?.size || 0, bootstrapped: swarm.dht?.bootstrapped })
@@ -1600,6 +1553,9 @@ export async function initializeStorage(config) {
     console.log('[Storage] Skipping peer pool discovery; P2P networking is offline:', swarm._peartubeOfflineReason)
     await appendDebugLine(`[storage] peer-pool discovery skipped offline reason=${swarm._peartubeOfflineReason}`)
     globalPeerPoolDiscovery = null
+  } else {
+    joinPeerPoolDiscoveryImmediately('startup')
+    await warmDialKnownPeers(swarm, metaDb, { reason: 'startup', limit: 5 })
   }
 
   // Start listening - DON'T block on it since it may hang on mobile
@@ -1629,14 +1585,6 @@ export async function initializeStorage(config) {
         console.log('[Storage] listen() failed:', e?.message)
         void appendDebugLine(`[storage] swarm.listen failed ${e?.message || String(e)}`)
       })
-  }
-
-  if (!swarm._peartubeOffline) {
-    void waitForSwarmDiscoveryReady(swarm).then(() => {
-      void maybeStartPeerPoolDiscovery('bootstrapped-and-listen-resolved')
-    }).catch((err) => {
-      console.log('[Storage] Peer pool discovery wait failed:', err?.message)
-    })
   }
 
   // Log DHT state for debugging
@@ -2705,6 +2653,8 @@ export async function resumeNetworking() {
   try {
     if (globalSwarm) {
       await globalSwarm.resume();
+      await restorePersistedDhtRoutingTable(globalSwarm, globalMetaDb, { reason: 'resume' })
+      await warmDialKnownPeers(globalSwarm, globalMetaDb, { reason: 'resume', limit: 5 })
       console.log('[Network] Swarm resumed, connections:', globalSwarm.connections?.size || 0);
     }
     if (globalBlobServer) {

--- a/packages/backend/test/public-feed-manager.test.mjs
+++ b/packages/backend/test/public-feed-manager.test.mjs
@@ -1092,6 +1092,46 @@ test('periodic feed gossip does not perform repeated app-level redials after soc
   }
 })
 
+
+
+test('HAVE_FEED accounting accumulates verified entries across repeated messages on one connection', () => {
+  const manager = new PublicFeedManager(createSwarm(), createMetaDb(), { requireSignedPeerEntries: false })
+  const conn = createConnection()
+  const key2 = '22'.repeat(32)
+  const bee2 = '33'.repeat(32)
+
+  try {
+    manager.handleMessage({ type: 'HAVE_FEED', entries: [{ driveKey: DRIVE_KEY, publicBeeKey: PUBLIC_BEE_KEY }] }, conn)
+    manager.handleMessage({ type: 'HAVE_FEED', entries: [{ driveKey: key2, publicBeeKey: bee2 }] }, conn)
+
+    assert.equal(manager.peerFeedKeys.get(conn)?.has(DRIVE_KEY), true)
+    assert.equal(manager.peerFeedKeys.get(conn)?.has(key2), true)
+    assert.equal(manager.entryPeerCounts.get(DRIVE_KEY), 1)
+    assert.equal(manager.entryPeerCounts.get(key2), 1)
+
+    manager._clearPeerFeedKeys(conn)
+    assert.equal(manager.entryPeerCounts.has(DRIVE_KEY), false)
+    assert.equal(manager.entryPeerCounts.has(key2), false)
+  } finally {
+    manager.stop()
+  }
+})
+
+test('SUBMIT_CHANNEL accounting records accepted gossip even when snapshot refreshes an existing entry', () => {
+  const manager = new PublicFeedManager(createSwarm(), createMetaDb(), { requireSignedPeerEntries: false })
+  const conn = createConnection()
+
+  try {
+    manager.addEntry(DRIVE_KEY, 'peer', PUBLIC_BEE_KEY, { channelName: 'old' })
+    manager.handleMessage({ type: 'SUBMIT_CHANNEL', key: DRIVE_KEY, publicBeeKey: PUBLIC_BEE_KEY, channelName: 'new' }, conn)
+
+    assert.equal(manager.peerFeedKeys.get(conn)?.has(DRIVE_KEY), true)
+    assert.equal(manager.entryPeerCounts.get(DRIVE_KEY), 1)
+  } finally {
+    manager.stop()
+  }
+})
+
 test('peer entries with publicBeeKey survive peer disconnect at peerCount zero', () => {
   const swarm = createSwarm()
   const manager = new PublicFeedManager(swarm, createMetaDb())

--- a/packages/backend/test/storage-startup-regression.test.mjs
+++ b/packages/backend/test/storage-startup-regression.test.mjs
@@ -49,18 +49,28 @@ test('blob server startup does not await listen before storage init can finish',
   assert.match(blobServerBody, /blobServerListenPromise\s*\.then\(/)
 })
 
-test('storage startup waits for listen and bootstrapping before peer pool discovery', () => {
-  assert.match(storageSource, /waitForSwarmDiscoveryReady\(swarm\)/)
-  assert.match(storageSource, /maybeStartPeerPoolDiscovery\('bootstrapped-and-listen-resolved'\)/)
-  assert.match(storageSource, /swarm\._peartubeListenPromise = listenPromise/)
-  assert.doesNotMatch(storageSource, /dialPersistedPeers/)
+test('storage joins the PearTube network topic immediately without DHT bootstrap gates', () => {
+  assert.doesNotMatch(storageSource, /function isSwarmDiscoveryReady/)
+  assert.doesNotMatch(storageSource, /waitForSwarmDiscoveryReady\(swarm\)/)
+  assert.doesNotMatch(storageSource, /dht\?\.bootstrapped[\s\S]{0,240}swarm\.join\(PEARTUBE_NETWORK_TOPIC/)
+  assert.match(storageSource, /joinPeerPoolDiscoveryImmediately\('startup'\)/)
+  assert.match(storageSource, /swarm\.join\(PEARTUBE_NETWORK_TOPIC, \{ server: true, client: true \}\)/)
 })
 
 test('storage persists and restores DHT routing table state around lifecycle events', () => {
   assert.match(storageSource, /DHT_ROUTING_TABLE_KEY/)
-  assert.match(storageSource, /persistDhtRoutingTable\([\s\S]*?reason: 'startup'/)
   assert.match(storageSource, /restorePersistedDhtRoutingTable\([\s\S]*?reason: 'startup'/)
   assert.match(storageSource, /persistDhtRoutingTable\(globalSwarm, globalMetaDb, \{ reason: 'suspend' \}\)/)
+})
+
+
+
+test('storage cold start and resume warm-dial recent known peers as explicit seed bootstrap', () => {
+  assert.match(storageSource, /import \{ createKnownPeerCache, loadKnownPeers \} from '\.\/known-peers\.js'/)
+  assert.match(storageSource, /async function warmDialKnownPeers\(swarm, metaDb, \{ reason = 'startup', limit = 5 \} = \{\}\)/)
+  assert.match(storageSource, /await warmDialKnownPeers\(swarm, metaDb, \{ reason: 'startup', limit: 5 \}\)/)
+  assert.match(storageSource, /await warmDialKnownPeers\(globalSwarm, globalMetaDb, \{ reason: 'resume', limit: 5 \}\)/)
+  assert.match(storageSource, /swarm\.joinPeer\(b4a\.from\(peer\.key, 'hex'\)\)/)
 })
 
 test('storage creates an offline swarm fallback when Hyperswarm is unavailable', () => {
@@ -98,7 +108,7 @@ test('offline swarm fallback exposes the swarm methods orchestrator and managers
 })
 
 test('offline swarm fallback skips peer pool discovery instead of joining noop topics at startup', () => {
-  assert.match(storageSource, /maybeStartPeerPoolDiscovery\('bootstrapped-and-listen-resolved'\)/)
+  assert.match(storageSource, /joinPeerPoolDiscoveryImmediately\('startup'\)/)
   assert.match(storageSource, /Skipping peer pool discovery; P2P networking is offline/)
 })
 


### PR DESCRIPTION
## Summary
- join `peartube-network` immediately on storage startup instead of waiting for DHT bootstrap/listen readiness
- restore persisted DHT routing state on startup/resume and warm-dial the last known successful peers as explicit seed bootstrap
- move Android multicast-lock ownership fully to native lifecycle and remove React-side acquire/release calls
- fix public-feed live peer accounting for repeated `HAVE_FEED` and `SUBMIT_CHANNEL` gossip while keeping feed catalog visibility decoupled from transport sockets

## Test Plan
- `node --test packages/backend/test/storage-startup-regression.test.mjs packages/app/tests/android-physical-discovery-regression.test.mjs packages/backend/test/public-feed-manager.test.mjs`
- `node --check packages/backend/src/storage.js`
- `node --check packages/backend/src/public-feed.js`
- `node --check packages/backend/src/channel-descriptor.js`
- `git diff --check`
- `npm run lint:changed -- --quiet`
- `./node_modules/.bin/eslint --quiet packages/app/app/_layout.tsx packages/backend/src/storage.js packages/backend/src/public-feed.js packages/backend/test/public-feed-manager.test.mjs packages/backend/test/storage-startup-regression.test.mjs packages/app/tests/android-physical-discovery-regression.test.mjs`
