### PR TITLE
fix(android): preserve restored feed previews as playable

### DIFF
--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -792,7 +792,8 @@ export function createApi({
             // optimistic startup hint. It lets feed cards render as playable while
             // peer/local byte proof catches up, but is revalidated by cache TTL.
             const hasOptimisticMetadata = video?.availability === 'playable' || video?.byteAvailability === 'playable'
-            if (hasOptimisticMetadata && (!peerHint || peerHint?.availability === 'playable')) {
+            const hasFeedPreviewGrace = video?.requiresAvailabilityProbe && video?.restoredFromCache && video?.blobId && video?.blobsCoreKey
+            if ((hasOptimisticMetadata || hasFeedPreviewGrace) && (!peerHint || peerHint?.availability === 'playable')) {
               return {
                 ...video,
                 availability: 'playable',

--- a/packages/backend/test/public-feed-api.test.mjs
+++ b/packages/backend/test/public-feed-api.test.mjs
@@ -295,6 +295,70 @@ test('listVideos uses legacy previewVideos from relay feed entries', async (t) =
   t.is(videos[0]?.publicBeeKey, '34'.repeat(32))
 })
 
+test('listVideos keeps restored relay preview refs playable while availability proof is pending', async (t) => {
+  const driveKey = '13'.repeat(32)
+  const publicBeeKey = '35'.repeat(32)
+  const blobsCoreKey = '57'.repeat(32)
+  const api = createApi({
+    ctx: {
+      store: {
+        get() {
+          return {
+            async ready() {},
+            async has() { return false },
+          }
+        },
+      },
+      semanticFinder: {
+        hasVideo() { return true },
+      },
+      metaDb: {
+        async get() { return null },
+        async put() {},
+      },
+    },
+    publicFeed: {
+      getFeed() {
+        return [{
+          driveKey,
+          publicBeeKey,
+          addedAt: 1,
+          source: 'peer',
+          peerCount: 1,
+          restoredFromCache: true,
+          requiresAvailabilityProbe: true,
+          previewVideos: [{
+            id: 'restored-relay-preview-1',
+            title: 'Restored relay preview',
+            blobId: '0:4:0:2048',
+            blobsCoreKey,
+            availability: 'unknown',
+            byteAvailability: 'unknown',
+            restoredFromCache: true,
+            requiresAvailabilityProbe: true,
+          }],
+        }]
+      },
+      getStats() { return { totalEntries: 1, hiddenCount: 0, peerCount: 1 } },
+      async requestAvailabilityHints() { return [] },
+    },
+    loadPublicBee: async () => ({
+      async listVideos() { return [] },
+      async getVideo() { return null },
+    }),
+    loadChannel: async () => {
+      throw new Error('should not load channel for restored preview-backed peer feed')
+    },
+  })
+
+  const videos = await api.listVideos(driveKey, publicBeeKey)
+
+  t.is(videos.length, 1)
+  t.is(videos[0]?.id, 'restored-relay-preview-1')
+  t.is(videos[0]?.availability, 'playable')
+  t.is(videos[0]?.byteAvailability, 'playable')
+})
+
 test('listVideos falls back to the owner public bee when the channel view is empty', async (t) => {
   let channelLoads = 0
   let publicBeeReads = 0


### PR DESCRIPTION
## Summary
- Keeps restored relay preview videos with direct blob refs playable while availability proof is pending.
- Adds a regression for the v0.1.177 Android behavior where feed entries hydrate but restored preview rows are downgraded to unavailable and filtered out.

## Root cause
Phone logs from v0.1.177 show feed discovery works, but hydration still returns zero videos:

```text
[API] Returning 50 feed entries (1 peers, keyed=50, fallback=0, raw=50)
[HomeTiming] feedHydrationFirstPass ... videos: 0
[API] LIST_VIDEOS: PublicBee returned 0 videos
[API] LIST_VIDEOS: PublicBee empty, using relay/feed preview direct refs
```

The missing case is restored/cache relay previews: `PublicFeedManager` intentionally downgrades restored preview `availability` to `unknown`, then `attachVideoAvailability()` turns that into `unavailable` when peer proof has not returned yet. Mobile filters those rows out before blob warmup can begin.

## Test Plan
- `cd packages/backend && ./node_modules/.bin/brittle test/public-feed-api.test.mjs test/public-feed-manager.test.mjs test/multiwriter-channel-hyperdb.test.mjs test/api-comments-hyperdb.test.mjs`
