### PR TITLE
refactor: modularize universal core resources

### DIFF
--- a/packages/backend/src/budget-manager.js
+++ b/packages/backend/src/budget-manager.js
@@ -48,7 +48,7 @@ async function readBareHcMemoryStats(source) {
 async function readBareHcCpuStats(source) {
   if (!source) return null
   if (typeof source === 'function') return normalizeCpuStats(await source())
-  for (const name of ['cpuStats', 'getCpuStats', 'getCPUStats', 'systemStats', 'getSystemStats']) {
+  for (const name of ['cpuStats', 'getCpuStats', 'getCPUStats', 'stats', 'getStats', 'systemStats', 'getSystemStats']) {
     if (typeof source[name] === 'function') {
       const stats = await source[name]()
       return normalizeCpuStats(stats?.cpu || stats)

--- a/packages/backend/src/budget-manager.js
+++ b/packages/backend/src/budget-manager.js
@@ -24,6 +24,14 @@ function normalizeMemoryStats(stats = {}) {
   return { rss, heapUsed, external, total, free, used, pressure }
 }
 
+function normalizeCpuStats(stats = {}) {
+  const cpu = stats.cpu || stats
+  const usagePercent = clamp(safeNumber(cpu.usagePercent ?? cpu.percent ?? cpu.usage ?? cpu.busy, 0), 0, 100)
+  const loadAverage = safeNumber(Array.isArray(cpu.loadAverage) ? cpu.loadAverage[0] : cpu.loadAverage ?? cpu.loadavg, 0)
+  const pressure = clamp(safeNumber(cpu.pressure ?? usagePercent, usagePercent), 0, 100)
+  return { usagePercent, loadAverage, pressure }
+}
+
 async function readBareHcMemoryStats(source) {
   if (!source) return null
   if (typeof source === 'function') return normalizeMemoryStats(await source())
@@ -37,11 +45,25 @@ async function readBareHcMemoryStats(source) {
   return null
 }
 
+async function readBareHcCpuStats(source) {
+  if (!source) return null
+  if (typeof source === 'function') return normalizeCpuStats(await source())
+  for (const name of ['cpuStats', 'getCpuStats', 'getCPUStats', 'systemStats', 'getSystemStats']) {
+    if (typeof source[name] === 'function') {
+      const stats = await source[name]()
+      return normalizeCpuStats(stats?.cpu || stats)
+    }
+  }
+  if (source.cpu || source.usagePercent || source.loadAverage) return normalizeCpuStats(source)
+  return null
+}
+
 export const budgetStateEncoding = {
   preencode(state, budget = {}) {
-    c.uint.preencode(state, 1)
+    c.uint.preencode(state, 2)
     c.string.preencode(state, String(budget.role || 'hybrid'))
     c.uint.preencode(state, Math.max(0, Math.floor(safeNumber(budget.memoryPressure, 0))))
+    c.uint.preencode(state, Math.max(0, Math.floor(safeNumber(budget.cpuPressure, 0))))
     c.uint.preencode(state, Math.max(0, Math.floor(safeNumber(budget.maxFanout, 0))))
     c.uint.preencode(state, Math.max(0, Math.floor(safeNumber(budget.maxRequestsPerWindow, 0))))
     c.uint.preencode(state, Math.max(0, Math.floor(safeNumber(budget.maxFeedEntries, 0))))
@@ -50,9 +72,10 @@ export const budgetStateEncoding = {
     c.uint.preencode(state, Math.max(0, Math.floor(safeNumber(budget.maxConcurrentFetches, 0))))
   },
   encode(state, budget = {}) {
-    c.uint.encode(state, 1)
+    c.uint.encode(state, 2)
     c.string.encode(state, String(budget.role || 'hybrid'))
     c.uint.encode(state, Math.max(0, Math.floor(safeNumber(budget.memoryPressure, 0))))
+    c.uint.encode(state, Math.max(0, Math.floor(safeNumber(budget.cpuPressure, 0))))
     c.uint.encode(state, Math.max(0, Math.floor(safeNumber(budget.maxFanout, 0))))
     c.uint.encode(state, Math.max(0, Math.floor(safeNumber(budget.maxRequestsPerWindow, 0))))
     c.uint.encode(state, Math.max(0, Math.floor(safeNumber(budget.maxFeedEntries, 0))))
@@ -62,10 +85,14 @@ export const budgetStateEncoding = {
   },
   decode(state) {
     const version = c.uint.decode(state)
-    if (version !== 1) throw new Error(`Unsupported budget state version ${version}`)
+    if (version !== 1 && version !== 2) throw new Error(`Unsupported budget state version ${version}`)
+    const role = c.string.decode(state)
+    const memoryPressure = c.uint.decode(state)
+    const cpuPressure = version >= 2 ? c.uint.decode(state) : 0
     return {
-      role: c.string.decode(state),
-      memoryPressure: c.uint.decode(state),
+      role,
+      memoryPressure,
+      cpuPressure,
       maxFanout: c.uint.decode(state),
       maxRequestsPerWindow: c.uint.decode(state),
       maxFeedEntries: c.uint.decode(state),
@@ -93,24 +120,32 @@ export function createBudgetManager(options = {}) {
   const baseConcurrentSync = safeNumber(options.maxConcurrentSync, role === ROLE_RELAY ? 8 : 1)
   const baseConcurrentProofs = safeNumber(options.maxConcurrentProofs, role === ROLE_RELAY ? 4 : 1)
   const baseConcurrentFetches = safeNumber(options.maxConcurrentFetches, role === ROLE_RELAY ? 8 : 1)
-  const memorySource = options.memoryStats || options.bareHc || options.libhc || null
+  const systemSource = options.systemStats || options.bareHc || options.libhc || null
+  const memorySource = options.memoryStats || systemSource
+  const cpuSource = options.cpuStats || systemSource
   let memoryStats = normalizeMemoryStats(options.initialMemoryStats || {})
+  let cpuStats = normalizeCpuStats(options.initialCpuStats || {})
   let lastThresholds = null
 
-  function thresholdsFor(stats = memoryStats) {
-    const pressure = clamp(safeNumber(stats?.pressure, 0), 0, 100)
+  function thresholdsFor(stats = memoryStats, cpu = cpuStats) {
+    const memoryPressure = clamp(safeNumber(stats?.pressure, 0), 0, 100)
+    const cpuPressure = clamp(safeNumber(cpu?.pressure ?? cpu?.usagePercent, 0), 0, 100)
+    const pressure = Math.max(memoryPressure, Math.floor(cpuPressure * 0.75))
     const relief = pressure >= 90 ? 0.25 : pressure >= 80 ? 0.4 : pressure >= 65 ? 0.65 : pressure >= 45 ? 0.85 : 1
-    const fanout = clamp((profile.maxFanout || 1) * relief, 1, profile.maxFanout || 1)
-    const requests = clamp((profile.maxRequestsPerWindow || 1) * relief, 1, profile.maxRequestsPerWindow || 1)
+    const cpuRelief = cpuPressure >= 90 ? 0.45 : cpuPressure >= 75 ? 0.7 : 1
+    const combinedRelief = Math.min(relief, cpuRelief)
+    const fanout = clamp((profile.maxFanout || 1) * combinedRelief, 1, profile.maxFanout || 1)
+    const requests = clamp((profile.maxRequestsPerWindow || 1) * combinedRelief, 1, profile.maxRequestsPerWindow || 1)
     const feeds = clamp((profile.maxFeedEntries || 32) * relief, role === ROLE_RELAY ? 64 : 16, profile.maxFeedEntries || 32)
     return {
       role,
-      memoryPressure: pressure,
+      memoryPressure,
+      cpuPressure,
       maxFanout: fanout,
       maxRequestsPerWindow: requests,
       maxFeedEntries: feeds,
-      maxConcurrentSync: clamp(baseConcurrentSync * relief, 1, baseConcurrentSync),
-      maxConcurrentProofs: clamp(baseConcurrentProofs * relief, 1, baseConcurrentProofs),
+      maxConcurrentSync: clamp(baseConcurrentSync * combinedRelief, 1, baseConcurrentSync),
+      maxConcurrentProofs: clamp(baseConcurrentProofs * combinedRelief, 1, baseConcurrentProofs),
       maxConcurrentFetches: clamp(baseConcurrentFetches * relief, 1, baseConcurrentFetches),
     }
   }
@@ -118,20 +153,62 @@ export function createBudgetManager(options = {}) {
   async function refreshMemoryStats(source = memorySource) {
     const next = await readBareHcMemoryStats(source)
     if (next) memoryStats = next
-    lastThresholds = thresholdsFor(memoryStats)
-    return { memoryStats, thresholds: lastThresholds }
+    lastThresholds = thresholdsFor(memoryStats, cpuStats)
+    return { memoryStats, cpuStats, thresholds: lastThresholds }
+  }
+
+  async function refreshCpuStats(source = cpuSource) {
+    const next = await readBareHcCpuStats(source)
+    if (next) cpuStats = next
+    lastThresholds = thresholdsFor(memoryStats, cpuStats)
+    return { memoryStats, cpuStats, thresholds: lastThresholds }
+  }
+
+  async function refreshSystemStats() {
+    await refreshMemoryStats(memorySource)
+    await refreshCpuStats(cpuSource)
+    lastThresholds = thresholdsFor(memoryStats, cpuStats)
+    return { memoryStats, cpuStats, thresholds: lastThresholds }
   }
 
   function updateMemoryStats(stats = {}) {
     memoryStats = normalizeMemoryStats(stats)
-    lastThresholds = thresholdsFor(memoryStats)
+    lastThresholds = thresholdsFor(memoryStats, cpuStats)
+    return lastThresholds
+  }
+
+  function updateCpuStats(stats = {}) {
+    cpuStats = normalizeCpuStats(stats)
+    lastThresholds = thresholdsFor(memoryStats, cpuStats)
     return lastThresholds
   }
 
   function getThresholds(resource = {}) {
     const resourceStats = resource.memory || resource.memoryStats ? normalizeMemoryStats(resource.memory || resource.memoryStats) : memoryStats
-    lastThresholds = thresholdsFor(resourceStats)
+    const resourceCpu = resource.cpu || resource.cpuStats ? normalizeCpuStats(resource.cpu || resource.cpuStats) : cpuStats
+    lastThresholds = thresholdsFor(resourceStats, resourceCpu)
     return lastThresholds
+  }
+
+  function allocate(requested = {}, resource = {}) {
+    const thresholds = getThresholds(resource)
+    const feedIndexers = clamp(safeNumber(requested.feedIndexers ?? requested.maxFeedEntries, thresholds.maxFeedEntries), 1, thresholds.maxFeedEntries)
+    const autobaseLinearizationBuffers = clamp(
+      safeNumber(requested.autobaseLinearizationBuffers ?? requested.linearizationBuffers, thresholds.maxConcurrentSync * 8),
+      1,
+      Math.max(1, thresholds.maxConcurrentSync * 8),
+    )
+    const activeSwarmConnections = clamp(safeNumber(requested.activeSwarmConnections ?? requested.swarmConnections, thresholds.maxFanout), 1, thresholds.maxFanout)
+    return {
+      feedIndexers,
+      autobaseLinearizationBuffers,
+      activeSwarmConnections,
+      maxConcurrentSync: thresholds.maxConcurrentSync,
+      maxConcurrentProofs: thresholds.maxConcurrentProofs,
+      maxConcurrentFetches: thresholds.maxConcurrentFetches,
+      memoryPressure: thresholds.memoryPressure,
+      cpuPressure: thresholds.cpuPressure,
+    }
   }
 
   function budgetFor(resource = {}) {
@@ -143,8 +220,9 @@ export function createBudgetManager(options = {}) {
 
     const mobilePenalty = role === ROLE_MOBILE ? Math.max(0, 30 - battery) + Math.max(0, 20 - bandwidth) + Math.max(0, thermal) : 0
     const memoryPenalty = Math.max(0, thresholds.memoryPressure - 70)
+    const cpuPenalty = Math.max(0, Math.floor((thresholds.cpuPressure - 75) / 2))
     const base = role === ROLE_RELAY ? 100 : 50
-    const credit = Math.max(0, base - mobilePenalty - memoryPenalty + (charging ? 10 : 0))
+    const credit = Math.max(0, base - mobilePenalty - memoryPenalty - cpuPenalty + (charging ? 10 : 0))
 
     return {
       role,
@@ -161,20 +239,37 @@ export function createBudgetManager(options = {}) {
       maxConcurrentProofs: thresholds.maxConcurrentProofs,
       maxConcurrentFetches: thresholds.maxConcurrentFetches,
       memoryPressure: thresholds.memoryPressure,
+      cpuPressure: thresholds.cpuPressure,
       memoryStats,
+      cpuStats,
+      allocation: allocate(resource.allocations || {}, resource),
       credit,
-      canSync: battery >= batteryFloor && bandwidth >= bandwidthFloor && thresholds.memoryPressure < 92,
-      canEmitProof: battery >= Math.max(10, batteryFloor - 5) && bandwidth >= bandwidthFloor && thresholds.memoryPressure < 95,
+      canSync: battery >= batteryFloor && bandwidth >= bandwidthFloor && thresholds.memoryPressure < 92 && thresholds.cpuPressure < 96,
+      canEmitProof: battery >= Math.max(10, batteryFloor - 5) && bandwidth >= bandwidthFloor && thresholds.memoryPressure < 95 && thresholds.cpuPressure < 98,
       canFetch: battery >= Math.max(10, batteryFloor - 10) && bandwidth >= bandwidthFloor && thresholds.memoryPressure < 97,
     }
   }
 
   function snapshot() {
     const thresholds = lastThresholds || getThresholds()
-    return { role, profile, memoryStats, thresholds }
+    return { role, profile, memoryStats, cpuStats, thresholds }
   }
 
-  return { role, profile, budgetFor, getThresholds, refreshMemoryStats, updateMemoryStats, snapshot, encodeBudgetState, decodeBudgetState }
+  return {
+    role,
+    profile,
+    budgetFor,
+    getThresholds,
+    allocate,
+    refreshMemoryStats,
+    refreshCpuStats,
+    refreshSystemStats,
+    updateMemoryStats,
+    updateCpuStats,
+    snapshot,
+    encodeBudgetState,
+    decodeBudgetState,
+  }
 }
 
 export function createResourcePolicy(options = {}) {

--- a/packages/backend/src/budget-manager.js
+++ b/packages/backend/src/budget-manager.js
@@ -35,7 +35,7 @@ function normalizeCpuStats(stats = {}) {
 async function readBareHcMemoryStats(source) {
   if (!source) return null
   if (typeof source === 'function') return normalizeMemoryStats(await source())
-  for (const name of ['memoryStats', 'getMemoryStats', 'stats', 'getStats']) {
+  for (const name of ['memoryStats', 'getMemoryStats', 'stats', 'getStats', 'systemStats', 'getSystemStats']) {
     if (typeof source[name] === 'function') {
       const stats = await source[name]()
       return normalizeMemoryStats(stats?.memory || stats)

--- a/packages/backend/src/peer-scorer.js
+++ b/packages/backend/src/peer-scorer.js
@@ -22,6 +22,10 @@ function clampScore(score) {
   return Math.max(0, Math.min(100, Math.floor(safeNumber(score, 0))))
 }
 
+function metricIncludes(metric = {}, names = []) {
+  return names.some((name) => metric[name] !== undefined && metric[name] !== null)
+}
+
 function normalizeMetric(peerId, metric = {}) {
   const handshakes = safeNumber(metric.handshakes ?? metric.handshakeCount, 0)
   const failures = safeNumber(metric.handshakeFailures ?? metric.failedHandshakes, 0)
@@ -29,13 +33,17 @@ function normalizeMetric(peerId, metric = {}) {
   const total = Math.max(handshakes, successes + failures)
   const latencyMs = Math.max(0, safeNumber(metric.latencyMs ?? metric.rttMs, 0))
   const handshakeDurationMs = Math.max(0, safeNumber(metric.handshakeDurationMs ?? metric.handshakeMs ?? metric.handshakeLatencyMs, 0))
-  const socketStability = Math.max(0, Math.min(100, safeNumber(metric.socketStability ?? metric.socketStabilityScore ?? metric.stability, 0)))
+  const socketStabilityObserved = metricIncludes(metric, ['socketStability', 'socketStabilityScore', 'stability'])
+  const socketStability = socketStabilityObserved
+    ? Math.max(0, Math.min(100, safeNumber(metric.socketStability ?? metric.socketStabilityScore ?? metric.stability, 0)))
+    : 0
   const throughput = Math.max(0, safeNumber(metric.udxThroughputBps ?? metric.throughputBps ?? metric.bytesPerSecond, 0))
   return {
     peerId: toHex(peerId || metric.peerId || metric.identityId || hashText(metric)),
     latencyMs,
     handshakeDurationMs,
     socketStability,
+    socketStabilityObserved,
     handshakeSuccesses: successes,
     handshakeFailures: failures,
     handshakes: total,
@@ -64,11 +72,12 @@ function performanceScore(metric = {}) {
 
 export const peerMetricEncoding = {
   preencode(state, metric = {}) {
-    c.uint.preencode(state, 2)
+    c.uint.preencode(state, 3)
     c.string.preencode(state, toHex(metric.peerId || ''))
     c.uint.preencode(state, Math.max(0, Math.floor(safeNumber(metric.latencyMs, 0))))
     c.uint.preencode(state, Math.max(0, Math.floor(safeNumber(metric.handshakeDurationMs, 0))))
     c.uint.preencode(state, Math.max(0, Math.floor(safeNumber(metric.socketStability, 0))))
+    c.bool.preencode(state, Boolean(metric.socketStabilityObserved))
     c.uint.preencode(state, Math.max(0, Math.floor(safeNumber(metric.handshakeSuccesses, 0))))
     c.uint.preencode(state, Math.max(0, Math.floor(safeNumber(metric.handshakeFailures, 0))))
     c.uint.preencode(state, Math.max(0, Math.floor(safeNumber(metric.handshakes, 0))))
@@ -76,11 +85,12 @@ export const peerMetricEncoding = {
     c.biguint.preencode(state, safeBigInt(metric.observedAt, 0n))
   },
   encode(state, metric = {}) {
-    c.uint.encode(state, 2)
+    c.uint.encode(state, 3)
     c.string.encode(state, toHex(metric.peerId || ''))
     c.uint.encode(state, Math.max(0, Math.floor(safeNumber(metric.latencyMs, 0))))
     c.uint.encode(state, Math.max(0, Math.floor(safeNumber(metric.handshakeDurationMs, 0))))
     c.uint.encode(state, Math.max(0, Math.floor(safeNumber(metric.socketStability, 0))))
+    c.bool.encode(state, Boolean(metric.socketStabilityObserved))
     c.uint.encode(state, Math.max(0, Math.floor(safeNumber(metric.handshakeSuccesses, 0))))
     c.uint.encode(state, Math.max(0, Math.floor(safeNumber(metric.handshakeFailures, 0))))
     c.uint.encode(state, Math.max(0, Math.floor(safeNumber(metric.handshakes, 0))))
@@ -89,16 +99,18 @@ export const peerMetricEncoding = {
   },
   decode(state) {
     const version = c.uint.decode(state)
-    if (version !== 1 && version !== 2) throw new Error(`Unsupported peer metric version ${version}`)
+    if (version !== 1 && version !== 2 && version !== 3) throw new Error(`Unsupported peer metric version ${version}`)
     const peerId = c.string.decode(state)
     const latencyMs = c.uint.decode(state)
     const handshakeDurationMs = version >= 2 ? c.uint.decode(state) : 0
     const socketStability = version >= 2 ? c.uint.decode(state) : 0
+    const socketStabilityObserved = version >= 3 ? c.bool.decode(state) : version >= 2
     return {
       peerId,
       latencyMs,
       handshakeDurationMs,
       socketStability,
+      socketStabilityObserved,
       handshakeSuccesses: c.uint.decode(state),
       handshakeFailures: c.uint.decode(state),
       handshakes: c.uint.decode(state),
@@ -321,10 +333,6 @@ export function createPeerScorer(options = {}) {
     return record
   }
 
-  function metricIncludes(metric = {}, names = []) {
-    return names.some((name) => metric[name] !== undefined && metric[name] !== null)
-  }
-
   async function recordPerformance(peerId, metric = {}) {
     const normalized = normalizeMetric(peerId, metric)
     const current = metrics.get(normalized.peerId)
@@ -334,6 +342,7 @@ export function createPeerScorer(options = {}) {
           latencyMs: metricIncludes(metric, ['latencyMs', 'rttMs']) ? normalized.latencyMs : current.latencyMs,
           handshakeDurationMs: metricIncludes(metric, ['handshakeDurationMs', 'handshakeMs', 'handshakeLatencyMs']) ? normalized.handshakeDurationMs : current.handshakeDurationMs,
           socketStability: metricIncludes(metric, ['socketStability', 'socketStabilityScore', 'stability']) ? normalized.socketStability : current.socketStability,
+          socketStabilityObserved: Boolean(current.socketStabilityObserved || normalized.socketStabilityObserved),
           handshakeSuccesses: current.handshakeSuccesses + normalized.handshakeSuccesses,
           handshakeFailures: current.handshakeFailures + normalized.handshakeFailures,
           handshakes: current.handshakes + normalized.handshakes,
@@ -387,7 +396,7 @@ export function createPeerScorer(options = {}) {
     const metric = metricFor(peer) || peer.performance || {}
     if (safeNumber(metric.handshakeFailures, 0) >= safeNumber(options.maxHandshakeFailures, 4)) return true
     const stability = safeNumber(metric.socketStability, 100)
-    if (Object.hasOwn(metric, 'socketStability') && stability < safeNumber(options.minSocketStability, 20)) return true
+    if (metric.socketStabilityObserved && stability < safeNumber(options.minSocketStability, 20)) return true
     return safeNumber(peer.score ?? scorePeer(peer), 0) < minScore
   }
 

--- a/packages/backend/src/peer-scorer.js
+++ b/packages/backend/src/peer-scorer.js
@@ -28,10 +28,14 @@ function normalizeMetric(peerId, metric = {}) {
   const successes = safeNumber(metric.handshakeSuccesses ?? metric.successfulHandshakes, 0)
   const total = Math.max(handshakes, successes + failures)
   const latencyMs = Math.max(0, safeNumber(metric.latencyMs ?? metric.rttMs, 0))
+  const handshakeDurationMs = Math.max(0, safeNumber(metric.handshakeDurationMs ?? metric.handshakeMs ?? metric.handshakeLatencyMs, 0))
+  const socketStability = Math.max(0, Math.min(100, safeNumber(metric.socketStability ?? metric.socketStabilityScore ?? metric.stability, 0)))
   const throughput = Math.max(0, safeNumber(metric.udxThroughputBps ?? metric.throughputBps ?? metric.bytesPerSecond, 0))
   return {
     peerId: toHex(peerId || metric.peerId || metric.identityId || hashText(metric)),
     latencyMs,
+    handshakeDurationMs,
+    socketStability,
     handshakeSuccesses: successes,
     handshakeFailures: failures,
     handshakes: total,
@@ -43,22 +47,28 @@ function normalizeMetric(peerId, metric = {}) {
 function performanceScore(metric = {}) {
   if (!metric) return 0
   const latency = safeNumber(metric.latencyMs, 0)
+  const handshakeDuration = safeNumber(metric.handshakeDurationMs, 0)
+  const stability = safeNumber(metric.socketStability, 0)
   const throughput = safeNumber(metric.udxThroughputBps, 0)
   const handshakes = Math.max(1, safeNumber(metric.handshakes, 0))
   const successes = safeNumber(metric.handshakeSuccesses, 0)
   const failures = safeNumber(metric.handshakeFailures, 0)
   const handshakeRate = Math.max(0, Math.min(1, successes / Math.max(handshakes, successes + failures, 1)))
   const latencyScore = latency <= 0 ? 5 : Math.max(-20, 20 - Math.floor(latency / 50))
+  const handshakeDurationScore = handshakeDuration <= 0 ? 0 : Math.max(-15, 12 - Math.floor(handshakeDuration / 75))
+  const stabilityScore = Math.floor(stability / 5) - (stability > 0 && stability < 20 ? 15 : 0)
   const throughputScore = Math.min(20, Math.floor(throughput / (128 * 1024)))
   const handshakeScore = Math.floor(handshakeRate * 20) - Math.min(20, failures * 4)
-  return latencyScore + throughputScore + handshakeScore
+  return latencyScore + handshakeDurationScore + stabilityScore + throughputScore + handshakeScore
 }
 
 export const peerMetricEncoding = {
   preencode(state, metric = {}) {
-    c.uint.preencode(state, 1)
+    c.uint.preencode(state, 2)
     c.string.preencode(state, toHex(metric.peerId || ''))
     c.uint.preencode(state, Math.max(0, Math.floor(safeNumber(metric.latencyMs, 0))))
+    c.uint.preencode(state, Math.max(0, Math.floor(safeNumber(metric.handshakeDurationMs, 0))))
+    c.uint.preencode(state, Math.max(0, Math.floor(safeNumber(metric.socketStability, 0))))
     c.uint.preencode(state, Math.max(0, Math.floor(safeNumber(metric.handshakeSuccesses, 0))))
     c.uint.preencode(state, Math.max(0, Math.floor(safeNumber(metric.handshakeFailures, 0))))
     c.uint.preencode(state, Math.max(0, Math.floor(safeNumber(metric.handshakes, 0))))
@@ -66,9 +76,11 @@ export const peerMetricEncoding = {
     c.biguint.preencode(state, safeBigInt(metric.observedAt, 0n))
   },
   encode(state, metric = {}) {
-    c.uint.encode(state, 1)
+    c.uint.encode(state, 2)
     c.string.encode(state, toHex(metric.peerId || ''))
     c.uint.encode(state, Math.max(0, Math.floor(safeNumber(metric.latencyMs, 0))))
+    c.uint.encode(state, Math.max(0, Math.floor(safeNumber(metric.handshakeDurationMs, 0))))
+    c.uint.encode(state, Math.max(0, Math.floor(safeNumber(metric.socketStability, 0))))
     c.uint.encode(state, Math.max(0, Math.floor(safeNumber(metric.handshakeSuccesses, 0))))
     c.uint.encode(state, Math.max(0, Math.floor(safeNumber(metric.handshakeFailures, 0))))
     c.uint.encode(state, Math.max(0, Math.floor(safeNumber(metric.handshakes, 0))))
@@ -77,10 +89,16 @@ export const peerMetricEncoding = {
   },
   decode(state) {
     const version = c.uint.decode(state)
-    if (version !== 1) throw new Error(`Unsupported peer metric version ${version}`)
+    if (version !== 1 && version !== 2) throw new Error(`Unsupported peer metric version ${version}`)
+    const peerId = c.string.decode(state)
+    const latencyMs = c.uint.decode(state)
+    const handshakeDurationMs = version >= 2 ? c.uint.decode(state) : 0
+    const socketStability = version >= 2 ? c.uint.decode(state) : 0
     return {
-      peerId: c.string.decode(state),
-      latencyMs: c.uint.decode(state),
+      peerId,
+      latencyMs,
+      handshakeDurationMs,
+      socketStability,
       handshakeSuccesses: c.uint.decode(state),
       handshakeFailures: c.uint.decode(state),
       handshakes: c.uint.decode(state),
@@ -251,6 +269,7 @@ export function createPeerScorer(options = {}) {
   const subscribers = new Set()
   const persist = typeof options.persist === 'function' ? options.persist : null
   const metaDb = options.metaDb || null
+  const evictPeer = typeof options.evictPeer === 'function' ? options.evictPeer : null
 
   function notify(peerId, record) {
     for (const subscriber of subscribers) {
@@ -309,6 +328,8 @@ export function createPeerScorer(options = {}) {
       ? {
           ...current,
           latencyMs: normalized.latencyMs || current.latencyMs,
+          handshakeDurationMs: normalized.handshakeDurationMs || current.handshakeDurationMs,
+          socketStability: normalized.socketStability || current.socketStability,
           handshakeSuccesses: current.handshakeSuccesses + normalized.handshakeSuccesses,
           handshakeFailures: current.handshakeFailures + normalized.handshakeFailures,
           handshakes: current.handshakes + normalized.handshakes,
@@ -349,6 +370,34 @@ export function createPeerScorer(options = {}) {
     return () => subscribers.delete(listener)
   }
 
+  function rankPeers(peers = Array.from(state.peers.values()), now = Date.now()) {
+    return peers
+      .map((peer) => registerPeer({ ...peer, score: scorePeer(peer, now) }))
+      .sort((a, b) => b.score - a.score)
+  }
+
+  function shouldEvict(peerOrId, options = {}) {
+    const minScore = safeNumber(options.minScore, 40)
+    const peer = typeof peerOrId === 'string' ? state.peers.get(peerOrId) : peerOrId
+    if (!peer) return false
+    const metric = metricFor(peer) || peer.performance || {}
+    if (safeNumber(metric.handshakeFailures, 0) >= safeNumber(options.maxHandshakeFailures, 4)) return true
+    if (safeNumber(metric.socketStability, 100) > 0 && safeNumber(metric.socketStability, 100) < safeNumber(options.minSocketStability, 20)) return true
+    return safeNumber(peer.score ?? scorePeer(peer), 0) < minScore
+  }
+
+  function evictLowPerformers(options = {}) {
+    const evicted = []
+    for (const peer of Array.from(state.peers.values())) {
+      if (!shouldEvict(peer, options)) continue
+      state.peers.delete(peer.peerId)
+      evicted.push(peer)
+      if (evictPeer) evictPeer(peer.peerId, peer)
+      notify(peer.peerId, { ...peer, evicted: true })
+    }
+    return { evicted, remaining: rankPeers() }
+  }
+
   function snapshot() {
     return {
       peers: Array.from(state.peers.values()),
@@ -366,6 +415,9 @@ export function createPeerScorer(options = {}) {
     applyPerformanceDiff,
     applyPerformanceDiffStream,
     createPerformanceDiffStream: createPeerMetricDiffStream,
+    rankPeers,
+    shouldEvict,
+    evictLowPerformers,
     subscribe,
     snapshot,
   }

--- a/packages/backend/src/peer-scorer.js
+++ b/packages/backend/src/peer-scorer.js
@@ -66,7 +66,9 @@ function performanceScore(metric = {}) {
   const handshakeRate = Math.max(0, Math.min(1, successes / Math.max(handshakes, successes + failures, 1)))
   const latencyScore = latency <= 0 ? 5 : Math.max(-20, 20 - Math.floor(latency / 50))
   const handshakeDurationScore = handshakeDuration <= 0 ? 0 : Math.max(-15, 12 - Math.floor(handshakeDuration / 75))
-  const stabilityScore = Math.floor(stability / 5) - (stability > 0 && stability < 20 ? 15 : 0)
+  const stabilityScore = metric.socketStabilityObserved
+    ? Math.floor(stability / 5) - (stability < 20 ? 15 : 0)
+    : 0
   const throughputScore = Math.min(20, Math.floor(throughput / (128 * 1024)))
   const handshakeScore = Math.floor(handshakeRate * 20) - Math.min(20, failures * 4)
   return latencyScore + handshakeDurationScore + stabilityScore + throughputScore + handshakeScore
@@ -366,7 +368,7 @@ export function createPeerScorer(options = {}) {
     if (diff.left) metrics.set(metric.peerId, metric)
     else metrics.delete(metric.peerId)
     const peer = state.peers.get(metric.peerId)
-    if (peer) registerPeer({ ...peer, performance: metric })
+    if (peer) registerPeer({ ...peer, performance: diff.left ? metric : null })
     return metric
   }
 

--- a/packages/backend/src/peer-scorer.js
+++ b/packages/backend/src/peer-scorer.js
@@ -33,7 +33,9 @@ function normalizeMetric(peerId, metric = {}) {
   const total = Math.max(handshakes, successes + failures)
   const latencyMs = Math.max(0, safeNumber(metric.latencyMs ?? metric.rttMs, 0))
   const handshakeDurationMs = Math.max(0, safeNumber(metric.handshakeDurationMs ?? metric.handshakeMs ?? metric.handshakeLatencyMs, 0))
-  const socketStabilityObserved = metricIncludes(metric, ['socketStability', 'socketStabilityScore', 'stability'])
+  const socketStabilityObserved = metric.socketStabilityObserved !== undefined && metric.socketStabilityObserved !== null
+    ? Boolean(metric.socketStabilityObserved)
+    : metricIncludes(metric, ['socketStability', 'socketStabilityScore', 'stability'])
   const socketStability = socketStabilityObserved
     ? Math.max(0, Math.min(100, safeNumber(metric.socketStability ?? metric.socketStabilityScore ?? metric.stability, 0)))
     : 0
@@ -358,11 +360,11 @@ export function createPeerScorer(options = {}) {
   }
 
   async function applyPerformanceDiff(diff) {
-    const entry = diff?.left || diff?.right
+    const entry = diff?.right || diff?.left
     if (!entry?.value) return null
     const metric = decodePeerMetric(entry.value)
-    if (!diff.left) metrics.delete(metric.peerId)
-    else metrics.set(metric.peerId, metric)
+    if (diff.right) metrics.set(metric.peerId, metric)
+    else metrics.delete(metric.peerId)
     const peer = state.peers.get(metric.peerId)
     if (peer) registerPeer({ ...peer, performance: metric })
     return metric

--- a/packages/backend/src/peer-scorer.js
+++ b/packages/backend/src/peer-scorer.js
@@ -360,10 +360,10 @@ export function createPeerScorer(options = {}) {
   }
 
   async function applyPerformanceDiff(diff) {
-    const entry = diff?.right || diff?.left
+    const entry = diff?.left || diff?.right
     if (!entry?.value) return null
     const metric = decodePeerMetric(entry.value)
-    if (diff.right) metrics.set(metric.peerId, metric)
+    if (diff.left) metrics.set(metric.peerId, metric)
     else metrics.delete(metric.peerId)
     const peer = state.peers.get(metric.peerId)
     if (peer) registerPeer({ ...peer, performance: metric })

--- a/packages/backend/src/peer-scorer.js
+++ b/packages/backend/src/peer-scorer.js
@@ -321,15 +321,19 @@ export function createPeerScorer(options = {}) {
     return record
   }
 
+  function metricIncludes(metric = {}, names = []) {
+    return names.some((name) => metric[name] !== undefined && metric[name] !== null)
+  }
+
   async function recordPerformance(peerId, metric = {}) {
     const normalized = normalizeMetric(peerId, metric)
     const current = metrics.get(normalized.peerId)
     const merged = current
       ? {
           ...current,
-          latencyMs: normalized.latencyMs || current.latencyMs,
-          handshakeDurationMs: normalized.handshakeDurationMs || current.handshakeDurationMs,
-          socketStability: normalized.socketStability || current.socketStability,
+          latencyMs: metricIncludes(metric, ['latencyMs', 'rttMs']) ? normalized.latencyMs : current.latencyMs,
+          handshakeDurationMs: metricIncludes(metric, ['handshakeDurationMs', 'handshakeMs', 'handshakeLatencyMs']) ? normalized.handshakeDurationMs : current.handshakeDurationMs,
+          socketStability: metricIncludes(metric, ['socketStability', 'socketStabilityScore', 'stability']) ? normalized.socketStability : current.socketStability,
           handshakeSuccesses: current.handshakeSuccesses + normalized.handshakeSuccesses,
           handshakeFailures: current.handshakeFailures + normalized.handshakeFailures,
           handshakes: current.handshakes + normalized.handshakes,
@@ -382,7 +386,8 @@ export function createPeerScorer(options = {}) {
     if (!peer) return false
     const metric = metricFor(peer) || peer.performance || {}
     if (safeNumber(metric.handshakeFailures, 0) >= safeNumber(options.maxHandshakeFailures, 4)) return true
-    if (safeNumber(metric.socketStability, 100) > 0 && safeNumber(metric.socketStability, 100) < safeNumber(options.minSocketStability, 20)) return true
+    const stability = safeNumber(metric.socketStability, 100)
+    if (Object.hasOwn(metric, 'socketStability') && stability < safeNumber(options.minSocketStability, 20)) return true
     return safeNumber(peer.score ?? scorePeer(peer), 0) < minScore
   }
 

--- a/packages/backend/src/universal-core.js
+++ b/packages/backend/src/universal-core.js
@@ -342,10 +342,11 @@ function createPlayerResourceGate(options = {}) {
   return { mainPolicy, shortsPolicy, budgetFor, shouldSuspend, chooseActiveSurface }
 }
 
-function createUnifiedAutobaseSink(options = {}) {
+export function createUnifiedAutobaseSink(options = {}) {
   const events = []
   const bySurface = new Map()
   const seen = new Set()
+  const appendSubscribers = new Set()
   const appendFn = typeof options.append === 'function'
     ? options.append
     : typeof options.autobase?.append === 'function'
@@ -355,6 +356,25 @@ function createUnifiedAutobaseSink(options = {}) {
         : typeof options.autobase?.log?.append === 'function'
           ? options.autobase.log.append.bind(options.autobase.log)
           : null
+  const nativeOnAppend = typeof options.autobase?.onappend === 'function'
+    ? options.autobase.onappend.bind(options.autobase)
+    : typeof options.autobase?.log?.onappend === 'function'
+      ? options.autobase.log.onappend.bind(options.autobase.log)
+      : null
+
+  function notifyAppend(record) {
+    for (const subscriber of appendSubscribers) {
+      try {
+        subscriber(record)
+      } catch {
+        // Keep native onappend fanout non-blocking.
+      }
+    }
+  }
+
+  const closeNativeOnAppend = nativeOnAppend
+    ? nativeOnAppend((record) => notifyAppend(record))
+    : null
 
   function surfaceBucket(surface) {
     const key = normalizePlayerSurface(surface)
@@ -393,8 +413,19 @@ function createUnifiedAutobaseSink(options = {}) {
     if (appendFn) {
       await appendFn(compactJson(envelope))
     }
+    notifyAppend(envelope)
 
     return { appended: true, duplicate: false, envelope }
+  }
+
+  function onappend(listener) {
+    if (typeof listener !== 'function') return () => {}
+    appendSubscribers.add(listener)
+    return () => appendSubscribers.delete(listener)
+  }
+
+  function close() {
+    if (typeof closeNativeOnAppend === 'function') closeNativeOnAppend()
   }
 
   function snapshot() {
@@ -409,7 +440,7 @@ function createUnifiedAutobaseSink(options = {}) {
     }
   }
 
-  return { append, snapshot, bySurface, events }
+  return { append, onappend, close, snapshot, bySurface, events }
 }
 
 export function createPlayerSplitState(options = {}) {

--- a/packages/backend/src/universal-core.js
+++ b/packages/backend/src/universal-core.js
@@ -372,8 +372,51 @@ export function createUnifiedAutobaseSink(options = {}) {
     }
   }
 
+  function decodeNativeRecord(record) {
+    if (!(record instanceof Uint8Array)) return record || {}
+    try {
+      return JSON.parse(c.decode(c.string, record))
+    } catch {
+      return { payload: record }
+    }
+  }
+
+  function storeEnvelope(envelope) {
+    const surface = normalizePlayerSurface(envelope.surface)
+    const bucket = surfaceBucket(surface)
+    const sequence = safeBigInt(envelope.sequence || envelope.seq || bucket.sequence + 1n, bucket.sequence + 1n)
+    const observedAt = safeBigInt(envelope.observedAt || Date.now(), nowMs())
+    const eventId = toHex(envelope.eventId || hashText({ surface, sequence: String(sequence), kind: envelope.kind, payload: envelope.payload || {} }))
+    const dedupeKey = `${surface}:${eventId}`
+    if (seen.has(dedupeKey)) return { duplicate: true, envelope: { ...envelope, surface, sequence, observedAt, eventId } }
+    const stored = {
+      version: safeNumber(envelope.version, 1),
+      domain: envelope.domain || 'playback',
+      surface,
+      playerId: toHex(envelope.playerId || envelope.sessionId || ''),
+      sessionId: toHex(envelope.sessionId || ''),
+      eventId,
+      sequence,
+      observedAt,
+      kind: envelope.kind || 'state',
+      payload: envelope.payload || {},
+    }
+    seen.add(dedupeKey)
+    bucket.sequence = sequence > bucket.sequence ? sequence : bucket.sequence
+    bucket.events.push(stored)
+    bucket.lastEventAt = observedAt > bucket.lastEventAt ? observedAt : bucket.lastEventAt
+    events.push(stored)
+    return { duplicate: false, envelope: stored }
+  }
+
+  function ingestNativeAppend(record) {
+    const { duplicate, envelope } = storeEnvelope(decodeNativeRecord(record))
+    if (!duplicate) notifyAppend(envelope)
+    return envelope
+  }
+
   const closeNativeOnAppend = nativeOnAppend
-    ? nativeOnAppend((record) => notifyAppend(record))
+    ? nativeOnAppend((record) => ingestNativeAppend(record))
     : null
 
   function surfaceBucket(surface) {
@@ -385,37 +428,30 @@ export function createUnifiedAutobaseSink(options = {}) {
   async function append(record = {}) {
     const surface = normalizePlayerSurface(record.surface)
     const bucket = surfaceBucket(surface)
-    const observedAt = safeBigInt(record.observedAt || Date.now(), nowMs())
     const sequence = bucket.sequence + 1n
-    bucket.sequence = sequence
-    const eventId = toHex(record.eventId || hashText({ surface, sequence: String(sequence), ...record }))
-    const dedupeKey = `${surface}:${eventId}`
-    if (seen.has(dedupeKey)) {
-      return { appended: false, duplicate: true, eventId, sequence, surface }
-    }
     const envelope = {
       version: 1,
       domain: 'playback',
       surface,
       playerId: toHex(record.playerId || record.sessionId || ''),
       sessionId: toHex(record.sessionId || ''),
-      eventId,
       sequence,
-      observedAt,
+      observedAt: safeBigInt(record.observedAt || Date.now(), nowMs()),
       kind: record.kind || 'state',
       payload: record.payload || {},
     }
-    seen.add(dedupeKey)
-    bucket.events.push(envelope)
-    bucket.lastEventAt = observedAt > bucket.lastEventAt ? observedAt : bucket.lastEventAt
-    events.push(envelope)
+    envelope.eventId = toHex(record.eventId || hashText({ surface, sequence: String(sequence), ...record }))
+    const stored = storeEnvelope(envelope)
+    if (stored.duplicate) {
+      return { appended: false, duplicate: true, eventId: stored.envelope.eventId, sequence, surface }
+    }
 
     if (appendFn) {
-      await appendFn(compactJson(envelope))
+      await appendFn(compactJson(stored.envelope))
     }
-    notifyAppend(envelope)
+    notifyAppend(stored.envelope)
 
-    return { appended: true, duplicate: false, envelope }
+    return { appended: true, duplicate: false, envelope: stored.envelope }
   }
 
   function onappend(listener) {
@@ -599,6 +635,10 @@ export function createDualPlayerPlaybackCore(options = {}) {
     }
   }
 
+  function close() {
+    sink.close()
+  }
+
   return {
     state,
     resourceGate,
@@ -609,6 +649,7 @@ export function createDualPlayerPlaybackCore(options = {}) {
     prioritizeShorts,
     suspendInactivePlayers,
     syncActiveSurface,
+    close,
     snapshot,
   }
 }
@@ -813,6 +854,7 @@ export function createUniversalCore(options = {}) {
     return await runLifecycle(async () => {
       lifecycleState = 'shutting_down'
       await transitionNative('shutdown', ['libudx', 'libkv', 'libhc'], ['shutdown', 'close', 'stop', 'destroy'], { platform: options.platform })
+      playerCore.close()
       lifecycleState = 'shutdown'
       emitCoreEvent('core.shutdown', { state: lifecycleState })
       return backend

--- a/packages/backend/test/universal-core-hardening.test.mjs
+++ b/packages/backend/test/universal-core-hardening.test.mjs
@@ -194,7 +194,15 @@ test('peer scorer persists compact performance metrics and updates reactive scor
   assert.equal(puts[0][0], 'universal-core:peer-metric:peer-a')
   assert.equal(puts[0][1] instanceof Uint8Array, true)
   assert.equal(decodePeerMetric(puts[0][1]).udxThroughputBps, 1024 * 1024)
-  assert.equal(decodePeerMetric(puts[0][1]).socketStabilityObserved, true)
+  assert.equal(decodePeerMetric(puts[0][1]).socketStabilityObserved, false)
+  assert.equal(decodePeerMetric(encodePeerMetric({ peerId: 'peer-unknown', latencyMs: 10, socketStability: 0, socketStabilityObserved: false })).socketStabilityObserved, false)
+
+  const diffValue = encodePeerMetric({ peerId: 'peer-b', latencyMs: 5, socketStability: 88, socketStabilityObserved: true })
+  await scorer.applyPerformanceDiff({ left: null, right: { value: diffValue } })
+  assert.equal(scorer.metrics.has('peer-b'), true)
+  await scorer.applyPerformanceDiff({ left: { value: diffValue }, right: null })
+  assert.equal(scorer.metrics.has('peer-b'), false)
+
   assert.equal(updates.length > 0, true)
   assert.equal(state.peers.get('peer-a').performance.udxThroughputBps, 1024 * 1024)
 })

--- a/packages/backend/test/universal-core-hardening.test.mjs
+++ b/packages/backend/test/universal-core-hardening.test.mjs
@@ -198,9 +198,9 @@ test('peer scorer persists compact performance metrics and updates reactive scor
   assert.equal(decodePeerMetric(encodePeerMetric({ peerId: 'peer-unknown', latencyMs: 10, socketStability: 0, socketStabilityObserved: false })).socketStabilityObserved, false)
 
   const diffValue = encodePeerMetric({ peerId: 'peer-b', latencyMs: 5, socketStability: 88, socketStabilityObserved: true })
-  await scorer.applyPerformanceDiff({ left: null, right: { value: diffValue } })
-  assert.equal(scorer.metrics.has('peer-b'), true)
   await scorer.applyPerformanceDiff({ left: { value: diffValue }, right: null })
+  assert.equal(scorer.metrics.has('peer-b'), true)
+  await scorer.applyPerformanceDiff({ left: null, right: { value: diffValue } })
   assert.equal(scorer.metrics.has('peer-b'), false)
 
   assert.equal(updates.length > 0, true)

--- a/packages/backend/test/universal-core-hardening.test.mjs
+++ b/packages/backend/test/universal-core-hardening.test.mjs
@@ -276,6 +276,19 @@ test('budget manager polls memory and cpu and scales feed/autobase/swarm allocat
   assert.equal(allocation.autobaseLinearizationBuffers < 128, true)
   assert.equal(allocation.activeSwarmConnections < 48, true)
   assert.equal(decodeBudgetState(encodeBudgetState(refreshed.thresholds)).cpuPressure, 92)
+
+  const combined = createBudgetManager({
+    role: 'relay',
+    bareHc: {
+      getSystemStats: async () => ({
+        memory: { total: 2000, rss: 1600 },
+        cpu: { usagePercent: 25 },
+      }),
+    },
+  })
+  const combinedRefreshed = await combined.refreshSystemStats()
+  assert.equal(combinedRefreshed.thresholds.memoryPressure, 80)
+  assert.equal(combinedRefreshed.thresholds.cpuPressure, 25)
 })
 
 test('autobase sink binds native onappend and emits zero-copy compact envelopes', async () => {
@@ -292,9 +305,31 @@ test('autobase sink binds native onappend and emits zero-copy compact envelopes'
   sink.onappend((record) => observed.push(record))
 
   await sink.append({ surface: 'main', kind: 'feed-update', payload: { feed: 'a' } })
-  listeners[0]({ seq: 9, kind: 'remote-feed-update', payload: { feed: 'b' } })
+  listeners[0]({ surface: 'main', sequence: 9n, eventId: 'remote-1', kind: 'remote-feed-update', payload: { feed: 'b' } })
+  listeners[0]({ surface: 'main', sequence: 9n, eventId: 'remote-1', kind: 'remote-feed-update', payload: { feed: 'b' } })
 
   assert.equal(appended[0] instanceof Uint8Array, true)
   assert.equal(sink.snapshot().events[0].payload.feed, 'a')
+  assert.equal(sink.snapshot().events[1].payload.feed, 'b')
+  assert.equal(sink.snapshot().bySurface[0].sequence, 9n)
   assert.equal(observed.at(-1).kind, 'remote-feed-update')
+  assert.equal(observed.length, 2)
+})
+
+test('universal core shutdown closes native autobase append subscriptions', async () => {
+  const calls = []
+  const core = createUniversalCore({
+    platform: 'relay',
+    storagePath: '/tmp/peartube-universal-core-test',
+    players: {
+      autobase: {
+        onappend: () => () => calls.push('closed'),
+      },
+    },
+    createBackendContext: async () => ({ ctx: {} }),
+  })
+
+  await core.init()
+  await core.shutdown()
+  assert.deepEqual(calls, ['closed'])
 })

--- a/packages/backend/test/universal-core-hardening.test.mjs
+++ b/packages/backend/test/universal-core-hardening.test.mjs
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 
 import { readFile } from 'node:fs/promises'
 
-import { createUniversalCore } from '../src/universal-core.js'
+import { createUniversalCore, createUnifiedAutobaseSink } from '../src/universal-core.js'
 import { createBudgetManager, decodeBudgetState, encodeBudgetState } from '../src/budget-manager.js'
 import { createPeerScorer, decodePeerMetric, encodePeerMetric } from '../src/peer-scorer.js'
 
@@ -234,4 +234,67 @@ test('universal core state persistence uses compact buffers and has no legacy go
   const source = await readFile(new URL('../src/universal-core.js', import.meta.url), 'utf8')
   assert.equal(/setInterval\s*\(/.test(source), false)
   assert.equal(/gossip/i.test(source) && /setInterval\s*\(/.test(source), false)
+})
+
+test('peer scorer ranks and evicts peers from latency handshake stability and udx throughput', async () => {
+  const evicted = []
+  const state = { peers: new Map() }
+  const scorer = createPeerScorer({
+    state,
+    availability: { shouldAdmit: () => true },
+    resources: { profile: { maxFanout: 4 }, budgetFor: () => ({ credit: 80 }), getThresholds: () => ({ maxFanout: 4 }) },
+    evictPeer: (peerId, record) => evicted.push([peerId, record.score]),
+  })
+
+  scorer.registerPeer({ peerId: 'fast', identity: { validProofCount: 3 } })
+  scorer.registerPeer({ peerId: 'slow', identity: { validProofCount: 3 } })
+  await scorer.recordPerformance('fast', { latencyMs: 25, handshakeDurationMs: 15, socketStability: 96, handshakes: 2, handshakeSuccesses: 2, udxThroughputBps: 3 * 1024 * 1024 })
+  await scorer.recordPerformance('slow', { latencyMs: 1200, handshakeDurationMs: 900, socketStability: 3, handshakes: 4, handshakeFailures: 4, udxThroughputBps: 1024 })
+
+  assert.equal(scorer.rankPeers().at(0).peerId, 'fast')
+  assert.equal(scorer.shouldEvict('slow'), true)
+  assert.equal(scorer.evictLowPerformers({ minScore: 40 }).evicted.length, 1)
+  assert.deepEqual(evicted.map(([peerId]) => peerId), ['slow'])
+  assert.equal(state.peers.has('slow'), false)
+})
+
+test('budget manager polls memory and cpu and scales feed/autobase/swarm allocations under pressure', async () => {
+  const manager = createBudgetManager({
+    role: 'relay',
+    bareHc: {
+      memoryStats: async () => ({ total: 1000, rss: 870 }),
+      cpuStats: async () => ({ usagePercent: 92, loadAverage: 5 }),
+    },
+  })
+
+  const refreshed = await manager.refreshSystemStats()
+  const allocation = manager.allocate({ feedIndexers: 500, autobaseLinearizationBuffers: 128, activeSwarmConnections: 48 })
+
+  assert.equal(refreshed.thresholds.memoryPressure, 87)
+  assert.equal(refreshed.thresholds.cpuPressure, 92)
+  assert.equal(allocation.feedIndexers < 500, true)
+  assert.equal(allocation.autobaseLinearizationBuffers < 128, true)
+  assert.equal(allocation.activeSwarmConnections < 48, true)
+  assert.equal(decodeBudgetState(encodeBudgetState(refreshed.thresholds)).cpuPressure, 92)
+})
+
+test('autobase sink binds native onappend and emits zero-copy compact envelopes', async () => {
+  const appended = []
+  const listeners = []
+  const sink = createUnifiedAutobaseSink({
+    autobase: {
+      append: async (buffer) => appended.push(buffer),
+      onappend: (listener) => { listeners.push(listener); return () => {} },
+    },
+    lightWriter: true,
+  })
+  const observed = []
+  sink.onappend((record) => observed.push(record))
+
+  await sink.append({ surface: 'main', kind: 'feed-update', payload: { feed: 'a' } })
+  listeners[0]({ seq: 9, kind: 'remote-feed-update', payload: { feed: 'b' } })
+
+  assert.equal(appended[0] instanceof Uint8Array, true)
+  assert.equal(sink.snapshot().events[0].payload.feed, 'a')
+  assert.equal(observed.at(-1).kind, 'remote-feed-update')
 })

--- a/packages/backend/test/universal-core-hardening.test.mjs
+++ b/packages/backend/test/universal-core-hardening.test.mjs
@@ -194,6 +194,7 @@ test('peer scorer persists compact performance metrics and updates reactive scor
   assert.equal(puts[0][0], 'universal-core:peer-metric:peer-a')
   assert.equal(puts[0][1] instanceof Uint8Array, true)
   assert.equal(decodePeerMetric(puts[0][1]).udxThroughputBps, 1024 * 1024)
+  assert.equal(decodePeerMetric(puts[0][1]).socketStabilityObserved, true)
   assert.equal(updates.length > 0, true)
   assert.equal(state.peers.get('peer-a').performance.udxThroughputBps, 1024 * 1024)
 })
@@ -265,7 +266,11 @@ test('peer scorer accepts zero-valued performance updates when merging metrics',
   })
 
   scorer.registerPeer({ peerId: 'peer', identity: { validProofCount: 3 } })
-  await scorer.recordPerformance('peer', { socketStability: 96, latencyMs: 25, handshakeDurationMs: 20, handshakes: 1, handshakeSuccesses: 1 })
+  await scorer.recordPerformance('peer', { latencyMs: 25, handshakeDurationMs: 20, handshakes: 1, handshakeSuccesses: 1 })
+  assert.equal(scorer.metrics.get('peer').socketStabilityObserved, false)
+  assert.equal(scorer.shouldEvict('peer', { minSocketStability: 20, maxHandshakeFailures: 99, minScore: 0 }), false)
+
+  await scorer.recordPerformance('peer', { socketStability: 96, handshakes: 1, handshakeSuccesses: 1 })
   await scorer.recordPerformance('peer', { socketStability: 0, latencyMs: 0, handshakeDurationMs: 0, handshakes: 1, handshakeFailures: 1 })
 
   assert.equal(scorer.metrics.get('peer').socketStability, 0)

--- a/packages/backend/test/universal-core-hardening.test.mjs
+++ b/packages/backend/test/universal-core-hardening.test.mjs
@@ -198,10 +198,13 @@ test('peer scorer persists compact performance metrics and updates reactive scor
   assert.equal(decodePeerMetric(encodePeerMetric({ peerId: 'peer-unknown', latencyMs: 10, socketStability: 0, socketStabilityObserved: false })).socketStabilityObserved, false)
 
   const diffValue = encodePeerMetric({ peerId: 'peer-b', latencyMs: 5, socketStability: 88, socketStabilityObserved: true })
+  scorer.registerPeer({ peerId: 'peer-b', identity: { validProofCount: 2 }, descriptor: { descriptorId: 'feed-b' } })
   await scorer.applyPerformanceDiff({ left: { value: diffValue }, right: null })
   assert.equal(scorer.metrics.has('peer-b'), true)
+  assert.equal(state.peers.get('peer-b').performance.socketStability, 88)
   await scorer.applyPerformanceDiff({ left: null, right: { value: diffValue } })
   assert.equal(scorer.metrics.has('peer-b'), false)
+  assert.equal(state.peers.get('peer-b').performance, null)
 
   assert.equal(updates.length > 0, true)
   assert.equal(state.peers.get('peer-a').performance.udxThroughputBps, 1024 * 1024)
@@ -279,9 +282,11 @@ test('peer scorer accepts zero-valued performance updates when merging metrics',
   assert.equal(scorer.shouldEvict('peer', { minSocketStability: 20, maxHandshakeFailures: 99, minScore: 0 }), false)
 
   await scorer.recordPerformance('peer', { socketStability: 96, handshakes: 1, handshakeSuccesses: 1 })
+  const stableScore = scorer.scorePeer({ peerId: 'peer', identity: { validProofCount: 3 } })
   await scorer.recordPerformance('peer', { socketStability: 0, latencyMs: 0, handshakeDurationMs: 0, handshakes: 1, handshakeFailures: 1 })
 
   assert.equal(scorer.metrics.get('peer').socketStability, 0)
+  assert.equal(scorer.scorePeer({ peerId: 'peer', identity: { validProofCount: 3 } }) < stableScore, true)
   assert.equal(scorer.metrics.get('peer').latencyMs, 0)
   assert.equal(scorer.metrics.get('peer').handshakeDurationMs, 0)
   assert.equal(scorer.shouldEvict('peer', { minSocketStability: 20, maxHandshakeFailures: 99, minScore: 0 }), true)

--- a/packages/backend/test/universal-core-hardening.test.mjs
+++ b/packages/backend/test/universal-core-hardening.test.mjs
@@ -258,6 +258,22 @@ test('peer scorer ranks and evicts peers from latency handshake stability and ud
   assert.equal(state.peers.has('slow'), false)
 })
 
+test('peer scorer accepts zero-valued performance updates when merging metrics', async () => {
+  const scorer = createPeerScorer({
+    availability: { shouldAdmit: () => true },
+    resources: { profile: { maxFanout: 4 }, budgetFor: () => ({ credit: 80 }), getThresholds: () => ({ maxFanout: 4 }) },
+  })
+
+  scorer.registerPeer({ peerId: 'peer', identity: { validProofCount: 3 } })
+  await scorer.recordPerformance('peer', { socketStability: 96, latencyMs: 25, handshakeDurationMs: 20, handshakes: 1, handshakeSuccesses: 1 })
+  await scorer.recordPerformance('peer', { socketStability: 0, latencyMs: 0, handshakeDurationMs: 0, handshakes: 1, handshakeFailures: 1 })
+
+  assert.equal(scorer.metrics.get('peer').socketStability, 0)
+  assert.equal(scorer.metrics.get('peer').latencyMs, 0)
+  assert.equal(scorer.metrics.get('peer').handshakeDurationMs, 0)
+  assert.equal(scorer.shouldEvict('peer', { minSocketStability: 20, maxHandshakeFailures: 99, minScore: 0 }), true)
+})
+
 test('budget manager polls memory and cpu and scales feed/autobase/swarm allocations under pressure', async () => {
   const manager = createBudgetManager({
     role: 'relay',
@@ -289,6 +305,19 @@ test('budget manager polls memory and cpu and scales feed/autobase/swarm allocat
   const combinedRefreshed = await combined.refreshSystemStats()
   assert.equal(combinedRefreshed.thresholds.memoryPressure, 80)
   assert.equal(combinedRefreshed.thresholds.cpuPressure, 25)
+
+  const genericStats = createBudgetManager({
+    role: 'relay',
+    bareHc: {
+      getStats: async () => ({
+        memory: { total: 1000, rss: 500 },
+        cpu: { usagePercent: 91 },
+      }),
+    },
+  })
+  const genericRefreshed = await genericStats.refreshSystemStats()
+  assert.equal(genericRefreshed.thresholds.memoryPressure, 50)
+  assert.equal(genericRefreshed.thresholds.cpuPressure, 91)
 })
 
 test('autobase sink binds native onappend and emits zero-copy compact envelopes', async () => {

--- a/packages/spec/schema.cjs
+++ b/packages/spec/schema.cjs
@@ -70,6 +70,9 @@ ns.register({
     { name: 'feedIndexers', type: 'uint', required: false },
     { name: 'autobaseLinearizationBuffers', type: 'uint', required: false },
     { name: 'activeSwarmConnections', type: 'uint', required: false },
+    { name: 'maxConcurrentSync', type: 'uint', required: false },
+    { name: 'maxConcurrentProofs', type: 'uint', required: false },
+    { name: 'maxConcurrentFetches', type: 'uint', required: false },
     { name: 'memoryPressure', type: 'uint', required: false },
     { name: 'cpuPressure', type: 'uint', required: false }
   ]

--- a/packages/spec/schema.cjs
+++ b/packages/spec/schema.cjs
@@ -33,6 +33,47 @@ ns.register({
   ]
 })
 
+ns.register({
+  name: 'peer-performance-metric',
+  fields: [
+    { name: 'peerId', type: 'string', required: true },
+    { name: 'latencyMs', type: 'uint', required: false },
+    { name: 'handshakeDurationMs', type: 'uint', required: false },
+    { name: 'socketStability', type: 'uint', required: false },
+    { name: 'handshakeSuccesses', type: 'uint', required: false },
+    { name: 'handshakeFailures', type: 'uint', required: false },
+    { name: 'handshakes', type: 'uint', required: false },
+    { name: 'udxThroughputBps', type: 'uint', required: false },
+    { name: 'observedAt', type: 'uint', required: false }
+  ]
+})
+
+ns.register({
+  name: 'resource-budget-state',
+  fields: [
+    { name: 'role', type: 'string', required: true },
+    { name: 'memoryPressure', type: 'uint', required: false },
+    { name: 'cpuPressure', type: 'uint', required: false },
+    { name: 'maxFanout', type: 'uint', required: false },
+    { name: 'maxRequestsPerWindow', type: 'uint', required: false },
+    { name: 'maxFeedEntries', type: 'uint', required: false },
+    { name: 'maxConcurrentSync', type: 'uint', required: false },
+    { name: 'maxConcurrentProofs', type: 'uint', required: false },
+    { name: 'maxConcurrentFetches', type: 'uint', required: false }
+  ]
+})
+
+ns.register({
+  name: 'resource-allocation-state',
+  fields: [
+    { name: 'feedIndexers', type: 'uint', required: false },
+    { name: 'autobaseLinearizationBuffers', type: 'uint', required: false },
+    { name: 'activeSwarmConnections', type: 'uint', required: false },
+    { name: 'memoryPressure', type: 'uint', required: false },
+    { name: 'cpuPressure', type: 'uint', required: false }
+  ]
+})
+
 // ============================================
 // Identity Types
 // ============================================

--- a/packages/spec/schema.cjs
+++ b/packages/spec/schema.cjs
@@ -40,6 +40,7 @@ ns.register({
     { name: 'latencyMs', type: 'uint', required: false },
     { name: 'handshakeDurationMs', type: 'uint', required: false },
     { name: 'socketStability', type: 'uint', required: false },
+    { name: 'socketStabilityObserved', type: 'bool', required: false },
     { name: 'handshakeSuccesses', type: 'uint', required: false },
     { name: 'handshakeFailures', type: 'uint', required: false },
     { name: 'handshakes', type: 'uint', required: false },


### PR DESCRIPTION
## Summary
- expands peer-scorer into a reactive performance scorer with latency, handshake duration, socket stability, UDX throughput, ranking, and eviction APIs
- expands budget-manager into a dynamic memory/CPU resource allocator with scaled feed indexing, autobase buffer, and swarm connection allocations
- exports and wires the universal autobase sink to native `onappend` events with compact Uint8Array append envelopes
- adds hyperschema state models for peer metrics, resource budgets, and resource allocations

## Test Plan
- `npx brittle test/universal-core-hardening.test.mjs`
- `npm test --prefix packages/backend`
- `npm run schema`
- `node --check packages/backend/src/peer-scorer.js && node --check packages/backend/src/budget-manager.js && node --check packages/backend/src/universal-core.js && node --check packages/spec/schema.cjs`

## Notes
- `npm run typecheck --prefix packages/backend` is currently blocked by repo config: `TS18003: No inputs were found in config file '/home/user/projects/peartube/tsconfig.json'`.
- Left unrelated local changes unstaged: `packages/backend/package.json`, `packages/backend/src/blob-byte-stream.js`, and `packages/backend/test/blob-byte-stream.test.mjs`.
