### PR TITLE
fix(android): prevent release dex OOM

### DIFF
--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -114,6 +114,16 @@ jobs:
             "android.injected.signing.key.password=$ANDROID_KEY_PASSWORD" \
             >> "$HOME/.gradle/gradle.properties"
 
+      - name: Configure release Gradle memory
+        shell: bash
+        run: |
+          mkdir -p "$HOME/.gradle"
+          printf '%s\n' \
+            'org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=1024m -Dfile.encoding=UTF-8' \
+            'org.gradle.workers.max=2' \
+            'kotlin.daemon.jvmargs=-Xmx1536m' \
+            >> "$HOME/.gradle/gradle.properties"
+
       - name: Build release APK (${{ matrix.abi }})
         working-directory: packages/app/android
         env:
@@ -124,6 +134,7 @@ jobs:
             "-PtargetAbis=${{ matrix.abi }}"
             "-PreactNativeArchitectures=${{ matrix.abi }}"
             --no-daemon
+            --max-workers 2
           )
 
           if [ "$HAS_KEYSTORE" != "true" ]; then

--- a/packages/app/plugins/withAndroidAbiSplits.js
+++ b/packages/app/plugins/withAndroidAbiSplits.js
@@ -13,7 +13,9 @@ function withAndroidAbiSplits(config) {
         abi {
             reset()
             enable true
-            include "armeabi-v7a", "arm64-v8a", "x86", "x86_64"
+            def targetAbiProperty = (findProperty('targetAbis') ?: findProperty('reactNativeArchitectures') ?: '').toString()
+            def includedAbis = targetAbiProperty ? targetAbiProperty.split(',').collect { it.trim() }.findAll { it } : ["armeabi-v7a", "arm64-v8a", "x86", "x86_64"]
+            include(*includedAbis)
             universalApk false
         }
     }

--- a/packages/app/plugins/withAndroidAbiSplits.js
+++ b/packages/app/plugins/withAndroidAbiSplits.js
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
 const { withAppBuildGradle } = require('@expo/config-plugins');
 
 function withAndroidAbiSplits(config) {

--- a/packages/app/tests/ci-workflow-split-regression.test.mjs
+++ b/packages/app/tests/ci-workflow-split-regression.test.mjs
@@ -64,6 +64,7 @@ test('build workflows stay separate from publish workflows', () => {
 
 test('tagged Android releases only build the arm64-v8a APK', () => {
   const releaseAndroid = readFile('.github/workflows/release-android.yml')
+  const abiSplitsPlugin = readFile('packages/app/plugins/withAndroidAbiSplits.js')
 
   assert.match(
     releaseAndroid,
@@ -74,6 +75,26 @@ test('tagged Android releases only build the arm64-v8a APK', () => {
     releaseAndroid,
     /abi:\s*\[[^\]]*(armeabi-v7a|x86|x86_64)/,
     'release-android should skip armv7 and emulator APK builds for tagged releases',
+  )
+  assert.match(
+    releaseAndroid,
+    /--max-workers\s+2/,
+    'release-android should cap Gradle workers so dex merging does not exhaust runner heap',
+  )
+  assert.match(
+    releaseAndroid,
+    /org\.gradle\.jvmargs=-Xmx4096m/,
+    'release-android should raise Gradle heap for D8 dex merging',
+  )
+  assert.match(
+    abiSplitsPlugin,
+    /findProperty\('targetAbis'\)/,
+    'ABI split generation should honor the release workflow targetAbis property',
+  )
+  assert.doesNotMatch(
+    abiSplitsPlugin,
+    /include "armeabi-v7a", "arm64-v8a", "x86", "x86_64"/,
+    'ABI split generation should not hard-code all Android ABIs for arm64-only releases',
   )
 })
 


### PR DESCRIPTION
## Summary
- raises release Gradle heap and caps workers for the Android tag build
- makes the ABI split config honor `targetAbis` / `reactNativeArchitectures` instead of hard-coding every ABI
- extends the Android release workflow regression test to cover the D8 OOM guardrails

## Test Plan
- `node packages/app/tests/ci-workflow-split-regression.test.mjs`
- `node packages/app/tests/android-apk-build-pipeline-regression.test.mjs`
- `node -e "require('./packages/app/plugins/withAndroidAbiSplits.js'); console.log('plugin loads')"`
- `git diff --check`

## Release note
The failed `v0.1.181` Android run died at `:app:mergeExtDexRelease` with `D8: java.lang.OutOfMemoryError: Java heap space`; its publish-release failure was consequential because no APK artifact existed. This workflow/config fix needs a new tag after merge.