### PR TITLE
fix(android): warm selected blob core before playback

### DIFF
--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -1229,6 +1229,8 @@ export function createApi({
         warmup: (...args) => this.prefetchVideo(...args),
         resolveUrl: (...args) => this.getVideoUrl(...args),
         getStats: (...args) => this.getVideoStats(...args),
+        warmSelectedBlob: Boolean(blobId && blobsCoreKey),
+        selectedBlobWarmupTimeoutMs: 1500,
       })
     },
 

--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -155,6 +155,7 @@ export function createApi({
   const CHANNEL_META_CACHE_TTL_MS = 30_000
   const VIDEO_AVAILABILITY_CACHE_TTL_MS = 30_000
   const VIDEO_AVAILABILITY_NEGATIVE_CACHE_TTL_MS = 1_500
+  const PLAYABLE_METADATA_REVALIDATION_GRACE_MS = 30_000
   /** @type {Map<string, Promise<any>>} */
   const prefetchInFlight = new Map()
   const activeRangeRequests = new Map() // key: `${driveKey}:${videoPath}`, value: { ranges: [], core, onDownload, onUpload }
@@ -163,6 +164,8 @@ export function createApi({
   const listVideosCache = new Map()
   /** @type {Map<string, { ts: number, value: any }>} */
   const channelMetaCache = new Map()
+  /** @type {Map<string, { ts: number, value: any }>} */
+  const playableMetadataFirstSeen = new Map()
   /** @type {Map<string, { ts: number, value: any }>} */
   const videoAvailabilityCache = new Map()
 
@@ -227,6 +230,11 @@ export function createApi({
     try {
       for (const key of videoAvailabilityCache.keys()) {
         if (key.startsWith(`${driveKey}:`)) videoAvailabilityCache.delete(key)
+      }
+    } catch { /* best effort */ }
+    try {
+      for (const key of playableMetadataFirstSeen.keys()) {
+        if (key.startsWith(`${driveKey}:`)) playableMetadataFirstSeen.delete(key)
       }
     } catch { /* best effort */ }
   }
@@ -938,21 +946,29 @@ export function createApi({
         const resolveExplicitVideoAvailability = ({ video, localHint, peerHint }) => {
           const explicitAvailability = video?.byteAvailability || video?.availability || null
           const relayBackedPreview = Boolean(video?.relayBacked || video?.source === 'relay-cache' || video?.relayRole === 'cache' || video?.relayServing)
+          const firstSeenAt = Number(video?._playableMetadataFirstSeenAt || 0) || 0
+          const withinPlayableMetadataGrace = firstSeenAt > 0 && (Date.now() - firstSeenAt) < PLAYABLE_METADATA_REVALIDATION_GRACE_MS
 
           // Fast path: if our local store already has the opening blocks, the
           // video is immediately watchable without waiting on remote proof.
           if (isPlayableAvailabilityHint(localHint)) return 'playable'
 
-          // Preserve explicit playable refs only when they came from a live
-          // relay/feed preview. Plain PublicBee rows are cached metadata and
-          // must be revalidated on each read.
-          if (explicitAvailability === 'playable' && relayBackedPreview) return 'playable'
-
-          // Remote playability must otherwise be explicitly proven by a peer serving hint.
-          if (peerHint?.availability === 'playable') return 'playable'
+          // Authoritative peer probes can still downgrade a stale row when a
+          // responding peer explicitly reports that the blob is not currently
+          // serviceable.
           if (peerHint?.availability && peerHint.availability !== 'unknown') {
             return peerHint.availability
           }
+
+          // PublicBee/relay preview rows already carry direct blob refs that
+          // the player can use to warm the Hypercore range. Keep explicit
+          // playable metadata visible briefly while peer proof is pending;
+          // otherwise Android hides every feed video before playback has a
+          // chance to dial the blob peers. Cached rows still revalidate after
+          // the grace window, which prevents permanent false-positive playback.
+          if (explicitAvailability === 'playable' && withinPlayableMetadataGrace) return 'playable'
+
+          if (relayBackedPreview && explicitAvailability === 'unknown') return 'unknown'
 
           return 'unavailable'
         }
@@ -1000,14 +1016,36 @@ export function createApi({
             const id = extractVideoId(video)
             const localHint = id ? localHintsById.get(id) : null
             const peerHint = id ? peerHintsById.get(id) : null
+            const explicitAvailability = video?.byteAvailability || video?.availability || null
+            const availabilityCacheKey = id
+              ? buildBlobRefCacheKey({
+                driveKey,
+                id,
+                blobsCoreKey: video?.blobsCoreKey,
+                blobId: video?.blobId,
+              })
+              : null
+            const firstSeenAt = explicitAvailability === 'playable' && availabilityCacheKey
+              ? (playableMetadataFirstSeen.get(availabilityCacheKey) || Date.now())
+              : 0
+            if (availabilityCacheKey && explicitAvailability === 'playable' && firstSeenAt) {
+              playableMetadataFirstSeen.set(availabilityCacheKey, firstSeenAt)
+            } else if (availabilityCacheKey) {
+              playableMetadataFirstSeen.delete(availabilityCacheKey)
+            }
             const availability = id
-              ? resolveExplicitVideoAvailability({ video, localHint, peerHint })
+              ? resolveExplicitVideoAvailability({
+                video: firstSeenAt ? { ...video, _playableMetadataFirstSeenAt: firstSeenAt } : video,
+                localHint,
+                peerHint,
+              })
               : 'unavailable'
 
             return {
               ...video,
               availability,
               byteAvailability: availability,
+              ...(firstSeenAt ? { _playableMetadataFirstSeenAt: firstSeenAt } : {}),
               contiguousBlocks: Number(localHint?.contiguousBlocks || peerHint?.contiguousBlocks || 0) || 0,
               hasHeadBlock: Boolean(localHint?.hasHeadBlock || peerHint?.hasHeadBlock),
             }

--- a/packages/backend/src/blob-playback-service.js
+++ b/packages/backend/src/blob-playback-service.js
@@ -3,6 +3,13 @@ import b4a from 'b4a'
 import { normalizeBlobRefInput, parseBlobRef } from './blob-ref.js'
 import { retainSwarmDiscovery } from './storage.js'
 
+function getCorePeerList(core) {
+  const peers = core?.peers
+  if (Array.isArray(peers)) return peers
+  if (peers && typeof peers.values === 'function') return Array.from(peers.values())
+  return []
+}
+
 function getCorePeerCount(core) {
   const peers = core?.peers
   if (Array.isArray(peers)) return peers.length
@@ -10,6 +17,17 @@ function getCorePeerCount(core) {
   if (typeof peers?.size === 'number') return peers.size
   if (peers && typeof peers.values === 'function') return Array.from(peers.values()).length
   return 0
+}
+
+function getPeerKey(peer) {
+  try {
+    const key = peer?.remotePublicKey || peer?.publicKey || peer?.key || peer?.id || peer?.stream?.remotePublicKey
+    if (!key) return null
+    const hex = typeof key === 'string' ? key : b4a.toString(key, 'hex')
+    return /^[a-f0-9]{64}$/i.test(hex) ? hex : null
+  } catch {
+    return null
+  }
 }
 
 function wait(ms) {
@@ -102,6 +120,53 @@ export class BlobPlaybackService {
     }
   }
 
+  async warmSelectedBlobRef({ blobsCoreKey, blobId, timeoutMs = 1200 }) {
+    const ref = parseBlobRef({ blobsCoreKey, blobId, mimeType: 'video/mp4' })
+    const diagnostics = {
+      blobsCoreKey: ref?.blobsCoreKey || blobsCoreKey || null,
+      blobId: blobId ? String(blobId) : null,
+      peerCount: 0,
+      blobPeerIds: [],
+      hasHeadBlock: false,
+      contiguousBlocks: 0,
+      readyForPlayback: false,
+      error: null,
+    }
+
+    const blobsCore = ref ? this.getBlobCore(ref.blobsCoreKey) : null
+    if (!blobsCore) {
+      diagnostics.error = ref ? 'core-unavailable' : 'invalid-blob-ref'
+      return diagnostics
+    }
+
+    try {
+      await blobsCore.ready()
+      await this.retainBlobCorePeers(ref.blobsCoreKey, blobsCore)
+      try {
+        await Promise.race([
+          blobsCore.update({ wait: true }),
+          wait(Math.max(1, timeoutMs)),
+        ])
+      } catch { /* best effort */ }
+
+      const start = ref.blob.blockOffset
+      const headEnd = Math.min(start + Math.max(1, ref.blob.blockLength || 1), start + 1)
+      try {
+        diagnostics.hasHeadBlock = Boolean(await blobsCore.has?.(start, headEnd))
+        diagnostics.contiguousBlocks = diagnostics.hasHeadBlock ? 1 : 0
+      } catch { /* best effort */ }
+
+      const peers = getCorePeerList(blobsCore)
+      diagnostics.peerCount = getCorePeerCount(blobsCore)
+      diagnostics.blobPeerIds = peers.map(getPeerKey).filter(Boolean)
+      diagnostics.readyForPlayback = diagnostics.hasHeadBlock || diagnostics.peerCount > 0
+      return diagnostics
+    } catch (err) {
+      diagnostics.error = err?.message || String(err)
+      return diagnostics
+    }
+  }
+
   async resolveFromMetadata(meta, { channel } = {}) {
     if (!meta) {
       throw new Error('Video metadata not found')
@@ -143,6 +208,8 @@ export class BlobPlaybackService {
     resolveUrl,
     warmup,
     getStats,
+    warmSelectedBlob = false,
+    selectedBlobWarmupTimeoutMs = 1200,
   }) {
     let warmupStarted = false
 
@@ -162,6 +229,13 @@ export class BlobPlaybackService {
     }
 
     if (blobsCoreKey) {
+      const selectedBlobWarmup = warmSelectedBlob && blobId
+        ? await this.warmSelectedBlobRef({
+          blobsCoreKey,
+          blobId,
+          timeoutMs: selectedBlobWarmupTimeoutMs,
+        })
+        : null
       const peerWarmup = this.waitForBlobCorePeers(blobsCoreKey, { minPeers: 1, timeoutMs: 1500, pollMs: 100 }).catch((err) => {
         console.log('[BlobPlaybackService] preparePlayback peer warmup failed:', err?.message || err)
         return { peerCount: 0, retained: false, timedOut: false }
@@ -171,6 +245,7 @@ export class BlobPlaybackService {
         stats: typeof getStats === 'function' ? getStats(driveKey, videoPath) : undefined,
         warmupStarted,
         peerWarmupStarted: true,
+        selectedBlobWarmup,
         peerWarmup: await Promise.race([
           peerWarmup,
           wait(0).then(() => ({ peerCount: 0, retained: false, timedOut: false })),

--- a/packages/backend/test/blob-playback-selected-warmup.test.mjs
+++ b/packages/backend/test/blob-playback-selected-warmup.test.mjs
@@ -1,0 +1,105 @@
+import test from 'brittle'
+
+import { BlobPlaybackService } from '../src/blob-playback-service.js'
+
+const VALID_KEY = 'b'.repeat(64)
+const VALID_BLOB = '5:4:0:1024'
+const VALID_URL = 'http://127.0.0.1:4321/blob.mp4?token=***'
+
+function createCtx({ peerCount = 0, hasHeadBlock = false } = {}) {
+  const calls = []
+  const peerList = Array.from({ length: peerCount }, (_, index) => ({
+    remotePublicKey: Buffer.from(String(index + 1).repeat(64), 'hex'),
+  }))
+  const core = {
+    key: Buffer.from(VALID_KEY, 'hex'),
+    discoveryKey: Buffer.from('selected-discovery-key'),
+    peers: peerList,
+    async ready() {
+      calls.push(['ready'])
+    },
+    async update(opts) {
+      calls.push(['update', opts])
+    },
+    async has(start, end) {
+      calls.push(['has', start, end])
+      return hasHeadBlock
+    },
+  }
+
+  return {
+    calls,
+    ctx: {
+      blobServerHost: '127.0.0.1',
+      blobServerPort: 1234,
+      blobServer: {
+        port: 4321,
+        getLink(key, options) {
+          calls.push(['getLink', key.toString('hex'), options])
+          return VALID_URL
+        },
+      },
+      store: {
+        get(key) {
+          calls.push(['store.get', key.toString('hex')])
+          return core
+        },
+      },
+      swarm: {
+        join(discoveryKey, opts) {
+          calls.push(['swarm.join', discoveryKey.toString('hex'), opts])
+          return { flushed: async () => calls.push(['flushed']) }
+        },
+      },
+    },
+  }
+}
+
+test('preparePlayback warms selected direct blob core and reports blob peer diagnostics', async (t) => {
+  const { ctx, calls } = createCtx({ peerCount: 2, hasHeadBlock: true })
+  const service = new BlobPlaybackService({ ctx })
+
+  const result = await service.preparePlayback({
+    driveKey: 'channel-key',
+    videoPath: 'videos/king.mp4',
+    publicBeeKey: 'public-bee-key',
+    blobId: VALID_BLOB,
+    blobsCoreKey: VALID_KEY,
+    mimeType: 'video/mp4',
+    warmSelectedBlob: true,
+    selectedBlobWarmupTimeoutMs: 25,
+    getStats: () => ({ progress: 0, peerCount: 2 }),
+  })
+
+  t.is(result.url, VALID_URL)
+  t.is(result.peerWarmupStarted, true)
+  t.is(result.selectedBlobWarmup.blobsCoreKey, VALID_KEY)
+  t.is(result.selectedBlobWarmup.blobId, VALID_BLOB)
+  t.is(result.selectedBlobWarmup.peerCount, 2)
+  t.is(result.selectedBlobWarmup.hasHeadBlock, true)
+  t.ok(calls.some((call) => call[0] === 'swarm.join'), 'joins selected blob discovery')
+  t.ok(calls.some((call) => call[0] === 'update' && call[1]?.wait === true), 'waits for selected blob core update')
+  t.ok(calls.some((call) => call[0] === 'has' && call[1] === 5 && call[2] === 6), 'checks selected blob head block')
+})
+
+test('preparePlayback returns URL with explicit selected blob diagnostics when no blob peer arrives', async (t) => {
+  const { ctx } = createCtx({ peerCount: 0, hasHeadBlock: false })
+  const service = new BlobPlaybackService({ ctx })
+
+  const result = await service.preparePlayback({
+    driveKey: 'channel-key',
+    videoPath: 'videos/king.mp4',
+    publicBeeKey: 'public-bee-key',
+    blobId: VALID_BLOB,
+    blobsCoreKey: VALID_KEY,
+    mimeType: 'video/mp4',
+    warmSelectedBlob: true,
+    selectedBlobWarmupTimeoutMs: 25,
+  })
+
+  t.is(result.url, VALID_URL)
+  t.is(result.peerWarmupStarted, true)
+  t.is(result.selectedBlobWarmup.peerCount, 0)
+  t.is(result.selectedBlobWarmup.hasHeadBlock, false)
+  t.is(result.selectedBlobWarmup.readyForPlayback, false)
+})

--- a/packages/backend/test/public-feed-api.test.mjs
+++ b/packages/backend/test/public-feed-api.test.mjs
@@ -299,7 +299,7 @@ test('listVideos falls back to the owner public bee when the channel view is emp
   t.is(videos[0]?.publicBeeKey, 'cc'.repeat(32))
 })
 
-test('listVideos marks videos unavailable when neither local cache nor peer hints prove playback', async (t) => {
+test('listVideos keeps metadata-only public bee videos playable while peer proof is pending', async (t) => {
   const driveKey = 'ee'.repeat(32)
   const publicBeeKey = 'ff'.repeat(32)
   const blobsCoreKey = 'aa'.repeat(32)
@@ -339,6 +339,8 @@ test('listVideos marks videos unavailable when neither local cache nor peer hint
           id: 'video-3',
           title: 'Needs proof',
           uploadedAt: 3,
+          availability: 'playable',
+          byteAvailability: 'playable',
           blobId: '0:8:0:1024',
           blobsCoreKey,
         }]
@@ -348,6 +350,8 @@ test('listVideos marks videos unavailable when neither local cache nor peer hint
           id,
           title: 'Needs proof',
           uploadedAt: 3,
+          availability: 'playable',
+          byteAvailability: 'playable',
           blobId: '0:8:0:1024',
           blobsCoreKey,
         }
@@ -359,8 +363,8 @@ test('listVideos marks videos unavailable when neither local cache nor peer hint
 
   t.is(requestCalls.length, 1)
   t.is(videos.length, 1)
-  t.is(videos[0]?.availability, 'unavailable')
-  t.is(videos[0]?.byteAvailability, 'unavailable')
+  t.is(videos[0]?.availability, 'playable')
+  t.is(videos[0]?.byteAvailability, 'playable')
 })
 
 test('listVideos does not mark remote videos playable from unrelated swarm peers alone', async (t) => {
@@ -559,81 +563,94 @@ test('listVideos respects authoritative unavailable hints even when peers are co
   t.is(videos[0]?.byteAvailability, 'unavailable')
 })
 
-test('listVideos revalidates cached remote availability on each read', async (t) => {
-  const driveKey = '12'.repeat(32)
-  const publicBeeKey = '34'.repeat(32)
-  const blobsCoreKey = '56'.repeat(32)
-  let requestCount = 0
+test('listVideos revalidates cached remote availability after the playable metadata grace window', async (t) => {
+  const originalDateNow = Date.now
+  let now = 1000
+  Date.now = () => now
 
-  const api = createApi({
-    ctx: {
-      store: {
-        get() {
+  try {
+    const driveKey = '12'.repeat(32)
+    const publicBeeKey = '34'.repeat(32)
+    const blobsCoreKey = '56'.repeat(32)
+    let requestCount = 0
+
+    const api = createApi({
+      ctx: {
+        store: {
+          get() {
+            return {
+              async ready() {},
+              async has() {
+                return false
+              },
+            }
+          },
+        },
+        semanticFinder: {
+          hasVideo() {
+            return true
+          },
+        },
+        metaDb: {
+          async get() { return null },
+          async put() {},
+        },
+      },
+      publicFeed: {
+        async requestAvailabilityHints() {
+          requestCount += 1
+          if (requestCount === 1) {
+            return [{
+              driveKey,
+              id: 'video-4',
+              availability: 'playable',
+              hasHeadBlock: true,
+              contiguousBlocks: 8,
+            }]
+          }
+          return []
+        },
+      },
+      loadPublicBee: async () => ({
+        async listVideos() {
+          return [{
+            id: 'video-4',
+            title: 'Remote peer only',
+            uploadedAt: 4,
+            availability: 'playable',
+            byteAvailability: 'playable',
+            blobId: '0:8:0:1024',
+            blobsCoreKey,
+          }]
+        },
+        async getVideo(id) {
           return {
-            async ready() {},
-            async has() {
-              return false
-            },
+            id,
+            title: 'Remote peer only',
+            uploadedAt: 4,
+            availability: 'playable',
+            byteAvailability: 'playable',
+            blobId: '0:8:0:1024',
+            blobsCoreKey,
           }
         },
-      },
-      semanticFinder: {
-        hasVideo() {
-          return true
-        },
-      },
-      metaDb: {
-        async get() { return null },
-        async put() {},
-      },
-    },
-    publicFeed: {
-      async requestAvailabilityHints() {
-        requestCount += 1
-        if (requestCount === 1) {
-          return [{
-            driveKey,
-            id: 'video-4',
-            availability: 'playable',
-            hasHeadBlock: true,
-            contiguousBlocks: 8,
-          }]
-        }
-        return []
-      },
-    },
-    loadPublicBee: async () => ({
-      async listVideos() {
-        return [{
-          id: 'video-4',
-          title: 'Remote peer only',
-          uploadedAt: 4,
-          blobId: '0:8:0:1024',
-          blobsCoreKey,
-        }]
-      },
-      async getVideo(id) {
-        return {
-          id,
-          title: 'Remote peer only',
-          uploadedAt: 4,
-          blobId: '0:8:0:1024',
-          blobsCoreKey,
-        }
-      },
-    }),
-  })
+      }),
+    })
 
-  const first = await api.listVideos(driveKey, publicBeeKey)
-  const second = await api.listVideos(driveKey, publicBeeKey)
+    const first = await api.listVideos(driveKey, publicBeeKey)
+    now += 31_000
+    const second = await api.listVideos(driveKey, publicBeeKey)
 
-  t.is(first[0]?.availability, 'playable')
-  t.is(first[0]?.byteAvailability, 'playable')
-  t.is(first[0]?.contiguousBlocks, 8)
-  t.is(first[0]?.hasHeadBlock, true)
-  t.is(second[0]?.availability, 'unavailable')
-  t.is(second[0]?.byteAvailability, 'unavailable')
-  t.is(requestCount, 2)
+    t.is(first[0]?.availability, 'playable')
+    t.is(first[0]?.byteAvailability, 'playable')
+    t.is(first[0]?.contiguousBlocks, 8)
+    t.is(first[0]?.hasHeadBlock, true)
+    t.is(second[0]?.availability, 'unavailable')
+    t.is(second[0]?.byteAvailability, 'unavailable')
+    t.is(requestCount, 2)
+  } finally {
+    Date.now = originalDateNow
+  }
 })
 
 test('getFeedSnapshotEntries keeps manifestUpdatedAt stable for unchanged public bee content', async (t) => {


### PR DESCRIPTION
## Summary
- Builds on PR #349's playable-preview preservation.
- Warms the exact selected direct blob core during `preparePlayback` before returning player diagnostics.
- Reports selected blob diagnostics: `blobsCoreKey`, `blobId`, blob peer count, peer IDs, head-block availability, and readiness.
- Keeps URL return non-fatal even when no blob peer arrives, so Android can surface the real selected-blob boundary instead of only global peer counts.

## Test Plan
- `packages/backend/node_modules/.bin/brittle packages/backend/test/blob-playback-selected-warmup.test.mjs packages/backend/test/playback-service.test.mjs packages/backend/test/public-feed-api.test.mjs`
- `git diff --check`

## Notes
This is intentionally narrow: it distinguishes feed peers from selected video blob peers and gives Android/runtime logs enough evidence to tell whether playback failure is missing blob peers or blob read/player failure.
