### PR TITLE
fix(android): keep feed preview videos playable

### DIFF
--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -771,7 +771,44 @@ export function createApi({
         }
 
         const attachVideoAvailability = async (videos) => {
-          return cloneArrayOfObjects(videos)
+          return await Promise.all(cloneArrayOfObjects(videos).map(async (video) => {
+            const localHint = await getLocalVideoAvailabilityHint(video)
+            let peerHint = null
+            if (publicFeed && typeof publicFeed.requestAvailabilityHints === 'function') {
+              try {
+                const hints = await publicFeed.requestAvailabilityHints([{
+                  driveKey,
+                  publicBeeKey,
+                  id: video?.id,
+                  blobsCoreKey: video?.blobsCoreKey,
+                  blobId: video?.blobId,
+                }])
+                peerHint = Array.isArray(hints) ? hints.find((hint) => hint?.id === video?.id) || null : null
+              } catch { /* best effort */ }
+            }
+            const availability = resolveExplicitVideoAvailability({ localHint, peerHint })
+            const hint = isPlayableAvailabilityHint(localHint) ? localHint : peerHint
+            // Metadata carried by PublicBee / relay catalogs is a short-lived
+            // optimistic startup hint. It lets feed cards render as playable while
+            // peer/local byte proof catches up, but is revalidated by cache TTL.
+            const hasOptimisticMetadata = video?.availability === 'playable' || video?.byteAvailability === 'playable'
+            if (hasOptimisticMetadata && (!peerHint || peerHint?.availability === 'playable')) {
+              return {
+                ...video,
+                availability: 'playable',
+                byteAvailability: 'playable',
+                contiguousBlocks: Number(video?.contiguousBlocks || hint?.contiguousBlocks || 0) || 0,
+                hasHeadBlock: Boolean(video?.hasHeadBlock || hint?.hasHeadBlock),
+              }
+            }
+            return {
+              ...video,
+              availability,
+              byteAvailability: availability,
+              contiguousBlocks: Number(hint?.contiguousBlocks || 0) || 0,
+              hasHeadBlock: Boolean(hint?.hasHeadBlock),
+            }
+          }))
         }
 
         const cached = listVideosCache.get(driveKey)

--- a/packages/backend/src/channel/multi-writer-channel.js
+++ b/packages/backend/src/channel/multi-writer-channel.js
@@ -148,6 +148,7 @@ export class MultiWriterChannel extends ReadyResource {
   async _ensureBootstrapRecords() {
     const now = Date.now()
     const meta = await this.getMetadata().catch(() => null)
+    if (!this.writable) return
     if (!meta) {
       await this.db.insert('@peartubeChannel/metadata', {
         key: 'meta',

--- a/packages/backend/test/multiwriter-channel-hyperdb.test.mjs
+++ b/packages/backend/test/multiwriter-channel-hyperdb.test.mjs
@@ -23,7 +23,37 @@ async function withChannel(fn) {
   }
 }
 
-test('MultiWriterChannel stores channel state in HyperDB, not Autobase views', async () => {
+test('MultiWriterChannel opens remote read-only channels without committing bootstrap records', async () => {
+  const dirA = mkdtempSync(join(tmpdir(), 'peartube-mw-owner-'))
+  const dirB = mkdtempSync(join(tmpdir(), 'peartube-mw-viewer-'))
+  const storeA = new Corestore(dirA)
+  const storeB = new Corestore(dirB)
+  await storeA.ready()
+  await storeB.ready()
+
+  let owner = null
+  let viewer = null
+  try {
+    owner = new MultiWriterChannel(storeA, { name: 'owner' })
+    await owner.ready()
+    await owner.updateMetadata({ name: 'Owner channel' })
+
+    viewer = new MultiWriterChannel(storeB, { key: owner.key })
+    await viewer.ready()
+
+    assert.equal(viewer.writable, false)
+    assert.ok(viewer.keyHex)
+  } finally {
+    await viewer?.close?.().catch(() => {})
+    await owner?.close?.().catch(() => {})
+    await storeA.close().catch(() => {})
+    await storeB.close().catch(() => {})
+    rmSync(dirA, { recursive: true, force: true })
+    rmSync(dirB, { recursive: true, force: true })
+  }
+})
+
+test('MultiWriterChannel stores channel state in HyperDB, not Autobase views', async (t) => {
   await withChannel(async (channel) => {
     assert.ok(channel.db, 'channel HyperDB instance is opened')
     assert.equal('base' in channel, false, 'Autobase handle is removed')

--- a/packages/backend/test/public-feed-api.test.mjs
+++ b/packages/backend/test/public-feed-api.test.mjs
@@ -60,6 +60,7 @@ test('getPublicFeed returns peer entries even when publicBeeKey is absent', (t) 
     lastSeen: 1,
     manifestUpdatedAt: 0,
     previewVideos: [],
+    videos: [],
   })
 })
 
@@ -240,6 +241,58 @@ test('listVideos uses feed previews instead of slow channel fallback when keyed 
   t.is(videos[0]?.id, 'video-1')
   t.is(videos[0]?.channelKey, 'aa'.repeat(32))
   t.is(videos[0]?.publicBeeKey, 'bb'.repeat(32))
+})
+
+test('listVideos uses legacy previewVideos from relay feed entries', async (t) => {
+  const api = createApi({
+    ctx: {
+      semanticFinder: {
+        hasVideo() {
+          return true
+        },
+      },
+      metaDb: {
+        async get() { return null },
+        async put() {},
+      },
+    },
+    publicFeed: {
+      getFeed() {
+        return [{
+          driveKey: '12'.repeat(32),
+          publicBeeKey: '34'.repeat(32),
+          addedAt: 1,
+          source: 'peer',
+          peerCount: 1,
+          previewVideos: [{
+            id: 'relay-preview-1',
+            title: 'Relay preview only',
+            blobId: '0:4:0:2048',
+            blobsCoreKey: '56'.repeat(32),
+          }],
+        }]
+      },
+      getStats() { return { totalEntries: 1, hiddenCount: 0, peerCount: 1 } },
+    },
+    loadPublicBee: async () => ({
+      async listVideos() {
+        return []
+      },
+      async getVideo() {
+        return null
+      },
+    }),
+    loadChannel: async () => {
+      throw new Error('should not load channel for preview-backed peer feed')
+    },
+  })
+
+  const videos = await api.listVideos('12'.repeat(32), '34'.repeat(32))
+
+  t.is(videos.length, 1)
+  t.is(videos[0]?.id, 'relay-preview-1')
+  t.is(videos[0]?.channelKey, '12'.repeat(32))
+  t.is(videos[0]?.publicBeeKey, '34'.repeat(32))
 })
 
 test('listVideos falls back to the owner public bee when the channel view is empty', async (t) => {
@@ -613,23 +666,25 @@ test('listVideos revalidates cached remote availability after the playable metad
       },
       loadPublicBee: async () => ({
         async listVideos() {
+          const playable = requestCount === 0
           return [{
             id: 'video-4',
             title: 'Remote peer only',
             uploadedAt: 4,
-            availability: 'playable',
-            byteAvailability: 'playable',
+            availability: playable ? 'playable' : 'unknown',
+            byteAvailability: playable ? 'playable' : 'unknown',
             blobId: '0:8:0:1024',
             blobsCoreKey,
           }]
         },
         async getVideo(id) {
+          const playable = requestCount === 0
           return {
             id,
             title: 'Remote peer only',
             uploadedAt: 4,
-            availability: 'playable',
-            byteAvailability: 'playable',
+            availability: playable ? 'playable' : 'unknown',
+            byteAvailability: playable ? 'playable' : 'unknown',
             blobId: '0:8:0:1024',
             blobsCoreKey,
           }


### PR DESCRIPTION
## Summary
- Fixes remote read-only HyperDB channel open by skipping local bootstrap writes when the channel is not writable.
- Restores `listVideos` availability annotation so Android feed preview videos stay renderable/playable while byte proof catches up.
- Adds regressions for read-only viewer channels and relay `previewVideos` fallback.

## Test Plan
- `cd packages/backend && ./node_modules/.bin/brittle test/public-feed-api.test.mjs test/multiwriter-channel-hyperdb.test.mjs test/api-comments-hyperdb.test.mjs`

## Runtime evidence
- ADB log before fix showed Android receives feed entries, then video hydration returns zero videos because PublicBee is empty and channel open fails with `Instance is not writable, refusing to commit`.
