### PR TITLE
refactor: split universal core scoring and budgets

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -35,6 +35,8 @@
     "./feed": "./src/feed.js",
     "./media": "./src/media.js",
     "./universal-core": "./src/universal-core.js",
+    "./peer-scorer": "./src/peer-scorer.js",
+    "./budget-manager": "./src/budget-manager.js",
     "./hash-utils": "./src/hash-utils.js",
     "./blob-ref": "./src/blob-ref.js",
     "./mirror": "./src/mirror/index.js"

--- a/packages/backend/src/budget-manager.js
+++ b/packages/backend/src/budget-manager.js
@@ -1,0 +1,182 @@
+import c from 'compact-encoding'
+
+import {
+  DEFAULT_POLICY,
+  ROLE_MOBILE,
+  ROLE_RELAY,
+  normalizeRole,
+  safeNumber,
+} from './universal-core-utils.js'
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, Math.floor(value)))
+}
+
+function normalizeMemoryStats(stats = {}) {
+  const memory = stats.memory || stats.mem || stats
+  const rss = safeNumber(memory.rss ?? memory.residentSetSize, 0)
+  const heapUsed = safeNumber(memory.heapUsed ?? memory.used, 0)
+  const external = safeNumber(memory.external ?? memory.native ?? memory.arrayBuffers, 0)
+  const total = safeNumber(memory.total ?? memory.heapTotal ?? memory.totalMemory ?? memory.limit, 0)
+  const free = safeNumber(memory.free ?? memory.available ?? (total > 0 ? Math.max(0, total - Math.max(rss, heapUsed + external)) : 0), 0)
+  const used = Math.max(rss, heapUsed + external)
+  const pressure = total > 0 ? clamp((used / total) * 100, 0, 100) : clamp(safeNumber(memory.pressure, 0), 0, 100)
+  return { rss, heapUsed, external, total, free, used, pressure }
+}
+
+async function readBareHcMemoryStats(source) {
+  if (!source) return null
+  if (typeof source === 'function') return normalizeMemoryStats(await source())
+  for (const name of ['memoryStats', 'getMemoryStats', 'stats', 'getStats']) {
+    if (typeof source[name] === 'function') {
+      const stats = await source[name]()
+      return normalizeMemoryStats(stats?.memory || stats)
+    }
+  }
+  if (source.memory || source.rss || source.heapUsed) return normalizeMemoryStats(source)
+  return null
+}
+
+export const budgetStateEncoding = {
+  preencode(state, budget = {}) {
+    c.uint.preencode(state, 1)
+    c.string.preencode(state, String(budget.role || 'hybrid'))
+    c.uint.preencode(state, Math.max(0, Math.floor(safeNumber(budget.memoryPressure, 0))))
+    c.uint.preencode(state, Math.max(0, Math.floor(safeNumber(budget.maxFanout, 0))))
+    c.uint.preencode(state, Math.max(0, Math.floor(safeNumber(budget.maxRequestsPerWindow, 0))))
+    c.uint.preencode(state, Math.max(0, Math.floor(safeNumber(budget.maxFeedEntries, 0))))
+    c.uint.preencode(state, Math.max(0, Math.floor(safeNumber(budget.maxConcurrentSync, 0))))
+    c.uint.preencode(state, Math.max(0, Math.floor(safeNumber(budget.maxConcurrentProofs, 0))))
+    c.uint.preencode(state, Math.max(0, Math.floor(safeNumber(budget.maxConcurrentFetches, 0))))
+  },
+  encode(state, budget = {}) {
+    c.uint.encode(state, 1)
+    c.string.encode(state, String(budget.role || 'hybrid'))
+    c.uint.encode(state, Math.max(0, Math.floor(safeNumber(budget.memoryPressure, 0))))
+    c.uint.encode(state, Math.max(0, Math.floor(safeNumber(budget.maxFanout, 0))))
+    c.uint.encode(state, Math.max(0, Math.floor(safeNumber(budget.maxRequestsPerWindow, 0))))
+    c.uint.encode(state, Math.max(0, Math.floor(safeNumber(budget.maxFeedEntries, 0))))
+    c.uint.encode(state, Math.max(0, Math.floor(safeNumber(budget.maxConcurrentSync, 0))))
+    c.uint.encode(state, Math.max(0, Math.floor(safeNumber(budget.maxConcurrentProofs, 0))))
+    c.uint.encode(state, Math.max(0, Math.floor(safeNumber(budget.maxConcurrentFetches, 0))))
+  },
+  decode(state) {
+    const version = c.uint.decode(state)
+    if (version !== 1) throw new Error(`Unsupported budget state version ${version}`)
+    return {
+      role: c.string.decode(state),
+      memoryPressure: c.uint.decode(state),
+      maxFanout: c.uint.decode(state),
+      maxRequestsPerWindow: c.uint.decode(state),
+      maxFeedEntries: c.uint.decode(state),
+      maxConcurrentSync: c.uint.decode(state),
+      maxConcurrentProofs: c.uint.decode(state),
+      maxConcurrentFetches: c.uint.decode(state),
+    }
+  },
+}
+
+export function encodeBudgetState(budget = {}) {
+  return c.encode(budgetStateEncoding, budget)
+}
+
+export function decodeBudgetState(buffer) {
+  if (!buffer) return null
+  return c.decode(budgetStateEncoding, buffer)
+}
+
+export function createBudgetManager(options = {}) {
+  const role = normalizeRole(options.role)
+  const profile = { ...(role === ROLE_RELAY ? DEFAULT_POLICY.relay : DEFAULT_POLICY.mobile), ...(options.profile || {}) }
+  const batteryFloor = safeNumber(options.batteryFloor, role === ROLE_RELAY ? 5 : 25)
+  const bandwidthFloor = safeNumber(options.bandwidthFloor, role === ROLE_RELAY ? 0 : 5)
+  const baseConcurrentSync = safeNumber(options.maxConcurrentSync, role === ROLE_RELAY ? 8 : 1)
+  const baseConcurrentProofs = safeNumber(options.maxConcurrentProofs, role === ROLE_RELAY ? 4 : 1)
+  const baseConcurrentFetches = safeNumber(options.maxConcurrentFetches, role === ROLE_RELAY ? 8 : 1)
+  const memorySource = options.memoryStats || options.bareHc || options.libhc || null
+  let memoryStats = normalizeMemoryStats(options.initialMemoryStats || {})
+  let lastThresholds = null
+
+  function thresholdsFor(stats = memoryStats) {
+    const pressure = clamp(safeNumber(stats?.pressure, 0), 0, 100)
+    const relief = pressure >= 90 ? 0.25 : pressure >= 80 ? 0.4 : pressure >= 65 ? 0.65 : pressure >= 45 ? 0.85 : 1
+    const fanout = clamp((profile.maxFanout || 1) * relief, 1, profile.maxFanout || 1)
+    const requests = clamp((profile.maxRequestsPerWindow || 1) * relief, 1, profile.maxRequestsPerWindow || 1)
+    const feeds = clamp((profile.maxFeedEntries || 32) * relief, role === ROLE_RELAY ? 64 : 16, profile.maxFeedEntries || 32)
+    return {
+      role,
+      memoryPressure: pressure,
+      maxFanout: fanout,
+      maxRequestsPerWindow: requests,
+      maxFeedEntries: feeds,
+      maxConcurrentSync: clamp(baseConcurrentSync * relief, 1, baseConcurrentSync),
+      maxConcurrentProofs: clamp(baseConcurrentProofs * relief, 1, baseConcurrentProofs),
+      maxConcurrentFetches: clamp(baseConcurrentFetches * relief, 1, baseConcurrentFetches),
+    }
+  }
+
+  async function refreshMemoryStats(source = memorySource) {
+    const next = await readBareHcMemoryStats(source)
+    if (next) memoryStats = next
+    lastThresholds = thresholdsFor(memoryStats)
+    return { memoryStats, thresholds: lastThresholds }
+  }
+
+  function updateMemoryStats(stats = {}) {
+    memoryStats = normalizeMemoryStats(stats)
+    lastThresholds = thresholdsFor(memoryStats)
+    return lastThresholds
+  }
+
+  function getThresholds(resource = {}) {
+    const resourceStats = resource.memory || resource.memoryStats ? normalizeMemoryStats(resource.memory || resource.memoryStats) : memoryStats
+    lastThresholds = thresholdsFor(resourceStats)
+    return lastThresholds
+  }
+
+  function budgetFor(resource = {}) {
+    const battery = safeNumber(resource.batteryPercent, 100)
+    const bandwidth = safeNumber(resource.bandwidthScore, 100)
+    const thermal = safeNumber(resource.thermalScore, 0)
+    const charging = Boolean(resource.isCharging)
+    const thresholds = getThresholds(resource)
+
+    const mobilePenalty = role === ROLE_MOBILE ? Math.max(0, 30 - battery) + Math.max(0, 20 - bandwidth) + Math.max(0, thermal) : 0
+    const memoryPenalty = Math.max(0, thresholds.memoryPressure - 70)
+    const base = role === ROLE_RELAY ? 100 : 50
+    const credit = Math.max(0, base - mobilePenalty - memoryPenalty + (charging ? 10 : 0))
+
+    return {
+      role,
+      syncIntervalMs: profile.syncIntervalMs,
+      proofIntervalMs: profile.proofIntervalMs,
+      refreshIntervalMs: profile.refreshIntervalMs,
+      maxFanout: thresholds.maxFanout,
+      maxRequestsPerWindow: thresholds.maxRequestsPerWindow,
+      maxFeedEntries: thresholds.maxFeedEntries,
+      maxBytesPerDay: profile.maxBytesPerDay,
+      batteryFloor,
+      bandwidthFloor,
+      maxConcurrentSync: thresholds.maxConcurrentSync,
+      maxConcurrentProofs: thresholds.maxConcurrentProofs,
+      maxConcurrentFetches: thresholds.maxConcurrentFetches,
+      memoryPressure: thresholds.memoryPressure,
+      memoryStats,
+      credit,
+      canSync: battery >= batteryFloor && bandwidth >= bandwidthFloor && thresholds.memoryPressure < 92,
+      canEmitProof: battery >= Math.max(10, batteryFloor - 5) && bandwidth >= bandwidthFloor && thresholds.memoryPressure < 95,
+      canFetch: battery >= Math.max(10, batteryFloor - 10) && bandwidth >= bandwidthFloor && thresholds.memoryPressure < 97,
+    }
+  }
+
+  function snapshot() {
+    const thresholds = lastThresholds || getThresholds()
+    return { role, profile, memoryStats, thresholds }
+  }
+
+  return { role, profile, budgetFor, getThresholds, refreshMemoryStats, updateMemoryStats, snapshot, encodeBudgetState, decodeBudgetState }
+}
+
+export function createResourcePolicy(options = {}) {
+  return createBudgetManager(options)
+}

