### PR TITLE
feat: add archival content-addressing pipeline

### DIFF
--- a/packages/backend/lib/archive-schema.js
+++ b/packages/backend/lib/archive-schema.js
@@ -1,0 +1,137 @@
+import c from 'compact-encoding'
+import b4a from 'b4a'
+
+const KEY_BYTES = 32
+
+function fixed32(value, fieldName) {
+  if (!value) throw new TypeError(`${fieldName} is required`)
+
+  const buffer = b4a.isBuffer(value)
+    ? value
+    : typeof value === 'string'
+      ? b4a.from(value, 'hex')
+      : b4a.from(value)
+
+  if (buffer.byteLength !== KEY_BYTES) {
+    throw new RangeError(`${fieldName} must be exactly ${KEY_BYTES} bytes`)
+  }
+
+  return buffer
+}
+
+function uint(value, fieldName) {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new RangeError(`${fieldName} must be a safe unsigned integer`)
+  }
+  return value
+}
+
+function normalizeVariant(variant, index) {
+  if (!variant || typeof variant !== 'object') {
+    throw new TypeError(`variants[${index}] must be an object`)
+  }
+
+  if (typeof variant.resolution !== 'string' || variant.resolution.length === 0) {
+    throw new TypeError(`variants[${index}].resolution must be a non-empty string`)
+  }
+
+  const startBlock = uint(variant.startBlock, `variants[${index}].startBlock`)
+  const endBlock = uint(variant.endBlock, `variants[${index}].endBlock`)
+
+  if (endBlock < startBlock) {
+    throw new RangeError(`variants[${index}].endBlock must be >= startBlock`)
+  }
+
+  return {
+    resolution: variant.resolution,
+    coreKey: fixed32(variant.coreKey, `variants[${index}].coreKey`),
+    startBlock,
+    endBlock,
+  }
+}
+
+export function normalize(mapping) {
+  if (!mapping || typeof mapping !== 'object') {
+    throw new TypeError('mapping must be an object')
+  }
+
+  if (typeof mapping.sourceId !== 'string' || mapping.sourceId.length === 0) {
+    throw new TypeError('sourceId must be a non-empty string')
+  }
+
+  if (!Array.isArray(mapping.variants)) {
+    throw new TypeError('variants must be an array')
+  }
+
+  return {
+    fileHash: fixed32(mapping.fileHash, 'fileHash'),
+    sourceId: mapping.sourceId,
+    variants: mapping.variants.map(normalizeVariant),
+  }
+}
+
+const variantCodec = {
+  preencode(state, variant) {
+    c.string.preencode(state, variant.resolution)
+    c.fixed32.preencode(state, variant.coreKey)
+    c.uint.preencode(state, variant.startBlock)
+    c.uint.preencode(state, variant.endBlock)
+  },
+  encode(state, variant) {
+    c.string.encode(state, variant.resolution)
+    c.fixed32.encode(state, variant.coreKey)
+    c.uint.encode(state, variant.startBlock)
+    c.uint.encode(state, variant.endBlock)
+  },
+  decode(state) {
+    return {
+      resolution: c.string.decode(state),
+      coreKey: c.fixed32.decode(state),
+      startBlock: c.uint.decode(state),
+      endBlock: c.uint.decode(state),
+    }
+  },
+}
+
+export const fileMappingCodec = {
+  preencode(state, mapping) {
+    c.fixed32.preencode(state, mapping.fileHash)
+    c.string.preencode(state, mapping.sourceId)
+    c.array(variantCodec).preencode(state, mapping.variants)
+  },
+  encode(state, mapping) {
+    c.fixed32.encode(state, mapping.fileHash)
+    c.string.encode(state, mapping.sourceId)
+    c.array(variantCodec).encode(state, mapping.variants)
+  },
+  decode(state) {
+    return {
+      fileHash: c.fixed32.decode(state),
+      sourceId: c.string.decode(state),
+      variants: c.array(variantCodec).decode(state),
+    }
+  },
+}
+
+export function encode(mapping) {
+  const canonical = normalize(mapping)
+  const state = c.state()
+
+  fileMappingCodec.preencode(state, canonical)
+  state.buffer = b4a.allocUnsafe(state.end)
+  fileMappingCodec.encode(state, canonical)
+
+  return state.buffer
+}
+
+export function decode(buf) {
+  const buffer = b4a.isBuffer(buf) ? buf : b4a.from(buf)
+  const state = c.state(0, buffer.byteLength, buffer)
+  const mapping = fileMappingCodec.decode(state)
+
+  if (state.start !== state.end) {
+    throw new Error('archive mapping buffer has trailing bytes')
+  }
+
+  return mapping
+}

