### PR TITLE
fix: prioritize mobile seek range downloads

### DIFF
--- a/packages/backend/src/storage.js
+++ b/packages/backend/src/storage.js
@@ -26,6 +26,7 @@ import {
 import { NETWORK_TOPIC_STRING } from './types.js'
 import { normalizeBlobRefInput } from './blob-ref.js'
 import { createKnownPeerCache } from './known-peers.js'
+import { prioritizeBlobServerRangeRequest } from './blob-range-priority.js'
 
 function resolveDebugLogPath() {
   return globalThis?.process?.env?.PEARTUBE_NATIVE_WORKLET_DEBUG_LOG || null
@@ -1255,6 +1256,11 @@ export async function initializeStorage(config) {
       res.setHeader('Access-Control-Allow-Headers', 'Range')
       res.setHeader('Access-Control-Expose-Headers', 'Content-Length, Content-Range, Accept-Ranges')
       if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return }
+      try {
+        await prioritizeBlobServerRangeRequest(blobServer, req)
+      } catch (err) {
+        console.log('[Storage] Blob range prioritization failed:', err?.message || err)
+      }
       return origOnRequest(req, res)
     }
 

--- a/packages/backend/test/blob-range-priority.test.mjs
+++ b/packages/backend/test/blob-range-priority.test.mjs
@@ -3,6 +3,10 @@ import c from 'compact-encoding'
 import HypercoreID from 'hypercore-id-encoding'
 import z32 from 'z32'
 
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
 import {
   getPrioritizedBlobDownloadRange,
   parseHttpByteRange,
@@ -102,4 +106,21 @@ test('prioritizeBlobServerRangeRequest starts a non-linear core download for the
   t.alike(calls[0], ['_getCore', key.toString('hex'), blob, true])
   t.alike(calls[1], ['download', { start: 14, end: 15, linear: false }])
   t.ok(calls.some((call) => call[0] === 'close'))
+})
+
+test('storage blob server prioritizes HTTP Range requests before streaming', (t) => {
+  const here = path.dirname(fileURLToPath(import.meta.url))
+  const storageSource = fs.readFileSync(path.join(here, '../src/storage.js'), 'utf8')
+
+  t.ok(
+    storageSource.includes("import { prioritizeBlobServerRangeRequest } from './blob-range-priority.js'"),
+    'storage should import blob range prioritization helper',
+  )
+
+  const priorityIndex = storageSource.indexOf('await prioritizeBlobServerRangeRequest(blobServer, req)')
+  const fallbackIndex = storageSource.indexOf('return origOnRequest(req, res)')
+
+  t.ok(priorityIndex > -1, 'blob server request handler should prioritize requested range')
+  t.ok(fallbackIndex > -1, 'blob server request handler should still call original handler')
+  t.ok(priorityIndex < fallbackIndex, 'range prioritization must happen before normal streaming starts')
 })


### PR DESCRIPTION
Summary
- Wire blob-server HTTP Range requests into the existing blob range prioritizer before normal streaming.
- This makes seeks into uncached parts of a partially cached video request the exact needed blob-core blocks instead of relying only on the background full-prefetch range.
- Add a regression that storage imports and calls the range prioritizer before falling through to the original blob-server handler.

Why
- Mobile can show a connected video peer but 0 B/s traffic when playback seeks into a missing range and the requested range is not promoted. That leaves the player waiting while the generic/background download path is idle or deprioritized.

Tests
- node --check packages/backend/src/storage.js
- node --test packages/backend/test/blob-range-priority.test.mjs packages/backend/test/storage-quota-api.test.mjs packages/backend/test/mobile-handlers.test.mjs packages/app/tests/mobile-video-stats-lifecycle-regression.test.mjs packages/app/tests/storage-accounting-regression.test.mjs
- git diff --check && node --test packages/backend/test/playback-api.test.mjs packages/backend/test/blob-range-priority.test.mjs packages/backend/test/storage-quota-api.test.mjs packages/backend/test/mobile-handlers.test.mjs
