### PR TITLE
fix(android): preserve playable previews during peer warmup

### DIFF
--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -155,6 +155,7 @@ export function createApi({
   const CHANNEL_META_CACHE_TTL_MS = 30_000
   const VIDEO_AVAILABILITY_CACHE_TTL_MS = 30_000
   const VIDEO_AVAILABILITY_NEGATIVE_CACHE_TTL_MS = 1_500
+  const PLAYABLE_METADATA_REVALIDATION_GRACE_MS = 30_000
   /** @type {Map<string, Promise<any>>} */
   const prefetchInFlight = new Map()
   const activeRangeRequests = new Map() // key: `${driveKey}:${videoPath}`, value: { ranges: [], core, onDownload, onUpload }
@@ -163,6 +164,8 @@ export function createApi({
   const listVideosCache = new Map()
   /** @type {Map<string, { ts: number, value: any }>} */
   const channelMetaCache = new Map()
+  /** @type {Map<string, { ts: number, value: any }>} */
+  const playableMetadataFirstSeen = new Map()
   /** @type {Map<string, { ts: number, value: any }>} */
   const videoAvailabilityCache = new Map()
 
@@ -227,6 +230,11 @@ export function createApi({
     try {
       for (const key of videoAvailabilityCache.keys()) {
         if (key.startsWith(`${driveKey}:`)) videoAvailabilityCache.delete(key)
+      }
+    } catch { /* best effort */ }
+    try {
+      for (const key of playableMetadataFirstSeen.keys()) {
+        if (key.startsWith(`${driveKey}:`)) playableMetadataFirstSeen.delete(key)
       }
     } catch { /* best effort */ }
   }
@@ -938,21 +946,29 @@ export function createApi({
         const resolveExplicitVideoAvailability = ({ video, localHint, peerHint }) => {
           const explicitAvailability = video?.byteAvailability || video?.availability || null
           const relayBackedPreview = Boolean(video?.relayBacked || video?.source === 'relay-cache' || video?.relayRole === 'cache' || video?.relayServing)
+          const firstSeenAt = Number(video?._playableMetadataFirstSeenAt || 0) || 0
+          const withinPlayableMetadataGrace = firstSeenAt > 0 && (Date.now() - firstSeenAt) < PLAYABLE_METADATA_REVALIDATION_GRACE_MS
 
           // Fast path: if our local store already has the opening blocks, the
           // video is immediately watchable without waiting on remote proof.
           if (isPlayableAvailabilityHint(localHint)) return 'playable'
 
-          // Preserve explicit playable refs only when they came from a live
-          // relay/feed preview. Plain PublicBee rows are cached metadata and
-          // must be revalidated on each read.
-          if (explicitAvailability === 'playable' && relayBackedPreview) return 'playable'
-
-          // Remote playability must otherwise be explicitly proven by a peer serving hint.
-          if (peerHint?.availability === 'playable') return 'playable'
+          // Authoritative peer probes can still downgrade a stale row when a
+          // responding peer explicitly reports that the blob is not currently
+          // serviceable.
           if (peerHint?.availability && peerHint.availability !== 'unknown') {
             return peerHint.availability
           }
+
+          // PublicBee/relay preview rows already carry direct blob refs that
+          // the player can use to warm the Hypercore range. Keep explicit
+          // playable metadata visible briefly while peer proof is pending;
+          // otherwise Android hides every feed video before playback has a
+          // chance to dial the blob peers. Cached rows still revalidate after
+          // the grace window, which prevents permanent false-positive playback.
+          if (explicitAvailability === 'playable' && withinPlayableMetadataGrace) return 'playable'
+
+          if (relayBackedPreview && explicitAvailability === 'unknown') return 'unknown'
 
           return 'unavailable'
         }
@@ -1000,14 +1016,36 @@ export function createApi({
             const id = extractVideoId(video)
             const localHint = id ? localHintsById.get(id) : null
             const peerHint = id ? peerHintsById.get(id) : null
+            const explicitAvailability = video?.byteAvailability || video?.availability || null
+            const availabilityCacheKey = id
+              ? buildBlobRefCacheKey({
+                driveKey,
+                id,
+                blobsCoreKey: video?.blobsCoreKey,
+                blobId: video?.blobId,
+              })
+              : null
+            const firstSeenAt = explicitAvailability === 'playable' && availabilityCacheKey
+              ? (playableMetadataFirstSeen.get(availabilityCacheKey) || Date.now())
+              : 0
+            if (availabilityCacheKey && explicitAvailability === 'playable' && firstSeenAt) {
+              playableMetadataFirstSeen.set(availabilityCacheKey, firstSeenAt)
+            } else if (availabilityCacheKey) {
+              playableMetadataFirstSeen.delete(availabilityCacheKey)
+            }
             const availability = id
-              ? resolveExplicitVideoAvailability({ video, localHint, peerHint })
+              ? resolveExplicitVideoAvailability({
+                video: firstSeenAt ? { ...video, _playableMetadataFirstSeenAt: firstSeenAt } : video,
+                localHint,
+                peerHint,
+              })
               : 'unavailable'
 
             return {
               ...video,
               availability,
               byteAvailability: availability,
+              ...(firstSeenAt ? { _playableMetadataFirstSeenAt: firstSeenAt } : {}),
               contiguousBlocks: Number(localHint?.contiguousBlocks || peerHint?.contiguousBlocks || 0) || 0,
               hasHeadBlock: Boolean(localHint?.hasHeadBlock || peerHint?.hasHeadBlock),
             }

--- a/packages/backend/test/public-feed-api.test.mjs
+++ b/packages/backend/test/public-feed-api.test.mjs
@@ -299,7 +299,7 @@ test('listVideos falls back to the owner public bee when the channel view is emp
   t.is(videos[0]?.publicBeeKey, 'cc'.repeat(32))
 })
 
-test('listVideos marks videos unavailable when neither local cache nor peer hints prove playback', async (t) => {
+test('listVideos keeps metadata-only public bee videos playable while peer proof is pending', async (t) => {
   const driveKey = 'ee'.repeat(32)
   const publicBeeKey = 'ff'.repeat(32)
   const blobsCoreKey = 'aa'.repeat(32)
@@ -339,6 +339,8 @@ test('listVideos marks videos unavailable when neither local cache nor peer hint
           id: 'video-3',
           title: 'Needs proof',
           uploadedAt: 3,
+          availability: 'playable',
+          byteAvailability: 'playable',
           blobId: '0:8:0:1024',
           blobsCoreKey,
         }]
@@ -348,6 +350,8 @@ test('listVideos marks videos unavailable when neither local cache nor peer hint
           id,
           title: 'Needs proof',
           uploadedAt: 3,
+          availability: 'playable',
+          byteAvailability: 'playable',
           blobId: '0:8:0:1024',
           blobsCoreKey,
         }
@@ -359,8 +363,8 @@ test('listVideos marks videos unavailable when neither local cache nor peer hint
 
   t.is(requestCalls.length, 1)
   t.is(videos.length, 1)
-  t.is(videos[0]?.availability, 'unavailable')
-  t.is(videos[0]?.byteAvailability, 'unavailable')
+  t.is(videos[0]?.availability, 'playable')
+  t.is(videos[0]?.byteAvailability, 'playable')
 })
 
 test('listVideos does not mark remote videos playable from unrelated swarm peers alone', async (t) => {
@@ -559,81 +563,94 @@ test('listVideos respects authoritative unavailable hints even when peers are co
   t.is(videos[0]?.byteAvailability, 'unavailable')
 })
 
-test('listVideos revalidates cached remote availability on each read', async (t) => {
-  const driveKey = '12'.repeat(32)
-  const publicBeeKey = '34'.repeat(32)
-  const blobsCoreKey = '56'.repeat(32)
-  let requestCount = 0
+test('listVideos revalidates cached remote availability after the playable metadata grace window', async (t) => {
+  const originalDateNow = Date.now
+  let now = 1000
+  Date.now = () => now
 
-  const api = createApi({
-    ctx: {
-      store: {
-        get() {
+  try {
+    const driveKey = '12'.repeat(32)
+    const publicBeeKey = '34'.repeat(32)
+    const blobsCoreKey = '56'.repeat(32)
+    let requestCount = 0
+
+    const api = createApi({
+      ctx: {
+        store: {
+          get() {
+            return {
+              async ready() {},
+              async has() {
+                return false
+              },
+            }
+          },
+        },
+        semanticFinder: {
+          hasVideo() {
+            return true
+          },
+        },
+        metaDb: {
+          async get() { return null },
+          async put() {},
+        },
+      },
+      publicFeed: {
+        async requestAvailabilityHints() {
+          requestCount += 1
+          if (requestCount === 1) {
+            return [{
+              driveKey,
+              id: 'video-4',
+              availability: 'playable',
+              hasHeadBlock: true,
+              contiguousBlocks: 8,
+            }]
+          }
+          return []
+        },
+      },
+      loadPublicBee: async () => ({
+        async listVideos() {
+          return [{
+            id: 'video-4',
+            title: 'Remote peer only',
+            uploadedAt: 4,
+            availability: 'playable',
+            byteAvailability: 'playable',
+            blobId: '0:8:0:1024',
+            blobsCoreKey,
+          }]
+        },
+        async getVideo(id) {
           return {
-            async ready() {},
-            async has() {
-              return false
-            },
+            id,
+            title: 'Remote peer only',
+            uploadedAt: 4,
+            availability: 'playable',
+            byteAvailability: 'playable',
+            blobId: '0:8:0:1024',
+            blobsCoreKey,
           }
         },
-      },
-      semanticFinder: {
-        hasVideo() {
-          return true
-        },
-      },
-      metaDb: {
-        async get() { return null },
-        async put() {},
-      },
-    },
-    publicFeed: {
-      async requestAvailabilityHints() {
-        requestCount += 1
-        if (requestCount === 1) {
-          return [{
-            driveKey,
-            id: 'video-4',
-            availability: 'playable',
-            hasHeadBlock: true,
-            contiguousBlocks: 8,
-          }]
-        }
-        return []
-      },
-    },
-    loadPublicBee: async () => ({
-      async listVideos() {
-        return [{
-          id: 'video-4',
-          title: 'Remote peer only',
-          uploadedAt: 4,
-          blobId: '0:8:0:1024',
-          blobsCoreKey,
-        }]
-      },
-      async getVideo(id) {
-        return {
-          id,
-          title: 'Remote peer only',
-          uploadedAt: 4,
-          blobId: '0:8:0:1024',
-          blobsCoreKey,
-        }
-      },
-    }),
-  })
+      }),
+    })
 
-  const first = await api.listVideos(driveKey, publicBeeKey)
-  const second = await api.listVideos(driveKey, publicBeeKey)
+    const first = await api.listVideos(driveKey, publicBeeKey)
+    now += 31_000
+    const second = await api.listVideos(driveKey, publicBeeKey)
 
-  t.is(first[0]?.availability, 'playable')
-  t.is(first[0]?.byteAvailability, 'playable')
-  t.is(first[0]?.contiguousBlocks, 8)
-  t.is(first[0]?.hasHeadBlock, true)
-  t.is(second[0]?.availability, 'unavailable')
-  t.is(second[0]?.byteAvailability, 'unavailable')
-  t.is(requestCount, 2)
+    t.is(first[0]?.availability, 'playable')
+    t.is(first[0]?.byteAvailability, 'playable')
+    t.is(first[0]?.contiguousBlocks, 8)
+    t.is(first[0]?.hasHeadBlock, true)
+    t.is(second[0]?.availability, 'unavailable')
+    t.is(second[0]?.byteAvailability, 'unavailable')
+    t.is(requestCount, 2)
+  } finally {
+    Date.now = originalDateNow
+  }
 })
 
 test('getFeedSnapshotEntries keeps manifestUpdatedAt stable for unchanged public bee content', async (t) => {


### PR DESCRIPTION
## Summary
- Keep explicit playable PublicBee/relay preview rows visible for a short warmup grace window so Android can actually dial blob peers before the UI marks every video unavailable.
- Preserve authoritative unavailable peer hints and local head-block fast paths.
- Revalidate cached playable metadata after the grace window to avoid permanent false-positive availability.

## Test plan
- `packages/backend/node_modules/.bin/brittle packages/backend/test/public-feed-api.test.mjs`
- `packages/backend/node_modules/.bin/brittle packages/backend/test/public-feed-manager.test.mjs`
- `node packages/app/backend/mobile-handlers.test.mjs`
- `./node_modules/.bin/eslint --quiet packages/backend/src/api.js packages/backend/test/public-feed-api.test.mjs`
- `git diff --check`

## Runtime note
The remote clawd relay host is also unhealthy right now: disk is full and all relay services are crash-looping, with catalog/storage errors. This PR fixes the Android app-side availability gating bug; relay recovery still needs disk cleanup/service restart authorization.