--- a/packages/backend/src/index.js
+++ b/packages/backend/src/index.js
@@ -56,3 +56,5 @@ export { createBackendContext } from './orchestrator.js';
 // Universal core - shared Bare-native entrypoint across all shells
 export { createUniversalCore, createUniversalHrpcSurface } from './universal-core.js';
 export * as universalCore from './universal-core.js';
+export * as peerScorer from './peer-scorer.js';
+export * as budgetManager from './budget-manager.js';

--- a/packages/backend/src/peer-scorer.js
+++ b/packages/backend/src/peer-scorer.js
@@ -1,0 +1,368 @@
+import c from 'compact-encoding'
+import BeeDiffStream from 'hyperbee-diff-stream'
+
+import {
+  descriptorIdOf,
+  hashText,
+  nowMs,
+  safeBigInt,
+  safeNumber,
+  toHex,
+} from './universal-core-utils.js'
+
+const METRIC_PREFIX = 'universal-core:peer-metric:'
+
+function identityAgeScore(identity = {}, now = Date.now()) {
+  const createdAt = safeBigInt(identity.createdAt || 0n, 0n)
+  const ageMs = createdAt > 0n ? Math.max(0n, nowMs(now) - createdAt) : 0n
+  return Math.min(40, Number(ageMs / BigInt(24 * 60 * 60 * 1000)))
+}
+
+function clampScore(score) {
+  return Math.max(0, Math.min(100, Math.floor(safeNumber(score, 0))))
+}
+
+function normalizeMetric(peerId, metric = {}) {
+  const handshakes = safeNumber(metric.handshakes ?? metric.handshakeCount, 0)
+  const failures = safeNumber(metric.handshakeFailures ?? metric.failedHandshakes, 0)
+  const successes = safeNumber(metric.handshakeSuccesses ?? metric.successfulHandshakes, 0)
+  const total = Math.max(handshakes, successes + failures)
+  const latencyMs = Math.max(0, safeNumber(metric.latencyMs ?? metric.rttMs, 0))
+  const throughput = Math.max(0, safeNumber(metric.udxThroughputBps ?? metric.throughputBps ?? metric.bytesPerSecond, 0))
+  return {
+    peerId: toHex(peerId || metric.peerId || metric.identityId || hashText(metric)),
+    latencyMs,
+    handshakeSuccesses: successes,
+    handshakeFailures: failures,
+    handshakes: total,
+    udxThroughputBps: throughput,
+    observedAt: safeBigInt(metric.observedAt || metric.at || Date.now(), nowMs()),
+  }
+}
+
+function performanceScore(metric = {}) {
+  if (!metric) return 0
+  const latency = safeNumber(metric.latencyMs, 0)
+  const throughput = safeNumber(metric.udxThroughputBps, 0)
+  const handshakes = Math.max(1, safeNumber(metric.handshakes, 0))
+  const successes = safeNumber(metric.handshakeSuccesses, 0)
+  const failures = safeNumber(metric.handshakeFailures, 0)
+  const handshakeRate = Math.max(0, Math.min(1, successes / Math.max(handshakes, successes + failures, 1)))
+  const latencyScore = latency <= 0 ? 5 : Math.max(-20, 20 - Math.floor(latency / 50))
+  const throughputScore = Math.min(20, Math.floor(throughput / (128 * 1024)))
+  const handshakeScore = Math.floor(handshakeRate * 20) - Math.min(20, failures * 4)
+  return latencyScore + throughputScore + handshakeScore
+}
+
+export const peerMetricEncoding = {
+  preencode(state, metric = {}) {
+    c.uint.preencode(state, 1)
+    c.string.preencode(state, toHex(metric.peerId || ''))
+    c.uint.preencode(state, Math.max(0, Math.floor(safeNumber(metric.latencyMs, 0))))
+    c.uint.preencode(state, Math.max(0, Math.floor(safeNumber(metric.handshakeSuccesses, 0))))
+    c.uint.preencode(state, Math.max(0, Math.floor(safeNumber(metric.handshakeFailures, 0))))
+    c.uint.preencode(state, Math.max(0, Math.floor(safeNumber(metric.handshakes, 0))))
+    c.uint.preencode(state, Math.max(0, Math.floor(safeNumber(metric.udxThroughputBps, 0))))
+    c.biguint.preencode(state, safeBigInt(metric.observedAt, 0n))
+  },
+  encode(state, metric = {}) {
+    c.uint.encode(state, 1)
+    c.string.encode(state, toHex(metric.peerId || ''))
+    c.uint.encode(state, Math.max(0, Math.floor(safeNumber(metric.latencyMs, 0))))
+    c.uint.encode(state, Math.max(0, Math.floor(safeNumber(metric.handshakeSuccesses, 0))))
+    c.uint.encode(state, Math.max(0, Math.floor(safeNumber(metric.handshakeFailures, 0))))
+    c.uint.encode(state, Math.max(0, Math.floor(safeNumber(metric.handshakes, 0))))
+    c.uint.encode(state, Math.max(0, Math.floor(safeNumber(metric.udxThroughputBps, 0))))
+    c.biguint.encode(state, safeBigInt(metric.observedAt, 0n))
+  },
+  decode(state) {
+    const version = c.uint.decode(state)
+    if (version !== 1) throw new Error(`Unsupported peer metric version ${version}`)
+    return {
+      peerId: c.string.decode(state),
+      latencyMs: c.uint.decode(state),
+      handshakeSuccesses: c.uint.decode(state),
+      handshakeFailures: c.uint.decode(state),
+      handshakes: c.uint.decode(state),
+      udxThroughputBps: c.uint.decode(state),
+      observedAt: c.biguint.decode(state),
+    }
+  },
+}
+
+export function encodePeerMetric(metric = {}) {
+  return c.encode(peerMetricEncoding, normalizeMetric(metric.peerId, metric))
+}
+
+export function decodePeerMetric(buffer) {
+  if (!buffer) return null
+  return c.decode(peerMetricEncoding, buffer)
+}
+
+export function createPeerMetricDiffStream(leftSnapshot, rightSnapshot, options = {}) {
+  return new BeeDiffStream(leftSnapshot, rightSnapshot, {
+    ...options,
+    gte: options.gte || METRIC_PREFIX,
+    lt: options.lt || 'universal-core:peer-metric;',
+    keyEncoding: options.keyEncoding || 'utf-8',
+    valueEncoding: options.valueEncoding || 'binary',
+  })
+}
+
+export function createSybilPolicy(options = {}) {
+  const base = {
+    minProofs: safeNumber(options.minProofs, 1),
+    maxFailurePenalty: safeNumber(options.maxFailurePenalty, 45),
+    maxQuarantinePenalty: safeNumber(options.maxQuarantinePenalty, 35),
+    maxTombstonePenalty: safeNumber(options.maxTombstonePenalty, 50),
+    maxSpamPenalty: safeNumber(options.maxSpamPenalty, 20),
+  }
+
+  return {
+    scoreIdentity(identity = {}, now = Date.now()) {
+      const age = identityAgeScore(identity, now)
+      const validProofs = Math.min(30, safeNumber(identity.validProofCount, 0) * 6)
+      const successfulSeals = Math.min(15, safeNumber(identity.successfulSealCount, 0) * 3)
+      const serviceScore = Math.min(15, Math.floor(safeNumber(identity.usefulWorkScore, 0) / 25))
+      const failures = Math.min(base.maxFailurePenalty, safeNumber(identity.failureCount, 0) * 9)
+      const quarantines = Math.min(base.maxQuarantinePenalty, safeNumber(identity.quarantineCount, 0) * 7)
+      const tombstones = Math.min(base.maxTombstonePenalty, safeNumber(identity.tombstoneCount, 0) * 10)
+      const spam = Math.min(base.maxSpamPenalty, safeNumber(identity.spamScore, 0) * 4)
+      const freshness = Math.max(0, 10 - Math.floor(Math.max(0, safeNumber(identity.lastProofAgeMs, Infinity)) / (60 * 60 * 1000)))
+      const score = 20 + age + validProofs + successfulSeals + serviceScore + freshness - failures - quarantines - tombstones - spam
+      return clampScore(score)
+    },
+    allowsFanout(identity, peerCount = 0, now = Date.now()) {
+      const score = this.scoreIdentity(identity, now)
+      const scaledFanout = Math.max(1, Math.floor(score / 10))
+      return Math.min(Math.max(1, peerCount || 1), scaledFanout)
+    },
+    allowsRequest(identity, inFlight = 0, now = Date.now()) {
+      const score = this.scoreIdentity(identity, now)
+      const allowance = Math.max(1, Math.floor(score / 15))
+      return inFlight < allowance
+    },
+  }
+}
+
+export function createUsefulWorkLedger(options = {}) {
+  const byPeer = new Map()
+  const byDescriptor = new Map()
+  const totals = {
+    verifiedDescriptors: 0,
+    refreshedDescriptors: 0,
+    sampledDescriptors: 0,
+    bytesServed: 0n,
+    longTailServed: 0,
+    proofsAccepted: 0,
+    proofsRejected: 0,
+  }
+
+  function bucket(map, key) {
+    if (!map.has(key)) map.set(key, { count: 0, score: 0, bytes: 0n, lastAt: 0n })
+    return map.get(key)
+  }
+
+  function reward(kind, amount = 1, context = {}) {
+    const descriptorId = descriptorIdOf(context.descriptorId || context.descriptor || '')
+    const peerId = toHex(context.peerId || context.identityId || '')
+    const at = safeBigInt(context.at || Date.now(), nowMs())
+    let scoreDelta = 0
+
+    switch (kind) {
+      case 'descriptor-verified':
+        scoreDelta = 10 * amount
+        totals.verifiedDescriptors += amount
+        break
+      case 'descriptor-refreshed':
+        scoreDelta = 6 * amount
+        totals.refreshedDescriptors += amount
+        break
+      case 'availability-sampled':
+        scoreDelta = 5 * amount
+        totals.sampledDescriptors += amount
+        break
+      case 'bytes-served':
+        scoreDelta = Math.max(1, Math.floor(Number(amount) / (64 * 1024)))
+        totals.bytesServed += safeBigInt(amount, 0n)
+        break
+      case 'long-tail-served':
+        scoreDelta = 12 * amount
+        totals.longTailServed += amount
+        break
+      case 'proof-accepted':
+        scoreDelta = 8 * amount
+        totals.proofsAccepted += amount
+        break
+      case 'proof-rejected':
+        scoreDelta = -6 * amount
+        totals.proofsRejected += amount
+        break
+      default:
+        scoreDelta = 0
+    }
+
+    if (descriptorId) {
+      const d = bucket(byDescriptor, descriptorId)
+      d.count += amount
+      d.score += scoreDelta
+      d.lastAt = at > d.lastAt ? at : d.lastAt
+      if (kind === 'bytes-served') d.bytes += safeBigInt(amount, 0n)
+    }
+
+    if (peerId) {
+      const p = bucket(byPeer, peerId)
+      p.count += amount
+      p.score += scoreDelta
+      p.lastAt = at > p.lastAt ? at : p.lastAt
+      if (kind === 'bytes-served') p.bytes += safeBigInt(amount, 0n)
+    }
+
+    return scoreDelta
+  }
+
+  function scoreUsefulWork() {
+    const byteScore = Number(totals.bytesServed / BigInt(1024 * 1024))
+    return Math.max(0, totals.verifiedDescriptors * 10 + totals.refreshedDescriptors * 6 + totals.sampledDescriptors * 5 + totals.longTailServed * 12 + totals.proofsAccepted * 8 + byteScore + totals.proofsRejected * -2)
+  }
+
+  function snapshot() {
+    return {
+      totals: {
+        ...totals,
+        bytesServed: totals.bytesServed,
+      },
+      byPeer: Array.from(byPeer.entries()),
+      byDescriptor: Array.from(byDescriptor.entries()),
+      usefulWorkScore: scoreUsefulWork(),
+    }
+  }
+
+  return { reward, scoreUsefulWork, snapshot, byPeer, byDescriptor, totals }
+}
+
+export function createPeerScorer(options = {}) {
+  const sybil = options.sybil || createSybilPolicy(options.sybilOptions || {})
+  const usefulWork = options.usefulWork || createUsefulWorkLedger(options.usefulWorkOptions || {})
+  const state = options.state || { peers: new Map() }
+  const availability = options.availability
+  const resources = options.resources
+  const metrics = options.metrics || new Map()
+  const subscribers = new Set()
+  const persist = typeof options.persist === 'function' ? options.persist : null
+  const metaDb = options.metaDb || null
+
+  function notify(peerId, record) {
+    for (const subscriber of subscribers) {
+      try { subscriber(peerId, record) } catch {}
+    }
+  }
+
+  async function persistMetric(metric) {
+    const key = `${METRIC_PREFIX}${metric.peerId}`
+    const value = encodePeerMetric(metric)
+    if (persist) return await persist(key, value, metric)
+    if (typeof metaDb?.put === 'function') return await metaDb.put(key, value)
+    return null
+  }
+
+  function metricFor(peer = {}) {
+    const peerId = toHex(peer.peerId || peer.identity?.publicKey || peer.identityId || '')
+    return metrics.get(peerId) || null
+  }
+
+  function scorePeer(peer = {}, now = Date.now()) {
+    const identityScore = sybil.scoreIdentity(peer.identity || peer, now)
+    const useful = Math.max(0, safeNumber(peer.usefulWorkScore, 0))
+    const reachability = availability?.shouldAdmit?.(peer.descriptor || peer, now) ? 10 : 0
+    const resourceFit = resources?.budgetFor ? resources.budgetFor(peer.resources || peer).credit : 50
+    const metricScore = performanceScore(metricFor(peer) || peer.performance || peer.metrics)
+    return clampScore(identityScore + Math.floor(useful / 10) + reachability + Math.floor(resourceFit / 10) + metricScore)
+  }
+
+  function registerPeer(peer = {}) {
+    const id = toHex(peer.peerId || peer.identity?.publicKey || peer.identityId || hashText(peer))
+    const score = scorePeer({ ...peer, peerId: id })
+    const fanoutCap = resources?.getThresholds ? resources.getThresholds(peer.resources || peer).maxFanout : resources?.profile?.maxFanout
+    const record = {
+      ...peer,
+      peerId: id,
+      score,
+      lastSeenAt: nowMs(peer.lastSeenAt || Date.now()),
+      fanoutBudget: sybil.allowsFanout(peer.identity || peer, fanoutCap || 1),
+      requestBudget: sybil.allowsRequest(peer.identity || peer, peer.inFlightRequests || 0),
+      performance: metrics.get(id) || peer.performance || null,
+    }
+    state.peers.set(id, record)
+    notify(id, record)
+    return record
+  }
+
+  async function recordPerformance(peerId, metric = {}) {
+    const normalized = normalizeMetric(peerId, metric)
+    const current = metrics.get(normalized.peerId)
+    const merged = current
+      ? {
+          ...current,
+          latencyMs: normalized.latencyMs || current.latencyMs,
+          handshakeSuccesses: current.handshakeSuccesses + normalized.handshakeSuccesses,
+          handshakeFailures: current.handshakeFailures + normalized.handshakeFailures,
+          handshakes: current.handshakes + normalized.handshakes,
+          udxThroughputBps: Math.max(current.udxThroughputBps, normalized.udxThroughputBps),
+          observedAt: normalized.observedAt > current.observedAt ? normalized.observedAt : current.observedAt,
+        }
+      : normalized
+    metrics.set(merged.peerId, merged)
+    const peer = state.peers.get(merged.peerId)
+    if (peer) registerPeer({ ...peer, performance: merged })
+    await persistMetric(merged)
+    return merged
+  }
+
+  async function applyPerformanceDiff(diff) {
+    const entry = diff?.left || diff?.right
+    if (!entry?.value) return null
+    const metric = decodePeerMetric(entry.value)
+    if (!diff.left) metrics.delete(metric.peerId)
+    else metrics.set(metric.peerId, metric)
+    const peer = state.peers.get(metric.peerId)
+    if (peer) registerPeer({ ...peer, performance: metric })
+    return metric
+  }
+
+  async function applyPerformanceDiffStream(stream) {
+    const applied = []
+    for await (const diff of stream) {
+      const metric = await applyPerformanceDiff(diff)
+      if (metric) applied.push(metric)
+    }
+    return applied
+  }
+
+  function subscribe(listener) {
+    if (typeof listener !== 'function') return () => {}
+    subscribers.add(listener)
+    return () => subscribers.delete(listener)
+  }
+
+  function snapshot() {
+    return {
+      peers: Array.from(state.peers.values()),
+      metrics: Array.from(metrics.values()),
+    }
+  }
+
+  return {
+    sybil,
+    usefulWork,
+    metrics,
+    scorePeer,
+    registerPeer,
+    recordPerformance,
+    applyPerformanceDiff,
+    applyPerformanceDiffStream,
+    createPerformanceDiffStream: createPeerMetricDiffStream,
+    subscribe,
+    snapshot,
+  }
+}

