### PR TITLE
fix(android): register discovery module for new architecture

### DIFF
--- a/packages/app/android/app/src/main/java/com/peartube/app/PeartubeNetworkDiscoveryPackage.kt
+++ b/packages/app/android/app/src/main/java/com/peartube/app/PeartubeNetworkDiscoveryPackage.kt
@@ -1,13 +1,35 @@
 package com.peartube.app
 
-import com.facebook.react.ReactPackage
+import com.facebook.react.TurboReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.module.model.ReactModuleInfo
+import com.facebook.react.module.model.ReactModuleInfoProvider
 import com.facebook.react.uimanager.ViewManager
 
-class PeartubeNetworkDiscoveryPackage : ReactPackage {
-  override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
-    return listOf(PeartubeNetworkDiscoveryModule(reactContext))
+class PeartubeNetworkDiscoveryPackage : TurboReactPackage() {
+  override fun getModule(name: String, reactContext: ReactApplicationContext): NativeModule? {
+    return if (name == "PeartubeNetworkDiscovery") {
+      PeartubeNetworkDiscoveryModule(reactContext)
+    } else {
+      null
+    }
+  }
+
+  override fun getReactModuleInfoProvider(): ReactModuleInfoProvider {
+    return ReactModuleInfoProvider {
+      mapOf(
+        "PeartubeNetworkDiscovery" to ReactModuleInfo(
+          "PeartubeNetworkDiscovery",
+          PeartubeNetworkDiscoveryModule::class.java.name,
+          false,
+          false,
+          false,
+          false,
+          true,
+        )
+      )
+    }
   }
 
   override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> {

--- a/packages/app/tests/android-physical-discovery-regression.test.mjs
+++ b/packages/app/tests/android-physical-discovery-regression.test.mjs
@@ -145,3 +145,13 @@ test('Home Discover separates feed counts from peers and does not call hydrating
   assert.match(source, /state === 'hydrating'[\s\S]*\? 'Loading playable previews'/, 'hydrating feed entries should not be labeled as looking for peers')
   assert.match(source, /feed entries detected; resolving playable video previews\./, 'hydrating detail should mention feed entries being resolved')
 })
+
+test('Android registers network discovery as a TurboReactPackage so release new-architecture builds expose NativeModules.PeartubeNetworkDiscovery', () => {
+  const packageSource = readAppFile('android/app/src/main/java/com/peartube/app/PeartubeNetworkDiscoveryPackage.kt')
+
+  assert.match(packageSource, /TurboReactPackage/, 'release new-architecture builds should use TurboReactPackage registration')
+  assert.match(packageSource, /override fun getModule\(name: String, reactContext: ReactApplicationContext\): NativeModule\?/, 'package should expose getModule lookup by module name')
+  assert.match(packageSource, /if \(name == "PeartubeNetworkDiscovery"\)/, 'package should return the discovery module by exported name')
+  assert.match(packageSource, /ReactModuleInfoProvider/, 'package should provide ReactModuleInfo metadata for the custom module')
+  assert.match(packageSource, /PeartubeNetworkDiscoveryModule::class\.java\.name/, 'metadata should reference the module class name')
+})


### PR DESCRIPTION
## Summary
- register `PeartubeNetworkDiscovery` via `TurboReactPackage` with `ReactModuleInfoProvider`
- keeps the module visible to release/new-architecture Android JS as `NativeModules.PeartubeNetworkDiscovery`
- adds a regression check for the exact native-module registration path

## Diagnosis
The physical Pixel log from the user's screenshot shows:

```text
PeartubeNetworkDiscovery native module is unavailable
multicastLockHeld:false
Returning 50 feed entries (0 peers ...)
Finding video peers: 0 peers
```

The app does eventually see the relay feed over WAN/DHT, but Android release builds never expose the custom native discovery module to JS. That means the app cannot confirm/acquire the multicast discovery path from JS, and the UI sits in cached/feed-present-but-no-blob-peer states. The screenshot's video is in the relay catalog and the relay status marks its blob as playable locally, so the issue is phone-side discovery/module registration, not missing relay bytes for that video.

## Test plan
- `node packages/app/tests/android-physical-discovery-regression.test.mjs`
- `node packages/app/tests/playback-url-cache-readiness-regression.test.mjs`
- `node packages/app/tests/vertical-discovery-regression.test.mjs`
- `git diff --check`

Local Android Gradle/bundle verification was blocked in this throwaway worktree by dependency install state (`bare-ffmpeg` package resolution after fresh local install). The release workflow uses the repository's normal CI install path and should be the decisive build check.
