### PR TITLE
fix: prioritize blob range downloads for seek requests

### DIFF
--- a/packages/backend/src/blob-range-priority.js
+++ b/packages/backend/src/blob-range-priority.js
@@ -103,6 +103,8 @@ function decodeBlobParam(value) {
 }
 
 function decodeBlobRangeRequest(blobServer, req) {
+  if (req?.method && req.method !== 'GET') return null
+
   const rangeHeader = req?.headers?.range
   if (!rangeHeader) return null
 

--- a/packages/backend/src/storage.js
+++ b/packages/backend/src/storage.js
@@ -26,6 +26,7 @@ import {
 import { NETWORK_TOPIC_STRING } from './types.js'
 import { normalizeBlobRefInput } from './blob-ref.js'
 import { createKnownPeerCache } from './known-peers.js'
+import { prioritizeBlobServerRangeRequest } from './blob-range-priority.js'
 
 function resolveDebugLogPath() {
   return globalThis?.process?.env?.PEARTUBE_NATIVE_WORKLET_DEBUG_LOG || null
@@ -1255,6 +1256,11 @@ export async function initializeStorage(config) {
       res.setHeader('Access-Control-Allow-Headers', 'Range')
       res.setHeader('Access-Control-Expose-Headers', 'Content-Length, Content-Range, Accept-Ranges')
       if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return }
+      try {
+        await prioritizeBlobServerRangeRequest(blobServer, req)
+      } catch (err) {
+        console.log('[Storage] Blob range priority failed:', err?.message || err)
+      }
       return origOnRequest(req, res)
     }
 

--- a/packages/backend/test/blob-range-priority.test.mjs
+++ b/packages/backend/test/blob-range-priority.test.mjs
@@ -2,6 +2,9 @@ import test from 'brittle'
 import c from 'compact-encoding'
 import HypercoreID from 'hypercore-id-encoding'
 import z32 from 'z32'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
 
 import {
   getPrioritizedBlobDownloadRange,
@@ -31,6 +34,9 @@ const blobIdEncoding = {
     }
   },
 }
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const storageSource = readFileSync(resolve(__dirname, '../src/storage.js'), 'utf8')
 
 test('parseHttpByteRange normalizes closed and open HTTP byte ranges', (t) => {
   t.alike(parseHttpByteRange('bytes=65536-131071', 1048576), { start: 65536, end: 131071 })
@@ -102,4 +108,16 @@ test('prioritizeBlobServerRangeRequest starts a non-linear core download for the
   t.alike(calls[0], ['_getCore', key.toString('hex'), blob, true])
   t.alike(calls[1], ['download', { start: 14, end: 15, linear: false }])
   t.ok(calls.some((call) => call[0] === 'close'))
+})
+
+test('storage wires blob range prioritization before delegating blob-server requests', (t) => {
+  const importIndex = storageSource.indexOf("import { prioritizeBlobServerRangeRequest } from './blob-range-priority.js'")
+  const wrapperIndex = storageSource.indexOf('blobServer._onrequest = async function (req, res)')
+  const priorityIndex = storageSource.indexOf('await prioritizeBlobServerRangeRequest(blobServer, req)')
+  const delegateIndex = storageSource.indexOf('return origOnRequest(req, res)')
+
+  t.ok(importIndex >= 0, 'storage imports range priority helper')
+  t.ok(wrapperIndex >= 0, 'storage wraps blob-server requests')
+  t.ok(priorityIndex > wrapperIndex, 'range priority runs inside the request wrapper')
+  t.ok(priorityIndex < delegateIndex, 'range priority runs before blob-server serves the range')
 })

--- a/packages/backend/test/blob-range-priority.test.mjs
+++ b/packages/backend/test/blob-range-priority.test.mjs
@@ -65,8 +65,7 @@ test('getPrioritizedBlobDownloadRange maps a seek byte range to the matching blo
   )
 })
 
-test('prioritizeBlobServerRangeRequest starts a non-linear core download for the requested HTTP range', async (t) => {
-  const calls = []
+function createRangeRequest({ method = 'GET', token = 'test-token' } = {}) {
   const key = Buffer.from('b'.repeat(64), 'hex')
   const blob = {
     blockOffset: 10,
@@ -76,11 +75,18 @@ test('prioritizeBlobServerRangeRequest starts a non-linear core download for the
   }
   const encodedBlob = z32.encode(c.encode(blobIdEncoding, blob))
   const req = {
-    url: `/?key=${HypercoreID.encode(key)}&blob=${encodedBlob}&type=video%2Fmp4&token=test-token`,
+    method,
+    url: `/?key=${HypercoreID.encode(key)}&blob=${encodedBlob}&type=video%2Fmp4&token=${token}`,
     headers: {
       range: `bytes=${4 * 65536}-${(5 * 65536) - 1}`,
     },
   }
+  return { key, blob, req }
+}
+
+test('prioritizeBlobServerRangeRequest starts a non-linear core download for the requested HTTP GET range', async (t) => {
+  const calls = []
+  const { key, blob, req } = createRangeRequest()
   const blobServer = {
     token: 'test-token',
     async _getCore(requestKey, info, active) {
@@ -108,6 +114,23 @@ test('prioritizeBlobServerRangeRequest starts a non-linear core download for the
   t.alike(calls[0], ['_getCore', key.toString('hex'), blob, true])
   t.alike(calls[1], ['download', { start: 14, end: 15, linear: false }])
   t.ok(calls.some((call) => call[0] === 'close'))
+})
+
+test('prioritizeBlobServerRangeRequest ignores HEAD range probes', async (t) => {
+  const calls = []
+  const { req } = createRangeRequest({ method: 'HEAD' })
+  const blobServer = {
+    token: 'test-token',
+    async _getCore() {
+      calls.push(['_getCore'])
+      throw new Error('HEAD should not prioritize blob downloads')
+    },
+  }
+
+  const result = await prioritizeBlobServerRangeRequest(blobServer, req)
+
+  t.is(result, null)
+  t.alike(calls, [])
 })
 
 test('storage wires blob range prioritization before delegating blob-server requests', (t) => {


### PR DESCRIPTION
## Summary
- Wire blob-server HTTP range requests into `prioritizeBlobServerRangeRequest` before delegating to `hypercore-blob-server`
- Keep playback fail-open if the priority prefetch fails, so normal ByteStream/206 serving still handles the request
- Add a regression that guards the storage request-wrapper wiring

## Why
`hypercore-blob-server` already serves player Range requests via `hypercore-byte-stream`, but seek/scrub performance on partially cached remote videos also needs the current HTTP byte range to be promoted into a non-linear Hypercore download. This connects the existing priority helper to the actual blob-server request path.

## Test Plan
- `packages/backend/node_modules/.bin/brittle packages/backend/test/blob-range-priority.test.mjs`
- `node --check packages/backend/src/storage.js`
- `git diff --check`
- `npm test --prefix packages/backend`
- `npx --no-install eslint --quiet packages/backend/src/storage.js packages/backend/test/blob-range-priority.test.mjs`
