### PR TITLE
fix(relay): promote discovered peers into feed sockets

### DIFF
--- a/packages/cli/src/runtime.js
+++ b/packages/cli/src/runtime.js
@@ -143,6 +143,14 @@ export async function createRelayRuntime({ config, logger } = {}) {
     }
   }
 
+  ctx.swarm.on('peer', (peer, topic) => {
+    try {
+      publicFeed.handleDiscoveredPeer(peer, topic)
+    } catch (err) {
+      logger.runtime?.warn('Shared-topic peer discovery promotion failed', { error: err?.message || String(err) })
+    }
+  })
+
   ctx.swarm.on('connection', (conn, info) => {
     publicFeed.handleConnection(conn, info)
   })

--- a/packages/cli/test/cli.test.mjs
+++ b/packages/cli/test/cli.test.mjs
@@ -222,8 +222,8 @@ test('relay runtime source wires client-equivalent feed availability providers',
   t.ok(content.includes('this.api.getAvailabilityHints(requests, conn)'), 'relay availability provider should use the same API path as clients')
   t.ok(content.includes('publicFeed.setFeedSnapshotProvider'), 'relay runtime should gossip compact playable feed snapshots')
   t.ok(content.includes('this.api.getFeedSnapshotEntries(entries, { limitPerChannel: 3 })'), 'relay feed snapshot provider should use the same API path as clients')
-  t.absent(content.includes("ctx.swarm.on('peer'"), 'relay runtime should not install app-level shared-topic peer discovery hooks')
-  t.absent(content.includes('publicFeed.handleDiscoveredPeer(peer, topic)'), 'relay runtime should leave peer discovery and dialing under storage-owned Hyperswarm control')
+  t.ok(content.includes("ctx.swarm.on('peer'"), 'relay runtime should promote shared-topic peer discoveries into Hyperswarm socket candidates')
+  t.ok(content.includes('publicFeed.handleDiscoveredPeer(peer, topic)'), 'relay runtime should pass discovered shared-topic peers through the same promotion path as app backends')
 })
 
 test('legacy relay init leaves shared-topic discovery under storage ownership', async (t) => {


### PR DESCRIPTION
## Summary
- Wires standalone relay runtime to consume Hyperswarm shared-topic `peer` discoveries.
- Passes discovered peers through `PublicFeedManager.handleDiscoveredPeer(peer, topic)` so queued/waiting relay candidates can be promoted/requeued into real sockets.
- Updates the relay runtime source regression so this hook must be present in release/runtime code.

## Why
Android v0.1.173 can connect to desktop/iOS peers but not standalone relays. The live relay runtime had this patch locally, but `origin/main` and the `v0.1.173` tag did not, so the APK/release path was testing relays whose published code never promoted discovered peers into feed sockets.

## Test Plan
- `packages/cli/node_modules/.bin/brittle packages/cli/test/cli.test.mjs`
- `node --check packages/cli/src/runtime.js`
- `packages/backend/node_modules/.bin/brittle packages/backend/test/public-feed-manager.test.mjs`
- `git diff --check`