--- a/packages/backend/lib/archive-writer.js
+++ b/packages/backend/lib/archive-writer.js
@@ -1,0 +1,136 @@
+import b4a from 'b4a'
+
+import { decode, encode, normalize } from './archive-schema.js'
+
+const archiveLocks = new WeakMap()
+
+function toHashBuffer(fileHash) {
+  if (!fileHash) throw new TypeError('fileHash is required')
+
+  const buffer = b4a.isBuffer(fileHash)
+    ? fileHash
+    : typeof fileHash === 'string'
+      ? b4a.from(fileHash, 'hex')
+      : b4a.from(fileHash)
+
+  if (buffer.byteLength !== 32) throw new RangeError('fileHash must be exactly 32 bytes')
+  return buffer
+}
+
+export function archiveKey(fileHash) {
+  return `/archives/${b4a.toString(toHashBuffer(fileHash), 'hex')}`
+}
+
+function getRawStore(db) {
+  if (!db || typeof db !== 'object') throw new TypeError('db must be an active database instance')
+  if (typeof db.put === 'function') return db
+  if (db.engine?.db && typeof db.engine.db.put === 'function') return db.engine.db
+  throw new TypeError('db must expose put(key, value) or a HyperDB engine.db raw store')
+}
+
+async function readExisting(db, key) {
+  const raw = getRawStore(db)
+  if (typeof raw.get !== 'function') return null
+
+  const node = await raw.get(key)
+  if (!node) return null
+  return node.value ? decode(node.value) : null
+}
+
+function variantId(variant) {
+  return `${variant.resolution}\0${b4a.toString(variant.coreKey, 'hex')}\0${variant.startBlock}`
+}
+
+function mergeMappings(existing, next) {
+  if (!existing) return next
+
+  const variants = new Map()
+  for (const variant of existing.variants) variants.set(variantId(variant), variant)
+  for (const variant of next.variants) variants.set(variantId(variant), variant)
+
+  return normalize({
+    fileHash: next.fileHash,
+    sourceId: next.sourceId || existing.sourceId,
+    variants: [...variants.values()],
+  })
+}
+
+async function withWriteLock(db, key, fn) {
+  const locks = archiveLocks.get(db) || new Map()
+  if (!archiveLocks.has(db)) archiveLocks.set(db, locks)
+
+  const previous = locks.get(key) || Promise.resolve()
+  let release
+  const current = new Promise((resolve) => { release = resolve })
+  locks.set(key, previous.then(() => current, () => current))
+
+  await previous
+  try {
+    return await fn()
+  } finally {
+    release()
+    if (locks.get(key) === current) locks.delete(key)
+  }
+}
+
+async function putRaw(db, key, value) {
+  const raw = getRawStore(db)
+
+  if (typeof raw.batch === 'function') {
+    const batch = raw.batch()
+    await batch.put(key, value)
+    await batch.flush()
+    return
+  }
+
+  await raw.put(key, value)
+}
+
+async function writeWithTransaction(db, key, next, merge) {
+  if (typeof db.exclusiveTransaction === 'function') {
+    const tx = await db.exclusiveTransaction()
+    try {
+      const mapping = merge ? mergeMappings(await readExisting(tx, key), next) : next
+      const value = encode(mapping)
+
+      await putRaw(tx, key, value)
+      if (typeof tx.flush === 'function') await tx.flush()
+
+      return { mapping, value }
+    } catch (error) {
+      if (typeof tx.close === 'function') await tx.close().catch(() => {})
+      throw error
+    }
+  }
+
+  const mapping = merge ? mergeMappings(await readExisting(db, key), next) : next
+  const value = encode(mapping)
+
+  await putRaw(db, key, value)
+  if (typeof db.flush === 'function') await db.flush()
+
+  return { mapping, value }
+}
+
+export async function writeArchiveMapping(db, fileHash, metadata, opts = {}) {
+  const fileHashBuffer = toHashBuffer(fileHash)
+  const key = archiveKey(fileHashBuffer)
+  const merge = opts.merge !== false
+
+  if (!metadata || typeof metadata !== 'object') {
+    throw new TypeError('metadata must be an object')
+  }
+
+  return withWriteLock(db, key, async () => {
+    const next = normalize({ ...metadata, fileHash: fileHashBuffer })
+    const { mapping, value } = await writeWithTransaction(db, key, next, merge)
+
+    return { key, mapping, value }
+  })
+}
+
+export async function readArchiveMapping(db, fileHash) {
+  return readExisting(db, archiveKey(fileHash))
+}
+
+export default writeArchiveMapping

