### PR TITLE
fix(relay): publish archive jobs to P2P feed

### DIFF
--- a/packages/cli/src/archive-console.js
+++ b/packages/cli/src/archive-console.js
@@ -38,7 +38,7 @@ export async function createArchiveConsole({
 }) {
   if (!service?.runtime?.ctx?.metaDb) throw new Error('archive console requires a relay service runtime')
   const store = createArchiveJobStore({ metaDb: service.runtime.ctx.metaDb })
-  const manager = createArchiveManager({ store, downloader, publisher, logger })
+  const manager = createArchiveManager({ store, downloader, publisher, logger, onCompleted: (job) => service.publishArchiveJobToFeed?.(job) })
 
   async function model() {
     return {

--- a/packages/cli/src/archive-manager.js
+++ b/packages/cli/src/archive-manager.js
@@ -352,19 +352,39 @@ export function createArchivePublisher({ identityManager, uploadManager, api, ru
     },
     async seedChannel({ channelKey, publicBeeKey, previewVideos }) {
       if (channelKey && publicBeeKey) {
-        await runtime?.cacheManager?.addChannel?.(channelKey, publicBeeKey, 'private').catch(() => {})
-        await runtime?.publicFeed?.submitChannel?.(channelKey, publicBeeKey).catch(() => {})
-        await runtime?.seeder?.seedChannel?.({
+        const playablePreviews = Array.isArray(previewVideos) ? previewVideos.filter(Boolean) : []
+        await runtime?.cacheManager?.addChannel?.(channelKey, publicBeeKey, 'private', {
+          previewVideos: playablePreviews
+        }).catch(() => {})
+        await runtime?.publicFeed?.submitChannel?.(channelKey, publicBeeKey, {
+          previewVideos: playablePreviews,
+          videoCount: playablePreviews.length,
+          manifestUpdatedAt: Date.now()
+        }).catch(() => {})
+        const seedStats = await runtime?.seeder?.seedChannel?.({
           driveKey: channelKey,
           publicBeeKey,
-          previewVideos: Array.isArray(previewVideos) ? previewVideos : []
-        }).catch(() => {})
+          previewVideos: playablePreviews
+        }).catch(() => null)
+        const catalogEntry = seedStats?.catalogEntry || {
+          schema: 'peartube.relayCatalog',
+          catalogVersion: 1,
+          driveKey: channelKey,
+          publicBeeKey,
+          source: 'relay-cache',
+          relayRole: 'cache',
+          relayServing: true,
+          previewVideos: playablePreviews,
+          videoCount: playablePreviews.length,
+          manifestUpdatedAt: Date.now()
+        }
+        await runtime?.publishRelayCatalogEntry?.(catalogEntry).catch(() => {})
       }
     }
   }
 }
 
-export function createArchiveManager({ store, downloader, publisher, logger = null }) {
+export function createArchiveManager({ store, downloader, publisher, logger = null, onCompleted = null }) {
   if (!store) throw new Error('store is required')
   if (!downloader) throw new Error('downloader is required')
   if (!publisher) throw new Error('publisher is required')
@@ -432,6 +452,9 @@ export function createArchiveManager({ store, downloader, publisher, logger = nu
           completedAt: now(),
           error: null
         })
+        if (typeof onCompleted === 'function') {
+          await onCompleted(completed)
+        }
         return completed
       } catch (err) {
         logger?.archive?.error?.('Archive job failed', { id, error: err?.message || String(err) })

--- a/packages/cli/src/archive/source-id.js
+++ b/packages/cli/src/archive/source-id.js
@@ -1,4 +1,9 @@
-import { ARCHIVE_TYPE_YOUTUBE } from '../constants.js'
+import { ARCHIVE_TYPE_RUMBLE, ARCHIVE_TYPE_YOUTUBE } from '../constants.js'
+
+const RUMBLE_HOSTS = new Set([
+  'rumble.com',
+  'www.rumble.com'
+])
 
 const YOUTUBE_HOSTS = new Set([
   'youtube.com',
@@ -46,6 +51,19 @@ function pickYoutubeChannelId(url) {
   return null
 }
 
+function pickRumbleVideoId(url) {
+  if (!url) return null
+
+  const host = url.hostname.toLowerCase()
+  if (!RUMBLE_HOSTS.has(host)) return null
+
+  const segments = url.pathname.replace(/\/+$/, '').split('/').filter(Boolean)
+  const slug = segments[0] || null
+  if (!slug) return null
+
+  return { kind: 'video', id: slug }
+}
+
 export function classifySourceUrl(input) {
   const url = parseUrl(input)
   if (!url) {
@@ -59,6 +77,16 @@ export function classifySourceUrl(input) {
       normalizedUrl: input.trim(),
       identifier: yt.id,
       kind: yt.kind
+    }
+  }
+
+  const rumble = pickRumbleVideoId(url)
+  if (rumble) {
+    return {
+      type: ARCHIVE_TYPE_RUMBLE,
+      normalizedUrl: input.trim(),
+      identifier: rumble.id,
+      kind: rumble.kind
     }
   }
 

--- a/packages/cli/src/constants.js
+++ b/packages/cli/src/constants.js
@@ -26,7 +26,8 @@ export const RETENTION_PRIORITY = {
 }
 
 export const ARCHIVE_TYPE_YOUTUBE = 'youtube'
-export const VALID_ARCHIVE_TYPES = [ARCHIVE_TYPE_YOUTUBE]
+export const ARCHIVE_TYPE_RUMBLE = 'rumble'
+export const VALID_ARCHIVE_TYPES = [ARCHIVE_TYPE_YOUTUBE, ARCHIVE_TYPE_RUMBLE]
 
 export const DEFAULT_ARCHIVE_POLL_SECONDS = 3600
 export const DEFAULT_ARCHIVE_FORMAT = 'bv*[height<=1080][ext=mp4]+ba[ext=m4a]/b[height<=1080][ext=mp4]/b'

--- a/packages/cli/src/service.js
+++ b/packages/cli/src/service.js
@@ -343,6 +343,75 @@ export async function createRelayService({
     return { accepted: true, retentionClass: decision.retentionClass, reason: decision.reason }
   }
 
+  async function publishArchiveJobToFeed(job) {
+    if (closed) return { published: false, reason: 'closed' }
+    if (job?.status !== 'completed') return { published: false, reason: 'not-completed' }
+    if (!job?.channelKey || !job?.publicBeeKey || !job?.previewVideo?.id) {
+      return { published: false, reason: 'missing-refs' }
+    }
+
+    const previewVideos = [{
+      ...job.previewVideo,
+      publicBeeKey: job.publicBeeKey || job.previewVideo.publicBeeKey || null,
+      channelKey: job.channelKey,
+      driveKey: job.channelKey,
+      relayBacked: true,
+      source: job.previewVideo.source || 'relay-cache',
+      relayRole: job.previewVideo.relayRole || 'cache',
+      relayServing: true,
+      availability: job.previewVideo.availability || 'playable',
+      byteAvailability: job.previewVideo.byteAvailability || job.previewVideo.availability || 'playable'
+    }]
+    const manifestUpdatedAt = Number(job.completedAt || job.updatedAt || nowFn()) || Date.now()
+
+    await relayCatalog.upsertChannel({
+      channelKey: job.channelKey,
+      publicBeeKey: job.publicBeeKey,
+      source: 'archive-job',
+      retentionClass: 'private',
+      relayRole: 'cache',
+      relayServing: true,
+      lastDecisionReason: 'archive-completed',
+      lastSeenAt: manifestUpdatedAt,
+      mirroredAt: manifestUpdatedAt,
+      previewVideos,
+      unavailableVideos: [],
+      videoCount: previewVideos.length,
+      manifestUpdatedAt
+    })
+
+    await runtime.cacheManager?.addChannel?.(job.channelKey, job.publicBeeKey, 'private', {
+      previewVideos
+    }).catch(() => {})
+    await runtime.publicFeed?.submitChannel?.(job.channelKey, job.publicBeeKey, {
+      channelName: job.channelName || previewVideos[0]?.channelName || null,
+      previewVideos,
+      videoCount: previewVideos.length,
+      manifestUpdatedAt
+    }).catch(() => {})
+    const seedStats = await runtime.seeder?.seedChannel?.({
+      driveKey: job.channelKey,
+      publicBeeKey: job.publicBeeKey,
+      previewVideos
+    }).catch(() => null)
+    const catalogEntry = seedStats?.catalogEntry || {
+      schema: 'peartube.relayCatalog',
+      catalogVersion: 1,
+      driveKey: job.channelKey,
+      publicBeeKey: job.publicBeeKey,
+      source: 'relay-cache',
+      relayRole: 'cache',
+      relayServing: true,
+      previewVideos,
+      unavailableVideos: [],
+      videoCount: previewVideos.length,
+      manifestUpdatedAt
+    }
+    await runtime.publishRelayCatalogEntry?.(catalogEntry).catch(() => {})
+    await persistStatus()
+    return { published: true, previewVideos: previewVideos.length }
+  }
+
   function scheduleCandidate(candidate) {
     queue = queue.then(() => processCandidate(candidate))
     return queue
@@ -386,6 +455,22 @@ export async function createRelayService({
         feedEntries: status.runtime.feedEntries,
         mirroredChannels: status.summary.totalChannels
       })
+
+      if (runtime.ctx?.metaDb) {
+        const store = createArchiveJobStore({ metaDb: runtime.ctx.metaDb })
+        const jobs = await store.listJobs().catch(() => [])
+        for (const job of jobs) {
+          if (job?.status === 'completed') {
+            await publishArchiveJobToFeed(job).catch((err) => {
+              logger.archive.warn('Completed archive job feed publication failed', {
+                id: job.id || null,
+                videoId: job.videoId || null,
+                error: err?.message || String(err)
+              })
+            })
+          }
+        }
+      }
 
       if (config.archive?.uiEnabled) {
         const runtimeFsModule = fsModule || await import('#fs')
@@ -508,6 +593,9 @@ export async function createRelayService({
     async processCandidate(candidate) {
       return scheduleCandidate(candidate)
     },
+    async publishArchiveJobToFeed(job) {
+      return publishArchiveJobToFeed(job)
+    },
     async enqueueArchiveJob(input, { runNow = false } = {}) {
       if (!runtime.ctx?.metaDb) throw new Error('archive jobs require relay runtime metadata storage')
       const runtimeFsModule = fsModule || await import('#fs')
@@ -535,7 +623,8 @@ export async function createRelayService({
           api: runtime.api,
           runtime,
           fs: runtimeFsModule
-        })
+        }),
+        onCompleted: (job) => service.publishArchiveJobToFeed(job)
       })
       const job = await manager.enqueue(input)
       if (runNow) return manager.runJob(job.id)

--- a/packages/cli/test/archive.test.mjs
+++ b/packages/cli/test/archive.test.mjs
@@ -192,6 +192,12 @@ test('classifySourceUrl recognises YouTube channels, handles, and playlists', (t
     identifier: 'PLxyz',
     kind: 'playlist'
   })
+  t.alike(classifySourceUrl('https://rumble.com/v7afkp6-america-first-ep.-1689.html'), {
+    type: 'rumble',
+    normalizedUrl: 'https://rumble.com/v7afkp6-america-first-ep.-1689.html',
+    identifier: 'v7afkp6-america-first-ep.-1689.html',
+    kind: 'video'
+  })
   t.is(classifySourceUrl('https://example.com/feed').type, null)
   t.is(classifySourceUrl('not-a-url').type, null)
 })


### PR DESCRIPTION
## Summary
- publish completed archive WebUI jobs into the P2P/public-feed path with playable preview refs
- republish existing completed archive jobs on relay startup so old imports are not stranded in job state
- preserve preview refs when archive jobs seed/cache their relay-owned channels
- accept Rumble archive source URLs in relay configs so current live relay configs do not crash-loop on startup

## Test Plan
- `node --check packages/cli/src/archive-manager.js`
- `node --check packages/cli/src/archive-console.js`
- `node --check packages/cli/src/service.js`
- `node --check packages/cli/src/archive/source-id.js`
- `node --check packages/cli/src/constants.js`
- `node --test packages/cli/test/archive.test.mjs packages/cli/test/service.test.mjs`
- `node packages/cli/bin.js validate --config /home/user/.config/peartube-relay/config.json`
- `node packages/cli/bin.js validate --config /home/user/.config/peartube-relay-2/config.json`
- `node packages/cli/bin.js validate --config /home/user/.config/peartube-relay-3/config.json`
- `node packages/cli/bin.js validate --config /home/user/.config/peartube-relay-4/config.json`

## Live relay proof
- local relays restarted on this branch and exposed archived preview refs through relay status
- all four relays reported `feedEntries=28`, `feedConnections=3`, and one completed archive preview each after settle
