### PR TITLE
fix: preserve archive metadata in relay previews

### DIFF
--- a/packages/cli/src/archive/index.js
+++ b/packages/cli/src/archive/index.js
@@ -150,10 +150,11 @@ export function createArchiver({
       const pub = await ensurePublisher()
       const result = await pub.publishVideo({ source, ytEntry, files })
 
+      const archivedTitle = result.title || ytEntry.title || ''
       await state.markArchived(source.sourceId, ytEntry.id, {
         peartubeVideoId: result.videoId,
         bytes: result.bytes,
-        title: ytEntry.title
+        title: archivedTitle
       })
 
       logger.archive.info('Video archived', {
@@ -161,7 +162,7 @@ export function createArchiver({
         ytId: ytEntry.id,
         peartubeVideoId: result.videoId,
         bytes: result.bytes,
-        title: ytEntry.title || ''
+        title: archivedTitle
       })
 
       return {

--- a/packages/cli/src/archive/publisher.js
+++ b/packages/cli/src/archive/publisher.js
@@ -13,8 +13,8 @@ function buildSourceMarker(source) {
 }
 
 function defaultChannelName(source) {
-  if (source.label) return source.label
   if (source.creatorName) return source.creatorName
+  if (source.label) return source.label
   if (source.channelName) return source.channelName
   if (source.uploader) return source.uploader
   if (source.kind === 'handle') return source.identifier
@@ -72,6 +72,52 @@ async function listChannelPreviewVideos(channelEntry, limit = 3) {
       thumbnailMimeType: video?.thumbnailMimeType || null,
       channelName
     }))
+}
+
+function normalizeText(value, maxLength = 5000) {
+  return String(value || '').split('').map((char) => {
+    const code = char.charCodeAt(0)
+    return code < 32 || code === 127 ? ' ' : char
+  }).join('').replace(/\s+/g, ' ').trim().slice(0, maxLength)
+}
+
+function readYtDlpInfoFile(fs, infoFile) {
+  if (!infoFile || typeof fs?.readFileSync !== 'function') return null
+  try {
+    if (typeof fs.existsSync === 'function' && !fs.existsSync(infoFile)) return null
+    const parsed = JSON.parse(String(fs.readFileSync(infoFile, 'utf8') || '{}'))
+    return parsed && typeof parsed === 'object' ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+function creatorNameFromInfo(info) {
+  return normalizeText(info?.channel || info?.uploader || info?.uploader_id || '', 160) || null
+}
+
+function titleFromInfo(info) {
+  return normalizeText(info?.title || info?.fulltitle || '', 240) || null
+}
+
+function durationFromInfo(info) {
+  const duration = Number(info?.duration)
+  return Number.isFinite(duration) && duration > 0 ? duration : null
+}
+
+function sourceUrlFromInfo(info, fallback) {
+  return normalizeText(info?.webpage_url || info?.original_url || info?.url || fallback || '', 1000) || null
+}
+
+function thumbnailUrlFromInfo(info) {
+  return normalizeText(info?.thumbnail || '', 1000) || null
+}
+
+function thumbnailMimeTypeForPath(filePath) {
+  const lower = String(filePath || '').toLowerCase()
+  if (lower.endsWith('.webp')) return 'image/webp'
+  if (lower.endsWith('.png')) return 'image/png'
+  return 'image/jpeg'
 }
 
 async function announceArchiveChannel(runtime, channelEntry, logger, sourceId, options = {}) {
@@ -255,9 +301,15 @@ export function createArchivePublisher({ ctx, uploadManager, runtime, fs, logger
   }
 
   async function publishVideo({ source, ytEntry, files }) {
+    const info = readYtDlpInfoFile(fs, files?.infoFile)
+    const importedTitle = titleFromInfo(info) || ytEntry?.title || files?.videoFile?.split('/')?.pop() || 'Untitled'
+    const importedCreatorName = creatorNameFromInfo(info) || ytEntry?.uploader || source?.creatorName || null
+    const importedDuration = durationFromInfo(info) ?? (Number.isFinite(ytEntry?.duration) ? Number(ytEntry.duration) : 0)
+    const importedSourceUrl = sourceUrlFromInfo(info, ytEntry?.webpageUrl || source?.url)
+    const importedThumbnailUrl = thumbnailUrlFromInfo(info)
     const sourceForChannel = {
       ...source,
-      creatorName: ytEntry?.uploader || source?.creatorName || null
+      creatorName: importedCreatorName
     }
     const channelEntry = await ensureSourceChannel(sourceForChannel)
     const { channel } = channelEntry
@@ -273,12 +325,17 @@ export function createArchivePublisher({ ctx, uploadManager, runtime, fs, logger
       channel,
       files.videoFile,
       {
-        title: ytEntry.title || files.videoFile.split('/').pop() || 'Untitled',
-        description: ytEntry.webpageUrl
-          ? `Source: ${ytEntry.webpageUrl}`
+        title: importedTitle,
+        description: importedSourceUrl
+          ? `Source: ${importedSourceUrl}`
           : '',
-        duration: Number.isFinite(ytEntry.duration) ? Number(ytEntry.duration) : 0,
-        category: 'archive'
+        duration: importedDuration || 0,
+        category: 'archive',
+        sourceType: info ? 'yt-dlp' : 'archive',
+        sourceUrl: importedSourceUrl,
+        sourceVideoId: normalizeText(info?.id || ytEntry?.id || '', 160) || null,
+        creatorName: importedCreatorName,
+        thumbnailUrl: importedThumbnailUrl
       },
       fs
     )
@@ -290,7 +347,16 @@ export function createArchivePublisher({ ctx, uploadManager, runtime, fs, logger
     if (files.thumbnailFile) {
       try {
         const thumbBuffer = fs.readFileSync(files.thumbnailFile)
-        await uploadManager.setThumbnailFromBuffer(channel, result.videoId, thumbBuffer, 'image/jpeg')
+        const thumbnailMimeType = thumbnailMimeTypeForPath(files.thumbnailFile)
+        const thumbnailResult = await uploadManager.setThumbnailFromBuffer(channel, result.videoId, thumbBuffer, thumbnailMimeType)
+        if (thumbnailResult?.success) {
+          result.metadata = {
+            ...(result.metadata || {}),
+            thumbnailBlobId: thumbnailResult.thumbnailBlobId || result.metadata?.thumbnailBlobId || null,
+            thumbnailBlobsCoreKey: channel.blobsKeyHex || result.metadata?.thumbnailBlobsCoreKey || null,
+            thumbnailMimeType
+          }
+        }
       } catch (err) {
         logger?.archive?.debug?.('Thumbnail attach failed', {
           videoId: result.videoId,
@@ -299,13 +365,35 @@ export function createArchivePublisher({ ctx, uploadManager, runtime, fs, logger
       }
     }
 
-    await announceArchiveChannel(runtime, channelEntry, logger, source.sourceId)
+    const metadata = result.metadata || {}
+    const previewVideo = {
+      id: String(result.videoId),
+      title: importedTitle,
+      description: importedSourceUrl ? `Source: ${importedSourceUrl}` : '',
+      path: metadata.path || `/videos/${result.videoId}.mp4`,
+      uploadedAt: Number(metadata.uploadedAt || 0) || Date.now(),
+      duration: Number(metadata.duration || importedDuration || 0) || 0,
+      size: Number(metadata.size || fileSize || 0) || 0,
+      mimeType: metadata.mimeType || 'video/mp4',
+      availability: 'playable',
+      blobId: metadata.blobId || null,
+      blobsCoreKey: metadata.blobsCoreKey || null,
+      thumbnailBlobId: metadata.thumbnailBlobId || null,
+      thumbnailBlobsCoreKey: metadata.thumbnailBlobsCoreKey || null,
+      thumbnailMimeType: metadata.thumbnailMimeType || null,
+      thumbnailUrl: metadata.thumbnailUrl || importedThumbnailUrl || null,
+      channelName: channelEntry.channelName || importedCreatorName || null
+    }
+
+    await announceArchiveChannel(runtime, channelEntry, logger, source.sourceId, { previewVideos: [previewVideo] })
 
     return {
       videoId: result.videoId,
       bytes: fileSize,
       channelKey: channelEntry.channelKey,
-      publicBeeKey: channelEntry.publicBeeKey
+      publicBeeKey: channelEntry.publicBeeKey,
+      title: importedTitle,
+      channelName: channelEntry.channelName || importedCreatorName || null
     }
   }
 

--- a/packages/cli/test/archive.test.mjs
+++ b/packages/cli/test/archive.test.mjs
@@ -180,6 +180,99 @@ test('archive publisher derives YouTube channel name from yt-dlp uploader metada
   t.is(channels.length, 1)
   t.is(channels[0].name, 'Actual Creator')
 })
+test('archive publisher uses yt-dlp info metadata and thumbnail refs for previews', async (t) => {
+  const submitted = []
+  const uploaded = []
+  const source = {
+    sourceId: 'youtube:rumble:video:v7ah96i-america-first-ep.-1690',
+    url: 'https://rumble.com/v7ah96i-america-first-ep.-1690.html',
+    type: 'youtube',
+    kind: 'rumble-video',
+    identifier: 'rumble:video:v7ah96i-america-first-ep.-1690',
+    label: 'America First Full Episodes'
+  }
+  const channel = {
+    writable: true,
+    blobsKeyHex: 'dd'.repeat(32),
+    async getMetadata() { return {} },
+    async updateMetadata(meta) { uploaded.push(['channel-meta', meta]) },
+    async ensureLocalBlobDrive() {},
+    async getPublicBeeKey() { return 'bb'.repeat(32) },
+    async listVideos() { return [] }
+  }
+  const infoJson = JSON.stringify({
+    id: 'v7ah96i-america-first-ep.-1690',
+    title: 'America First Ep. 1690 - Real Rumble Title',
+    uploader: 'Nicholas J. Fuentes',
+    webpage_url: 'https://rumble.com/v7ah96i-america-first-ep.-1690.html',
+    duration: 1234,
+    thumbnail: 'https://rumble.com/thumb.jpg'
+  })
+  const fs = makeFakeFs({
+    '/tmp/video.mp4': 'video bytes',
+    '/tmp/video.info.json': infoJson,
+    '/tmp/video.jpg': 'jpeg bytes'
+  })
+  fs.existsSync = (path) => path in {
+    '/tmp/video.mp4': true,
+    '/tmp/video.info.json': true,
+    '/tmp/video.jpg': true
+  }
+  const publisher = createArchivePublisher({
+    ctx: {},
+    uploadManager: {
+      async uploadFromPath(_channel, _filePath, options) {
+        uploaded.push(['video', options])
+        return {
+          success: true,
+          videoId: 'video-1',
+          metadata: {
+            blobId: '0:1:0:10',
+            blobsCoreKey: 'cc'.repeat(32),
+            mimeType: 'video/mp4',
+            size: 10,
+            duration: options.duration
+          }
+        }
+      },
+      async setThumbnailFromBuffer(_channel, videoId, image, mimeType) {
+        uploaded.push(['thumbnail', videoId, image.toString(), mimeType])
+        return { success: true, thumbnailBlobId: '1:1:0:4' }
+      }
+    },
+    runtime: {
+      publicFeed: {
+        async submitChannel(_driveKey, _publicBeeKey, options) { submitted.push(options) }
+      },
+      cacheManager: { async pinChannel() {}, async addChannel() {} },
+      seeder: { async seedChannel() {} },
+      async publishRelayCatalogEntry() {}
+    },
+    fs,
+    logger: makeFakeLogger(),
+    state: null,
+    createChannelFn: async () => ({ channel, channelKeyHex: 'aa'.repeat(32) })
+  })
+
+  const result = await publisher.publishVideo({
+    source,
+    ytEntry: { id: 'v7ah96i-america-first-ep.-1690', title: 'America First Full Episodes', uploader: null, duration: null, webpageUrl: source.url },
+    files: { videoFile: '/tmp/video.mp4', infoFile: '/tmp/video.info.json', thumbnailFile: '/tmp/video.jpg' }
+  })
+
+  t.is(result.title, 'America First Ep. 1690 - Real Rumble Title')
+  t.is(uploaded[0][1].name, 'Nicholas J. Fuentes')
+  t.is(uploaded[1][1].title, 'America First Ep. 1690 - Real Rumble Title')
+  t.is(uploaded[2][3], 'image/jpeg')
+  const preview = submitted.at(-1).previewVideos[0]
+  t.is(preview.title, 'America First Ep. 1690 - Real Rumble Title')
+  t.is(preview.channelName, 'Nicholas J. Fuentes')
+  t.is(preview.thumbnailBlobId, '1:1:0:4')
+  t.is(preview.thumbnailBlobsCoreKey, 'dd'.repeat(32))
+  t.is(preview.thumbnailMimeType, 'image/jpeg')
+  t.is(preview.thumbnailUrl, 'https://rumble.com/thumb.jpg')
+})
+
 test('classifySourceUrl recognises YouTube channels, handles, and playlists', (t) => {
   t.alike(classifySourceUrl('https://www.youtube.com/@somechannel'), {
     type: 'youtube',


### PR DESCRIPTION
## Summary
- Read yt-dlp `.info.json` during archive import so Rumble video archives keep real titles, source URLs, duration, and uploader/channel names.
- Include thumbnail upload metadata in preview videos so public feed cards can render thumbnails.
- Log/archive state with the imported title instead of the configured source label.

## Test Plan
- `node --check packages/cli/src/archive/publisher.js`
- `node --check packages/cli/src/archive/index.js`
- `./packages/cli/node_modules/.bin/brittle packages/cli/test/archive.test.mjs`
- `git diff --check HEAD~1..HEAD`
