### PR TITLE
fix(android): avoid unready playback URL cache hits

### DIFF
--- a/packages/app/app/(tabs)/discover.tsx
+++ b/packages/app/app/(tabs)/discover.tsx
@@ -407,7 +407,7 @@ export default function VerticalDiscoveryScreen() {
     const isStalePlaybackRequest = () => pendingPlayKeyRef.current !== playKey || playbackRequestSeqRef.current !== requestSeq
 
     try {
-      const cachedUrl = cacheKey ? getCachedVideoUrl(cacheKey) : null
+      const cachedUrl = cacheKey ? getCachedVideoUrl(cacheKey, { requireReady: true }) : null
       if (cachedUrl) {
         void rpc.preparePlayback(playbackRequest).catch(() => undefined)
         if (isStalePlaybackRequest()) return
@@ -420,7 +420,7 @@ export default function VerticalDiscoveryScreen() {
       const result = await rpc.preparePlayback(playbackRequest)
       if (isStalePlaybackRequest()) return
       if (result?.url) {
-        if (cacheKey) setCachedVideoUrl(cacheKey, result.url)
+        if (cacheKey) setCachedVideoUrl(cacheKey, result.url, Boolean(result.selectedBlobWarmup?.readyForPlayback))
         setShortsVideoUrl(result.url)
         setShortsPlaybackSession((prev) => prev + 1)
       }

--- a/packages/app/app/(tabs)/index.tsx
+++ b/packages/app/app/(tabs)/index.tsx
@@ -236,7 +236,7 @@ export default function HomeScreen() {
         blobsCoreKey: videoAny.blobsCoreKey || undefined,
         mimeType: videoAny.mimeType || undefined,
       })
-      if (result?.url) setCachedVideoUrl(cacheKey, result.url)
+      if (result?.url) setCachedVideoUrl(cacheKey, result.url, Boolean(result.selectedBlobWarmup?.readyForPlayback))
     } catch {
       // Best-effort URL warming; playback still resolves on tap.
     } finally {
@@ -766,7 +766,7 @@ export default function HomeScreen() {
         videoAny.blobId || undefined,
         videoAny.blobsCoreKey || undefined,
       )
-      const cachedUrl = cacheKey ? getCachedVideoUrl(cacheKey) : null
+      const cachedUrl = cacheKey ? getCachedVideoUrl(cacheKey, { requireReady: true }) : null
       const playbackRequest = {
         channelKey: video.channelKey,
         videoId: videoRef,
@@ -783,7 +783,7 @@ export default function HomeScreen() {
       const result = await rpc.preparePlayback(playbackRequest)
 
       if (result?.url) {
-        if (cacheKey) setCachedVideoUrl(cacheKey, result.url)
+        if (cacheKey) setCachedVideoUrl(cacheKey, result.url, Boolean(result.selectedBlobWarmup?.readyForPlayback))
         loadAndPlayVideo(video, result.url)
       }
     } catch (err) {
@@ -814,7 +814,7 @@ export default function HomeScreen() {
         videoAny.blobId || undefined,
         videoAny.blobsCoreKey || undefined,
       )
-      const cachedUrl = cacheKey ? getCachedVideoUrl(cacheKey) : null
+      const cachedUrl = cacheKey ? getCachedVideoUrl(cacheKey, { requireReady: true }) : null
       const playbackRequest = {
         channelKey: video.channelKey,
         videoId: videoRef,
@@ -831,7 +831,7 @@ export default function HomeScreen() {
       const result = await rpc.preparePlayback(playbackRequest)
 
       if (result?.url) {
-        if (cacheKey) setCachedVideoUrl(cacheKey, result.url)
+        if (cacheKey) setCachedVideoUrl(cacheKey, result.url, Boolean(result.selectedBlobWarmup?.readyForPlayback))
         // Load video into the overlay player (animates from mini to fullscreen)
         loadAndPlayVideo(video, result.url)
       }

--- a/packages/app/app/video/[id].tsx
+++ b/packages/app/app/video/[id].tsx
@@ -479,7 +479,7 @@ function MobileVideoPlayerScreen() {
         videoAny.blobId || undefined,
         videoAny.blobsCoreKey || undefined,
       )
-      const cachedUrl = cacheKey ? getCachedVideoUrl(cacheKey) : null
+      const cachedUrl = cacheKey ? getCachedVideoUrl(cacheKey, { requireReady: true }) : null
       if (cachedUrl) {
         if (!mountedRef.current || loadGenerationRef.current !== generation) return
         loadAndPlayVideo(videoData, cachedUrl)
@@ -504,7 +504,7 @@ function MobileVideoPlayerScreen() {
       if (!mountedRef.current || loadGenerationRef.current !== generation) return
 
       if (result?.url) {
-        if (cacheKey) setCachedVideoUrl(cacheKey, result.url)
+        if (cacheKey) setCachedVideoUrl(cacheKey, result.url, Boolean(result.selectedBlobWarmup?.readyForPlayback))
         // Use context's loadAndPlayVideo - this uses the shared player
         loadAndPlayVideo(videoData, result.url)
 

--- a/packages/app/lib/discover-feed-controller.js
+++ b/packages/app/lib/discover-feed-controller.js
@@ -148,7 +148,7 @@ export async function warmNextPlaybackUrls({
     if (cacheKey) inflightPlaybackWarmups?.current?.add?.(cacheKey)
     try {
       const result = await preparePlayback?.(playbackRequest)
-      if (result?.url && cacheKey) setCachedVideoUrl(cacheKey, result.url)
+      if (result?.url && cacheKey) setCachedVideoUrl(cacheKey, result.url, Boolean(result?.selectedBlobWarmup?.readyForPlayback))
       return result?.url || null
     } finally {
       if (cacheKey) inflightPlaybackWarmups?.current?.delete?.(cacheKey)

--- a/packages/app/lib/video-url-cache.ts
+++ b/packages/app/lib/video-url-cache.ts
@@ -1,6 +1,7 @@
 type CacheEntry = {
   url: string
   expiresAt: number
+  readyForPlayback?: boolean
 }
 
 const VIDEO_URL_CACHE_TTL_MS = 2 * 60 * 1000
@@ -18,7 +19,7 @@ export function makeVideoUrlCacheKey(
   return `${normalizedChannelKey}:${normalizedVideoRef}:${blobId || ''}:${blobsCoreKey || ''}`
 }
 
-export function getCachedVideoUrl(cacheKey: string): string | null {
+export function getCachedVideoUrl(cacheKey: string, options: { requireReady?: boolean } = {}): string | null {
   const now = Date.now()
   const cached = videoUrlCache.get(cacheKey)
   if (!cached) return null
@@ -26,12 +27,14 @@ export function getCachedVideoUrl(cacheKey: string): string | null {
     videoUrlCache.delete(cacheKey)
     return null
   }
+  if (options.requireReady && !cached.readyForPlayback) return null
   return cached.url
 }
 
-export function setCachedVideoUrl(cacheKey: string, url: string): void {
+export function setCachedVideoUrl(cacheKey: string, url: string, readyForPlayback?: boolean): void {
   videoUrlCache.set(cacheKey, {
     url,
+    readyForPlayback,
     expiresAt: Date.now() + VIDEO_URL_CACHE_TTL_MS,
   })
 }

--- a/packages/app/tests/playback-url-cache-readiness-regression.test.mjs
+++ b/packages/app/tests/playback-url-cache-readiness-regression.test.mjs
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const appRoot = path.resolve(__dirname, '..')
+
+function readAppFile(relativePath) {
+  return fs.readFileSync(path.join(appRoot, relativePath), 'utf8')
+}
+
+test('playback URL cache records selected blob readiness, not only blob-server URLs', () => {
+  const cacheSource = readAppFile('lib/video-url-cache.ts')
+
+  assert.match(cacheSource, /readyForPlayback\?:\s*boolean/, 'cache entries should store whether selected blob warmup proved bytes or peers')
+  assert.match(cacheSource, /setCachedVideoUrl\([^)]*readyForPlayback\?:\s*boolean/s, 'cache writes should accept readiness from preparePlayback diagnostics')
+  assert.match(cacheSource, /getCachedVideoUrl\([^)]*requireReady\?:\s*boolean/s, 'cache reads should support requiring ready playback instead of any URL')
+  assert.match(cacheSource, /if \(options\.requireReady && !cached\.readyForPlayback\) return null/, 'tap playback should not reuse a URL cached before selected blob acquisition was ready')
+})
+
+test('home and vertical tap playback require ready cached URLs before attaching native player', () => {
+  const homeSource = readAppFile('app/(tabs)/index.tsx')
+  const discoverSource = readAppFile('app/(tabs)/discover.tsx')
+
+  const homePlayStart = homeSource.indexOf('const playVideo = useCallback')
+  const homePlayBlock = homeSource.slice(homePlayStart, homeSource.indexOf('// Legacy: Play video in overlay only', homePlayStart))
+  assert.match(homePlayBlock, /getCachedVideoUrl\(cacheKey, \{ requireReady: true \}\)/, 'Home taps should not attach speculative warmup URLs that are not ready')
+  assert.match(homePlayBlock, /setCachedVideoUrl\(cacheKey, result\.url, Boolean\(result\.selectedBlobWarmup\?\.readyForPlayback\)\)/, 'Home taps should record selected blob readiness')
+
+  const discoverPlayStart = discoverSource.indexOf('const playVideo = useCallback')
+  const discoverPlayBlock = discoverSource.slice(discoverPlayStart, discoverSource.indexOf('useEffect(() => {\n    if (!activeVideo', discoverPlayStart))
+  assert.match(discoverPlayBlock, /getCachedVideoUrl\(cacheKey, \{ requireReady: true \}\)/, 'Shorts taps should not attach speculative warmup URLs that are not ready')
+  assert.match(discoverPlayBlock, /setCachedVideoUrl\(cacheKey, result\.url, Boolean\(result\.selectedBlobWarmup\?\.readyForPlayback\)\)/, 'Shorts taps should record selected blob readiness')
+})
+
+test('background warmups may cache speculative URLs but mark them unready until diagnostics prove playback', () => {
+  const homeSource = readAppFile('app/(tabs)/index.tsx')
+  const controllerSource = readAppFile('lib/discover-feed-controller.js')
+
+  const warmBlock = homeSource.slice(homeSource.indexOf('const warmPlaybackUrl = useCallback'), homeSource.indexOf('const refreshFeed', homeSource.indexOf('const warmPlaybackUrl = useCallback')))
+  assert.match(warmBlock, /setCachedVideoUrl\(cacheKey, result\.url, Boolean\(result\.selectedBlobWarmup\?\.readyForPlayback\)\)/, 'Home background warmups should not imply playable bytes merely because a URL exists')
+  assert.match(controllerSource, /setCachedVideoUrl\(cacheKey, result\.url, Boolean\(result\?\.selectedBlobWarmup\?\.readyForPlayback\)\)/, 'Shorts background warmups should preserve readiness diagnostics')
+})

--- a/packages/app/tests/vertical-discovery-regression.test.mjs
+++ b/packages/app/tests/vertical-discovery-regression.test.mjs
@@ -35,10 +35,10 @@ test('vertical discovery uses paged full-screen feed and plays inline in the sho
   assert.doesNotMatch(source, /useVideoPlayerContext\(/, 'vertical discovery should not bind the Shorts player to the global watch player context')
   assert.doesNotMatch(source, /handoffToShorts\(\)/, 'Shorts playback should not hand off through the normal player')
   assert.match(source, /preparePlayback\(playbackRequest\)/, 'vertical player should resolve playback through backend preparePlayback')
-  assert.match(source, /getCachedVideoUrl\(cacheKey\)/, 'vertical player should use the short playback URL cache')
+  assert.match(source, /getCachedVideoUrl\(cacheKey(?:, \{ requireReady: true \})?\)/, 'vertical player should use the short playback URL cache')
   assert.doesNotMatch(source, /setAmbientVideoContext\(/, 'Shorts playback and comments should not update global watch-player metadata')
   assert.match(source, /setShortsVideoUrl\(/, 'vertical player should keep playback URL in local shorts-player state')
-  assert.match(source, /const cachedUrl = cacheKey \? getCachedVideoUrl\(cacheKey\) : null/, 'cached Shorts playback should attach directly to the Shorts player')
+  assert.match(source, /const cachedUrl = cacheKey \? getCachedVideoUrl\(cacheKey(?:, \{ requireReady: true \})?\) : null/, 'cached Shorts playback should attach directly to the Shorts player')
   assert.match(source, /const result = await rpc\.preparePlayback\(playbackRequest\)/, 'prepared Shorts playback should attach directly to the Shorts player')
 })
 
@@ -113,7 +113,7 @@ test('vertical discovery preloads the next few videos into the playback URL cach
   assert.match(controllerSource, /const nextVideos = \(videos \|\| \[\]\)\.slice\(activeIndex \+ 1, activeIndex \+ 1 \+ windowSize\)/, 'controller should warm the next few videos, not only one or two')
   assert.match(controllerSource, /inflightPlaybackWarmups\?\.current\?\.has\?\.\(cacheKey\)/, 'controller preload should de-dupe overlapping preparePlayback warmups')
   assert.match(controllerSource, /const result = await preparePlayback\?\.\(playbackRequest\)/, 'controller preload should await preparePlayback so it can keep the resolved URL')
-  assert.match(controllerSource, /if \(result\?\.url && cacheKey\) setCachedVideoUrl\(cacheKey, result\.url\)/, 'controller preload should populate the playback URL cache for instant swipe playback')
+  assert.match(controllerSource, /if \(result\?\.url && cacheKey\) setCachedVideoUrl\(cacheKey, result\.url(?:, Boolean\(result\?\.selectedBlobWarmup\?\.readyForPlayback\))?\)/, 'controller preload should populate the playback URL cache for instant swipe playback')
 })
 
 test('Home Discover preloads visible feed playback URLs into the shared URL cache', () => {
@@ -123,7 +123,7 @@ test('Home Discover preloads visible feed playback URLs into the shared URL cach
   assert.match(source, /inflightPlaybackWarmups\.current\.has\(cacheKey\)/, 'Home warmups should be de-duped')
   assert.match(source, /const nextVideos = feedVideosWithThumbs\.slice\(0, 4\)/, 'Home should warm the first few visible Discover cards')
   assert.match(source, /const result = await rpc\.preparePlayback\(\{[\s\S]*blobId:[\s\S]*blobsCoreKey:[\s\S]*mimeType:/, 'Home warmups should preserve direct blob playback refs')
-  assert.match(source, /if \(result\?\.url\) setCachedVideoUrl\(cacheKey, result\.url\)/, 'Home warmups should populate the shared playback URL cache')
+  assert.match(source, /if \(result\?\.url\) setCachedVideoUrl\(cacheKey, result\.url(?:, Boolean\(result\.selectedBlobWarmup\?\.readyForPlayback\))?\)/, 'Home warmups should populate the shared playback URL cache')
 })
 
 test('Home Discover falls back to public feed RPC and labels feed entries separately from live peers', () => {


### PR DESCRIPTION
## Summary
- track whether cached blob-server playback URLs are actually ready for selected blob playback
- require ready cached URLs before attaching Android/Home/Shorts/video-route players
- keep background warmups useful but mark speculative URLs unready until `selectedBlobWarmup.readyForPlayback` proves peers/head block

## Diagnosis
Physical Android showed the feed card and called `preparePlayback`, but the tapped player opened to a black indefinite load. Logcat showed direct blob URL resolution happened, then repeated `GET_VIDEO_DATA` fallback errors on the channel DB path. The dangerous part was that Home/Shorts preload cached any returned blob-server URL, even when selected blob warmup had not proven the phone had a peer/head block for that blob. A later tap could attach that speculative URL directly to ExoPlayer and skip the bounded selected-blob wait/diagnostics.

## Test plan
- `node packages/app/tests/playback-url-cache-readiness-regression.test.mjs`
- `node packages/app/tests/vertical-discovery-regression.test.mjs`
- `node packages/app/tests/playback-url-instant-regression.test.mjs`
- `packages/backend/node_modules/.bin/brittle packages/backend/test/blob-playback-selected-warmup.test.mjs packages/backend/test/playback-api.test.mjs packages/backend/test/playback-service.test.mjs`
- `git diff --check`

Known unrelated existing failure:
- `node packages/app/tests/feed-hydration.test.mjs` fails on `backend preview fallback preserves live-peer preview availability for Home rendering` against current `origin/main`; this branch does not touch that backend preview fallback path.
