### PR TITLE
fix: show measured mobile cache storage stats

### DIFF
--- a/packages/app/app/(tabs)/settings.tsx
+++ b/packages/app/app/(tabs)/settings.tsx
@@ -18,6 +18,10 @@ interface StorageStats {
   maxGB: number
   seedCount: number
   pinnedCount: number
+  totalStorageBytes?: number
+  totalStorageGB?: string
+  untrackedStorageBytes?: number
+  untrackedStorageGB?: string
 }
 
 interface TranscodeSettings {
@@ -63,6 +67,10 @@ export default function SettingsScreen() {
   const [swarmStatus, setSwarmStatus] = useState<any | null>(null)
   const [seedingStatus, setSeedingStatus] = useState<any | null>(null)
   const nativeButtonStyle = { width: '100%' }
+  const peerCacheUsedBytes = storageStats?.totalStorageBytes ?? storageStats?.usedBytes ?? 0
+  const peerCacheUsedGB = storageStats?.totalStorageGB ?? storageStats?.usedGB
+  const trackedCacheGB = storageStats?.usedGB ?? '0.00'
+  const untrackedStorageGB = storageStats?.untrackedStorageGB ?? '0.00'
 
   // Check if channel is published
   const checkPublishStatus = useCallback(async () => {
@@ -493,7 +501,7 @@ export default function SettingsScreen() {
           <View className="flex-1 ml-4">
             <Text className="text-label text-pear-text">Peer Content Cache</Text>
             <Text className="text-caption text-pear-text-muted mt-0.5">
-              {storageStats ? `${storageStats.usedGB} GB / ${storageStats.maxGB} GB used` : 'Loading...'}
+              {storageStats ? `${peerCacheUsedGB} GB / ${storageStats.maxGB} GB used` : 'Loading...'}
             </Text>
           </View>
         </View>
@@ -503,12 +511,20 @@ export default function SettingsScreen() {
             <View className="h-2 bg-pear-bg-card rounded-full overflow-hidden">
               <View
                 className="h-full bg-pear-primary rounded-full"
-                style={{ width: `${Math.min(100, storageStats.maxBytes > 0 ? (storageStats.usedBytes / storageStats.maxBytes) * 100 : 0)}%` }}
+                style={{ width: `${Math.min(100, storageStats.maxBytes > 0 ? (peerCacheUsedBytes / storageStats.maxBytes) * 100 : 0)}%` }}
               />
             </View>
             <Text className="text-caption text-pear-text-muted mt-2">
               {storageStats.seedCount} cached videos • {storageStats.pinnedCount} pinned channels
             </Text>
+            <Text className="text-caption text-pear-text-muted mt-1">
+              PearTube Storage: {peerCacheUsedGB} GB total • {trackedCacheGB} GB cached
+            </Text>
+            {storageStats.untrackedStorageGB !== undefined ? (
+              <Text className="text-caption text-pear-text-muted mt-1">
+                {untrackedStorageGB} GB app/P2P data outside tracked peer cache
+              </Text>
+            ) : null}
           </View>
         )}
 

--- a/packages/app/components/native-diagnostics/DiagnosticsPanel.android.tsx
+++ b/packages/app/components/native-diagnostics/DiagnosticsPanel.android.tsx
@@ -29,14 +29,17 @@ export default function DiagnosticsPanel({
   loading,
   onRefresh,
 }: DiagnosticsPanelProps) {
+  const cacheUsedBytes = storageStats?.totalStorageBytes ?? storageStats?.usedBytes ?? 0
+  const cacheUsedGB = storageStats?.totalStorageGB ?? storageStats?.usedGB
+  const trackedCacheGB = storageStats?.usedGB ?? '0.00'
   const cacheRatio = useMemo(() => {
     if (!storageStats?.maxBytes) return 0
-    return Math.max(0, Math.min(1, storageStats.usedBytes / storageStats.maxBytes))
-  }, [storageStats])
+    return Math.max(0, Math.min(1, cacheUsedBytes / storageStats.maxBytes))
+  }, [cacheUsedBytes, storageStats])
 
   const p2pLabel = swarmStatus?.swarmOffline
     ? 'Network paused'
-    : (swarmStatus?.connected || 0) > 0
+    : (Boolean(swarmStatus?.connected) || Number(swarmStatus?.swarmConnections ?? swarmStatus?.peerCount ?? 0) > 0)
       ? 'Connected to peers'
       : 'Searching for peers'
 
@@ -99,8 +102,13 @@ export default function DiagnosticsPanel({
             strokeCap="round"
           />
           <Text style={styles.detailText}>
-            {storageStats ? `${storageStats.usedGB} GB used of ${storageStats.maxGB} GB` : 'Loading cache stats…'}
+            {storageStats ? `${cacheUsedGB} GB used of ${storageStats.maxGB} GB` : 'Loading cache stats…'}
           </Text>
+          {storageStats?.totalStorageGB ? (
+            <Text style={styles.detailText}>
+              {trackedCacheGB} GB tracked cache • {storageStats.untrackedStorageGB ?? '0.00'} GB other app/P2P data
+            </Text>
+          ) : null}
           <Text style={styles.detailText}>
             {storageStats ? `${storageStats.seedCount} cached videos • ${storageStats.pinnedCount} pinned channels` : 'Loading cache stats…'}
           </Text>

--- a/packages/app/components/native-diagnostics/DiagnosticsPanel.ios.tsx
+++ b/packages/app/components/native-diagnostics/DiagnosticsPanel.ios.tsx
@@ -21,14 +21,16 @@ export default function DiagnosticsPanel({
   loading,
   onRefresh,
 }: DiagnosticsPanelProps) {
+  const cacheUsedBytes = storageStats?.totalStorageBytes ?? storageStats?.usedBytes ?? 0
+  const cacheUsedGB = storageStats?.totalStorageGB ?? storageStats?.usedGB
   const cacheRatio = useMemo(() => {
     if (!storageStats?.maxBytes) return 0
-    return Math.max(0, Math.min(1, storageStats.usedBytes / storageStats.maxBytes))
-  }, [storageStats])
+    return Math.max(0, Math.min(1, cacheUsedBytes / storageStats.maxBytes))
+  }, [cacheUsedBytes, storageStats])
 
   const p2pLabel = swarmStatus?.swarmOffline
     ? 'Network paused'
-    : (swarmStatus?.connected || 0) > 0
+    : (Boolean(swarmStatus?.connected) || Number(swarmStatus?.swarmConnections ?? swarmStatus?.peerCount ?? 0) > 0)
       ? 'Connected to peers'
       : 'Searching for peers'
 
@@ -86,7 +88,7 @@ export default function DiagnosticsPanel({
             value={cacheRatio}
             min={0}
             max={1}
-            currentValueLabel={storageStats ? `${storageStats.usedGB} GB used` : 'Loading…'}
+            currentValueLabel={storageStats ? `${cacheUsedGB} GB used` : 'Loading…'}
             maximumValueLabel={storageStats ? `${storageStats.maxGB} GB budget` : '—'}
           >
             Cached content budget

--- a/packages/app/components/native-diagnostics/DiagnosticsPanel.web.tsx
+++ b/packages/app/components/native-diagnostics/DiagnosticsPanel.web.tsx
@@ -15,12 +15,13 @@ export default function DiagnosticsPanel({
   storageStats,
   seedingStatus,
 }: DiagnosticsPanelProps) {
+  const cacheUsedGB = storageStats?.totalStorageGB ?? storageStats?.usedGB
   return (
     <View style={styles.card}>
       <Text style={styles.title}>Native diagnostics</Text>
       <Text style={styles.text}>P2P: {swarmStatus?.swarmConnections ?? swarmStatus?.peerCount ?? 0} connections</Text>
       <Text style={styles.text}>
-        Cache: {storageStats ? `${storageStats.usedGB} GB used of ${storageStats.maxGB} GB` : 'loading...'}
+        Cache: {storageStats ? `${cacheUsedGB} GB used of ${storageStats.maxGB} GB` : 'loading...'}
       </Text>
       <Text style={styles.text}>
         Seeding: {seedingStatus?.status?.enabled ? 'enabled' : 'disabled'}

--- a/packages/app/components/native-diagnostics/types.ts
+++ b/packages/app/components/native-diagnostics/types.ts
@@ -5,6 +5,10 @@ export interface StorageStats {
   maxGB: number
   seedCount: number
   pinnedCount: number
+  totalStorageBytes?: number
+  totalStorageGB?: string
+  untrackedStorageBytes?: number
+  untrackedStorageGB?: string
 }
 
 export interface SeedingStatus {

--- a/packages/app/tests/settings-storage-cache-ui.test.mjs
+++ b/packages/app/tests/settings-storage-cache-ui.test.mjs
@@ -24,8 +24,25 @@ test('settings renders storage controls before account onboarding', () => {
   assert.match(storageSection, /GB total/)
   assert.match(storageSection, /GB cached/)
   assert.match(storageSection, /app\/P2P data outside tracked peer cache/)
+  assert.match(settingsSource, /totalStorageGB \?\? storageStats\?\.usedGB/)
+  assert.match(settingsSource, /totalStorageBytes \?\? storageStats\?\.usedBytes/)
   assert.match(storageSection, /handleStorageLimitChange/)
   assert.match(storageSection, /handleClearCache/)
+})
+
+test('native diagnostics cache meter prefers measured storage totals', () => {
+  const androidSource = fs.readFileSync(path.join(__dirname, '..', 'components', 'native-diagnostics', 'DiagnosticsPanel.android.tsx'), 'utf8')
+  const iosSource = fs.readFileSync(path.join(__dirname, '..', 'components', 'native-diagnostics', 'DiagnosticsPanel.ios.tsx'), 'utf8')
+  const webSource = fs.readFileSync(path.join(__dirname, '..', 'components', 'native-diagnostics', 'DiagnosticsPanel.web.tsx'), 'utf8')
+  const typesSource = fs.readFileSync(path.join(__dirname, '..', 'components', 'native-diagnostics', 'types.ts'), 'utf8')
+
+  for (const source of [androidSource, iosSource, webSource]) {
+    assert.match(source, /totalStorageGB \?\? storageStats\?\.usedGB/)
+  }
+  assert.match(androidSource, /totalStorageBytes \?\? storageStats\?\.usedBytes/)
+  assert.match(iosSource, /totalStorageBytes \?\? storageStats\?\.usedBytes/)
+  assert.match(typesSource, /totalStorageBytes\?: number/)
+  assert.match(typesSource, /untrackedStorageGB\?: string/)
 })
 
 test('settings exposes a custom cache limit input rather than only preset buttons', () => {


### PR DESCRIPTION
Summary
- Fix mobile Settings Peer Content Cache to prefer measured app/P2P disk totals over logical tracked seed bytes.
- Update Android/iOS/web native diagnostics cache meters to use measured totals when present.
- Add source regressions so future UI changes keep measured storage fields wired through.

Test Plan
- node --test packages/app/tests/settings-storage-cache-ui.test.mjs packages/app/tests/storage-accounting-regression.test.mjs
- packages/backend/node_modules/.bin/brittle packages/backend/test/seeding-storage-accounting.test.mjs
- npm run -s desktop:worker --prefix packages/app
- ./node_modules/.bin/eslint --quiet packages/app/app/'(tabs)'/settings.tsx packages/app/components/native-diagnostics/types.ts packages/app/components/native-diagnostics/DiagnosticsPanel.android.tsx packages/app/components/native-diagnostics/DiagnosticsPanel.ios.tsx packages/app/components/native-diagnostics/DiagnosticsPanel.web.tsx packages/app/tests/settings-storage-cache-ui.test.mjs
- node --test packages/backend/test/mobile-handlers.test.mjs packages/backend/test/storage-quota-api.test.mjs packages/app/tests/settings-storage-cache-ui.test.mjs packages/app/tests/storage-accounting-regression.test.mjs packages/app/tests/mobile-video-stats-lifecycle-regression.test.mjs

Note
- The worktree has unrelated pre-existing Android/backend modifications that were not included in this commit.