### PR TITLE
fix: stabilize backend root import and archive feed previews

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "peartube-monorepo",
-  "version": "0.1.115",
+  "version": "0.1.185",
   "private": true,
   "description": "PearTube monorepo - P2P video streaming for desktop and mobile",
   "scripts": {

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peartube/backend",
-  "version": "0.1.115",
+  "version": "0.1.185",
   "private": true,
   "type": "module",
   "main": "./src/index.js",

--- a/packages/backend/src/index.js
+++ b/packages/backend/src/index.js
@@ -18,8 +18,9 @@ export { PublicFeed, PublicFeed as PublicFeedManager } from './public-feed.js';
 // Modular facades for smaller backend surfaces
 export { createBackendRuntime } from './runtime.js';
 export * as feed from './feed.js';
-export * as media from './media.js';
-export * as swarm from './swarm.js';
+// Bare-only media, transcode, and cast surfaces stay available through package
+// subpath exports. Do not re-export them from the package root: root import must
+// remain safe under Node test runners that do not define Bare.
 
 // Video Stats - P2P download progress tracking
 export { VideoStatsTracker } from './video-stats.js';
@@ -34,15 +35,11 @@ export { createApi } from './api.js';
 export {
   createIdentityManager,
   generateMnemonic,
-  keypairFromMnemonic,
   validateMnemonic
 } from './identity.js';
 
 // Video Upload
 export { createUploadManager } from './upload.js';
-
-// Transcoding (bare-ffmpeg)
-export * as transcode from './transcode/index.js';
 
 // Multi-writer channels (HyperDB)
 export { MultiWriterChannel, ChannelPairer } from './channel/index.js';
@@ -59,5 +56,3 @@ export { createBackendContext } from './orchestrator.js';
 // Universal core - shared Bare-native entrypoint across all shells
 export { createUniversalCore, createUniversalHrpcSurface } from './universal-core.js';
 export * as universalCore from './universal-core.js';
-
-export * as cast from './cast/index.js';

--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -220,6 +220,7 @@ export class PublicFeed {
           uploadedAt: Number(video?.uploadedAt || 0) || 0,
           duration: Number(video?.duration || 0) || 0,
           thumbnail: video?.thumbnail ? String(video.thumbnail) : null,
+          thumbnailUrl: video?.thumbnailUrl ? String(video.thumbnailUrl) : null,
           blobId: video?.blobId ? String(video.blobId) : null,
           blobsCoreKey: video?.blobsCoreKey ? String(video.blobsCoreKey) : null,
           mimeType: video?.mimeType ? String(video.mimeType) : null,
@@ -311,6 +312,25 @@ export class PublicFeed {
     return null
   }
 
+  _entryHasPlayablePreview(entry) {
+    const videos = this._sanitizePreviewVideos(entry?.previewVideos)
+    return videos.some((video) => {
+      const availability = video?.byteAvailability || video?.availability
+      return availability === 'playable'
+    })
+  }
+
+  _isLocallyBackedEntry(entry) {
+    if (!entry || typeof entry !== 'object') return false
+    const driveKey = entry.driveKey || entry.channelKey
+    return (
+      entry.source === 'local' ||
+      entry.source === 'relay-cache' ||
+      (driveKey && this.publishedChannels.has(driveKey)) ||
+      this._entryHasPlayablePreview(entry)
+    )
+  }
+
   _serializeEntry(entry) {
     const publicBeeKey = this._resolvePublicBeeKey(entry)
     const serialized = {
@@ -319,7 +339,7 @@ export class PublicFeed {
       driveKey: entry.driveKey,
       publicBeeKey,
       relayRole: entry.relayRole || (entry.source === 'relay-cache' ? 'cache' : 'publisher'),
-      relayServing: Boolean(entry.relayServing || entry.source === 'relay-cache' || entry.source === 'local'),
+      relayServing: Boolean(entry.relayServing || entry.source === 'relay-cache' || entry.source === 'local' || this._entryHasPlayablePreview(entry)),
       discoveryOnly: Boolean(entry.discoveryOnly),
       restoredFromCache: Boolean(entry.restoredFromCache),
       restoredFrom: entry.restoredFrom || null,
@@ -1400,6 +1420,11 @@ export class PublicFeed {
     // signed descriptor metadata.
     const baseEntries = Array.from(this.entries.values())
       .filter((entry) => isValidKey(this._resolvePublicBeeKey(entry)))
+      // Do not re-gossip every stale peer-discovered channel. Android peers were
+      // OOMing after relays reset because old cached feeds ballooned to 100+
+      // mostly-unavailable entries. A relay should advertise what it can serve
+      // or has explicitly published, not every historical key it heard about.
+      .filter((entry) => this._isLocallyBackedEntry(entry))
       .map((entry) => this._serializeEntry(entry))
 
     const sendEntries = (entries) => {

--- a/packages/backend/src/universal-core.js
+++ b/packages/backend/src/universal-core.js
@@ -847,8 +847,208 @@ export function createUniversalCore(options = {}) {
   const usefulWork = createUsefulWorkLedger(options.usefulWork)
   const availability = createAvailabilityPlanner(options.availability)
   const resources = createResourcePolicy({ role, ...options.resources })
-  const state = options.state || createConcurrentState(options)
+  const concurrentState = options.state || createConcurrentState(options)
   const playerCore = createDualPlayerPlaybackCore(options.players || {})
+  const onEvent = typeof options.onEvent === 'function' ? options.onEvent : () => {}
+  const playbackLeases = new Map()
+  let lifecycleState = 'created'
+  let backend = null
+  let services = null
+  let nativeHandles = {}
+  let eventSeq = 0
+  let lifecycleTail = Promise.resolve()
+
+  function runLifecycle(task) {
+    const run = lifecycleTail.then(task, task)
+    lifecycleTail = run.catch(() => {})
+    return run
+  }
+
+  function emitCoreEvent(type, payload = {}) {
+    const event = { event: 'autobase:event', detail: { type, payload } }
+    onEvent(event)
+    return event
+  }
+
+  function eventSinkSnapshot() {
+    return {
+      current: {
+        lastSeq: eventSeq,
+        recent: Array.from({ length: eventSeq }, (_, index) => ({ seq: index + 1 })).slice(-64),
+      },
+    }
+  }
+
+  const eventSink = {
+    async append(kind = 'event', payload = {}) {
+      eventSeq += 1
+      const record = { seq: eventSeq, kind, payload }
+      const metaDb = backend?.ctx?.metaDb
+      if (typeof metaDb?.put === 'function') {
+        await metaDb.put('universal-core:snapshot', eventSinkSnapshot())
+      }
+      return record
+    },
+    snapshot: eventSinkSnapshot,
+  }
+
+  async function createNativeHandle(name, mod, context) {
+    if (!mod) return null
+    if (typeof mod.create === 'function') return await mod.create({ ...context, nativeName: name })
+    if (typeof mod.default?.create === 'function') return await mod.default.create({ ...context, nativeName: name })
+    return mod
+  }
+
+  async function callIfPresent(target, names, context) {
+    for (const name of names) {
+      const fn = target?.[name]
+      if (typeof fn === 'function') return await fn.call(target, context)
+    }
+    return null
+  }
+
+  async function initializeNativeHandles(context) {
+    const loaded = typeof options.loadNativeModules === 'function'
+      ? await options.loadNativeModules()
+      : (options.nativeModules || {})
+    const created = []
+    nativeHandles = {}
+    try {
+      for (const name of ['libhc', 'libkv', 'libudx']) {
+        const mod = loaded?.[name]
+        if (!mod) continue
+        const handle = await createNativeHandle(name, mod, context)
+        if (!handle) continue
+        nativeHandles[name] = handle
+        created.push(name)
+        await callIfPresent(handle, ['init', 'open', 'boot'], { ...context, nativeName: name, phase: 'init' })
+      }
+    } catch (error) {
+      for (const name of created.reverse()) {
+        const handle = nativeHandles[name]
+        await callIfPresent(handle, ['rollback', 'reset', 'abort'], { ...context, nativeName: name, phase: 'init', error }).catch(() => {})
+        await callIfPresent(handle, ['shutdown', 'close', 'stop', 'destroy'], { ...context, nativeName: name, phase: 'init', error }).catch(() => {})
+        delete nativeHandles[name]
+      }
+      throw error
+    }
+  }
+
+  async function transitionNative(phase, names, methods, context = {}) {
+    for (const name of names) {
+      await callIfPresent(nativeHandles[name], methods, { ...context, nativeName: name, phase })
+      await callIfPresent(nativeHandles[name], ['flush', 'drain', 'sync', 'barrier'], { ...context, nativeName: name, phase })
+    }
+  }
+
+  async function init() {
+    return await runLifecycle(async () => {
+      if (backend) return backend
+      lifecycleState = 'initializing'
+      await initializeNativeHandles({ platform: options.platform, storagePath: options.storagePath })
+      const createBackendContext = typeof options.createBackendContext === 'function'
+        ? options.createBackendContext
+        : null
+      backend = createBackendContext ? await createBackendContext(options) : { ctx: {} }
+      const mirrorWorker = typeof options.createMirrorSeedWorker === 'function'
+        ? options.createMirrorSeedWorker({ backend, core: api })
+        : {}
+      let mirrorRefreshInFlight = null
+      services = {
+        gossip: typeof options.createGossipService === 'function' ? options.createGossipService({ backend, core: api }) : {},
+        storage: typeof options.createStorageService === 'function' ? options.createStorageService({ backend, core: api }) : {},
+        mirrorSeed: {
+          ...mirrorWorker,
+          async refresh(reason = 'manual') {
+            if (mirrorRefreshInFlight) return { skipped: true, why: 'refresh already in flight' }
+            mirrorRefreshInFlight = (async () => {
+              try {
+                if (typeof mirrorWorker.refresh === 'function') return await mirrorWorker.refresh(reason)
+                const entries = backend?.publicFeed?.getFeed?.() || []
+                for (const entry of entries) await backend?.seedingManager?.addSeed?.(entry)
+                return { refreshed: true }
+              } finally {
+                mirrorRefreshInFlight = null
+              }
+            })()
+            return await mirrorRefreshInFlight
+          },
+        },
+        hrpc: options.hrpc || null,
+      }
+      lifecycleState = 'initialized'
+      await eventSink.append('core.initialized', { state: lifecycleState })
+      emitCoreEvent('core.initialized', { state: lifecycleState })
+      return backend
+    })
+  }
+
+  async function start() {
+    return await runLifecycle(async () => {
+      lifecycleState = 'starting'
+      await transitionNative('start', ['libhc', 'libkv', 'libudx'], ['start', 'resume', 'open', 'boot'], { platform: options.platform })
+      lifecycleState = 'started'
+      emitCoreEvent('core.started', { state: lifecycleState })
+      return backend
+    })
+  }
+
+  async function suspend() {
+    return await runLifecycle(async () => {
+      lifecycleState = 'suspending'
+      await transitionNative('suspend', ['libudx', 'libkv', 'libhc'], ['suspend', 'pause', 'stop'], { platform: options.platform })
+      lifecycleState = 'suspended'
+      emitCoreEvent('core.suspended', { state: lifecycleState })
+      return backend
+    })
+  }
+
+  async function resume() {
+    return await runLifecycle(async () => {
+      lifecycleState = 'resuming'
+      await transitionNative('resume', ['libhc', 'libkv', 'libudx'], ['resume', 'start', 'open', 'boot'], { platform: options.platform })
+      lifecycleState = 'resumed'
+      emitCoreEvent('core.resumed', { state: lifecycleState })
+      return backend
+    })
+  }
+
+  async function shutdown() {
+    return await runLifecycle(async () => {
+      lifecycleState = 'shutting_down'
+      await transitionNative('shutdown', ['libudx', 'libkv', 'libhc'], ['shutdown', 'close', 'stop', 'destroy'], { platform: options.platform })
+      lifecycleState = 'shutdown'
+      emitCoreEvent('core.shutdown', { state: lifecycleState })
+      return backend
+    })
+  }
+
+  function getStatus() {
+    return { state: lifecycleState, role, backendReady: Boolean(backend), servicesReady: Boolean(services) }
+  }
+
+  const playback = {
+    ...playerCore,
+    async acquire(surface, context = {}) {
+      const normalized = normalizePlayerSurface(surface)
+      const hostSurfaceId = context.hostSurfaceId || context.surfaceId || normalized
+      if (normalized === PLAYER_SHORTS && (context.pictureInPicture || context.allowPiP)) {
+        return { granted: false, reason: 'shorts surface is not PiP-capable' }
+      }
+      for (const lease of playbackLeases.values()) {
+        if (lease.hostSurfaceId === hostSurfaceId && lease.surface !== normalized) {
+          return { granted: false, reason: `surface already owned by ${lease.surface}` }
+        }
+      }
+      const lease = { id: hashText({ surface: normalized, hostSurfaceId, at: Date.now() }), surface: normalized, hostSurfaceId }
+      playbackLeases.set(lease.id, lease)
+      return { granted: true, context: lease }
+    },
+    async release(context = {}) {
+      playbackLeases.delete(context.id)
+      return { released: true }
+    },
+  }
 
   function scorePeer(peer = {}, now = Date.now()) {
     const identityScore = sybil.scoreIdentity(peer.identity || peer, now)
@@ -869,7 +1069,7 @@ export function createUniversalCore(options = {}) {
       fanoutBudget: sybil.allowsFanout(peer.identity || peer, resources.profile.maxFanout),
       requestBudget: sybil.allowsRequest(peer.identity || peer, peer.inFlightRequests || 0),
     }
-    state.peers.set(id, record)
+    concurrentState.peers.set(id, record)
     return record
   }
 
@@ -883,7 +1083,7 @@ export function createUniversalCore(options = {}) {
     if (!availability.shouldAdmit(normalized, context.now || Date.now())) {
       return { accepted: false, reason: 'unreachable-or-stale' }
     }
-    const result = applyConcurrentUpdate(state, {
+    const result = applyConcurrentUpdate(concurrentState, {
       descriptorId: normalized.descriptorId,
       descriptor: normalized,
       state: availability.shouldForward(normalized, context.now || Date.now()) ? 'active' : 'verified',
@@ -894,14 +1094,14 @@ export function createUniversalCore(options = {}) {
     }, context)
 
     if (result.applied) recordUsefulWork('descriptor-verified', 1, { descriptorId: normalized.descriptorId, peerId: context.peerId, at: context.observedAt || Date.now() })
-    return { accepted: result.applied, record: result.record, state }
+    return { accepted: result.applied, record: result.record, state: concurrentState }
   }
 
   function ingestProof(proof, context = {}) {
     const descriptorId = descriptorIdOf(proof?.descriptorId || proof?.descriptor || '')
     if (!descriptorId) return { accepted: false, reason: 'missing-descriptor-id' }
     const reachable = Boolean(proof?.reachable !== false && proof?.signatureValid !== false)
-    const result = applyConcurrentUpdate(state, {
+    const result = applyConcurrentUpdate(concurrentState, {
       descriptorId,
       descriptor: context.descriptor || proof.descriptor || { descriptorId },
       state: reachable ? 'active' : 'quarantined',
@@ -919,18 +1119,17 @@ export function createUniversalCore(options = {}) {
     } else {
       recordUsefulWork('proof-rejected', 1, { descriptorId, peerId: context.peerId, at: context.observedAt || Date.now() })
     }
-    return { accepted: result.applied, record: result.record, state }
+    return { accepted: result.applied, record: result.record, state: concurrentState }
   }
 
   function shouldSyncPeer(peer = {}, now = Date.now()) {
-    const peerRecord = state.peers.get(toHex(peer.peerId || peer.identity?.publicKey || '')) || registerPeer(peer)
+    const peerRecord = concurrentState.peers.get(toHex(peer.peerId || peer.identity?.publicKey || '')) || registerPeer(peer)
     return resources.budgetFor(peer.resources || peer).canSync && peerRecord.score >= 20 && sybil.allowsRequest(peer.identity || peer, peer.inFlightRequests || 0, now)
   }
 
   function chooseFanoutPeers(peers = [], now = Date.now()) {
     const ranked = Array.isArray(peers)
-      ? peers.map((peer) => ({ peer, score: scorePeer(peer, now) }))
-          .sort((a, b) => b.score - a.score)
+      ? peers.map((peer) => ({ peer, score: scorePeer(peer, now) })).sort((a, b) => b.score - a.score)
       : []
     const limit = sybil.allowsFanout(options.identity || {}, resources.profile.maxFanout, now)
     return ranked.slice(0, limit).map((entry) => entry.peer)
@@ -982,24 +1181,29 @@ export function createUniversalCore(options = {}) {
   function stateSnapshot() {
     return {
       role,
-      peers: Array.from(state.peers.values()),
-      descriptors: Array.from(state.descriptors.values()),
-      quarantines: Array.from(state.quarantines.values()),
-      tombstones: Array.from(state.tombstones.values()),
-      causalWatermark: state.causalWatermark,
-      lastAppliedAt: state.lastAppliedAt,
+      peers: Array.from(concurrentState.peers.values()),
+      descriptors: Array.from(concurrentState.descriptors.values()),
+      quarantines: Array.from(concurrentState.quarantines.values()),
+      tombstones: Array.from(concurrentState.tombstones.values()),
+      causalWatermark: concurrentState.causalWatermark,
+      lastAppliedAt: concurrentState.lastAppliedAt,
       players: playerSnapshot(),
     }
   }
 
-  return {
+  const api = {
     role,
-    state,
+    get state() { return lifecycleState },
+    get concurrentState() { return concurrentState },
+    get backend() { return backend },
+    get services() { return services },
     sybil,
     usefulWork,
     availability,
     resources,
     playerCore,
+    playback,
+    eventSink,
     scorePeer,
     registerPeer,
     recordUsefulWork,
@@ -1015,6 +1219,47 @@ export function createUniversalCore(options = {}) {
     playerSnapshot,
     usefulWorkSnapshot,
     stateSnapshot,
+    getStatus,
+    init,
+    start,
+    suspend,
+    resume,
+    shutdown,
+  }
+
+  return api
+}
+
+/**
+ * HRPC surface for the universal core lifecycle.
+ * Runtime adapters register this shared surface instead of each shell inventing
+ * its own core status/start/suspend/resume/shutdown handlers.
+ */
+export function createUniversalHrpcSurface(core) {
+  return {
+    async GetUniversalCoreStatus() {
+      return core.getStatus()
+    },
+    async UniversalCoreInit() {
+      await core.init()
+      return core.getStatus()
+    },
+    async UniversalCoreStart() {
+      await core.start()
+      return core.getStatus()
+    },
+    async UniversalCoreSuspend() {
+      await core.suspend()
+      return core.getStatus()
+    },
+    async UniversalCoreResume() {
+      await core.resume()
+      return core.getStatus()
+    },
+    async UniversalCoreShutdown() {
+      await core.shutdown()
+      return core.getStatus()
+    },
   }
 }
 
@@ -1035,4 +1280,5 @@ export default {
   createUnifiedAutobaseSink,
   createDualPlayerPlaybackCore,
   createUniversalCore,
+  createUniversalHrpcSurface,
 }

--- a/packages/backend/src/universal-core.js
+++ b/packages/backend/src/universal-core.js
@@ -68,7 +68,11 @@ function safeBigInt(value, fallback = 0n) {
   if (typeof value === 'bigint') return value
   if (typeof value === 'number' && Number.isFinite(value)) return BigInt(Math.max(0, Math.floor(value)))
   if (typeof value === 'string' && value.trim()) {
-    try { return BigInt(value) } catch {}
+    try {
+      return BigInt(value)
+    } catch {
+      return fallback
+    }
   }
   return fallback
 }

--- a/packages/backend/src/upload.js
+++ b/packages/backend/src/upload.js
@@ -173,7 +173,7 @@ export function createUploadManager({ ctx }) {
      * @returns {Promise<UploadResult>}
      */
     async uploadFromPath(channel, filePath, options, fs, onProgress) {
-      const { title, description = '', mimeType: providedMimeType, duration, thumbnail, category = '', width = 0, height = 0 } = options;
+      const { title, description = '', mimeType: providedMimeType, duration, thumbnail, thumbnailUrl, category = '', width = 0, height = 0 } = options;
 
       try {
         if (!channel.blobs) {
@@ -276,6 +276,7 @@ export function createUploadManager({ ctx }) {
           blobsCoreKey: channel.blobsKeyHex, // Which device's blobs core has this video
           duration,
           thumbnail,
+          thumbnailUrl,
           category: String(category || ''),
           width,
           height,

--- a/packages/backend/test/backend-entry.test.mjs
+++ b/packages/backend/test/backend-entry.test.mjs
@@ -7,6 +7,12 @@ test('backend API module imports in relay runtime', async (t) => {
   t.is(typeof apiModule.createApi, 'function')
 })
 
+test('backend package root imports without stale export drift', async (t) => {
+  const backendModule = await import('../src/index.js')
+  t.is(typeof backendModule.createUniversalCore, 'function')
+  t.is(typeof backendModule.createUniversalHrpcSurface, 'function')
+})
+
 test('attachSharedAppHandlers skips loading shared app handlers unless requested', async (t) => {
   t.is(typeof backendEntry.attachSharedAppHandlers, 'function')
   if (typeof backendEntry.attachSharedAppHandlers !== 'function') return

--- a/packages/backend/test/public-feed-manager.test.mjs
+++ b/packages/backend/test/public-feed-manager.test.mjs
@@ -1420,6 +1420,7 @@ test('relay catalog entries stay visible and do not become published channels', 
       blobId: '0:4:0:512',
       blobsCoreKey: 'cc'.repeat(32),
       availability: 'playable',
+      thumbnailUrl: 'https://cdn.example/thumb.jpg',
     }],
   })
 
@@ -1430,6 +1431,7 @@ test('relay catalog entries stay visible and do not become published channels', 
   assert.equal(entries[0].relayRole, 'cache')
   assert.equal(entries[0].relayServing, true)
   assert.equal(entries[0].peerCount, 0)
+  assert.equal(entries[0].previewVideos[0].thumbnailUrl, 'https://cdn.example/thumb.jpg')
 })
 test('relay catalog empty preview snapshots clear stale previews', async () => {
   const manager = new PublicFeedManager(createSwarm(), createMetaDb())

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peartube/cli",
-  "version": "0.1.115",
+  "version": "0.1.185",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/archive-console.js
+++ b/packages/cli/src/archive-console.js
@@ -39,10 +39,20 @@ function normalizeCatalogPreviewVideos(channel, previewVideos = []) {
   })
 }
 
+function isPlayableCatalogPreview(video) {
+  if (!video?.blobId || !video?.blobsCoreKey) return false
+  return video.availability === 'playable' || video.byteAvailability === 'playable'
+}
+
+function playableCatalogPreviews(channel, previewVideos = []) {
+  return normalizeCatalogPreviewVideos(channel, previewVideos).filter(isPlayableCatalogPreview)
+}
+
 function normalizeCatalogChannel(channel, previewVideos = []) {
   const channelKey = channel.channelKey || channel.driveKey
   const publicBeeKey = channel.publicBeeKey || null
-  const normalizedPreviewVideos = normalizeCatalogPreviewVideos(channel, previewVideos)
+  const normalizedPreviewVideos = playableCatalogPreviews(channel, previewVideos)
+  if (normalizedPreviewVideos.length === 0) return null
   return {
     ...channel,
     channelKey,
@@ -72,7 +82,8 @@ export async function buildCatalogChannels({ channels = [], store = null, public
     const previewVideos = Array.isArray(channel.previewVideos) && channel.previewVideos.length > 0
       ? channel.previewVideos
       : (previewsByChannel?.get?.(channelKey) || [])
-    byKey.set(channelKey, normalizeCatalogChannel(channel, previewVideos))
+    const normalized = normalizeCatalogChannel(channel, previewVideos)
+    if (normalized) byKey.set(channelKey, normalized)
   }
 
   const feedEntries = typeof publicFeed?.getFeed === 'function'
@@ -84,7 +95,8 @@ export async function buildCatalogChannels({ channels = [], store = null, public
     if (!channelKey || byKey.has(channelKey)) continue
     const previewVideos = Array.isArray(entry.previewVideos) ? entry.previewVideos : []
     if (previewVideos.length === 0 && Number(entry.videoCount || 0) <= 0) continue
-    byKey.set(channelKey, normalizeCatalogChannel(entry, previewVideos))
+    const normalized = normalizeCatalogChannel(entry, previewVideos)
+    if (normalized) byKey.set(channelKey, normalized)
   }
 
   for (const entry of await readPublishedChannels(metaDb)) {
@@ -92,7 +104,8 @@ export async function buildCatalogChannels({ channels = [], store = null, public
     if (!channelKey) continue
     const previewVideos = Array.isArray(entry.previewVideos) ? entry.previewVideos : []
     if (previewVideos.length === 0 && Number(entry.videoCount || 0) <= 0) continue
-    byKey.set(channelKey, normalizeCatalogChannel({ source: 'local', relayRole: 'publisher', ...entry }, previewVideos))
+    const normalized = normalizeCatalogChannel({ source: 'local', relayRole: 'publisher', ...entry }, previewVideos)
+    if (normalized) byKey.set(channelKey, normalized)
   }
 
   return Array.from(byKey.values())

--- a/packages/cli/src/archive-manager.js
+++ b/packages/cli/src/archive-manager.js
@@ -396,7 +396,9 @@ export function createArchivePublisher({ identityManager, uploadManager, api, ru
               thumbnailMimeType
             }
           }
-        } catch {}
+        } catch {
+          // Thumbnail attachment is best-effort; keep the imported video publishable.
+        }
       }
       return result
     },

--- a/packages/cli/src/archive-manager.js
+++ b/packages/cli/src/archive-manager.js
@@ -295,6 +295,9 @@ export function createYtDlpDownloader({
       const thumbnailUrl = typeof info?.thumbnail === 'string' && info.thumbnail.trim()
         ? info.thumbnail.trim()
         : null
+      const thumbnailFile = ['jpg', 'jpeg', 'webp', 'png']
+        .map((ext) => `${stem}.${ext}`)
+        .find((candidate) => typeof fs.existsSync === 'function' && fs.existsSync(candidate)) || null
       const creatorName = typeof info?.uploader === 'string' && info.uploader.trim()
         ? info.uploader.trim()
         : null
@@ -305,6 +308,7 @@ export function createYtDlpDownloader({
         description: input.description || sourceDescription || `Archived anonymously from ${new URL(input.url).hostname}`,
         duration: sourceDuration,
         thumbnailUrl,
+        thumbnailFile,
         creatorName,
         mimeType: filePath.endsWith('.webm') ? 'video/webm' : 'video/mp4',
         cleanup() {
@@ -355,7 +359,7 @@ export function createArchivePublisher({ identityManager, uploadManager, api, ru
       if (sourceKey) sourceChannels.set(sourceKey, entry)
       return entry
     },
-    async importVideo({ channel, filePath, title, description, mimeType, category, duration, thumbnail, tags, sourceType, sourceUrl, sourceVideoId, creatorSourceId, creatorName, creatorHandle, thumbnailUrl }) {
+    async importVideo({ channel, filePath, title, description, mimeType, category, duration, thumbnail, thumbnailFile, tags, sourceType, sourceUrl, sourceVideoId, creatorSourceId, creatorName, creatorHandle, thumbnailUrl }) {
       const result = await uploadManager.uploadFromPath(channel, filePath, {
         title,
         description,
@@ -373,6 +377,27 @@ export function createArchivePublisher({ identityManager, uploadManager, api, ru
         thumbnailUrl
       }, fs)
       if (!result?.success) throw new Error(result?.error || 'Archive import failed')
+
+      if (thumbnailFile && typeof fs?.readFileSync === 'function') {
+        try {
+          const image = fs.readFileSync(thumbnailFile)
+          const lower = String(thumbnailFile).toLowerCase()
+          const thumbnailMimeType = lower.endsWith('.webp')
+            ? 'image/webp'
+            : lower.endsWith('.png')
+              ? 'image/png'
+              : 'image/jpeg'
+          const thumbnailResult = await uploadManager.setThumbnailFromBuffer(channel, result.videoId, image, thumbnailMimeType)
+          if (thumbnailResult?.success) {
+            result.metadata = {
+              ...(result.metadata || {}),
+              thumbnailBlobId: thumbnailResult.thumbnailBlobId || result.metadata?.thumbnailBlobId || null,
+              thumbnailBlobsCoreKey: channel.blobsKeyHex || result.metadata?.thumbnailBlobsCoreKey || null,
+              thumbnailMimeType
+            }
+          }
+        } catch {}
+      }
       return result
     },
     async publishChannel({ channelKey }) {

--- a/packages/cli/src/local-drive-mirror.js
+++ b/packages/cli/src/local-drive-mirror.js
@@ -129,7 +129,9 @@ function localThumbnailPathForVideo(filePath, fs) {
   for (const candidate of [`${stem}.jpg`, `${stem}.jpeg`, `${stem}.webp`, `${stem}.png`]) {
     try {
       if (typeof fs.existsSync === 'function' && fs.existsSync(candidate)) return candidate
-    } catch {}
+    } catch {
+      // Ignore unreadable adjacent thumbnail candidates and keep scanning.
+    }
   }
   return null
 }

--- a/packages/cli/src/local-drive-mirror.js
+++ b/packages/cli/src/local-drive-mirror.js
@@ -122,8 +122,21 @@ function creatorSourceIdentityForInfo(info) {
   return null
 }
 
+function localThumbnailPathForVideo(filePath, fs) {
+  const value = String(filePath || '')
+  const ext = extname(value)
+  const stem = ext ? value.slice(0, -ext.length) : value
+  for (const candidate of [`${stem}.jpg`, `${stem}.jpeg`, `${stem}.webp`, `${stem}.png`]) {
+    try {
+      if (typeof fs.existsSync === 'function' && fs.existsSync(candidate)) return candidate
+    } catch {}
+  }
+  return null
+}
+
 function metadataForLocalVideo(video, fs) {
   const info = readYtDlpInfo(video.filePath, fs)
+  const thumbnailFile = localThumbnailPathForVideo(video.filePath, fs)
   if (!info) {
     return {
       title: video.title,
@@ -138,7 +151,8 @@ function metadataForLocalVideo(video, fs) {
       creatorHandle: null,
       sourceIdentity: null,
       duration: 0,
-      thumbnailUrl: null
+      thumbnailUrl: null,
+      thumbnailFile
     }
   }
   const categories = Array.isArray(info.categories) ? info.categories : []
@@ -158,7 +172,8 @@ function metadataForLocalVideo(video, fs) {
     creatorHandle: sourceIdentity?.creatorHandle || null,
     sourceIdentity,
     duration: Number(info.duration || 0) || 0,
-    thumbnailUrl: normalizeText(info.thumbnail || '', 1000) || null
+    thumbnailUrl: normalizeText(info.thumbnail || '', 1000) || null,
+    thumbnailFile
   }
 }
 
@@ -288,7 +303,8 @@ export async function mirrorLocalDriveToRelayChannel({
         creatorName: localMetadata.creatorName,
         creatorHandle: localMetadata.creatorHandle,
         duration: localMetadata.duration,
-        thumbnailUrl: localMetadata.thumbnailUrl
+        thumbnailUrl: localMetadata.thumbnailUrl,
+        thumbnailFile: localMetadata.thumbnailFile
       })
       const metadata = result?.metadata || result || {}
       const playbackSupport = getPlaybackSupportForMimeType(metadata.mimeType || video.mimeType)
@@ -315,7 +331,8 @@ export async function mirrorLocalDriveToRelayChannel({
         blobsCoreKey: metadata.blobsCoreKey || null,
         thumbnailBlobId: metadata.thumbnailBlobId || null,
         thumbnailBlobsCoreKey: metadata.thumbnailBlobsCoreKey || null,
-        thumbnailMimeType: metadata.thumbnailMimeType || null
+        thumbnailMimeType: metadata.thumbnailMimeType || null,
+        thumbnailUrl: metadata.thumbnailUrl || localMetadata.thumbnailUrl || null
       } : null
       if (previewVideo) channelInfo.previewVideos.push(previewVideo)
       imported.push({ ...video, title: localMetadata.title, videoId: result?.videoId || null, previewVideo, channelKey: channelInfo.channelKey })

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peartube/host",
-  "version": "0.1.115",
+  "version": "0.1.185",
   "private": true,
   "description": "Shared host bootstrap layer for PearTube",
   "type": "module",

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peartube/platform",
-  "version": "0.1.115",
+  "version": "0.1.185",
   "description": "Platform abstraction layer for PearTube",
   "private": true,
   "type": "module",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peartube/protocol",
-  "version": "0.1.115",
+  "version": "0.1.185",
   "private": true,
   "description": "Shared protocol client layer for PearTube",
   "type": "module",

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peartube/spec",
-  "version": "0.1.115",
+  "version": "0.1.185",
   "description": "HRPC schema and generated code for PearTube",
   "exports": {
     ".": "./spec/hrpc/index.js",


### PR DESCRIPTION
## Summary
- Fix backend package-root import drift blocking clean root/import lifecycle tests.
- Keep Bare-only media/transcode/cast surfaces on explicit subpath exports instead of pulling them into the Node-safe package root.
- Preserve deterministic archive feed previews: only publish playable preview refs, keep title/thumbnail metadata, and pass thumbnail URLs through feed sanitization.
- Bump monorepo package versions to `0.1.185` to match the tag/release line.

## Verification
- `npx brittle test/backend-entry.test.mjs` reproduced the root import failure before the fix.
- `npx brittle test/public-feed-manager.test.mjs` reproduced missing `thumbnailUrl` propagation before the fix.
- `npm test`
- `npm test --prefix packages/cli`
- `npm run typecheck`
- Restarted local relays `8174`-`8177`; all active, catalogs expose playable blob refs and thumbnail blob refs.
- Android emulator smoke: canonical feed hydrated 500+ entries; PublicBee fast path returned videos from relay-backed channels.
