### PR TITLE
fix: correct mobile seeding stats accounting

### DIFF
--- a/packages/app/backend/mobile-handlers.mjs
+++ b/packages/app/backend/mobile-handlers.mjs
@@ -13,6 +13,28 @@
  * @param {Object} B - Backend object to attach handlers to
  * @param {Object} deps - Dependencies from the backend context
  */
+function normalizeSeedingStatus(s) {
+  const maxStorageGB = Number.isFinite(Number(s?.maxStorageGB))
+    ? Number(s.maxStorageGB)
+    : Number.isFinite(Number(s?.config?.maxStorageGB))
+      ? Number(s.config.maxStorageGB)
+      : 10
+  const activeSeeds = Number.isFinite(Number(s?.activeSeeds))
+    ? Number(s.activeSeeds)
+    : Array.isArray(s?.seeds)
+      ? s.seeds.length
+      : 0
+  return {
+    status: {
+      enabled: Boolean(s?.config?.autoSeedWatched),
+      usedStorage: Math.max(0, Number(s?.storageUsedBytes || 0) || 0),
+      maxStorage: Math.max(0, maxStorageGB * 1024 * 1024 * 1024),
+      seedingCount: Math.max(0, activeSeeds)
+    }
+  }
+}
+
+
 export function attachMobileHandlers(B, deps) {
   const { api, identityManager, uploadManager, ctx, initializeIdentityFromMnemonic, rpc, fs, path, generateAndStoreThumbnail, transcoder } = deps
   const refreshPublishedChannelFeed = async (driveKey) => {
@@ -197,7 +219,7 @@ export function attachMobileHandlers(B, deps) {
   }
 
   // --- Seeding/Storage handlers ---
-  B.getSeedingStatus = async () => { const s = await api.getSeedingStatus(); return { status: { enabled: s.config?.autoSeedWatched || false, usedStorage: s.storageUsedBytes || 0, maxStorage: (s.maxStorageGB || 10) * 1024 * 1024 * 1024, seedingCount: s.activeSeeds || 0 } } }
+  B.getSeedingStatus = async () => normalizeSeedingStatus(await api.getSeedingStatus())
   B.setSeedingConfig = async (r) => { await api.setSeedingConfig(r.config || {}); return { success: true } }
   B.pinChannel = async (r) => { await api.pinChannel(r.channelKey); return { success: true } }
   B.unpinChannel = async (r) => { await api.unpinChannel(r.channelKey); return { success: true } }

--- a/packages/app/workers/desktop/index.ts
+++ b/packages/app/workers/desktop/index.ts
@@ -572,7 +572,29 @@ B.removeComment = async (r: any) => { try { const res = await api.removeComment(
 B.addReaction = async (r: any) => { try { const res = await api.addReaction(r.channelKey, r.videoId, r.reactionType, r.publicBeeKey); return { success: res.success, error: res.error } } catch (e: any) { return { success: false, error: e?.message } } }
 B.removeReaction = async (r: any) => { try { const res = await api.removeReaction(r.channelKey, r.videoId, r.publicBeeKey); return { success: res.success, error: res.error } } catch (e: any) { return { success: false, error: e?.message } } }
 B.getReactions = async (r: any) => { try { const res = await api.getReactions(r.channelKey, r.videoId, r.publicBeeKey); const counts = Object.entries(res?.counts && typeof res.counts === 'object' ? res.counts : {}).map(([t, c]) => ({ reactionType: t, count: typeof c === 'number' ? c : 0 })); return { success: Boolean(res?.success), counts, userReaction: res?.userReaction || null, error: res?.error || null } } catch (e: any) { return { success: false, counts: [], userReaction: null, error: e?.message } } }
-B.getSeedingStatus = async () => { const s = await api.getSeedingStatus(); return { status: { enabled: s.config?.autoSeedWatched || false, usedStorage: s.storageUsedBytes || 0, maxStorage: (s.maxStorageGB || 10) * 1024 * 1024 * 1024, seedingCount: s.activeSeeds || 0 } } }
+
+function normalizeSeedingStatus(s: any) {
+  const maxStorageGB = Number.isFinite(Number(s?.maxStorageGB))
+    ? Number(s.maxStorageGB)
+    : Number.isFinite(Number(s?.config?.maxStorageGB))
+      ? Number(s.config.maxStorageGB)
+      : 10
+  const activeSeeds = Number.isFinite(Number(s?.activeSeeds))
+    ? Number(s.activeSeeds)
+    : Array.isArray(s?.seeds)
+      ? s.seeds.length
+      : 0
+  return {
+    status: {
+      enabled: Boolean(s?.config?.autoSeedWatched),
+      usedStorage: Math.max(0, Number(s?.storageUsedBytes || 0) || 0),
+      maxStorage: Math.max(0, maxStorageGB * 1024 * 1024 * 1024),
+      seedingCount: Math.max(0, activeSeeds)
+    }
+  }
+}
+
+B.getSeedingStatus = async () => normalizeSeedingStatus(await api.getSeedingStatus())
 B.setSeedingConfig = async (r: any) => { await api.setSeedingConfig(r.config); return { success: true } }
 B.getTranscodeSettings = async () => api.getTranscodeSettings()
 B.setTranscodeSettings = async (r: any) => api.setTranscodeSettings(r)

--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -1886,14 +1886,16 @@ export function createApi({
           const totalBlocks = blobId.blockLength
           const totalBytes = blobId.byteLength || blobMeta.byteLength || 0
 
+          const normalizedBlobId = typeof blobMeta.blobId === 'string'
+            ? blobMeta.blobId
+            : `${blobId.blockOffset}:${blobId.blockLength}:${blobId.byteOffset}:${blobId.byteLength}`
+
           if (!existingIntent && blobMeta?.blobsCoreKey) {
             await saveDownloadIntent(ctx, {
               driveKey,
               videoPath,
               blobsCoreKey: blobMeta.blobsCoreKey,
-              blobId: typeof blobMeta.blobId === 'string'
-                ? blobMeta.blobId
-                : `${blobId.blockOffset}:${blobId.blockLength}:${blobId.byteOffset}:${blobId.byteLength}`,
+              blobId: normalizedBlobId,
               startBlock,
               endBlock,
               totalBlocks,
@@ -1901,6 +1903,20 @@ export function createApi({
               mimeType: v?.mimeType || existingIntent?.mimeType || '',
               startedAt: Date.now()
             }).catch(err => console.log('[API] Failed to save download intent:', err?.message))
+          }
+
+          if (seedingManager) {
+            await seedingManager.addSeed(driveKey, videoPath, 'watched', {
+              blockLength: totalBlocks,
+              byteLength: totalBytes,
+              publicBeeKey: publicBeeKey || v?.publicBeeKey || existingIntent?.publicBeeKey || null,
+              blobId: normalizedBlobId,
+              blobsCoreKey: blobMeta.blobsCoreKey,
+              thumbnailBlobId: v?.thumbnailBlobId || existingIntent?.thumbnailBlobId || null,
+              thumbnailBlobsCoreKey: v?.thumbnailBlobsCoreKey || existingIntent?.thumbnailBlobsCoreKey || null,
+              mimeType: v?.mimeType || existingIntent?.mimeType || null,
+              thumbnailMimeType: v?.thumbnailMimeType || existingIntent?.thumbnailMimeType || null
+            }, { protectSelf: true }).catch(err => console.log('[API] Failed to register seed intent:', err?.message))
           }
 
           // Count initial blocks already available
@@ -2056,8 +2072,10 @@ export function createApi({
             uploadSpeed: () => (Date.now() - lastUploadTime > 2000 ? 0 : uploadSpeed)
           }
 
-          core.on('download', onDownload)
-          core.on('upload', onUpload)
+          if (!wasCached || videoStats) {
+            core.on('download', onDownload)
+            core.on('upload', onUpload)
+          }
           if (videoStats) {
             videoStats.registerMonitor(driveKey, videoPath, monitor, () => {
               core.off('download', onDownload)
@@ -2652,8 +2670,8 @@ export function createApi({
     async clearCache() {
       console.log('[API] CLEAR_CACHE');
       if (seedingManager) {
-        const clearedBytes = await seedingManager.clearCache();
-        return { success: true, clearedBytes };
+        const clearResult = await seedingManager.clearCache();
+        return { success: true, ...clearResult };
       }
       return { success: false, clearedBytes: 0 };
     },

--- a/packages/backend/src/mobile-handlers.js
+++ b/packages/backend/src/mobile-handlers.js
@@ -20,6 +20,27 @@ function safeJson(value) {
   }
 }
 
+function normalizeSeedingStatus(s) {
+  const maxStorageGB = Number.isFinite(Number(s?.maxStorageGB))
+    ? Number(s.maxStorageGB)
+    : Number.isFinite(Number(s?.config?.maxStorageGB))
+      ? Number(s.config.maxStorageGB)
+      : 10
+  const activeSeeds = Number.isFinite(Number(s?.activeSeeds))
+    ? Number(s.activeSeeds)
+    : Array.isArray(s?.seeds)
+      ? s.seeds.length
+      : 0
+  return {
+    status: {
+      enabled: Boolean(s?.config?.autoSeedWatched),
+      usedStorage: Math.max(0, Number(s?.storageUsedBytes || 0) || 0),
+      maxStorage: Math.max(0, maxStorageGB * 1024 * 1024 * 1024),
+      seedingCount: Math.max(0, activeSeeds)
+    }
+  }
+}
+
 export function attachMobileHandlers(B, deps) {
   const { api, identityManager, uploadManager, ctx, initializeIdentityFromMnemonic, rpc, fs, path, generateAndStoreThumbnail, transcoder } = deps
   const refreshPublishedChannelFeed = async (driveKey) => {
@@ -215,7 +236,7 @@ export function attachMobileHandlers(B, deps) {
     }
   }
 
-  B.getSeedingStatus = async () => { const s = await api.getSeedingStatus(); return { status: { enabled: s.config?.autoSeedWatched || false, usedStorage: s.storageUsedBytes || 0, maxStorage: (s.maxStorageGB || 10) * 1024 * 1024 * 1024, seedingCount: s.activeSeeds || 0 } } }
+  B.getSeedingStatus = async () => normalizeSeedingStatus(await api.getSeedingStatus())
   B.setSeedingConfig = async (r) => { await api.setSeedingConfig(r.config || {}); return { success: true } }
   B.pinChannel = async (r) => { await api.pinChannel(r.channelKey); return { success: true } }
   B.unpinChannel = async (r) => { await api.unpinChannel(r.channelKey); return { success: true } }

--- a/packages/backend/src/seeding.js
+++ b/packages/backend/src/seeding.js
@@ -384,6 +384,46 @@ export class SeedingManager {
   }
 
   /**
+   * Clear persisted partial download intents that reserve cache storage but may
+   * not have been promoted into activeSeeds yet.
+   * @param {{ excludeKeys?: Set<string> | string[] }} [options]
+   * @returns {Promise<{ clearedBytes: number, clearedCount: number, clearedBlob: boolean }>}
+   */
+  async clearDownloadIntents(options = {}) {
+    const excludeKeys = normalizeProtectedSeedKeys(options.excludeKeys)
+    if (typeof this.metaDb?.createReadStream !== 'function') {
+      return { clearedBytes: 0, clearedCount: 0, clearedBlob: false }
+    }
+
+    const entries = []
+    for await (const entry of this.metaDb.createReadStream({ gte: 'download-intent:', lt: 'download-intent:~' })) {
+      const intent = entry?.value
+      if (!intent?.driveKey || !intent?.videoPath) continue
+      const seedKey = `${intent.driveKey}:${intent.videoPath}`
+      if (excludeKeys.has(seedKey)) continue
+      entries.push({ key: entry.key, seedKey, intent })
+    }
+
+    let clearedBytes = 0
+    let clearedBlob = false
+    for (const entry of entries) {
+      const intent = entry.intent
+      clearedBytes += Math.max(0, Number(intent.totalBytes || intent.byteLength || 0) || 0)
+      clearedBlob = (await this.clearSeedBlob({
+        driveKey: intent.driveKey,
+        videoPath: intent.videoPath,
+        blobId: intent.blobId || null,
+        blobsCoreKey: intent.blobsCoreKey || null
+      })) || clearedBlob
+      await this.metaDb.del?.(entry.key)
+      this.activeSeeds.delete(entry.seedKey)
+    }
+
+    if (entries.length > 0) await this.persistSeeds()
+    return { clearedBytes: Math.round(clearedBytes), clearedCount: entries.length, clearedBlob }
+  }
+
+  /**
    * Persist seeds to database
    */
   async persistSeeds() {
@@ -443,6 +483,13 @@ export class SeedingManager {
     this.config.maxStorageGB = gb;
     await this.metaDb.put('seeding-config', this.config);
     console.log('[SeedingManager] Set max storage to', gb, 'GB');
+    const partials = await this.clearDownloadIntents()
+    if (partials.clearedBlob) {
+      await collectCorestoreGarbage(this.store, {
+        label: 'partial download intent clear',
+        log: console.log
+      });
+    }
     // Enforce quota with new limit
     await this.enforceQuota();
   }
@@ -513,6 +560,10 @@ export class SeedingManager {
       this.activeSeeds.delete(key);
       clearedBlob = (await this.clearSeedBlob(seed)) || clearedBlob;
     }
+
+    const partials = await this.clearDownloadIntents({ excludeKeys: new Set(this.activeSeeds.keys()) })
+    clearedBytes += partials.clearedBytes
+    clearedBlob = partials.clearedBlob || clearedBlob
 
     await this.persistSeeds();
 

--- a/packages/backend/test/mobile-handlers.test.mjs
+++ b/packages/backend/test/mobile-handlers.test.mjs
@@ -79,6 +79,34 @@ test('feed handlers use getPublicFeed for public and canonical RPC names', async
   assert.deepEqual(calls, ['getPublicFeed', 'getPublicFeed'])
 })
 
+test('mobile getSeedingStatus reports normalized backend cache counters', async () => {
+  const backend = {}
+  const deps = createDeps({
+    api: {
+      async getSeedingStatus() {
+        return {
+          activeSeeds: 0,
+          storageUsedBytes: 0,
+          maxStorageGB: 5,
+          config: { autoSeedWatched: false },
+          seeds: [],
+        }
+      },
+    },
+  })
+
+  attachMobileHandlers(backend, deps)
+
+  assert.deepEqual(await backend.getSeedingStatus(), {
+    status: {
+      enabled: false,
+      usedStorage: 0,
+      maxStorage: 5 * 1024 * 1024 * 1024,
+      seedingCount: 0,
+    },
+  })
+})
+
 test('uploadVideo re-gossips an already-published mobile channel after thumbnail metadata is stored', async () => {
   const backend = {}
   const calls = []


### PR DESCRIPTION
## Summary
- Count watched video cache entries when prefetch/download intent starts, not only after full completion
- Clear persisted partial download intents during cache clear/storage-limit updates so stale mobile counters do not linger
- Normalize mobile/desktop seeding status responses so zero values stay accurate
- Add a mobile handler regression for normalized seeding counters

## Test Plan
- node --check packages/app/backend/mobile-handlers.mjs
- node --check packages/backend/src/mobile-handlers.js
- npm run -s desktop:worker --prefix packages/app
- node --test packages/backend/test/mobile-handlers.test.mjs packages/backend/test/storage-quota-api.test.mjs packages/app/tests/storage-accounting-regression.test.mjs packages/app/tests/mobile-video-stats-lifecycle-regression.test.mjs
