### PR TITLE
fix(p2p): keep feed discovery topic-owned

### DIFF
--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -787,38 +787,6 @@ export class PublicFeed {
     return this._peerDirectory.get(keyHex) || null
   }
 
-  _queuePublicJoinPeer(record, peer = null, topic = null) {
-    if (!record || !record.publicKey || typeof this.swarm?.joinPeer !== 'function') return false
-    if (record.joined && record.lastJoinedAt && this._now() - record.lastJoinedAt < this._peerJoinCooldownMs) {
-      return true
-    }
-    if (record.demoted && !record.joined) return false
-
-    const lowest = this._lowestScoringPeer(record.keyHex)
-    if (!record.joined && this._peerDirectory.size >= this.maxPeers && lowest && lowest.keyHex !== record.keyHex && lowest.score > record.score) {
-      record.demoted = true
-      return false
-    }
-
-    try {
-      this.swarm.joinPeer(record.publicKey)
-      record.joined = true
-      record.demoted = false
-      record.joinAttempts++
-      record.lastJoinedAt = this._now()
-      record.lastJoinError = null
-      this._directPeerDialStats.queued++
-      this._directPeerDialStats.lastReason = 'joinPeer'
-      this._directPeerDialStats.lastDialedAt = record.lastJoinedAt
-      return true
-    } catch (err) {
-      record.lastJoinError = err?.message || String(err)
-      this._directPeerDialStats.failed++
-      this._directPeerDialStats.lastReason = 'joinPeer-error'
-      return false
-    }
-  }
-
   _recordPeerConnectionOutcome(conn, reason = 'closed') {
     const remoteKey = this._connectionPeerKeys.get(conn) || conn?.remotePublicKey || conn?.publicKey || null
     const keyHex = this._peerKeyHex(remoteKey)

--- a/packages/backend/src/storage.js
+++ b/packages/backend/src/storage.js
@@ -25,7 +25,7 @@ import {
 } from './runtime-modules.js'
 import { NETWORK_TOPIC_STRING } from './types.js'
 import { normalizeBlobRefInput } from './blob-ref.js'
-import { createKnownPeerCache, loadKnownPeers } from './known-peers.js'
+import { createKnownPeerCache } from './known-peers.js'
 
 function resolveDebugLogPath() {
   return globalThis?.process?.env?.PEARTUBE_NATIVE_WORKLET_DEBUG_LOG || null
@@ -210,38 +210,6 @@ function decodePersistedValue(value) {
     return out
   }
   return value
-}
-
-async function warmDialKnownPeers(swarm, metaDb, { reason = 'startup', limit = 5 } = {}) {
-  if (!swarm || swarm._peartubeOffline || typeof swarm.joinPeer !== 'function' || !metaDb) {
-    return { dialed: 0, skipped: true }
-  }
-
-  let peers = []
-  try {
-    peers = await loadKnownPeers(metaDb)
-  } catch (err) {
-    console.log('[Storage] Known-peer warm dial load failed:', err?.message)
-    return { dialed: 0, error: err?.message || String(err) }
-  }
-
-  let dialed = 0
-  for (const peer of peers.slice(0, Math.max(0, Math.min(5, Number(limit) || 5)))) {
-    if (!peer?.key || !/^[a-f0-9]{64}$/i.test(peer.key)) continue
-    try {
-      swarm.joinPeer(b4a.from(peer.key, 'hex'))
-      dialed++
-    } catch (err) {
-      console.log('[Storage] Known-peer warm dial failed:', peer.key.slice(0, 16), err?.message)
-    }
-  }
-
-  if (dialed > 0) {
-    globalNetworkStartupTiming?.record('known-peer-warm-dial', { reason, dialed })
-    console.log('[Storage] Warm-dialed known peers:', dialed, 'reason:', reason)
-  }
-
-  return { dialed }
 }
 
 function collectPersistedDhtRoutingEntries(swarm) {
@@ -690,22 +658,6 @@ function installSwarmConnectDiagnostics(swarm, diagnostics) {
     return result
   }
   swarm._peartubeConnectDiagnosticsInstalled = true
-  return true
-}
-
-function installSwarmPeerDiscoveryEmitter(swarm) {
-  if (!swarm || swarm._peartubePeerDiscoveryEmitterInstalled) return false
-  if (typeof swarm._handlePeer !== 'function' || typeof swarm.emit !== 'function') return false
-
-  const handlePeer = swarm._handlePeer
-  swarm._handlePeer = function peartubeHandlePeer(peer, topic) {
-    const result = handlePeer.call(this, peer, topic)
-    try {
-      swarm.emit('peer', peer, topic)
-    } catch { /* best effort */ }
-    return result
-  }
-  swarm._peartubePeerDiscoveryEmitterInstalled = true
   return true
 }
 
@@ -1407,7 +1359,6 @@ export async function initializeStorage(config) {
   await appendDebugLine(`[storage] hyperswarm created offline=${Boolean(swarm._peartubeOffline)}`)
   globalSwarmDiagnostics = createSwarmDiagnostics(swarm)
   installSwarmConnectDiagnostics(swarm, globalSwarmDiagnostics)
-  installSwarmPeerDiscoveryEmitter(swarm)
 
   // Set global references for suspend/resume and stats
   globalSwarm = swarm;
@@ -1505,16 +1456,6 @@ export async function initializeStorage(config) {
     log.debug('Swarm update event', { connections: swarm.connections?.size || 0, peers: swarm.peers?.size || 0 })
   });
 
-  // Log peer discovery events (DHT found a peer)
-  swarm.on('peer', (peer, topic) => {
-    globalSwarmDiagnostics?.recordPeer?.(peer, topic)
-    const peerKey = peer?.publicKey ? b4a.toString(peer.publicKey, 'hex').slice(0, 16) : 'unknown'
-    globalNetworkStartupTiming?.record('peer-discovered', { key: peerKey, relayAddresses: Array.isArray(peer?.relayAddresses) ? peer.relayAddresses.length : 0, connections: swarm.connections?.size || 0, connecting: swarm.connecting || 0 })
-    const relayAddresses = Array.isArray(peer?.relayAddresses) ? peer.relayAddresses.length : 0
-    console.log('[Storage] PEER DISCOVERED:', peerKey, 'total peers:', swarm.peers?.size || 0, 'relayAddresses:', relayAddresses, 'connecting:', swarm.connecting || 0)
-    void appendDebugLine(`[storage] peer discovered ${peerKey} totalPeers=${swarm.peers?.size || 0} relayAddresses=${relayAddresses} connecting=${swarm.connecting || 0}`)
-  })
-
   await restorePersistedDhtRoutingTable(swarm, metaDb, { reason: 'startup' })
 
   // Join the PearTube network topic immediately. Do not wait for DHT bootstrap
@@ -1555,7 +1496,6 @@ export async function initializeStorage(config) {
     globalPeerPoolDiscovery = null
   } else {
     joinPeerPoolDiscoveryImmediately('startup')
-    await warmDialKnownPeers(swarm, metaDb, { reason: 'startup', limit: 5 })
   }
 
   // Start listening - DON'T block on it since it may hang on mobile
@@ -2654,7 +2594,6 @@ export async function resumeNetworking() {
     if (globalSwarm) {
       await globalSwarm.resume();
       await restorePersistedDhtRoutingTable(globalSwarm, globalMetaDb, { reason: 'resume' })
-      await warmDialKnownPeers(globalSwarm, globalMetaDb, { reason: 'resume', limit: 5 })
       console.log('[Network] Swarm resumed, connections:', globalSwarm.connections?.size || 0);
     }
     if (globalBlobServer) {

--- a/packages/backend/src/swarm-peer-dial.js
+++ b/packages/backend/src/swarm-peer-dial.js
@@ -93,14 +93,6 @@ export function swarmRememberPeer(swarm, peer, topic = null) {
   return peerInfo
 }
 
-export function swarmQueuePeer(swarm, peerInfo) {
-  if (!swarm || !peerInfo || !peerInfo.publicKey) return false
-  if (typeof swarm.joinPeer === 'function') {
-    peerInfo.explicit = true
-    peerInfo.queued = false
-    peerInfo.waiting = false
-    swarm.joinPeer(peerInfo.publicKey)
-    return true
-  }
+export function swarmQueuePeer(_swarm, _peerInfo) {
   return false
 }

--- a/packages/backend/test/storage-startup-regression.test.mjs
+++ b/packages/backend/test/storage-startup-regression.test.mjs
@@ -65,12 +65,12 @@ test('storage persists and restores DHT routing table state around lifecycle eve
 
 
 
-test('storage cold start and resume warm-dial recent known peers as explicit seed bootstrap', () => {
-  assert.match(storageSource, /import \{ createKnownPeerCache, loadKnownPeers \} from '\.\/known-peers\.js'/)
-  assert.match(storageSource, /async function warmDialKnownPeers\(swarm, metaDb, \{ reason = 'startup', limit = 5 \} = \{\}\)/)
-  assert.match(storageSource, /await warmDialKnownPeers\(swarm, metaDb, \{ reason: 'startup', limit: 5 \}\)/)
-  assert.match(storageSource, /await warmDialKnownPeers\(globalSwarm, globalMetaDb, \{ reason: 'resume', limit: 5 \}\)/)
-  assert.match(storageSource, /swarm\.joinPeer\(b4a\.from\(peer\.key, 'hex'\)\)/)
+test('storage does not warm-dial cached peers in the default feed discovery path', () => {
+  assert.match(storageSource, /import \{ createKnownPeerCache \} from '\.\/known-peers\.js'/)
+  assert.doesNotMatch(storageSource, /warmDialKnownPeers/)
+  assert.doesNotMatch(storageSource, /loadKnownPeers\(/)
+  assert.doesNotMatch(storageSource, /swarm\.joinPeer\(b4a\.from\(peer\.key, 'hex'\)\)/)
+  assert.doesNotMatch(storageSource, /swarm\.joinPeer\(/)
 })
 
 test('storage creates an offline swarm fallback when Hyperswarm is unavailable', () => {
@@ -120,28 +120,15 @@ test('storage exposes public bee content discovery retention for cached serving 
   assert.match(storageSource, /retainSwarmDiscovery\(ctx, core\.discoveryKey/)
 })
 
-test('storage exposes Hyperswarm peer discovery as a diagnostic peer event', () => {
-  assert.match(
-    storageSource,
-    /function installSwarmPeerDiscoveryEmitter\(swarm\)/,
-    'storage should install a peer discovery event adapter'
-  )
-  assert.match(
-    storageSource,
-    /installSwarmPeerDiscoveryEmitter\(swarm\)/,
-    'real swarm startup should install the peer discovery event adapter'
-  )
-  assert.match(
-    storageSource,
-    /swarm\.emit\('peer', peer, topic\)/,
-    'adapter should emit peer events with the discovered peer and topic'
-  )
+test('storage does not monkey-patch Hyperswarm peer discovery into app-level peer events', () => {
+  assert.doesNotMatch(storageSource, /function installSwarmPeerDiscoveryEmitter\(swarm\)/)
+  assert.doesNotMatch(storageSource, /installSwarmPeerDiscoveryEmitter\(swarm\)/)
+  assert.doesNotMatch(storageSource, /swarm\.emit\('peer', peer, topic\)/)
 })
 
 test('storage captures Hyperswarm connection lifecycle diagnostics', () => {
   assert.match(storageSource, /function createSwarmDiagnostics\(swarm\)/)
   assert.match(storageSource, /globalSwarmDiagnostics = createSwarmDiagnostics\(swarm\)/)
-  assert.match(storageSource, /globalSwarmDiagnostics\?\.recordPeer\?\.\(peer, topic\)/)
   assert.match(storageSource, /globalSwarmDiagnostics\?\.recordConnection\?\.\(conn, info\)/)
   assert.match(storageSource, /hyperswarm: diagnostics/)
 })

--- a/packages/backend/test/swarm-peer-dial-regression.test.mjs
+++ b/packages/backend/test/swarm-peer-dial-regression.test.mjs
@@ -21,7 +21,7 @@ test('swarmRememberPeer does not fabricate Hyperswarm peer info when peer is unk
   assert.equal(swarm.peers.has(keyHex), false)
 })
 
-test('swarmQueuePeer queues through public joinPeer and avoids private priority mutation', () => {
+test('swarmQueuePeer does not call joinPeer or mutate private queue flags', () => {
   const publicKey = b4a.alloc(32, 9)
   const peerInfo = {
     publicKey,
@@ -38,8 +38,8 @@ test('swarmQueuePeer queues through public joinPeer and avoids private priority 
     },
   }
 
-  assert.equal(swarmQueuePeer(swarm, peerInfo), true)
-  assert.deepEqual(swarm.joinPeerCalls, [publicKey])
+  assert.equal(swarmQueuePeer(swarm, peerInfo), false)
+  assert.deepEqual(swarm.joinPeerCalls, [])
   assert.equal(peerInfo.queued, false)
-  assert.equal(peerInfo.explicit, true)
+  assert.equal(peerInfo.explicit, false)
 })

--- a/packages/backend/test/swarm-peer-dial.test.mjs
+++ b/packages/backend/test/swarm-peer-dial.test.mjs
@@ -42,17 +42,16 @@ function createSwarm() {
   }
 }
 
-test('swarmQueuePeer promotes peer info and queues via public joinPeer without private enqueue', () => {
+test('swarmQueuePeer leaves peer selection to Hyperswarm topic discovery', () => {
   const publicKey = b4a.alloc(32, 2)
   const swarm = createSwarm()
   const peerInfo = swarm._upsertPeer(publicKey, [{ host: '127.0.0.1', port: 49737 }])
 
-  assert.equal(swarmQueuePeer(swarm, peerInfo), true)
+  assert.equal(swarmQueuePeer(swarm, peerInfo), false)
   assert.equal(swarm.enqueueCalls.length, 0)
-  assert.equal(peerInfo.explicit, true)
+  assert.equal(peerInfo.explicit, undefined)
   assert.equal(peerInfo.queued, false)
-  assert.equal(swarm.joinPeerCalls.length, 1)
-  assert.equal(swarm.joinPeerCalls[0], publicKey)
+  assert.equal(swarm.joinPeerCalls.length, 0)
 })
 
 test('swarmRememberPeer preserves existing relay hints when rediscovery lacks hints', () => {

--- a/packages/backend/test/swarm-peer-requeue.test.mjs
+++ b/packages/backend/test/swarm-peer-requeue.test.mjs
@@ -4,7 +4,7 @@ import b4a from 'b4a'
 
 import { swarmQueuePeer } from '../src/swarm-peer-dial.js'
 
-test('swarmQueuePeer clears stale queued/waiting flags before joinPeer requeue', () => {
+test('swarmQueuePeer does not perform app-level joinPeer requeue by default', () => {
   const publicKey = b4a.alloc(32, 31)
   const peerInfo = {
     publicKey,
@@ -19,9 +19,9 @@ test('swarmQueuePeer clears stale queued/waiting flags before joinPeer requeue',
     },
   }
 
-  assert.equal(swarmQueuePeer(swarm, peerInfo), true)
-  assert.deepEqual(swarm.joinPeerCalls, [publicKey])
-  assert.equal(peerInfo.explicit, true)
-  assert.equal(peerInfo.queued, false)
-  assert.equal(peerInfo.waiting, false)
+  assert.equal(swarmQueuePeer(swarm, peerInfo), false)
+  assert.deepEqual(swarm.joinPeerCalls, [])
+  assert.equal(peerInfo.explicit, false)
+  assert.equal(peerInfo.queued, true)
+  assert.equal(peerInfo.waiting, true)
 })


### PR DESCRIPTION
## Summary
- remove default cached-peer warm dialing on storage startup/resume
- remove the `_handlePeer` monkey-patch that emitted app-level peer discovery events
- keep public feed discovery on the shared `peartube-network` Hyperswarm topic and open Protomux feed channels only on real sockets delivered by Hyperswarm
- remove dead public-feed and helper `joinPeer` fallback paths so fast feed discovery stays topic-owned

## Test Plan
- `node --test packages/backend/test/storage-startup-regression.test.mjs packages/backend/test/public-feed-manager.test.mjs packages/backend/test/known-peers.test.mjs packages/backend/test/blob-playback-service-peer-warmup.test.mjs packages/backend/test/swarm-peer-dial.test.mjs packages/backend/test/swarm-peer-dial-regression.test.mjs packages/backend/test/swarm-peer-requeue.test.mjs`
- `./node_modules/.bin/eslint --quiet packages/backend/src/storage.js packages/backend/test/storage-startup-regression.test.mjs packages/backend/src/public-feed.js packages/backend/test/public-feed-manager.test.mjs packages/backend/src/known-peers.js packages/backend/test/known-peers.test.mjs packages/backend/src/swarm-peer-dial.js packages/backend/test/swarm-peer-dial.test.mjs packages/backend/test/swarm-peer-dial-regression.test.mjs packages/backend/test/swarm-peer-requeue.test.mjs`
- `git diff --check`
- `node --check packages/backend/src/storage.js && node --check packages/backend/src/public-feed.js && node --check packages/backend/src/swarm-peer-dial.js`

## Notes
Live relays already show healthy feed gossip on the shared topic: four relays each reported `feedConnections=3` and `feedEntries=408` before this patch. This PR tightens the default architecture so the mobile/client path does not bypass Hyperswarm topic ownership with cached direct peer dials or app-level discovery events.
