### PR TITLE
fix(android): reassert play when video source becomes ready

### DIFF
--- a/packages/app/components/video-player/PearInlineVideoView.tsx
+++ b/packages/app/components/video-player/PearInlineVideoView.tsx
@@ -439,7 +439,14 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
         onBuffering?.({ isBuffering: true })
       } else if (status === 'readyToPlay') {
         onBuffering?.({ isBuffering: false })
-        if (Date.now() <= seekPlaybackRecoveryUntilRef.current && isPlayingRef.current) {
+        if (!hasReceivedPlayEventRef.current && isPlayingRef.current) {
+          try {
+            player.play()
+          } catch {
+            // Best effort: Android can report readyToPlay while remaining
+            // paused if play() was requested before the source was ready.
+          }
+        } else if (Date.now() <= seekPlaybackRecoveryUntilRef.current && isPlayingRef.current) {
           player.play()
         }
       }

--- a/packages/app/tests/android-video-opens-playing-regression.test.mjs
+++ b/packages/app/tests/android-video-opens-playing-regression.test.mjs
@@ -18,3 +18,13 @@ test('Android keeps initial desired play state when expo-video emits a pre-play 
   assert.match(handler, /player\.play\(\)/, 'ignored pre-play paused events should reassert native play')
   assert.doesNotMatch(handler, /Platform\.OS === 'web' && !hasReceivedPlayEventRef\.current/, 'the pre-play paused guard must not be web-only')
 })
+
+test('Android reasserts desired play when source first becomes ready before native playing event', async () => {
+  const src = await source(inlineViewPath)
+  const handlerStart = src.indexOf("useEventListener(player, 'statusChange'")
+  assert.notEqual(handlerStart, -1, 'expected expo-video statusChange handler')
+  const handler = src.slice(handlerStart, src.indexOf("useEventListener(player, 'playToEnd'", handlerStart))
+
+  assert.match(handler, /status === 'readyToPlay'[\s\S]*!hasReceivedPlayEventRef\.current[\s\S]*isPlayingRef\.current[\s\S]*player\.play\(\)/, 'readyToPlay should reassert play when Android has desired playback but has not emitted native playing yet')
+  assert.ok(handler.indexOf("status === 'readyToPlay'") < handler.indexOf('Date.now() <= seekPlaybackRecoveryUntilRef.current'), 'initial ready-to-play reassertion should run before seek-only recovery')
+})


### PR DESCRIPTION
## Summary
- reassert expo-video play when a source reaches readyToPlay before Android emits the first native playing event
- keep the existing pre-play paused-event guard
- add a regression for click-to-play opening paused

## Tests
- node packages/app/tests/android-video-opens-playing-regression.test.mjs
- node packages/app/tests/android-video-click-starts-playing-regression.test.mjs
- node --check packages/app/tests/android-video-opens-playing-regression.test.mjs
- node --check packages/app/tests/android-video-click-starts-playing-regression.test.mjs
- git diff --check

Note: no adb binary is available in this environment, so physical Android playback proof must come from the release APK/device.