### PR TITLE
fix: render playable archive previews on Android feed

### DIFF
--- a/packages/app/lib/feed-hydration.js
+++ b/packages/app/lib/feed-hydration.js
@@ -1,8 +1,20 @@
 function getFeedEntryPriority(entry) {
   if (entry?.source === 'local') return 0
-  if ((entry?.peerCount ?? 0) > 0) return 1
-  if (entry?.publicBeeKey) return 2
-  return 3
+  if (hasRenderableDirectFeedPreview(entry)) return 1
+  if ((entry?.peerCount ?? 0) > 0) return 2
+  if (entry?.publicBeeKey) return 3
+  return 4
+}
+
+function hasRenderableDirectFeedPreview(entry) {
+  return Boolean(
+    entry?.publicBeeKey &&
+    Array.isArray(entry?.previewVideos) &&
+    entry.previewVideos.some((video) => (
+      hasDirectBlobRef(video) &&
+      (video?.byteAvailability || video?.availability) === 'playable'
+    ))
+  )
 }
 
 export function getMissingChannelMetaRequests(feedEntries, channelMeta, limit = Infinity) {

--- a/packages/app/tests/feed-hydration.test.mjs
+++ b/packages/app/tests/feed-hydration.test.mjs
@@ -58,6 +58,34 @@ test('getFeedVideoLoadEntries prioritizes local and live-peer entries before cac
   ])
 })
 