--- a/packages/backend/lib/archive-writer.js
+++ b/packages/backend/lib/archive-writer.js
@@ -62,14 +62,15 @@ async function withWriteLock(db, key, fn) {
   const previous = locks.get(key) || Promise.resolve()
   let release
   const current = new Promise((resolve) => { release = resolve })
-  locks.set(key, previous.then(() => current, () => current))
+  const next = previous.then(() => current, () => current)
+  locks.set(key, next)
 
   await previous
   try {
     return await fn()
   } finally {
     release()
-    if (locks.get(key) === current) locks.delete(key)
+    if (locks.get(key) === next) locks.delete(key)
   }
 }
 
@@ -86,15 +87,30 @@ async function putRaw(db, key, value) {
   await raw.put(key, value)
 }
 
+function hasPendingHyperDbUpdates(db) {
+  return Boolean(
+    (typeof db.updated === 'function' && db.updated()) ||
+    (Number.isSafeInteger(db.updates?.mutating) && db.updates.mutating > 0)
+  )
+}
+
 async function writeWithTransaction(db, key, next, merge) {
   if (typeof db.exclusiveTransaction === 'function') {
+    if (hasPendingHyperDbUpdates(db)) {
+      throw new Error('Cannot write archive mapping while HyperDB has pending updates; flush or discard them first')
+    }
+
     const tx = await db.exclusiveTransaction()
     try {
+      if (hasPendingHyperDbUpdates(db)) {
+        throw new Error('Cannot write archive mapping while HyperDB has pending updates; flush or discard them first')
+      }
+
       const mapping = merge ? mergeMappings(await readExisting(tx, key), next) : next
       const value = encode(mapping)
 
       await putRaw(tx, key, value)
-      if (typeof tx.flush === 'function') await tx.flush()
+      if (typeof tx.close === 'function') await tx.close()
 
       return { mapping, value }
     } catch (error) {

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -39,6 +39,8 @@
     "./budget-manager": "./src/budget-manager.js",
     "./hash-utils": "./src/hash-utils.js",
     "./blob-ref": "./src/blob-ref.js",
+    "./archive-schema": "./lib/archive-schema.js",
+    "./archive-writer": "./lib/archive-writer.js",
     "./mirror": "./src/mirror/index.js"
   },
   "scripts": {

--- a/packages/backend/test/archive-schema-writer.test.mjs
+++ b/packages/backend/test/archive-schema-writer.test.mjs
@@ -1,0 +1,117 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import b4a from 'b4a'
+import Corestore from 'corestore'
+import HyperDB from 'hyperdb'
+
+import { decode, encode } from '../lib/archive-schema.js'
+import { archiveKey, readArchiveMapping, writeArchiveMapping } from '../lib/archive-writer.js'
+import publicDbDefinition from '../src/channel/public-hyperdb-spec/hyperdb/index.js'
+
+const fileHash = b4a.alloc(32, 1)
+const coreKey = b4a.alloc(32, 2)
+const secondCoreKey = b4a.alloc(32, 3)
+
+function sampleMapping(overrides = {}) {
+  return {
+    fileHash,
+    sourceId: 'youtube:dQw4w9WgXcQ',
+    variants: [
+      {
+        resolution: '1080p',
+        coreKey,
+        startBlock: 7,
+        endBlock: 42,
+      },
+    ],
+    ...overrides,
+  }
+}
+
+function makeTempDir(prefix) {
+  return mkdtempSync(join(tmpdir(), prefix))
+}
+
+async function withHyperDb(fn) {
+  const dir = makeTempDir('peartube-archive-writer-')
+  const store = new Corestore(dir)
+  let db = null
+
+  try {
+    await store.ready()
+    const core = store.get({ name: `archive-writer-${Date.now()}-${Math.random()}` })
+    await core.ready()
+    db = HyperDB.bee(core, publicDbDefinition, {
+      autoUpdate: true,
+      writable: true,
+      extension: false,
+    })
+    await db.ready()
+    await fn(db)
+  } finally {
+    if (db) await db.close().catch(() => {})
+    await store.close().catch(() => {})
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+test('archive schema encodes compact file mappings and decodes canonical objects', () => {
+  const mapping = sampleMapping()
+  const encoded = encode(mapping)
+  const decoded = decode(encoded)
+
+  assert.ok(b4a.isBuffer(encoded))
+  assert.equal(encoded.byteLength, 93)
+  assert.deepEqual(decoded, mapping)
+})
+
+test('archive schema rejects malformed fixed hashes and ranges', () => {
+  assert.throws(() => encode(sampleMapping({ fileHash: b4a.alloc(31) })), /fileHash must be exactly 32 bytes/)
+  assert.throws(() => encode(sampleMapping({ variants: [{ resolution: '720p', coreKey, startBlock: 10, endBlock: 9 }] })), /endBlock must be >= startBlock/)
+  assert.throws(() => decode(b4a.concat([encode(sampleMapping()), b4a.from([0])])), /trailing bytes/)
+})
+
+test('archive writer writes cenc records under the content-addressed archive key', async () => {
+  await withHyperDb(async (db) => {
+    const result = await writeArchiveMapping(db, fileHash, {
+      sourceId: 'youtube:dQw4w9WgXcQ',
+      variants: [{ resolution: '1080p', coreKey, startBlock: 7, endBlock: 42 }],
+    })
+
+    assert.equal(result.key, `/archives/${b4a.toString(fileHash, 'hex')}`)
+    assert.deepEqual(result.mapping, sampleMapping())
+
+    const raw = await db.engine.db.get(archiveKey(fileHash))
+    assert.ok(raw?.value)
+    assert.deepEqual(decode(raw.value), sampleMapping())
+    assert.deepEqual(await readArchiveMapping(db, fileHash), sampleMapping())
+  })
+})
+
+test('archive writer serializes upserts and merges variants without dropping existing refs', async () => {
+  await withHyperDb(async (db) => {
+    await writeArchiveMapping(db, fileHash, {
+      sourceId: 'youtube:dQw4w9WgXcQ',
+      variants: [{ resolution: '1080p', coreKey, startBlock: 7, endBlock: 42 }],
+    })
+
+    await Promise.all([
+      writeArchiveMapping(db, fileHash, {
+        sourceId: 'youtube:dQw4w9WgXcQ',
+        variants: [{ resolution: '720p', coreKey: secondCoreKey, startBlock: 43, endBlock: 70 }],
+      }),
+      writeArchiveMapping(db, fileHash, {
+        sourceId: 'youtube:dQw4w9WgXcQ',
+        variants: [{ resolution: '480p', coreKey, startBlock: 71, endBlock: 99 }],
+      }),
+    ])
+
+    const stored = await readArchiveMapping(db, fileHash)
+    assert.equal(stored.variants.length, 3)
+    assert.deepEqual(stored.variants.map((variant) => variant.resolution), ['1080p', '720p', '480p'])
+  })
+})

--- a/packages/backend/test/archive-schema-writer.test.mjs
+++ b/packages/backend/test/archive-schema-writer.test.mjs
@@ -92,6 +92,66 @@ test('archive writer writes cenc records under the content-addressed archive key
   })
 })
 
+test('archive writer rejects pending HyperDB collection writes instead of committing caller state', async () => {
+  await withHyperDb(async (db) => {
+    await db.insert('@peartubePublic/metadata', { key: 'meta', name: 'Pending metadata' })
+
+    await assert.rejects(
+      writeArchiveMapping(db, fileHash, {
+        sourceId: 'youtube:dQw4w9WgXcQ',
+        variants: [{ resolution: '1080p', coreKey, startBlock: 7, endBlock: 42 }],
+      }),
+      /pending updates/
+    )
+
+    await db.flush()
+
+    db.updates.mutating++
+    try {
+      await assert.rejects(
+        writeArchiveMapping(db, fileHash, {
+          sourceId: 'youtube:dQw4w9WgXcQ',
+          variants: [{ resolution: '720p', coreKey, startBlock: 8, endBlock: 43 }],
+        }),
+        /pending updates/
+      )
+    } finally {
+      db.updates.mutating--
+    }
+
+    const originalExclusiveTransaction = db.exclusiveTransaction.bind(db)
+    db.exclusiveTransaction = async (...args) => {
+      const tx = await originalExclusiveTransaction(...args)
+      await db.insert('@peartubePublic/metadata', { key: 'late-meta', name: 'Late pending metadata' })
+      return tx
+    }
+    try {
+      await assert.rejects(
+        writeArchiveMapping(db, fileHash, {
+          sourceId: 'youtube:dQw4w9WgXcQ',
+          variants: [{ resolution: '720p', coreKey, startBlock: 8, endBlock: 43 }],
+        }),
+        /pending updates/
+      )
+    } finally {
+      db.exclusiveTransaction = originalExclusiveTransaction
+    }
+
+    await db.flush()
+
+    await writeArchiveMapping(db, fileHash, {
+      sourceId: 'youtube:dQw4w9WgXcQ',
+      variants: [{ resolution: '1080p', coreKey, startBlock: 7, endBlock: 42 }],
+    })
+
+    const meta = await db.get('@peartubePublic/metadata', { key: 'meta' })
+    const stored = await readArchiveMapping(db, fileHash)
+
+    assert.equal(meta.name, 'Pending metadata')
+    assert.deepEqual(stored, sampleMapping())
+  })
+})
+
 test('archive writer serializes upserts and merges variants without dropping existing refs', async () => {
   await withHyperDb(async (db) => {
     await writeArchiveMapping(db, fileHash, {


### PR DESCRIPTION
Summary
- Add compact-encoding archive fileMapping schema with fixed 32-byte file/core keys and canonical validation
- Add HyperDB-backed archive writer for /archives/<fileHash> upserts with transaction locking and b4a buffer handling
- Export the schema and writer modules from @peartube/backend
- Add regression coverage for cenc roundtrips, malformed records, raw HyperDB writes, and concurrent variant merges

Test plan
- node test/archive-schema-writer.test.mjs
- node --input-type=module package export smoke check for @peartube/backend/archive-schema and @peartube/backend/archive-writer
- ./node_modules/.bin/eslint --quiet packages/backend/lib/archive-schema.js packages/backend/lib/archive-writer.js packages/backend/test/archive-schema-writer.test.mjs
- npm test --prefix packages/backend
