### PR TITLE
fix(backend): omit null writer blob keys

### DIFF
--- a/packages/backend/src/channel/multi-writer-channel.js
+++ b/packages/backend/src/channel/multi-writer-channel.js
@@ -1325,34 +1325,40 @@ export class MultiWriterChannel extends ReadyResource {
     if (!this.localWriterKeyHex) throw new Error('Channel not ready')
     if (!this.blobs) throw new Error('Blobs not initialized')
 
+    const blobDriveKey = typeof this.blobsKeyHex === 'string' && this.blobsKeyHex.length > 0
+      ? this.blobsKeyHex
+      : undefined
+
     // Check if writer is already registered
     const existing = await this.view.get(prefixedKey('writers', this.localWriterKeyHex)).catch(() => null)
     if (existing?.value) {
       // Backfill blobDriveKey/deviceName if this writer record was created before blobs were ready.
-      const needsBlobDriveKey = !existing.value.blobDriveKey && this.blobsKeyHex
+      const needsBlobDriveKey = !existing.value.blobDriveKey && blobDriveKey
       const needsDeviceName = deviceName && existing.value.deviceName !== deviceName
       if (needsBlobDriveKey || needsDeviceName) {
-        await this.appendOp({
+        const op = {
           type: 'upsert-writer',
           schemaVersion: CURRENT_SCHEMA_VERSION,
           keyHex: this.localWriterKeyHex,
-          deviceName,
-          blobDriveKey: this.blobsKeyHex
-        })
+          deviceName
+        }
+        if (blobDriveKey) op.blobDriveKey = blobDriveKey
+        await this.appendOp(op)
       }
-      return this.blobsKeyHex // Return shared blobs key for compatibility
+      return blobDriveKey || null // Return shared blobs key for compatibility
     }
 
     // Register the writer (all writers share the same Hyperblobs)
-    await this.appendOp({
+    const op = {
       type: 'upsert-writer',
       schemaVersion: CURRENT_SCHEMA_VERSION,
       keyHex: this.localWriterKeyHex,
-      deviceName,
-      blobDriveKey: this.blobsKeyHex // Point to shared blobs
-    })
+      deviceName
+    }
+    if (blobDriveKey) op.blobDriveKey = blobDriveKey
+    await this.appendOp(op)
 
-    return this.blobsKeyHex
+    return blobDriveKey || null
   }
 
   async addWriter({ keyHex, role = 'device', deviceName = '' }) {

--- a/packages/backend/test/channel-writer-null-blobdrive-regression.test.mjs
+++ b/packages/backend/test/channel-writer-null-blobdrive-regression.test.mjs
@@ -1,0 +1,47 @@
+import test from 'brittle'
+
+import { MultiWriterChannel } from '../src/channel/multi-writer-channel.js'
+
+function makeChannelWithBlobKey(blobsKeyHex) {
+  const channel = Object.create(MultiWriterChannel.prototype)
+  Object.defineProperty(channel, 'localWriterKeyHex', {
+    value: 'a'.repeat(64),
+    configurable: true
+  })
+  channel.blobs = {}
+  channel.view = {
+    async get() {
+      return null
+    }
+  }
+  channel.appended = null
+  channel.appendOp = async (op) => {
+    channel.appended = op
+  }
+  Object.defineProperty(channel, 'blobsKeyHex', {
+    value: blobsKeyHex,
+    configurable: true
+  })
+  return channel
+}
+
+test('ensureLocalBlobDrive omits null blobDriveKey from writer ops', async (t) => {
+  const channel = makeChannelWithBlobKey(null)
+
+  const result = await channel.ensureLocalBlobDrive({ deviceName: 'Desktop' })
+
+  t.is(result, null)
+  t.ok(channel.appended)
+  t.is(channel.appended.type, 'upsert-writer')
+  t.is(Object.hasOwn(channel.appended, 'blobDriveKey'), false)
+})
+
+test('ensureLocalBlobDrive includes blobDriveKey once the core key exists', async (t) => {
+  const blobDriveKey = 'b'.repeat(64)
+  const channel = makeChannelWithBlobKey(blobDriveKey)
+
+  const result = await channel.ensureLocalBlobDrive({ deviceName: 'Desktop' })
+
+  t.is(result, blobDriveKey)
+  t.is(channel.appended.blobDriveKey, blobDriveKey)
+})


### PR DESCRIPTION
## Summary
- omit `blobDriveKey` from local writer upsert ops until a real blobs core key exists
- prevents JSON `null` from reaching Hypercore/Autobase storage encoding on desktop startup
- add a regression covering null-key and real-key writer registration paths

## Test Plan
- `packages/backend/node_modules/.bin/brittle packages/backend/test/channel-writer-null-blobdrive-regression.test.mjs`
- `node --check packages/backend/src/channel/multi-writer-channel.js`
- `node --check packages/backend/test/channel-writer-null-blobdrive-regression.test.mjs`
- `git diff --check`

Note: `packages/backend/test/multiwriter-channel-harness.mjs` is currently not usable on `origin/main` in this checkout because it calls removed `chA.getBlobDrive`; the new focused regression passes.
