### PR TITLE
fix: restore backend API index key encoder

### DIFF
--- a/packages/backend/src/index-encoder.js
+++ b/packages/backend/src/index-encoder.js
@@ -1,0 +1,8 @@
+export function encodeIndexKey(...parts) {
+  return parts
+    .map((part) => {
+      const value = part == null ? '' : String(part)
+      return `${value.length}:${value}`
+    })
+    .join('|')
+}

--- a/packages/backend/test/backend-entry.test.mjs
+++ b/packages/backend/test/backend-entry.test.mjs
@@ -2,6 +2,11 @@ import test from 'brittle'
 
 import * as backendEntry from '../src/backend-entry.js'
 
+test('backend API module imports in relay runtime', async (t) => {
+  const apiModule = await import('../src/api.js')
+  t.is(typeof apiModule.createApi, 'function')
+})
+
 test('attachSharedAppHandlers skips loading shared app handlers unless requested', async (t) => {
   t.is(typeof backendEntry.attachSharedAppHandlers, 'function')
   if (typeof backendEntry.attachSharedAppHandlers !== 'function') return


### PR DESCRIPTION
## Summary
- restores the backend API `index-encoder.js` module required by `api.js`
- adds a relay-runtime import regression so missing backend API imports fail in backend tests

## Test Plan
- `packages/backend/node_modules/.bin/brittle packages/backend/test/backend-entry.test.mjs`
- `npm test --prefix packages/backend`
- `node -e "import('./packages/backend/src/api.js').then(m=>console.log(typeof m.createApi))"`

## Context
PR #373 merged and the live relay checkout exposed a startup crash because `packages/backend/src/api.js` imports `./index-encoder.js`, but that module was absent on `origin/main`. This restores the small deterministic key encoder used for in-flight prefetch/range maps.