### PR TITLE
fix(android): keep startup play tap from pausing video

### DIFF
--- a/packages/app/components/VideoPlayerOverlayImpl.tsx
+++ b/packages/app/components/VideoPlayerOverlayImpl.tsx
@@ -175,6 +175,7 @@ export function VideoPlayerOverlay() {
     currentVideo,
     videoUrl,
     isPlaying,
+    isStartingPlayback,
     isLoading,
     playerMode,
     videoStats,
@@ -1858,12 +1859,14 @@ export function VideoPlayerOverlay() {
       return
     }
 
-    if (isPlaying) {
+    if (isStartingPlayback) {
+      resumeVideo()
+    } else if (isPlaying) {
       pauseVideo()
     } else {
       resumeVideo()
     }
-  }, [isCasting, castIsPlaying, cast, isPlaying, pauseVideo, resumeVideo])
+  }, [isCasting, castIsPlaying, cast, isPlaying, isStartingPlayback, pauseVideo, resumeVideo])
 
   const handleDesktopSeekStart = useCallback(() => {
     if (effectiveDuration > 0) {

--- a/packages/app/lib/VideoPlayerContext.tsx
+++ b/packages/app/lib/VideoPlayerContext.tsx
@@ -50,6 +50,7 @@ interface VideoPlayerContextType {
 
   // Player state
   isPlaying: boolean
+  isStartingPlayback: boolean
   isLoading: boolean
   playerMode: PlayerMode
   videoStats: VideoStats | null
@@ -109,6 +110,7 @@ type VideoPlayerSessionContextType = Pick<VideoPlayerContextType,
   | 'currentVideo'
   | 'videoUrl'
   | 'isPlaying'
+  | 'isStartingPlayback'
   | 'isLoading'
   | 'playerMode'
   | 'videoStats'
@@ -1313,6 +1315,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
   }, [])
 
   const progress = duration > 0 ? currentTime / duration : 0
+  const isStartingPlayback = Boolean(currentVideo && isLoading && isPlaying)
   
   const shouldEnablePip = useMemo(() => {
     if (Platform.OS !== 'android') return false
@@ -1326,6 +1329,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
     currentVideo,
     videoUrl,
     isPlaying,
+    isStartingPlayback,
     isLoading,
     playerMode,
     videoStats,
@@ -1342,6 +1346,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
     currentVideo,
     videoUrl,
     isPlaying,
+    isStartingPlayback,
     isLoading,
     playerMode,
     videoStats,

--- a/packages/app/tests/android-video-click-starts-playing-regression.test.mjs
+++ b/packages/app/tests/android-video-click-starts-playing-regression.test.mjs
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { test } from 'node:test'
+
+const overlayPath = new URL('../components/VideoPlayerOverlayImpl.tsx', import.meta.url)
+const contextPath = new URL('../lib/VideoPlayerContext.tsx', import.meta.url)
+
+async function source(url) {
+  return readFile(url, 'utf8')
+}
+
+test('watch-page play button keeps desired playback true after Android opens initially paused', async () => {
+  const src = await source(overlayPath)
+  const handlerStart = src.indexOf('const handlePlayPause = useCallback')
+  assert.notEqual(handlerStart, -1, 'expected handlePlayPause callback')
+  const handler = src.slice(handlerStart, src.indexOf('const handleDesktopSeekStart', handlerStart))
+
+  assert.match(handler, /if \(isStartingPlayback\) \{\s*resumeVideo\(\)/, 'startup state should reassert resume instead of pausing')
+  assert.match(handler, /else if \(isPlaying\) \{\s*pauseVideo\(\)/, 'native playing state should still pause on deliberate tap after startup')
+  assert.ok(handler.indexOf('if (isStartingPlayback)') < handler.indexOf('else if (isPlaying)'), 'startup guard must run before normal isPlaying pause branch')
+})
+
+test('VideoPlayerContext exposes desired startup state separately from native playing state', async () => {
+  const src = await source(contextPath)
+
+  assert.match(src, /const isStartingPlayback = Boolean\(currentVideo && isLoading && isPlaying\)/, 'context should expose startup intent while native playback is still loading')
+  assert.match(src, /isStartingPlayback,/, 'session value should include isStartingPlayback for Android controls')
+})


### PR DESCRIPTION
## Summary
- Adds an explicit `isStartingPlayback` state for video sessions where JS has requested play but Android/expo-video has not emitted native playing yet
- Makes the watch-page play/pause button reassert resume during startup instead of interpreting the first tap as a pause
- Adds a regression covering Android videos that open initially paused/loading but should play when clicked

## Verification
- `node packages/app/tests/android-video-click-starts-playing-regression.test.mjs`
- `node packages/app/tests/android-video-opens-playing-regression.test.mjs`
- `git diff --check`
- `node_modules/.bin/eslint --quiet packages/app/components/VideoPlayerOverlayImpl.tsx packages/app/lib/VideoPlayerContext.tsx`
- `npm run lint:changed`