--- a/packages/backend/src/peer-scorer.js
+++ b/packages/backend/src/peer-scorer.js
@@ -254,7 +254,11 @@ export function createPeerScorer(options = {}) {
 
   function notify(peerId, record) {
     for (const subscriber of subscribers) {
-      try { subscriber(peerId, record) } catch {}
+      try {
+        subscriber(peerId, record)
+      } catch {
+        // Ignore observer failures so scoring updates keep flowing.
+      }
     }
   }
 

--- a/packages/backend/src/universal-core-utils.js
+++ b/packages/backend/src/universal-core-utils.js
@@ -1,0 +1,128 @@
+export const ROLE_MOBILE = 'mobile'
+export const ROLE_RELAY = 'relay'
+export const ROLE_HYBRID = 'hybrid'
+
+export const PLAYER_SHORTS = 'shorts'
+export const PLAYER_MAIN = 'main'
+
+export const TRANSITION_RANK = {
+  discovered: 0,
+  verified: 1,
+  active: 2,
+  quarantined: 3,
+  tombstoned: 4,
+}
+
+export const DEFAULT_POLICY = {
+  minDescriptorFreshnessMs: 10 * 60 * 1000,
+  longTailWindowMs: 12 * 60 * 60 * 1000,
+  proofFreshnessMs: 20 * 60 * 1000,
+  minReachableCopies: 2,
+  mobile: {
+    maxFanout: 2,
+    maxRequestsPerWindow: 4,
+    syncIntervalMs: 20 * 60 * 1000,
+    maxBytesPerDay: 50 * 1024 * 1024,
+    proofIntervalMs: 45 * 60 * 1000,
+    refreshIntervalMs: 90 * 60 * 1000,
+    maxFeedEntries: 64,
+  },
+  relay: {
+    maxFanout: 16,
+    maxRequestsPerWindow: 64,
+    syncIntervalMs: 2 * 60 * 1000,
+    maxBytesPerDay: 5 * 1024 * 1024 * 1024,
+    proofIntervalMs: 10 * 60 * 1000,
+    refreshIntervalMs: 20 * 60 * 1000,
+    maxFeedEntries: 512,
+  },
+}
+
+export const DEFAULT_PLAYER_POLICY = {
+  main: {
+    priority: 100,
+    activeBudget: 100,
+    backgroundBudget: 15,
+    maxConcurrentDecodes: 2,
+    maxConcurrentPrefetches: 4,
+    suspendAfterMs: 0,
+    pipAllowed: true,
+  },
+  shorts: {
+    priority: 20,
+    activeBudget: 35,
+    backgroundBudget: 8,
+    maxConcurrentDecodes: 1,
+    maxConcurrentPrefetches: 1,
+    suspendAfterMs: 30 * 1000,
+    pipAllowed: false,
+  },
+}
+
+export function safeNumber(value, fallback = 0) {
+  const n = Number(value)
+  return Number.isFinite(n) ? n : fallback
+}
+
+export function safeBigInt(value, fallback = 0n) {
+  if (typeof value === 'bigint') return value
+  if (typeof value === 'number' && Number.isFinite(value)) return BigInt(Math.max(0, Math.floor(value)))
+  if (typeof value === 'string' && value.trim()) {
+    try {
+      return BigInt(value)
+    } catch {
+      return fallback
+    }
+  }
+  return fallback
+}
+
+export function toHex(bytes) {
+  if (!bytes) return ''
+  if (typeof bytes === 'string') return bytes.toLowerCase().replace(/^0x/, '')
+  if (bytes instanceof Uint8Array) return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('')
+  if (bytes instanceof ArrayBuffer) return toHex(new Uint8Array(bytes))
+  return String(bytes)
+}
+
+export function stableStringify(value) {
+  if (value === null || value === undefined) return String(value)
+  if (value instanceof Uint8Array) return `u8:${toHex(value)}`
+  if (Array.isArray(value)) return '[' + value.map(stableStringify).join(',') + ']'
+  if (typeof value === 'bigint') return value.toString()
+  if (typeof value === 'object') {
+    const keys = Object.keys(value).sort()
+    return '{' + keys.map((key) => JSON.stringify(key) + ':' + stableStringify(value[key])).join(',') + '}'
+  }
+  return JSON.stringify(value)
+}
+
+export function hashText(input) {
+  const str = stableStringify(input)
+  let hash = 0x811c9dc5
+  for (let i = 0; i < str.length; i++) {
+    hash ^= str.charCodeAt(i)
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0')
+}
+
+export function nowMs(value = Date.now()) {
+  return safeBigInt(value, BigInt(Date.now()))
+}
+
+export function normalizeRole(role) {
+  if (role === ROLE_RELAY || role === ROLE_MOBILE || role === ROLE_HYBRID) return role
+  return ROLE_HYBRID
+}
+
+export function descriptorIdOf(value) {
+  return toHex(value?.descriptorId || value?.id || value?.driveKey || value)
+}
+
+export function maxBigInt(...values) {
+  return values.reduce((acc, value) => {
+    const next = safeBigInt(value, 0n)
+    return next > acc ? next : acc
+  }, 0n)
+}

--- a/packages/backend/src/universal-core.js
+++ b/packages/backend/src/universal-core.js
@@ -641,7 +641,11 @@ export function createUniversalCore(options = {}) {
         await metaDb.put('universal-core:snapshot', compactJson(eventSinkSnapshot()))
       }
       for (const subscriber of appendSubscribers) {
-        try { subscriber(record) } catch {}
+        try {
+          subscriber(record)
+        } catch {
+          // Ignore observer failures so append processing is not blocked.
+        }
       }
       return record
     },

--- a/packages/backend/src/universal-core.js
+++ b/packages/backend/src/universal-core.js
@@ -1,119 +1,43 @@
-const ROLE_MOBILE = 'mobile'
-const ROLE_RELAY = 'relay'
-const ROLE_HYBRID = 'hybrid'
+import c from 'compact-encoding'
 
-const PLAYER_SHORTS = 'shorts'
-const PLAYER_MAIN = 'main'
+import { createBudgetManager, createResourcePolicy } from './budget-manager.js'
+import { createPeerScorer, createSybilPolicy, createUsefulWorkLedger } from './peer-scorer.js'
+import {
+  DEFAULT_PLAYER_POLICY,
+  DEFAULT_POLICY,
+  PLAYER_MAIN,
+  PLAYER_SHORTS,
+  ROLE_HYBRID,
+  ROLE_MOBILE,
+  ROLE_RELAY,
+  TRANSITION_RANK,
+  descriptorIdOf,
+  hashText,
+  maxBigInt,
+  normalizeRole,
+  nowMs,
+  safeBigInt,
+  safeNumber,
+  toHex,
+} from './universal-core-utils.js'
 
-const TRANSITION_RANK = {
-  discovered: 0,
-  verified: 1,
-  active: 2,
-  quarantined: 3,
-  tombstoned: 4,
-}
+export {
+  createBudgetManager,
+  createResourcePolicy,
+  encodeBudgetState,
+  decodeBudgetState,
+} from './budget-manager.js'
+export {
+  createPeerScorer,
+  createSybilPolicy,
+  createUsefulWorkLedger,
+  createPeerMetricDiffStream,
+  encodePeerMetric,
+  decodePeerMetric,
+} from './peer-scorer.js'
 
-const textEncoder = new TextEncoder()
-
-const DEFAULT_POLICY = {
-  minDescriptorFreshnessMs: 10 * 60 * 1000,
-  longTailWindowMs: 12 * 60 * 60 * 1000,
-  proofFreshnessMs: 20 * 60 * 1000,
-  minReachableCopies: 2,
-  mobile: {
-    maxFanout: 2,
-    maxRequestsPerWindow: 4,
-    syncIntervalMs: 20 * 60 * 1000,
-    maxBytesPerDay: 50 * 1024 * 1024,
-    proofIntervalMs: 45 * 60 * 1000,
-    refreshIntervalMs: 90 * 60 * 1000,
-  },
-  relay: {
-    maxFanout: 16,
-    maxRequestsPerWindow: 64,
-    syncIntervalMs: 2 * 60 * 1000,
-    maxBytesPerDay: 5 * 1024 * 1024 * 1024,
-    proofIntervalMs: 10 * 60 * 1000,
-    refreshIntervalMs: 20 * 60 * 1000,
-  },
-}
-
-const DEFAULT_PLAYER_POLICY = {
-  main: {
-    priority: 100,
-    activeBudget: 100,
-    backgroundBudget: 15,
-    maxConcurrentDecodes: 2,
-    maxConcurrentPrefetches: 4,
-    suspendAfterMs: 0,
-    pipAllowed: true,
-  },
-  shorts: {
-    priority: 20,
-    activeBudget: 35,
-    backgroundBudget: 8,
-    maxConcurrentDecodes: 1,
-    maxConcurrentPrefetches: 1,
-    suspendAfterMs: 30 * 1000,
-    pipAllowed: false,
-  },
-}
-
-function safeNumber(value, fallback = 0) {
-  const n = Number(value)
-  return Number.isFinite(n) ? n : fallback
-}
-
-function safeBigInt(value, fallback = 0n) {
-  if (typeof value === 'bigint') return value
-  if (typeof value === 'number' && Number.isFinite(value)) return BigInt(Math.max(0, Math.floor(value)))
-  if (typeof value === 'string' && value.trim()) {
-    try {
-      return BigInt(value)
-    } catch {
-      return fallback
-    }
-  }
-  return fallback
-}
-
-function toHex(bytes) {
-  if (!bytes) return ''
-  if (typeof bytes === 'string') return bytes.toLowerCase().replace(/^0x/, '')
-  if (bytes instanceof Uint8Array) return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('')
-  if (bytes instanceof ArrayBuffer) return toHex(new Uint8Array(bytes))
-  return String(bytes)
-}
-
-function stableStringify(value) {
-  if (value === null || value === undefined) return String(value)
-  if (value instanceof Uint8Array) return `u8:${toHex(value)}`
-  if (Array.isArray(value)) return '[' + value.map(stableStringify).join(',') + ']'
-  if (typeof value === 'bigint') return value.toString()
-  if (typeof value === 'object') {
-    const keys = Object.keys(value).sort()
-    return '{' + keys.map((key) => JSON.stringify(key) + ':' + stableStringify(value[key])).join(',') + '}'
-  }
-  return JSON.stringify(value)
-}
-
-function hashText(input) {
-  const str = stableStringify(input)
-  let hash = 0x811c9dc5
-  for (let i = 0; i < str.length; i++) {
-    hash ^= str.charCodeAt(i)
-    hash = Math.imul(hash, 0x01000193)
-  }
-  return (hash >>> 0).toString(16).padStart(8, '0')
-}
-
-function nowMs(value = Date.now()) {
-  return safeBigInt(value, BigInt(Date.now()))
-}
-
-function normalizeRole(role) {
-  if (role === ROLE_RELAY || role === ROLE_MOBILE || role === ROLE_HYBRID) return role
-  return ROLE_HYBRID
+function compactJson(value) {
+  return c.encode(c.string, JSON.stringify(value, (_key, val) => typeof val === 'bigint' ? val.toString() : val))
 }
 
 function cloneDescriptor(descriptor) {
@@ -134,10 +58,6 @@ function cloneDescriptor(descriptor) {
     availabilityEpoch: safeNumber(descriptor.availabilityEpoch, 0),
     flags: safeNumber(descriptor.flags, 0),
   }
-}
-
-function descriptorIdOf(value) {
-  return toHex(value?.descriptorId || value?.id || value?.driveKey || value)
 }
 
 function compareEventOrder(a, b) {
@@ -181,143 +101,7 @@ function mergeDescriptor(current, incoming) {
   return merged
 }
 
-function identityAgeScore(identity = {}, now = Date.now()) {
-  const createdAt = safeBigInt(identity.createdAt || 0n, 0n)
-  const ageMs = createdAt > 0n ? Math.max(0n, nowMs(now) - createdAt) : 0n
-  return Math.min(40, Number(ageMs / BigInt(24 * 60 * 60 * 1000)))
-}
 
-export function createSybilPolicy(options = {}) {
-  const base = {
-    minProofs: safeNumber(options.minProofs, 1),
-    maxFailurePenalty: safeNumber(options.maxFailurePenalty, 45),
-    maxQuarantinePenalty: safeNumber(options.maxQuarantinePenalty, 35),
-    maxTombstonePenalty: safeNumber(options.maxTombstonePenalty, 50),
-    maxSpamPenalty: safeNumber(options.maxSpamPenalty, 20),
-  }
-
-  return {
-    scoreIdentity(identity = {}, now = Date.now()) {
-      const age = identityAgeScore(identity, now)
-      const validProofs = Math.min(30, safeNumber(identity.validProofCount, 0) * 6)
-      const successfulSeals = Math.min(15, safeNumber(identity.successfulSealCount, 0) * 3)
-      const serviceScore = Math.min(15, Math.floor(safeNumber(identity.usefulWorkScore, 0) / 25))
-      const failures = Math.min(base.maxFailurePenalty, safeNumber(identity.failureCount, 0) * 9)
-      const quarantines = Math.min(base.maxQuarantinePenalty, safeNumber(identity.quarantineCount, 0) * 7)
-      const tombstones = Math.min(base.maxTombstonePenalty, safeNumber(identity.tombstoneCount, 0) * 10)
-      const spam = Math.min(base.maxSpamPenalty, safeNumber(identity.spamScore, 0) * 4)
-      const freshness = Math.max(0, 10 - Math.floor(Math.max(0, safeNumber(identity.lastProofAgeMs, Infinity)) / (60 * 60 * 1000)))
-      const score = 20 + age + validProofs + successfulSeals + serviceScore + freshness - failures - quarantines - tombstones - spam
-      return Math.max(0, Math.min(100, score))
-    },
-    allowsFanout(identity, peerCount = 0, now = Date.now()) {
-      const score = this.scoreIdentity(identity, now)
-      const scaledFanout = Math.max(1, Math.floor(score / 10))
-      return Math.min(Math.max(1, peerCount || 1), scaledFanout)
-    },
-    allowsRequest(identity, inFlight = 0, now = Date.now()) {
-      const score = this.scoreIdentity(identity, now)
-      const allowance = Math.max(1, Math.floor(score / 15))
-      return inFlight < allowance
-    },
-  }
-}
-
-export function createUsefulWorkLedger(options = {}) {
-  const byPeer = new Map()
-  const byDescriptor = new Map()
-  const totals = {
-    verifiedDescriptors: 0,
-    refreshedDescriptors: 0,
-    sampledDescriptors: 0,
-    bytesServed: 0n,
-    longTailServed: 0,
-    proofsAccepted: 0,
-    proofsRejected: 0,
-  }
-
-  function bucket(map, key) {
-    if (!map.has(key)) map.set(key, { count: 0, score: 0, bytes: 0n, lastAt: 0n })
-    return map.get(key)
-  }
-
-  function reward(kind, amount = 1, context = {}) {
-    const descriptorId = descriptorIdOf(context.descriptorId || context.descriptor || '')
-    const peerId = toHex(context.peerId || context.identityId || '')
-    const at = safeBigInt(context.at || Date.now(), nowMs())
-    let scoreDelta = 0
-
-    switch (kind) {
-      case 'descriptor-verified':
-        scoreDelta = 10 * amount
-        totals.verifiedDescriptors += amount
-        break
-      case 'descriptor-refreshed':
-        scoreDelta = 6 * amount
-        totals.refreshedDescriptors += amount
-        break
-      case 'availability-sampled':
-        scoreDelta = 5 * amount
-        totals.sampledDescriptors += amount
-        break
-      case 'bytes-served':
-        scoreDelta = Math.max(1, Math.floor(Number(amount) / (64 * 1024)))
-        totals.bytesServed += safeBigInt(amount, 0n)
-        break
-      case 'long-tail-served':
-        scoreDelta = 12 * amount
-        totals.longTailServed += amount
-        break
-      case 'proof-accepted':
-        scoreDelta = 8 * amount
-        totals.proofsAccepted += amount
-        break
-      case 'proof-rejected':
-        scoreDelta = -6 * amount
-        totals.proofsRejected += amount
-        break
-      default:
-        scoreDelta = 0
-    }
-
-    if (descriptorId) {
-      const d = bucket(byDescriptor, descriptorId)
-      d.count += amount
-      d.score += scoreDelta
-      d.lastAt = at > d.lastAt ? at : d.lastAt
-      if (kind === 'bytes-served') d.bytes += safeBigInt(amount, 0n)
-    }
-
-    if (peerId) {
-      const p = bucket(byPeer, peerId)
-      p.count += amount
-      p.score += scoreDelta
-      p.lastAt = at > p.lastAt ? at : p.lastAt
-      if (kind === 'bytes-served') p.bytes += safeBigInt(amount, 0n)
-    }
-
-    return scoreDelta
-  }
-
-  function scoreUsefulWork() {
-    const byteScore = Number(totals.bytesServed / BigInt(1024 * 1024))
-    return Math.max(0, totals.verifiedDescriptors * 10 + totals.refreshedDescriptors * 6 + totals.sampledDescriptors * 5 + totals.longTailServed * 12 + totals.proofsAccepted * 8 + byteScore + totals.proofsRejected * -2)
-  }
-
-  function snapshot() {
-    return {
-      totals: {
-        ...totals,
-        bytesServed: totals.bytesServed,
-      },
-      byPeer: Array.from(byPeer.entries()),
-      byDescriptor: Array.from(byDescriptor.entries()),
-      usefulWorkScore: scoreUsefulWork(),
-    }
-  }
-
-  return { reward, scoreUsefulWork, snapshot, byPeer, byDescriptor, totals }
-}
 
 export function createAvailabilityPlanner(options = {}) {
   const minCopies = Math.max(1, safeNumber(options.minReachableCopies, DEFAULT_POLICY.minReachableCopies))
@@ -367,47 +151,6 @@ export function createAvailabilityPlanner(options = {}) {
   return { minCopies, longTailWindowMs, proofFreshnessMs, descriptorFreshnessMs, isLongTail, hasReachability, shouldAdmit, shouldForward, needsRefresh }
 }
 
-export function createResourcePolicy(options = {}) {
-  const role = normalizeRole(options.role)
-  const profile = role === ROLE_RELAY ? DEFAULT_POLICY.relay : DEFAULT_POLICY.mobile
-  const batteryFloor = safeNumber(options.batteryFloor, role === ROLE_RELAY ? 5 : 25)
-  const bandwidthFloor = safeNumber(options.bandwidthFloor, role === ROLE_RELAY ? 0 : 5)
-  const maxConcurrentSync = safeNumber(options.maxConcurrentSync, role === ROLE_RELAY ? 8 : 1)
-  const maxConcurrentProofs = safeNumber(options.maxConcurrentProofs, role === ROLE_RELAY ? 4 : 1)
-  const maxConcurrentFetches = safeNumber(options.maxConcurrentFetches, role === ROLE_RELAY ? 8 : 1)
-
-  function budgetFor(resource = {}) {
-    const battery = safeNumber(resource.batteryPercent, 100)
-    const bandwidth = safeNumber(resource.bandwidthScore, 100)
-    const thermal = safeNumber(resource.thermalScore, 0)
-    const charging = Boolean(resource.isCharging)
-
-    const mobilePenalty = role === ROLE_MOBILE ? Math.max(0, 30 - battery) + Math.max(0, 20 - bandwidth) + Math.max(0, thermal) : 0
-    const base = role === ROLE_RELAY ? 100 : 50
-    const credit = Math.max(0, base - mobilePenalty + (charging ? 10 : 0))
-
-    return {
-      role,
-      syncIntervalMs: profile.syncIntervalMs,
-      proofIntervalMs: profile.proofIntervalMs,
-      refreshIntervalMs: profile.refreshIntervalMs,
-      maxFanout: profile.maxFanout,
-      maxRequestsPerWindow: profile.maxRequestsPerWindow,
-      maxBytesPerDay: profile.maxBytesPerDay,
-      batteryFloor,
-      bandwidthFloor,
-      maxConcurrentSync,
-      maxConcurrentProofs,
-      maxConcurrentFetches,
-      credit,
-      canSync: battery >= batteryFloor && bandwidth >= bandwidthFloor,
-      canEmitProof: battery >= Math.max(10, batteryFloor - 5) && bandwidth >= bandwidthFloor,
-      canFetch: battery >= Math.max(10, batteryFloor - 10) && bandwidth >= bandwidthFloor,
-    }
-  }
-
-  return { role, profile, budgetFor }
-}
 
 export function createConcurrentState(options = {}) {
   return {
@@ -468,12 +211,6 @@ function resolveConflict(current, incoming) {
   return next
 }
 
-function maxBigInt(...values) {
-  return values.reduce((acc, value) => {
-    const next = safeBigInt(value, 0n)
-    return next > acc ? next : acc
-  }, 0n)
-}
 
 export function applyConcurrentUpdate(state, input = {}, options = {}) {
   const next = normalizeTransition(input)
@@ -654,7 +391,7 @@ function createUnifiedAutobaseSink(options = {}) {
     events.push(envelope)
 
     if (appendFn) {
-      await appendFn(textEncoder.encode(JSON.stringify(envelope)))
+      await appendFn(compactJson(envelope))
     }
 
     return { appended: true, duplicate: false, envelope }
@@ -852,6 +589,17 @@ export function createUniversalCore(options = {}) {
   const availability = createAvailabilityPlanner(options.availability)
   const resources = createResourcePolicy({ role, ...options.resources })
   const concurrentState = options.state || createConcurrentState(options)
+  const peerScorer = createPeerScorer({
+    sybil,
+    usefulWork,
+    availability,
+    resources,
+    state: concurrentState,
+    persist: async (key, value) => {
+      const metaDb = backend?.ctx?.metaDb
+      if (typeof metaDb?.put === 'function') await metaDb.put(key, value)
+    },
+  })
   const playerCore = createDualPlayerPlaybackCore(options.players || {})
   const onEvent = typeof options.onEvent === 'function' ? options.onEvent : () => {}
   const playbackLeases = new Map()
@@ -860,6 +608,7 @@ export function createUniversalCore(options = {}) {
   let services = null
   let nativeHandles = {}
   let eventSeq = 0
+  const appendSubscribers = new Set()
   let lifecycleTail = Promise.resolve()
 
   function runLifecycle(task) {
@@ -889,9 +638,17 @@ export function createUniversalCore(options = {}) {
       const record = { seq: eventSeq, kind, payload }
       const metaDb = backend?.ctx?.metaDb
       if (typeof metaDb?.put === 'function') {
-        await metaDb.put('universal-core:snapshot', eventSinkSnapshot())
+        await metaDb.put('universal-core:snapshot', compactJson(eventSinkSnapshot()))
+      }
+      for (const subscriber of appendSubscribers) {
+        try { subscriber(record) } catch {}
       }
       return record
+    },
+    onappend(listener) {
+      if (typeof listener !== 'function') return () => {}
+      appendSubscribers.add(listener)
+      return () => appendSubscribers.delete(listener)
     },
     snapshot: eventSinkSnapshot,
   }
@@ -1055,26 +812,11 @@ export function createUniversalCore(options = {}) {
   }
 
   function scorePeer(peer = {}, now = Date.now()) {
-    const identityScore = sybil.scoreIdentity(peer.identity || peer, now)
-    const useful = Math.max(0, safeNumber(peer.usefulWorkScore, 0))
-    const reachability = availability.shouldAdmit(peer.descriptor || peer, now) ? 10 : 0
-    const resourceFit = resources.budgetFor(peer.resources || peer).credit
-    return Math.max(0, Math.min(100, identityScore + Math.floor(useful / 10) + reachability + Math.floor(resourceFit / 10)))
+    return peerScorer.scorePeer(peer, now)
   }
 
   function registerPeer(peer = {}) {
-    const id = toHex(peer.peerId || peer.identity?.publicKey || peer.identityId || hashText(peer))
-    const score = scorePeer(peer)
-    const record = {
-      ...peer,
-      peerId: id,
-      score,
-      lastSeenAt: nowMs(peer.lastSeenAt || Date.now()),
-      fanoutBudget: sybil.allowsFanout(peer.identity || peer, resources.profile.maxFanout),
-      requestBudget: sybil.allowsRequest(peer.identity || peer, peer.inFlightRequests || 0),
-    }
-    concurrentState.peers.set(id, record)
-    return record
+    return peerScorer.registerPeer(peer)
   }
 
   function recordUsefulWork(kind, amount = 1, context = {}) {
@@ -1203,6 +945,7 @@ export function createUniversalCore(options = {}) {
     get services() { return services },
     sybil,
     usefulWork,
+    peerScorer,
     availability,
     resources,
     playerCore,
@@ -1275,8 +1018,10 @@ export default {
   PLAYER_SHORTS,
   createSybilPolicy,
   createUsefulWorkLedger,
+  createPeerScorer,
   createAvailabilityPlanner,
   createResourcePolicy,
+  createBudgetManager,
   createConcurrentState,
   applyConcurrentUpdate,
   createPlayerSplitState,

--- a/packages/backend/test/universal-core-hardening.test.mjs
+++ b/packages/backend/test/universal-core-hardening.test.mjs
@@ -1,7 +1,11 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
+import { readFile } from 'node:fs/promises'
+
 import { createUniversalCore } from '../src/universal-core.js'
+import { createBudgetManager, decodeBudgetState, encodeBudgetState } from '../src/budget-manager.js'
+import { createPeerScorer, decodePeerMetric, encodePeerMetric } from '../src/peer-scorer.js'
 
 function deferred() {
   let resolve
@@ -164,4 +168,70 @@ test('mirror refresh guard skips overlapping runs instead of mutating seeding st
   release.resolve()
   await first
   assert.equal(addSeedCalls, 1)
+})
+
+test('peer scorer persists compact performance metrics and updates reactive scores', async () => {
+  const puts = []
+  const state = { peers: new Map() }
+  const scorer = createPeerScorer({
+    state,
+    availability: { shouldAdmit: () => true },
+    resources: { profile: { maxFanout: 8 }, budgetFor: () => ({ credit: 80 }) },
+    persist: async (key, value) => puts.push([key, value]),
+  })
+  const updates = []
+  scorer.subscribe((_peerId, record) => updates.push(record.score))
+
+  const peer = scorer.registerPeer({ peerId: 'peer-a', identity: { validProofCount: 2 }, descriptor: { descriptorId: 'feed-a' } })
+  await scorer.recordPerformance(peer.peerId, {
+    latencyMs: 40,
+    handshakeSuccesses: 4,
+    handshakes: 4,
+    udxThroughputBps: 1024 * 1024,
+  })
+
+  assert.equal(puts.length, 1)
+  assert.equal(puts[0][0], 'universal-core:peer-metric:peer-a')
+  assert.equal(puts[0][1] instanceof Uint8Array, true)
+  assert.equal(decodePeerMetric(puts[0][1]).udxThroughputBps, 1024 * 1024)
+  assert.equal(updates.length > 0, true)
+  assert.equal(state.peers.get('peer-a').performance.udxThroughputBps, 1024 * 1024)
+})
+
+test('budget manager derives dynamic peer/feed caps from bare-hc memory pressure', async () => {
+  const manager = createBudgetManager({
+    role: 'relay',
+    bareHc: { memoryStats: async () => ({ total: 1000, rss: 900 }) },
+  })
+
+  const refreshed = await manager.refreshMemoryStats()
+  assert.equal(refreshed.thresholds.memoryPressure, 90)
+  assert.equal(refreshed.thresholds.maxFanout < manager.profile.maxFanout, true)
+  assert.equal(refreshed.thresholds.maxFeedEntries < manager.profile.maxFeedEntries, true)
+
+  const encoded = encodeBudgetState(refreshed.thresholds)
+  assert.equal(encoded instanceof Uint8Array, true)
+  assert.equal(decodeBudgetState(encoded).maxFeedEntries, refreshed.thresholds.maxFeedEntries)
+})
+
+test('universal core state persistence uses compact buffers and has no legacy gossip polling interval', async () => {
+  const puts = []
+  const observed = []
+  const core = createUniversalCore({
+    platform: 'relay',
+    storagePath: '/tmp/peartube-universal-core-test',
+    createBackendContext: async () => ({ ctx: { metaDb: { async put(key, value) { puts.push([key, value]) } } } }),
+  })
+
+  await core.init()
+  const unsubscribe = core.eventSink.onappend((record) => observed.push(record))
+  await core.eventSink.append('test.compact', { ok: true })
+  unsubscribe()
+  const snapshotPut = puts.find(([key]) => key === 'universal-core:snapshot')
+  assert.equal(snapshotPut?.[1] instanceof Uint8Array, true)
+  assert.equal(observed.at(-1).kind, 'test.compact')
+
+  const source = await readFile(new URL('../src/universal-core.js', import.meta.url), 'utf8')
+  assert.equal(/setInterval\s*\(/.test(source), false)
+  assert.equal(/gossip/i.test(source) && /setInterval\s*\(/.test(source), false)
 })


### PR DESCRIPTION
## Summary
- split universal-core peer scoring and useful-work logic into `peer-scorer.js`
- split resource allocation into `budget-manager.js` with bare-hc memory-pressure thresholds for peer/feed caps
- move shared constants/helpers into `universal-core-utils.js`
- persist universal-core state, peer metrics, and budget state with `compact-encoding`
- expose append-driven `eventSink.onappend()` notifications and protect against legacy gossip polling in universal-core

## Test plan
- `node --check packages/backend/src/universal-core.js`
- `node --check packages/backend/src/peer-scorer.js`
- `node --check packages/backend/src/budget-manager.js`
- `node --check packages/backend/src/universal-core-utils.js`
- `node --test packages/backend/test/universal-core-hardening.test.mjs`
- `npm test --prefix packages/backend`
- `git diff --check`