+test('getFeedVideoLoadEntries prioritizes playable relay archive previews before stale live-peer entries', () => {
+  const directPlayable = {
+    driveKey: 'relay-playable',
+    peerCount: 0,
+    publicBeeKey: 'bee-relay',
+    previewVideos: [{
+      id: 'playable-archive',
+      availability: 'playable',
+      byteAvailability: 'playable',
+      blobId: '0:1:0:32',
+      blobsCoreKey: 'aa'.repeat(32),
+    }],
+  }
+  const staleLive = { driveKey: 'stale-live', peerCount: 4, publicBeeKey: 'bee-live', previewVideos: [] }
+  const cached = { driveKey: 'cached', peerCount: 0, publicBeeKey: 'bee-cached', previewVideos: [] }
+
+  const entries = getFeedVideoLoadEntries([
+    staleLive,
+    cached,
+    directPlayable,
+  ], 2)
+
+  assert.deepEqual(entries.map((entry) => entry.driveKey), [
+    'relay-playable',
+    'stale-live',
+  ])
+})
+
 test('getFeedVideoHydrationMode uses local-only hydration for cached entries before peers arrive', () => {
   assert.equal(getFeedVideoHydrationMode({
     feedEntries: [{ driveKey: 'a' }],

--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -289,10 +289,12 @@ export function createApi({
         : []
     if (videos.length === 0) return []
     const resolvedPublicBeeKey = publicBeeKey || entry?.publicBeeKey || null
+    const feedEntryHasLivePeer = Number(entry?.peerCount || 0) > 0
     return videos
       .filter((video) => video?.id || video?.path)
       .map((video) => {
         const id = normalizeVideoId(video.id || video.path)
+        const videoAvailability = video.availability || video.byteAvailability || (feedEntryHasLivePeer ? 'playable' : null)
         return {
           ...video,
           id,
@@ -301,6 +303,8 @@ export function createApi({
           publicBeeKey: resolvedPublicBeeKey,
           relayBacked: Boolean(entry?.relayServing || entry?.relayRole === 'cache' || entry?.source === 'relay-cache'),
           mimeType: video.mimeType || 'video/mp4',
+          availability: videoAvailability || video.availability,
+          byteAvailability: video.byteAvailability || videoAvailability || video.availability,
         }
       })
   }
@@ -756,15 +760,20 @@ export function createApi({
 
         const isPlayableAvailabilityHint = (hint) => hint?.availability === 'playable'
 
-        const resolveExplicitVideoAvailability = ({ localHint, peerHint }) => {
+        const resolveExplicitVideoAvailability = ({ localHint, peerHint, video }) => {
+          const explicitAvailability = video?.byteAvailability || video?.availability || null
           // Fast path: if our local store already has the opening blocks, the
           // video is immediately watchable without waiting on remote proof.
           if (isPlayableAvailabilityHint(localHint)) return 'playable'
+          if (explicitAvailability === 'playable') return 'playable'
 
           // Remote playability must be explicitly proven by a peer serving hint.
           if (peerHint?.availability === 'playable') return 'playable'
           if (peerHint?.availability && peerHint.availability !== 'unknown') {
             return peerHint.availability
+          }
+          if (explicitAvailability && explicitAvailability !== 'unknown') {
+            return explicitAvailability
           }
 
           return 'unavailable'
@@ -786,7 +795,7 @@ export function createApi({
                 peerHint = Array.isArray(hints) ? hints.find((hint) => hint?.id === video?.id) || null : null
               } catch { /* best effort */ }
             }
-            const availability = resolveExplicitVideoAvailability({ localHint, peerHint })
+            const availability = resolveExplicitVideoAvailability({ localHint, peerHint, video })
             const hint = isPlayableAvailabilityHint(localHint) ? localHint : peerHint
             // Metadata carried by PublicBee / relay catalogs is a short-lived
             // optimistic startup hint. It lets feed cards render as playable while

--- a/packages/cli/Dockerfile
+++ b/packages/cli/Dockerfile
@@ -18,7 +18,8 @@ FROM debian:13-slim AS runtime-libs
 ARG TARGETARCH
 ARG YT_DLP_VERSION=2026.03.17
 ARG DENO_VERSION=v2.5.6
-ARG FFMPEG_VERSION=release
+ARG FFMPEG_VERSION=n7.1-latest
+ARG FFMPEG_SERIES=7.1
 ARG BGUTIL_POT_PROVIDER_VERSION=v0.8.1
 
 RUN apt-get update \
@@ -65,16 +66,16 @@ RUN case "${TARGETARCH}" in \
   && /usr/local/bin/deno --version
 
 RUN case "${TARGETARCH}" in \
-    amd64) FFMPEG_ASSET=ffmpeg-${FFMPEG_VERSION}-amd64-static.tar.xz ;; \
-    arm64) FFMPEG_ASSET=ffmpeg-${FFMPEG_VERSION}-arm64-static.tar.xz ;; \
+    amd64) FFMPEG_ASSET=ffmpeg-${FFMPEG_VERSION}-linux64-gpl-${FFMPEG_SERIES}.tar.xz ;; \
+    arm64) FFMPEG_ASSET=ffmpeg-${FFMPEG_VERSION}-linuxarm64-gpl-${FFMPEG_SERIES}.tar.xz ;; \
     *) echo "Unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
   esac \
-  && curl -fsSL "https://johnvansickle.com/ffmpeg/releases/${FFMPEG_ASSET}" \
+  && curl -fsSL "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/${FFMPEG_ASSET}" \
     -o /tmp/ffmpeg.tar.xz \
   && mkdir -p /tmp/ffmpeg \
   && tar -xJf /tmp/ffmpeg.tar.xz -C /tmp/ffmpeg --strip-components=1 \
-  && cp /tmp/ffmpeg/ffmpeg /usr/local/bin/ffmpeg \
-  && cp /tmp/ffmpeg/ffprobe /usr/local/bin/ffprobe \
+  && cp /tmp/ffmpeg/bin/ffmpeg /usr/local/bin/ffmpeg \
+  && cp /tmp/ffmpeg/bin/ffprobe /usr/local/bin/ffprobe \
   && rm -rf /tmp/ffmpeg /tmp/ffmpeg.tar.xz \
   && chmod 755 /usr/local/bin/ffmpeg /usr/local/bin/ffprobe \
   && /usr/local/bin/ffmpeg -version

--- a/packages/cli/src/archive/index.js
+++ b/packages/cli/src/archive/index.js
@@ -164,7 +164,13 @@ export function createArchiver({
         title: ytEntry.title || ''
       })
 
-      return { archived: true, status: 'archived', bytes: result.bytes }
+      return {
+        archived: true,
+        status: 'archived',
+        bytes: result.bytes,
+        channelKey: result.channelKey || null,
+        publicBeeKey: result.publicBeeKey || null
+      }
     } catch (err) {
       const updated = await state.markFailed(source.sourceId, ytEntry.id, err, {
         maxRetries: archiveConfig.maxRetries
@@ -225,6 +231,9 @@ export function createArchiver({
     let failedCount = 0
     let skippedCount = 0
     let bytesAddedThisPoll = 0
+    let channelKey = null
+    let publicBeeKey = null
+    let sawArchivedContent = false
 
     for (const ytEntry of listing) {
       if (stopped) break
@@ -232,20 +241,46 @@ export function createArchiver({
       if (result.archived) {
         archivedCount += 1
         bytesAddedThisPoll += Number(result.bytes) || 0
+        channelKey = result.channelKey || channelKey
+        publicBeeKey = result.publicBeeKey || publicBeeKey
+        sawArchivedContent = true
       } else if (result.skipped && result.status === 'budget') {
         skippedCount += 1
         // budget exhausted — stop processing this poll; the next poll will try again
         break
       } else if (result.skipped) {
         skippedCount += 1
+        if (result.status === ARCHIVE_STATUS.ARCHIVED) sawArchivedContent = true
       } else {
         failedCount += 1
       }
     }
 
+    if (sawArchivedContent) {
+      try {
+        const pub = await ensurePublisher()
+        if (typeof pub.ensureSourceChannel === 'function') {
+          const channelEntry = await pub.ensureSourceChannel(source)
+          channelKey = channelEntry?.channelKey || channelKey
+          publicBeeKey = channelEntry?.publicBeeKey || publicBeeKey
+        }
+      } catch (err) {
+        logger.archive.warn('Archive source reannounce failed', {
+          sourceId: source.sourceId,
+          error: err?.message || String(err)
+        })
+      }
+    }
+
+    const existingSourceRecord = await state.getSource(source.sourceId).catch(() => null)
+
     await state.putSource(source.sourceId, {
+      ...(existingSourceRecord || {}),
       url: source.url,
       type: source.type,
+      label: source.label || existingSourceRecord?.label || null,
+      channelKey: channelKey || existingSourceRecord?.channelKey || null,
+      publicBeeKey: publicBeeKey || existingSourceRecord?.publicBeeKey || null,
       lastPolledAt: Date.now(),
       lastError: null,
       lastSeenVideos: listing.length,

--- a/packages/cli/test/archive.test.mjs
+++ b/packages/cli/test/archive.test.mjs
@@ -438,6 +438,95 @@ test('createArchiver getSourcesStatus exposes per-source state for the WebUI', a
   t.alike(status[0].counts, { archived: 1, failed: 1, abandoned: 0 })
 })
 
+test('createArchiver poll preserves archive source channel keys after publishing', async (t) => {
+  const metaDb = makeFakeMetaDb()
+  const config = resolveRelayConfig({
+    storage: { path: '/tmp/peartube-test', maxBytes: 100000 },
+    archive: {
+      enabled: true,
+      tmpPath: '/tmp/peartube-test/archive-tmp',
+      sources: [{ url: 'https://www.youtube.com/@chan', label: 'Chan' }]
+    }
+  }, { env: {} })
+
+  const archiver = createArchiver({
+    config,
+    runtime: makeFakeRuntime({ metaDb }),
+    logger: makeFakeLogger(),
+    fs: makeFakeFs({ '/tmp/v1.mp4': 'video bytes' }),
+    ytDlp: {
+      async listVideos() { return [{ id: 'v1', title: 'Video 1', webpageUrl: 'https://yt/v1' }] },
+      async downloadVideo() { return { videoFile: '/tmp/v1.mp4' } }
+    },
+    publisherFactory: () => ({
+      async publishVideo() {
+        return {
+          videoId: 'pt-v1',
+          bytes: 200,
+          channelKey: 'channel-key-hex',
+          publicBeeKey: 'public-bee-hex'
+        }
+      }
+    }),
+    setIntervalFn: () => null,
+    clearIntervalFn: () => {},
+    setTimeoutFn: () => {}
+  })
+
+  await archiver.runOnce()
+
+  const sourceRecord = await createArchiveState({ metaDb }).getSource('youtube:@chan')
+  t.is(sourceRecord.channelKey, 'channel-key-hex')
+  t.is(sourceRecord.publicBeeKey, 'public-bee-hex')
+})
+
+test('createArchiver reannounces archived source channels even when every video is already archived', async (t) => {
+  const metaDb = makeFakeMetaDb()
+  const config = resolveRelayConfig({
+    storage: { path: '/tmp/peartube-test', maxBytes: 100000 },
+    archive: {
+      enabled: true,
+      tmpPath: '/tmp/peartube-test/archive-tmp',
+      sources: [{ url: 'https://www.youtube.com/@chan', label: 'Chan' }]
+    }
+  }, { env: {} })
+  const state = createArchiveState({ metaDb })
+  await state.markArchived('youtube:@chan', 'v1', { peartubeVideoId: 'pt-v1', bytes: 100, title: 'Video 1' })
+
+  const ensured = []
+  const archiver = createArchiver({
+    config,
+    runtime: makeFakeRuntime({ metaDb }),
+    logger: makeFakeLogger(),
+    fs: makeFakeFs(),
+    ytDlp: {
+      async listVideos() { return [{ id: 'v1', title: 'Video 1', webpageUrl: 'https://yt/v1' }] },
+      async downloadVideo() { throw new Error('already archived video should not be downloaded') }
+    },
+    publisherFactory: () => ({
+      async ensureSourceChannel(source) {
+        ensured.push(source.sourceId)
+        await state.putSource(source.sourceId, {
+          url: source.url,
+          type: source.type,
+          channelKey: 'channel-key-hex',
+          publicBeeKey: 'public-bee-hex'
+        })
+      }
+    }),
+    setIntervalFn: () => null,
+    clearIntervalFn: () => {},
+    setTimeoutFn: () => {}
+  })
+
+  await archiver.runOnce()
+
+  t.alike(ensured, ['youtube:@chan'])
+  const sourceRecord = await state.getSource('youtube:@chan')
+  t.is(sourceRecord.channelKey, 'channel-key-hex')
+  t.is(sourceRecord.publicBeeKey, 'public-bee-hex')
+})
+
 test('createArchiver returns no-op when disabled', async (t) => {
   const metaDb = makeFakeMetaDb()
   const config = resolveRelayConfig({}, { env: {} })

--- a/packages/cli/test/cli.test.mjs
+++ b/packages/cli/test/cli.test.mjs
@@ -207,7 +207,8 @@ test('Dockerfile packages ffmpeg for yt-dlp archive merging', async (t) => {
   const dockerfile = readFileSync(join(__dirname, '..', 'Dockerfile'), 'utf8')
 
   t.ok(dockerfile.includes('ARG FFMPEG_VERSION='), 'Dockerfile pins an ffmpeg static build version')
-  t.ok(dockerfile.includes('johnvansickle.com/ffmpeg/releases'), 'Dockerfile downloads static ffmpeg release assets')
+  t.ok(dockerfile.includes('github.com/BtbN/FFmpeg-Builds/releases/download/latest'), 'Dockerfile downloads static ffmpeg release assets from GitHub releases')
+  t.ok(dockerfile.includes('/tmp/ffmpeg/bin/ffmpeg'), 'Dockerfile copies ffmpeg from the static build bin directory')
   t.ok(dockerfile.includes('/usr/local/bin/ffmpeg -version'), 'Dockerfile validates ffmpeg during image build')
   t.ok(dockerfile.includes('PEARTUBE_ARCHIVE_FFMPEG_PATH=/usr/local/bin/ffmpeg'), 'final image exposes configured ffmpeg path to archive jobs')
   t.ok(dockerfile.includes('COPY --from=runtime-libs /usr/local/bin/ffmpeg /usr/local/bin/ffmpeg'), 'final image includes ffmpeg executable')


### PR DESCRIPTION
## Summary
- Preserve explicit playable availability from relay/feed preview metadata when PublicBee returns empty metadata
- Prioritize feed entries with playable direct blob refs ahead of stale live-peer entries so Android hydrates archive cards immediately
- Add regression coverage for archive preview prioritization and existing backend preview fallback behavior

## Verification
- `node --test packages/app/tests/feed-hydration.test.mjs`
- `node --check packages/backend/src/api.js`
- `npm run prepare:mobile-backend --prefix packages/app`
- `./gradlew :app:assembleRelease -PtargetAbis=x86_64 -PreactNativeArchitectures=x86_64 --no-daemon -Dorg.gradle.jvmargs='-Xmx4096m -XX:MaxMetaspaceSize=1024m'`
- Installed fresh x86_64 APK on emulator, cleared app data, granted permissions, and verified Android feed shows archive cards with `Peers: 7`, `Feed: 106`, `Channels: 106`; first pass logs now show `feedHydrationFirstPass ... videos: 3`

## Notes
Local Android build initially hit a Bare link `ELOOP` caused by the workspace symlink cycle `packages/backend -> packages/host -> packages/backend`; temporarily removing the nested host-to-backend symlink during the Gradle build avoided the packer loop, then the symlink was restored.
