### PR TITLE
fix(p2p): promote pending discovered peers

### DIFF
--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -845,6 +845,32 @@ export class PublicFeed {
   _rememberDiscoveredPeerInSwarm(peer, topic, keyHex) {
     if (!this.swarm || !peer || typeof peer !== 'object') return null
     try {
+      const publicKey = this._peerEntryPublicKey(peer)
+      const peers = this.swarm?.peers
+      let peerInfo = peers && typeof peers.get === 'function' ? peers.get(keyHex) : null
+      if (!peerInfo && peers && typeof peers.get === 'function' && publicKey) {
+        try { peerInfo = peers.get(publicKey) } catch { peerInfo = null }
+      }
+
+      if (peerInfo && typeof peerInfo === 'object') {
+        const relayAddresses = Array.isArray(peer?.relayAddresses) ? peer.relayAddresses : []
+        if (relayAddresses.length > 0 && (!Array.isArray(peerInfo.relayAddresses) || peerInfo.relayAddresses.length === 0)) {
+          peerInfo.relayAddresses = relayAddresses
+        }
+        if (topic) {
+          if (typeof peerInfo._topic === 'function') peerInfo._topic(topic)
+          else {
+            if (!Array.isArray(peerInfo.topics)) peerInfo.topics = []
+            if (!peerInfo.topics.some((seen) => b4a.equals(seen, topic))) peerInfo.topics.push(topic)
+          }
+        }
+        if ((peerInfo.queued || peerInfo.waiting) && peerInfo.explicit !== true) {
+          peerInfo.explicit = true
+          if (typeof peerInfo._updatePriority === 'function') peerInfo._updatePriority()
+          this._directPeerDialStats.lastReason = 'dial-already-pending-promoted'
+        }
+      }
+
       return this._discoveredPeerHints.get(keyHex) || null
     } catch (err) {
       this._directPeerLastDialError.set(keyHex, err?.message || String(err))

--- a/packages/backend/test/public-feed-manager.test.mjs
+++ b/packages/backend/test/public-feed-manager.test.mjs
@@ -192,6 +192,48 @@ test('PublicFeedManager keeps discovered relay address hints as Hyperswarm diagn
   }
 })
 
+
+test('PublicFeedManager promotes pending discovered topic peers to explicit priority', () => {
+  const publicKey = b4a.alloc(32, 19)
+  const keyHex = b4a.toString(publicKey, 'hex')
+  const relayAddresses = [{ host: '167.86.111.230', port: 49737 }]
+  const swarm = createSwarm()
+  let priorityUpdates = 0
+  swarm.peers.set(keyHex, {
+    publicKey,
+    relayAddresses: [],
+    topics: [],
+    queued: true,
+    waiting: false,
+    explicit: false,
+    _topic(topic) {
+      if (topic && !this.topics.some((seen) => b4a.equals(seen, topic))) this.topics.push(topic)
+    },
+    _updatePriority() {
+      priorityUpdates++
+      return true
+    },
+  })
+
+  const manager = new PublicFeedManager(swarm, createMetaDb())
+
+  try {
+    assert.equal(manager.handleDiscoveredPeer({ publicKey, relayAddresses }, NETWORK_TOPIC), true)
+    assert.equal(swarm.joinPeerCalls.length, 0)
+    const peerInfo = swarm.peers.get(keyHex)
+    assert.equal(peerInfo.explicit, true)
+    assert.equal(priorityUpdates, 1)
+    assert.equal(peerInfo.relayAddresses, relayAddresses)
+    assert.deepEqual(peerInfo.topics, [NETWORK_TOPIC])
+    const stats = manager.getStats().directPeerDial
+    assert.equal(stats.lastReason, 'dial-already-pending-promoted')
+    assert.equal(stats.peers[0].pending, true)
+    assert.equal(stats.peers[0].swarm.explicit, true)
+  } finally {
+    manager.stop()
+  }
+})
+
 test('PublicFeedManager bounds remembered discovered peers for long-running desktop sessions', () => {
   const swarm = createSwarm()
   const manager = new PublicFeedManager(swarm, createMetaDb(), { maxDiscoveredPeers: 3 })
@@ -407,7 +449,7 @@ test('PublicFeedManager preserves relay-address hints without joinPeer fallback'
   }
 })
 
-test('PublicFeedManager leaves pending Hyperswarm peer candidates untouched', () => {
+test('PublicFeedManager promotes pending Hyperswarm peer candidates without joinPeer fallback', () => {
   const publicKey = b4a.alloc(32, 23)
   const keyHex = b4a.toString(publicKey, 'hex')
   const swarm = createSwarm()
@@ -430,10 +472,13 @@ test('PublicFeedManager leaves pending Hyperswarm peer candidates untouched', ()
   try {
     assert.equal(manager.handleDiscoveredPeer({ publicKey, relayAddresses: peerInfo.relayAddresses }, NETWORK_TOPIC), true)
     assert.equal(swarm.joinPeerCalls.length, 0)
-    assert.equal(peerInfo.explicit, false)
-    assert.equal(priorityUpdates, 0)
+    assert.equal(peerInfo.explicit, true)
+    assert.equal(priorityUpdates, 1)
     const stats = manager.getStats().directPeerDial
+    assert.equal(stats.lastReason, 'dial-already-pending-promoted')
     assert.equal(stats.peers[0].connected, false)
+    assert.equal(stats.peers[0].pending, true)
+    assert.equal(stats.peers[0].swarm.explicit, true)
   } finally {
     manager.stop()
   }


### PR DESCRIPTION
## Summary
- promote already-pending Hyperswarm peer candidates to explicit priority when rediscovered on the PearTube network topic
- preserve relay-address/topic hints without reintroducing app-level `joinPeer` fallback loops
- update regressions for the physical-Android boundary where discovery can see candidates but no sockets/feed channels open

## Context
Physical Android can show zero connected peers even while relays and other systems are alive. The bad boundary is often `PEER DISCOVERED` / pending Hyperswarm candidate -> no socket -> no Protomux feed channel. This patch does not hardcode relay keys or restore default direct dials; it only nudges Hyperswarm's existing pending peer candidate into explicit priority when the same shared-topic peer is rediscovered.

## Test Plan
- [x] `node --check packages/backend/src/public-feed.js`
- [x] `node --test packages/backend/test/public-feed-manager.test.mjs --test-name-pattern 'promotes pending'` (RED before implementation, GREEN after)
- [x] `node --test packages/backend/test/storage-startup-regression.test.mjs packages/backend/test/public-feed-manager.test.mjs`
- [x] `git diff --check`
- [x] `./packages/backend/node_modules/.bin/brittle packages/backend/test/public-feed-manager.test.mjs`
