### PR TITLE
fix(backend): require identity for seeding mutations

### DIFF
--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -19,6 +19,7 @@ import { getVideoToolboxDecodeSettings, setVideoToolboxDecodeEnabled, setVideoTo
 import { buildBlobRefCacheKey, normalizeBlobsCoreKey, normalizeBlobRefInput, parseBlobRef, stringifyBlobId } from './blob-ref.js';
 import { NETWORK_TOPIC_STRING } from './types.js'
 import { collectCorestoreGarbage } from './corestore-gc.js'
+import { SeedingAuthorizationError } from './seeding.js'
 
 /**
  * @typedef {import('./types.js').StorageContext} StorageContext
@@ -549,6 +550,14 @@ export function createApi({
       return Number.isFinite(value) ? Math.max(0, Math.round(value)) : 0
     }
     return 0
+  }
+
+  function isSeedingAuthorizationError(err) {
+    return err instanceof SeedingAuthorizationError || err?.name === 'SeedingAuthorizationError'
+  }
+
+  function seedingUnauthorizedResult(extra = {}) {
+    return { success: false, ...extra, error: 'Unauthorized seeding mutation' }
   }
 
   return {
@@ -2749,8 +2758,13 @@ export function createApi({
      */
     async setSeedingConfig(config) {
       if (seedingManager) {
-        await seedingManager.setConfig(config);
-        return { success: true, config: seedingManager.config };
+        try {
+          await seedingManager.setConfig(config);
+          return { success: true, config: seedingManager.config };
+        } catch (err) {
+          if (isSeedingAuthorizationError(err)) return seedingUnauthorizedResult()
+          throw err
+        }
       }
       return { success: false, error: 'Seeding manager not initialized' };
     },
@@ -2763,9 +2777,14 @@ export function createApi({
     async pinChannel(driveKey) {
       console.log('[API] PIN_CHANNEL:', driveKey?.slice(0, 16));
       if (seedingManager && driveKey) {
-        await seedingManager.pinChannel(driveKey);
-        await loadChannel(ctx, driveKey);
-        return { success: true };
+        try {
+          await seedingManager.pinChannel(driveKey);
+          await loadChannel(ctx, driveKey);
+          return { success: true };
+        } catch (err) {
+          if (isSeedingAuthorizationError(err)) return seedingUnauthorizedResult()
+          throw err
+        }
       }
       return { success: false, error: 'Invalid request' };
     },
@@ -2778,8 +2797,13 @@ export function createApi({
     async unpinChannel(driveKey) {
       console.log('[API] UNPIN_CHANNEL:', driveKey?.slice(0, 16));
       if (seedingManager && driveKey) {
-        await seedingManager.unpinChannel(driveKey);
-        return { success: true };
+        try {
+          await seedingManager.unpinChannel(driveKey);
+          return { success: true };
+        } catch (err) {
+          if (isSeedingAuthorizationError(err)) return seedingUnauthorizedResult()
+          throw err
+        }
       }
       return { success: false, error: 'Invalid request' };
     },
@@ -2825,10 +2849,15 @@ export function createApi({
     async setStorageLimit(maxGB) {
       console.log('[API] SET_STORAGE_LIMIT:', maxGB, 'GB');
       if (seedingManager) {
-        await clearDownloadIntents().catch(err => console.log('[API] Failed to clear partial downloads for storage limit:', err?.message))
-        await seedingManager.setMaxStorageGB(maxGB);
-        cancelRangeRequestsForRemovedSeeds()
-        return { success: true };
+        try {
+          await clearDownloadIntents().catch(err => console.log('[API] Failed to clear partial downloads for storage limit:', err?.message))
+          await seedingManager.setMaxStorageGB(maxGB);
+          cancelRangeRequestsForRemovedSeeds()
+          return { success: true };
+        } catch (err) {
+          if (isSeedingAuthorizationError(err)) return seedingUnauthorizedResult()
+          throw err
+        }
       }
       return { success: false };
     },
@@ -2840,13 +2869,18 @@ export function createApi({
     async clearCache() {
       console.log('[API] CLEAR_CACHE');
       if (seedingManager) {
-        const partial = await clearDownloadIntents().catch(err => {
-          console.log('[API] Failed to clear partial downloads:', err?.message)
-          return { clearedBytes: 0 }
-        });
-        const cleared = await seedingManager.clearCache();
-        cancelRangeRequestsForRemovedSeeds()
-        return { success: true, clearedBytes: normalizeClearedBytes(cleared) + normalizeClearedBytes(partial) };
+        try {
+          const partial = await clearDownloadIntents().catch(err => {
+            console.log('[API] Failed to clear partial downloads:', err?.message)
+            return { clearedBytes: 0 }
+          });
+          const cleared = await seedingManager.clearCache();
+          cancelRangeRequestsForRemovedSeeds()
+          return { success: true, clearedBytes: normalizeClearedBytes(cleared) + normalizeClearedBytes(partial) };
+        } catch (err) {
+          if (isSeedingAuthorizationError(err)) return seedingUnauthorizedResult({ clearedBytes: 0 })
+          throw err
+        }
       }
       return { success: false, clearedBytes: 0 };
     },

--- a/packages/backend/src/orchestrator.js
+++ b/packages/backend/src/orchestrator.js
@@ -336,10 +336,11 @@ export async function createBackendContext(config) {
   ctx.publicFeed = publicFeed
   const startupGate = createStartupGate()
   const videoStats = new VideoStatsTracker();
+  const identityManager = createIdentityManager({ ctx });
   const seedingManager = new SeedingManager(ctx.store, ctx.metaDb, {
+    identityManager,
     getDiskUsageBytes: createStorageUsageMeasurer(storagePath)
   });
-  const identityManager = createIdentityManager({ ctx });
   const uploadManager = createUploadManager({ ctx });
 
   // Phase 3: Wire up callbacks

--- a/packages/backend/src/seeding.js
+++ b/packages/backend/src/seeding.js
@@ -39,6 +39,17 @@ function mergeSeedReason(existingReason, nextReason) {
     : existingReason
 }
 
+export class SeedingAuthorizationError extends Error {
+  constructor(message = 'Unauthorized seeding mutation') {
+    super(message)
+    this.name = 'SeedingAuthorizationError'
+  }
+}
+
+function normalizeDriveKey(value) {
+  return typeof value === 'string' && value.length > 0 ? value : null
+}
+
 export class SeedingManager {
   /**
    * @param {import('corestore')} store - Corestore instance
@@ -48,6 +59,8 @@ export class SeedingManager {
   constructor(store, metaDb, options = {}) {
     this.store = store;
     this.metaDb = metaDb;
+    this.identityManager = options.identityManager || null;
+    this.requiresIdentityAuthorization = Object.prototype.hasOwnProperty.call(options, 'identityManager');
     this.getDiskUsageBytes = typeof options.getDiskUsageBytes === 'function'
       ? options.getDiskUsageBytes
       : (typeof store?.getDiskUsageBytes === 'function' ? () => store.getDiskUsageBytes() : null);
@@ -63,6 +76,23 @@ export class SeedingManager {
       maxVideosPerChannel: 10     // Max videos to seed per channel if auto-seeding subscriptions
     };
     console.log('[SeedingManager] Initialized');
+  }
+
+  getActiveIdentityDriveKey() {
+    const active = this.identityManager?.getActiveIdentity?.()
+    return normalizeDriveKey(active?.driveKey || active?.channelKey)
+  }
+
+  assertAuthorizedMutation(options = {}) {
+    if (options.authorized === true) return
+    if (!this.requiresIdentityAuthorization) return
+    if (this.getActiveIdentityDriveKey()) return
+    throw new SeedingAuthorizationError()
+  }
+
+  assertAuthorizedForSeed(driveKey, reason, options = {}) {
+    if (reason === 'watched' && options.userInitiated !== true) return
+    this.assertAuthorizedMutation(options)
   }
 
   /**
@@ -105,6 +135,8 @@ export class SeedingManager {
    * @returns {Promise<boolean>}
    */
   async addSeed(driveKey, videoPath, reason, blobInfo, options = {}) {
+    this.assertAuthorizedForSeed(driveKey, reason, options)
+
     if (!this.config.autoSeedWatched && reason === 'watched') {
       console.log('[SeedingManager] Auto-seed watched disabled, skipping');
       return false;
@@ -199,7 +231,8 @@ export class SeedingManager {
    * Pin a channel for always seeding
    * @param {string} driveKey
    */
-  async pinChannel(driveKey) {
+  async pinChannel(driveKey, options = {}) {
+    this.assertAuthorizedMutation(options)
     this.pinnedChannels.add(driveKey);
     await this.persistPinnedChannels();
     console.log('[SeedingManager] Pinned channel:', driveKey.slice(0, 16));
@@ -209,7 +242,8 @@ export class SeedingManager {
    * Unpin a channel
    * @param {string} driveKey
    */
-  async unpinChannel(driveKey) {
+  async unpinChannel(driveKey, options = {}) {
+    this.assertAuthorizedMutation(options)
     this.pinnedChannels.delete(driveKey);
     await this.persistPinnedChannels();
     console.log('[SeedingManager] Unpinned channel:', driveKey.slice(0, 16));
@@ -219,7 +253,8 @@ export class SeedingManager {
    * Update seeding config
    * @param {Partial<SeedingConfig>} newConfig
    */
-  async setConfig(newConfig) {
+  async setConfig(newConfig, options = {}) {
+    this.assertAuthorizedMutation(options)
     this.config = { ...this.config, ...newConfig };
     await this.metaDb.put('seeding-config', this.config);
     console.log('[SeedingManager] Updated config:', this.config);
@@ -401,7 +436,8 @@ export class SeedingManager {
    * @param {number} gb
    * @returns {Promise<void>}
    */
-  async setMaxStorageGB(gb) {
+  async setMaxStorageGB(gb, options = {}) {
+    this.assertAuthorizedMutation(options)
     if (gb < 1) gb = 1;
     if (gb > 100) gb = 100;
     this.config.maxStorageGB = gb;
@@ -459,7 +495,8 @@ export class SeedingManager {
    * Clear all non-pinned cached content
    * @returns {Promise<{ clearedBytes: number, totalStorageBytes: number, totalStorageGB: string, untrackedStorageBytes: number, untrackedStorageGB: string }>} bytes cleared and post-clear total storage snapshot
    */
-  async clearCache() {
+  async clearCache(options = {}) {
+    this.assertAuthorizedMutation(options)
     let clearedBytes = 0;
     const toRemove = [];
     let clearedBlob = false;

--- a/packages/backend/test/seeding-auth.test.mjs
+++ b/packages/backend/test/seeding-auth.test.mjs
@@ -1,0 +1,126 @@
+import b4a from 'b4a'
+import test from 'brittle'
+
+import { createApi } from '../src/api.js'
+import { SeedingAuthorizationError, SeedingManager } from '../src/seeding.js'
+
+function createMetaDb(seed = {}) {
+  const state = new Map(Object.entries(seed))
+  return {
+    state,
+    async get(key) {
+      return state.has(key) ? { value: state.get(key) } : null
+    },
+    async put(key, value) {
+      state.set(key, value)
+    },
+    async del(key) {
+      state.delete(key)
+    },
+    createReadStream({ gte, lt } = {}) {
+      const entries = Array.from(state.entries())
+        .filter(([key]) => (!gte || key >= gte) && (!lt || key < lt))
+        .map(([key, value]) => ({ key, value }))
+
+      return {
+        async *[Symbol.asyncIterator]() {
+          yield * entries
+        }
+      }
+    }
+  }
+}
+
+function createStore() {
+  const cores = new Map()
+  return {
+    storage: {
+      async flush() {},
+      async compact() {}
+    },
+    get(input) {
+      const key = b4a.isBuffer(input)
+        ? b4a.toString(input, 'hex')
+        : b4a.isBuffer(input?.key)
+          ? b4a.toString(input.key, 'hex')
+          : String(input)
+      if (!cores.has(key)) {
+        cores.set(key, {
+          async ready() {},
+          async clear() {}
+        })
+      }
+      return cores.get(key)
+    }
+  }
+}
+
+function createIdentityManager(activeIdentity = null) {
+  return {
+    getActiveIdentity() {
+      return activeIdentity
+    }
+  }
+}
+
+test('SeedingManager rejects explicit seeding mutations without an active identity', async (t) => {
+  const manager = new SeedingManager(createStore(), createMetaDb(), {
+    identityManager: createIdentityManager(null)
+  })
+
+  await t.exception(
+    () => manager.pinChannel('aa'.repeat(32)),
+    SeedingAuthorizationError
+  )
+  await t.exception(
+    () => manager.setMaxStorageGB(10),
+    SeedingAuthorizationError
+  )
+  await t.exception(
+    () => manager.clearCache(),
+    SeedingAuthorizationError
+  )
+})
+
+test('SeedingManager allows automatic watched seeds but requires active identity for explicit pins', async (t) => {
+  const metaDb = createMetaDb()
+  const manager = new SeedingManager(createStore(), metaDb, {
+    identityManager: createIdentityManager(null)
+  })
+
+  t.is(await manager.addSeed('drive-a', 'videos/watched.mp4', 'watched', { byteLength: 1024 }), true)
+  t.is(manager.getActiveSeeds().length, 1)
+
+  await t.exception(
+    () => manager.addSeed('drive-a', 'videos/pinned.mp4', 'pinned', { byteLength: 1024 }),
+    SeedingAuthorizationError
+  )
+})
+
+test('SeedingManager allows explicit seeding mutations for the active channel identity', async (t) => {
+  const active = { publicKey: 'identity-a', driveKey: 'channel-a' }
+  const manager = new SeedingManager(createStore(), createMetaDb(), {
+    identityManager: createIdentityManager(active)
+  })
+
+  await manager.pinChannel('channel-a')
+  t.alike(manager.getPinnedChannels(), ['channel-a'])
+
+  await manager.addSeed('channel-a', 'videos/pinned.mp4', 'pinned', { byteLength: 2048 })
+  t.is(manager.getActiveSeeds().length, 1)
+  t.is(manager.getActiveSeeds()[0].reason, 'pinned')
+
+  await manager.setMaxStorageGB(8)
+  t.is(manager.config.maxStorageGB, 8)
+})
+
+test('seeding API mutation endpoints return unauthorized without active identity', async (t) => {
+  const manager = new SeedingManager(createStore(), createMetaDb(), {
+    identityManager: createIdentityManager(null)
+  })
+  const api = createApi({ ctx: { store: createStore(), metaDb: createMetaDb() }, seedingManager: manager })
+
+  t.alike(await api.pinChannel('aa'.repeat(32)), { success: false, error: 'Unauthorized seeding mutation' })
+  t.alike(await api.setStorageLimit(5), { success: false, error: 'Unauthorized seeding mutation' })
+  t.alike(await api.clearCache(), { success: false, clearedBytes: 0, error: 'Unauthorized seeding mutation' })
+})


### PR DESCRIPTION
## Summary
- Require an active local identity before explicit SeedingManager mutations: pin/unpin, config changes, storage limit changes, and cache clears.
- Preserve automatic watched-video seeding so playback/prefetch can still seed content without a UI auth prompt.
- Return structured unauthorized failures from API mutation endpoints instead of throwing through HRPC.

Closes #234

## Test Plan
- `packages/backend/node_modules/.bin/brittle packages/backend/test/seeding-auth.test.mjs packages/backend/test/storage-quota-api.test.mjs packages/backend/test/seeding-quota.test.mjs packages/backend/test/seeding-storage-accounting.test.mjs`
- `git diff --check`
- `node --check packages/backend/src/seeding.js`
- `node --check packages/backend/src/api.js`
- `node --check packages/backend/src/orchestrator.js`
- `./node_modules/.bin/eslint --quiet packages/backend/src/seeding.js packages/backend/src/api.js packages/backend/src/orchestrator.js packages/backend/test/seeding-auth.test.mjs`
- `npm run lint:changed` (reported no changed JS/TS files)
