### PR TITLE
refactor: enforce canonical archive swarm mapping

### DIFF
--- a/packages/backend/lib/archive-schema.js
+++ b/packages/backend/lib/archive-schema.js
@@ -117,6 +117,30 @@ export const fileMappingCodec = {
   },
 }
 
+const legacyFileMappingCodec = {
+  preencode(state, mapping) {
+    c.fixed32.preencode(state, mapping.fileHash)
+    c.string.preencode(state, mapping.sourceId)
+    c.array(variantCodec).preencode(state, mapping.variants)
+  },
+  encode(state, mapping) {
+    c.fixed32.encode(state, mapping.fileHash)
+    c.string.encode(state, mapping.sourceId)
+    c.array(variantCodec).encode(state, mapping.variants)
+  },
+  decode(state) {
+    const fileHash = c.fixed32.decode(state)
+    const sourceId = c.string.decode(state)
+    const variants = c.array(variantCodec).decode(state)
+    return {
+      fileHash,
+      hypercoreKey: variants[0]?.coreKey,
+      sourceId,
+      variants,
+    }
+  },
+}
+
 export function encode(mapping) {
   const canonical = normalize(mapping)
   const state = c.state()
@@ -128,14 +152,37 @@ export function encode(mapping) {
   return state.buffer
 }
 
+export function encodeLegacyForTest(mapping) {
+  const canonical = normalize(mapping)
+  const state = c.state()
+
+  legacyFileMappingCodec.preencode(state, canonical)
+  state.buffer = b4a.allocUnsafe(state.end)
+  legacyFileMappingCodec.encode(state, canonical)
+
+  return state.buffer
+}
+
 export function decode(buf) {
   const buffer = b4a.isBuffer(buf) ? buf : b4a.from(buf)
-  const state = c.state(0, buffer.byteLength, buffer)
-  const mapping = fileMappingCodec.decode(state)
+  let state = c.state(0, buffer.byteLength, buffer)
+  let mapping
+
+  try {
+    mapping = fileMappingCodec.decode(state)
+    if (state.start !== state.end) throw new Error('archive mapping buffer has trailing bytes')
+  } catch (error) {
+    state = c.state(0, buffer.byteLength, buffer)
+    try {
+      mapping = legacyFileMappingCodec.decode(state)
+    } catch {
+      throw error
+    }
+  }
 
   if (state.start !== state.end) {
     throw new Error('archive mapping buffer has trailing bytes')
   }
 
-  return mapping
+  return normalize(mapping)
 }

--- a/packages/backend/lib/archive-schema.js
+++ b/packages/backend/lib/archive-schema.js
@@ -63,11 +63,19 @@ export function normalize(mapping) {
     throw new TypeError('variants must be an array')
   }
 
+  const variants = mapping.variants.map(normalizeVariant)
+  const hypercoreKey = fixed32(mapping.hypercoreKey ?? mapping.coreKey ?? variants[0]?.coreKey, 'hypercoreKey')
+  for (const variant of variants) {
+    if (!b4a.equals(variant.coreKey, hypercoreKey)) {
+      throw new Error('variants must reference the canonical hypercoreKey')
+    }
+  }
+
   return {
     fileHash: fixed32(mapping.fileHash, 'fileHash'),
-    hypercoreKey: fixed32(mapping.hypercoreKey ?? mapping.coreKey ?? mapping.variants?.[0]?.coreKey, 'hypercoreKey'),
+    hypercoreKey,
     sourceId: mapping.sourceId,
-    variants: mapping.variants.map(normalizeVariant),
+    variants,
   }
 }
 
@@ -97,22 +105,23 @@ const variantCodec = {
 export const fileMappingCodec = {
   preencode(state, mapping) {
     c.fixed32.preencode(state, mapping.fileHash)
-    c.fixed32.preencode(state, mapping.hypercoreKey)
     c.string.preencode(state, mapping.sourceId)
     c.array(variantCodec).preencode(state, mapping.variants)
   },
   encode(state, mapping) {
     c.fixed32.encode(state, mapping.fileHash)
-    c.fixed32.encode(state, mapping.hypercoreKey)
     c.string.encode(state, mapping.sourceId)
     c.array(variantCodec).encode(state, mapping.variants)
   },
   decode(state) {
+    const fileHash = c.fixed32.decode(state)
+    const sourceId = c.string.decode(state)
+    const variants = c.array(variantCodec).decode(state)
     return {
-      fileHash: c.fixed32.decode(state),
-      hypercoreKey: c.fixed32.decode(state),
-      sourceId: c.string.decode(state),
-      variants: c.array(variantCodec).decode(state),
+      fileHash,
+      hypercoreKey: variants[0]?.coreKey,
+      sourceId,
+      variants,
     }
   },
 }

--- a/packages/backend/lib/archive-schema.js
+++ b/packages/backend/lib/archive-schema.js
@@ -65,11 +65,6 @@ export function normalize(mapping) {
 
   const variants = mapping.variants.map(normalizeVariant)
   const hypercoreKey = fixed32(mapping.hypercoreKey ?? mapping.coreKey ?? variants[0]?.coreKey, 'hypercoreKey')
-  for (const variant of variants) {
-    if (!b4a.equals(variant.coreKey, hypercoreKey)) {
-      throw new Error('variants must reference the canonical hypercoreKey')
-    }
-  }
 
   return {
     fileHash: fixed32(mapping.fileHash, 'fileHash'),
@@ -162,12 +157,11 @@ export function encode(mapping) {
 }
 
 export function encodeLegacyForTest(mapping) {
-  const canonical = normalize(mapping)
   const state = c.state()
 
-  legacyFileMappingCodec.preencode(state, canonical)
+  legacyFileMappingCodec.preencode(state, mapping)
   state.buffer = b4a.allocUnsafe(state.end)
-  legacyFileMappingCodec.encode(state, canonical)
+  legacyFileMappingCodec.encode(state, mapping)
 
   return state.buffer
 }

--- a/packages/backend/lib/archive-schema.js
+++ b/packages/backend/lib/archive-schema.js
@@ -65,6 +65,7 @@ export function normalize(mapping) {
 
   return {
     fileHash: fixed32(mapping.fileHash, 'fileHash'),
+    hypercoreKey: fixed32(mapping.hypercoreKey ?? mapping.coreKey ?? mapping.variants?.[0]?.coreKey, 'hypercoreKey'),
     sourceId: mapping.sourceId,
     variants: mapping.variants.map(normalizeVariant),
   }
@@ -96,17 +97,20 @@ const variantCodec = {
 export const fileMappingCodec = {
   preencode(state, mapping) {
     c.fixed32.preencode(state, mapping.fileHash)
+    c.fixed32.preencode(state, mapping.hypercoreKey)
     c.string.preencode(state, mapping.sourceId)
     c.array(variantCodec).preencode(state, mapping.variants)
   },
   encode(state, mapping) {
     c.fixed32.encode(state, mapping.fileHash)
+    c.fixed32.encode(state, mapping.hypercoreKey)
     c.string.encode(state, mapping.sourceId)
     c.array(variantCodec).encode(state, mapping.variants)
   },
   decode(state) {
     return {
       fileHash: c.fixed32.decode(state),
+      hypercoreKey: c.fixed32.decode(state),
       sourceId: c.string.decode(state),
       variants: c.array(variantCodec).decode(state),
     }

--- a/packages/backend/lib/archive-writer.js
+++ b/packages/backend/lib/archive-writer.js
@@ -170,7 +170,11 @@ async function writeWithTransaction(db, key, next, merge) {
         throw new Error('Cannot write archive mapping while HyperDB has pending updates; flush or discard them first')
       }
 
-      const mapping = merge ? mergeMappings(await readExisting(tx, key), next) : next
+      const existing = await readExisting(tx, key)
+      if (existing && !b4a.equals(existing.hypercoreKey, next.hypercoreKey)) {
+        throw new Error('archive mapping already has a canonical hypercore key for this content hash')
+      }
+      const mapping = existing && merge ? mergeMappings(existing, next) : next
       const value = encode(mapping)
 
       await putRaw(tx, key, value)
@@ -183,7 +187,11 @@ async function writeWithTransaction(db, key, next, merge) {
     }
   }
 
-  const mapping = merge ? mergeMappings(await readExisting(db, key), next) : next
+  const existing = await readExisting(db, key)
+  if (existing && !b4a.equals(existing.hypercoreKey, next.hypercoreKey)) {
+    throw new Error('archive mapping already has a canonical hypercore key for this content hash')
+  }
+  const mapping = existing && merge ? mergeMappings(existing, next) : next
   const value = encode(mapping)
 
   await putRaw(db, key, value)

--- a/packages/backend/lib/archive-writer.js
+++ b/packages/backend/lib/archive-writer.js
@@ -41,8 +41,23 @@ function variantId(variant) {
   return `${variant.resolution}\0${b4a.toString(variant.coreKey, 'hex')}\0${variant.startBlock}`
 }
 
+function toCoreKeyBuffer(coreKey) {
+  if (!coreKey) throw new TypeError('hypercoreKey is required')
+  const buffer = b4a.isBuffer(coreKey)
+    ? coreKey
+    : typeof coreKey === 'string'
+      ? b4a.from(coreKey, 'hex')
+      : b4a.from(coreKey)
+  if (buffer.byteLength !== 32) throw new RangeError('hypercoreKey must be exactly 32 bytes')
+  return buffer
+}
+
 function mergeMappings(existing, next) {
   if (!existing) return next
+
+  if (!b4a.equals(existing.hypercoreKey, next.hypercoreKey)) {
+    throw new Error('archive mapping already has a canonical hypercore key for this content hash')
+  }
 
   const variants = new Map()
   for (const variant of existing.variants) variants.set(variantId(variant), variant)
@@ -50,9 +65,47 @@ function mergeMappings(existing, next) {
 
   return normalize({
     fileHash: next.fileHash,
+    hypercoreKey: existing.hypercoreKey,
     sourceId: next.sourceId || existing.sourceId,
     variants: [...variants.values()],
   })
+}
+
+function canonicalVariantFor(core, metadata = {}) {
+  const key = toCoreKeyBuffer(core?.key || metadata.hypercoreKey || metadata.coreKey || metadata.variants?.[0]?.coreKey)
+  const length = Number.isSafeInteger(core?.length) ? core.length : Number(metadata.endBlock || metadata.length || 0)
+  return {
+    resolution: metadata.resolution || metadata.variant || 'original',
+    coreKey: key,
+    startBlock: Number.isSafeInteger(metadata.startBlock) ? metadata.startBlock : 0,
+    endBlock: Number.isSafeInteger(metadata.endBlock) ? metadata.endBlock : Math.max(0, length),
+  }
+}
+
+async function readyCore(core) {
+  if (core && typeof core.ready === 'function') await core.ready()
+  return core
+}
+
+function archiveCoreName(fileHash) {
+  return `archives/${b4a.toString(toHashBuffer(fileHash), 'hex')}`
+}
+
+function openCoreByKey(store, key) {
+  if (!store || typeof store.get !== 'function') throw new TypeError('store with get() is required')
+  return store.get({ key: toCoreKeyBuffer(key) })
+}
+
+function createCoreForHash(store, fileHash) {
+  if (!store || typeof store.get !== 'function') throw new TypeError('store with get() is required')
+  return store.get({ name: archiveCoreName(fileHash) })
+}
+
+async function joinCoreSwarm(swarm, core, opts = {}) {
+  if (!swarm || typeof swarm.join !== 'function' || !core?.discoveryKey) return null
+  const handle = swarm.join(core.discoveryKey, { server: true, client: true, ...opts })
+  if (handle && typeof handle.flushed === 'function') await handle.flushed().catch(() => {})
+  return handle
 }
 
 async function withWriteLock(db, key, fn) {
@@ -142,6 +195,41 @@ export async function writeArchiveMapping(db, fileHash, metadata, opts = {}) {
     const { mapping, value } = await writeWithTransaction(db, key, next, merge)
 
     return { key, mapping, value }
+  })
+}
+
+export async function ensureCanonicalArchiveCore(db, fileHash, options = {}) {
+  const fileHashBuffer = toHashBuffer(fileHash)
+  const key = archiveKey(fileHashBuffer)
+  const store = options.store
+  const swarm = options.swarm
+  const metadata = options.metadata || {}
+
+  return withWriteLock(db, key, async () => {
+    const existing = await readExisting(db, key)
+    if (existing?.hypercoreKey) {
+      const core = await readyCore(openCoreByKey(store, existing.hypercoreKey))
+      const discoveryHandle = await joinCoreSwarm(swarm, core, options.swarmOptions)
+      return { key, mapping: existing, core, discoveryHandle, created: false }
+    }
+
+    const core = await readyCore(
+      typeof options.createCore === 'function'
+        ? await options.createCore({ fileHash: fileHashBuffer, name: archiveCoreName(fileHashBuffer) })
+        : createCoreForHash(store, fileHashBuffer)
+    )
+    const hypercoreKey = toCoreKeyBuffer(core.key)
+    const next = normalize({
+      fileHash: fileHashBuffer,
+      hypercoreKey,
+      sourceId: metadata.sourceId || options.sourceId || 'archive:unknown',
+      variants: Array.isArray(metadata.variants) && metadata.variants.length > 0
+        ? metadata.variants.map((variant) => ({ ...variant, coreKey: variant.coreKey || hypercoreKey }))
+        : [canonicalVariantFor(core, { ...metadata, hypercoreKey })],
+    })
+    const { mapping, value } = await writeWithTransaction(db, key, next, false)
+    const discoveryHandle = await joinCoreSwarm(swarm, core, options.swarmOptions)
+    return { key, mapping, value, core, discoveryHandle, created: true }
   })
 }
 

--- a/packages/backend/lib/archive-writer.js
+++ b/packages/backend/lib/archive-writer.js
@@ -60,7 +60,9 @@ function mergeMappings(existing, next) {
   }
 
   const variants = new Map()
-  for (const variant of existing.variants) variants.set(variantId(variant), variant)
+  for (const variant of existing.variants) {
+    if (b4a.equals(variant.coreKey, existing.hypercoreKey)) variants.set(variantId(variant), variant)
+  }
   for (const variant of next.variants) variants.set(variantId(variant), variant)
 
   return normalize({

--- a/packages/backend/lib/archive-writer.js
+++ b/packages/backend/lib/archive-writer.js
@@ -71,6 +71,15 @@ function mergeMappings(existing, next) {
   })
 }
 
+function enforceCanonicalWrite(mapping) {
+  for (const variant of mapping.variants) {
+    if (!b4a.equals(variant.coreKey, mapping.hypercoreKey)) {
+      throw new Error('archive writes must reference the canonical hypercoreKey')
+    }
+  }
+  return mapping
+}
+
 function canonicalVariantFor(core, metadata = {}) {
   const key = toCoreKeyBuffer(core?.key || metadata.hypercoreKey || metadata.coreKey || metadata.variants?.[0]?.coreKey)
   const length = Number.isSafeInteger(core?.length) ? core.length : Number(metadata.endBlock || metadata.length || 0)
@@ -191,7 +200,7 @@ export async function writeArchiveMapping(db, fileHash, metadata, opts = {}) {
   }
 
   return withWriteLock(db, key, async () => {
-    const next = normalize({ ...metadata, fileHash: fileHashBuffer })
+    const next = enforceCanonicalWrite(normalize({ ...metadata, fileHash: fileHashBuffer }))
     const { mapping, value } = await writeWithTransaction(db, key, next, merge)
 
     return { key, mapping, value }
@@ -224,7 +233,7 @@ export async function ensureCanonicalArchiveCore(db, fileHash, options = {}) {
       hypercoreKey,
       sourceId: metadata.sourceId || options.sourceId || 'archive:unknown',
       variants: Array.isArray(metadata.variants) && metadata.variants.length > 0
-        ? metadata.variants.map((variant) => ({ ...variant, coreKey: variant.coreKey || hypercoreKey }))
+        ? metadata.variants.map((variant) => ({ ...variant, coreKey: hypercoreKey }))
         : [canonicalVariantFor(core, { ...metadata, hypercoreKey })],
     })
     const { mapping, value } = await writeWithTransaction(db, key, next, false)

--- a/packages/backend/src/orchestrator.js
+++ b/packages/backend/src/orchestrator.js
@@ -161,6 +161,7 @@ export async function createBackendContext(config) {
     disableStandalonePrimaryKeyFile = false,
     network = {},
     swarmOptions = {},
+    peerScorer = null,
     ipcLog: _ipcLog
   } = config;
 
@@ -332,7 +333,7 @@ export async function createBackendContext(config) {
   await appendDebugLine('[orchestrator] managers creating')
 
   // Phase 2: Create managers (synchronous, fast)
-  const publicFeed = new PublicFeedManager(ctx.swarm, ctx.metaDb);
+  const publicFeed = new PublicFeedManager(ctx.swarm, ctx.metaDb, { peerScorer });
   ctx.publicFeed = publicFeed
   const startupGate = createStartupGate()
   const videoStats = new VideoStatsTracker();

--- a/packages/backend/src/peer-scorer.js
+++ b/packages/backend/src/peer-scorer.js
@@ -337,6 +337,10 @@ export function createPeerScorer(options = {}) {
     return record
   }
 
+  function metricIncludes(metric = {}, names = []) {
+    return names.some((name) => metric[name] !== undefined && metric[name] !== null)
+  }
+
   async function recordPerformance(peerId, metric = {}) {
     const normalized = normalizeMetric(peerId, metric)
     const current = metrics.get(normalized.peerId)

--- a/packages/backend/src/peer-scorer.js
+++ b/packages/backend/src/peer-scorer.js
@@ -420,8 +420,11 @@ export function createPeerScorer(options = {}) {
   }
 
   function requestTimeout(peerOrId) {
-    const peer = typeof peerOrId === 'string' ? state.peers.get(peerOrId) : peerOrId
-    const metric = (peer ? metricFor(peer) : null) || (typeof peerOrId === 'string' ? metrics.get(peerOrId) : null) || peer?.performance || peerOrId?.metrics || {}
+    const peerId = typeof peerOrId === 'string'
+      ? peerOrId
+      : toHex(peerOrId?.peerId || peerOrId?.identity?.publicKey || peerOrId?.publicKey || peerOrId?.remotePublicKey || peerOrId)
+    const peer = state.peers.get(peerId) || (peerOrId && typeof peerOrId === 'object' && !ArrayBuffer.isView(peerOrId) ? peerOrId : null)
+    const metric = (peer ? metricFor(peer) : null) || metrics.get(peerId) || peer?.performance || peerOrId?.metrics || {}
     return timeoutFromSrtt(metric.srttMs ?? metric.latencyMs ?? 1000)
   }
 

--- a/packages/backend/src/peer-scorer.js
+++ b/packages/backend/src/peer-scorer.js
@@ -32,6 +32,7 @@ function normalizeMetric(peerId, metric = {}) {
   const successes = safeNumber(metric.handshakeSuccesses ?? metric.successfulHandshakes, 0)
   const total = Math.max(handshakes, successes + failures)
   const latencyMs = Math.max(0, safeNumber(metric.latencyMs ?? metric.rttMs, 0))
+  const srttMs = Math.max(0, safeNumber(metric.srttMs ?? metric.smoothedRttMs ?? metric.srtt ?? latencyMs, latencyMs))
   const handshakeDurationMs = Math.max(0, safeNumber(metric.handshakeDurationMs ?? metric.handshakeMs ?? metric.handshakeLatencyMs, 0))
   const socketStabilityObserved = metric.socketStabilityObserved !== undefined && metric.socketStabilityObserved !== null
     ? Boolean(metric.socketStabilityObserved)
@@ -43,6 +44,7 @@ function normalizeMetric(peerId, metric = {}) {
   return {
     peerId: toHex(peerId || metric.peerId || metric.identityId || hashText(metric)),
     latencyMs,
+    srttMs,
     handshakeDurationMs,
     socketStability,
     socketStabilityObserved,
@@ -74,11 +76,16 @@ function performanceScore(metric = {}) {
   return latencyScore + handshakeDurationScore + stabilityScore + throughputScore + handshakeScore
 }
 
+function timeoutFromSrtt(srttMs) {
+  return Math.max(300, Math.min(5000, Math.floor(safeNumber(srttMs, 0) * 3)))
+}
+
 export const peerMetricEncoding = {
   preencode(state, metric = {}) {
-    c.uint.preencode(state, 3)
+    c.uint.preencode(state, 4)
     c.string.preencode(state, toHex(metric.peerId || ''))
     c.uint.preencode(state, Math.max(0, Math.floor(safeNumber(metric.latencyMs, 0))))
+    c.uint.preencode(state, Math.max(0, Math.floor(safeNumber(metric.srttMs ?? metric.latencyMs, 0))))
     c.uint.preencode(state, Math.max(0, Math.floor(safeNumber(metric.handshakeDurationMs, 0))))
     c.uint.preencode(state, Math.max(0, Math.floor(safeNumber(metric.socketStability, 0))))
     c.bool.preencode(state, Boolean(metric.socketStabilityObserved))
@@ -89,9 +96,10 @@ export const peerMetricEncoding = {
     c.biguint.preencode(state, safeBigInt(metric.observedAt, 0n))
   },
   encode(state, metric = {}) {
-    c.uint.encode(state, 3)
+    c.uint.encode(state, 4)
     c.string.encode(state, toHex(metric.peerId || ''))
     c.uint.encode(state, Math.max(0, Math.floor(safeNumber(metric.latencyMs, 0))))
+    c.uint.encode(state, Math.max(0, Math.floor(safeNumber(metric.srttMs ?? metric.latencyMs, 0))))
     c.uint.encode(state, Math.max(0, Math.floor(safeNumber(metric.handshakeDurationMs, 0))))
     c.uint.encode(state, Math.max(0, Math.floor(safeNumber(metric.socketStability, 0))))
     c.bool.encode(state, Boolean(metric.socketStabilityObserved))
@@ -103,15 +111,17 @@ export const peerMetricEncoding = {
   },
   decode(state) {
     const version = c.uint.decode(state)
-    if (version !== 1 && version !== 2 && version !== 3) throw new Error(`Unsupported peer metric version ${version}`)
+    if (version !== 1 && version !== 2 && version !== 3 && version !== 4) throw new Error(`Unsupported peer metric version ${version}`)
     const peerId = c.string.decode(state)
     const latencyMs = c.uint.decode(state)
+    const srttMs = version >= 4 ? c.uint.decode(state) : latencyMs
     const handshakeDurationMs = version >= 2 ? c.uint.decode(state) : 0
     const socketStability = version >= 2 ? c.uint.decode(state) : 0
     const socketStabilityObserved = version >= 3 ? c.bool.decode(state) : version >= 2
     return {
       peerId,
       latencyMs,
+      srttMs,
       handshakeDurationMs,
       socketStability,
       socketStabilityObserved,
@@ -344,6 +354,11 @@ export function createPeerScorer(options = {}) {
       ? {
           ...current,
           latencyMs: metricIncludes(metric, ['latencyMs', 'rttMs']) ? normalized.latencyMs : current.latencyMs,
+          srttMs: metricIncludes(metric, ['srttMs', 'smoothedRttMs', 'srtt'])
+            ? normalized.srttMs
+            : metricIncludes(metric, ['latencyMs', 'rttMs'])
+              ? Math.max(0, Math.floor((safeNumber(current.srttMs ?? current.latencyMs, 0) * 7 + normalized.latencyMs) / 8))
+              : safeNumber(current.srttMs ?? current.latencyMs, 0),
           handshakeDurationMs: metricIncludes(metric, ['handshakeDurationMs', 'handshakeMs', 'handshakeLatencyMs']) ? normalized.handshakeDurationMs : current.handshakeDurationMs,
           socketStability: metricIncludes(metric, ['socketStability', 'socketStabilityScore', 'stability']) ? normalized.socketStability : current.socketStability,
           socketStabilityObserved: Boolean(current.socketStabilityObserved || normalized.socketStabilityObserved),
@@ -404,6 +419,12 @@ export function createPeerScorer(options = {}) {
     return safeNumber(peer.score ?? scorePeer(peer), 0) < minScore
   }
 
+  function requestTimeout(peerOrId) {
+    const peer = typeof peerOrId === 'string' ? state.peers.get(peerOrId) : peerOrId
+    const metric = (peer ? metricFor(peer) : null) || (typeof peerOrId === 'string' ? metrics.get(peerOrId) : null) || peer?.performance || peerOrId?.metrics || {}
+    return timeoutFromSrtt(metric.srttMs ?? metric.latencyMs ?? 1000)
+  }
+
   function evictLowPerformers(options = {}) {
     const evicted = []
     for (const peer of Array.from(state.peers.values())) {
@@ -435,6 +456,7 @@ export function createPeerScorer(options = {}) {
     createPerformanceDiffStream: createPeerMetricDiffStream,
     rankPeers,
     shouldEvict,
+    requestTimeout,
     evictLowPerformers,
     subscribe,
     snapshot,

--- a/packages/backend/src/peer-scorer.js
+++ b/packages/backend/src/peer-scorer.js
@@ -337,10 +337,6 @@ export function createPeerScorer(options = {}) {
     return record
   }
 
-  function metricIncludes(metric = {}, names = []) {
-    return names.some((name) => metric[name] !== undefined && metric[name] !== null)
-  }
-
   async function recordPerformance(peerId, metric = {}) {
     const normalized = normalizeMetric(peerId, metric)
     const current = metrics.get(normalized.peerId)

--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -73,6 +73,8 @@ export class PublicFeed {
     this.wiredConnections = new Set();
     /** @type {((requests: any[], conn?: any) => Promise<any[]>) | null} */
     this.availabilityHintProvider = null;
+    /** @type {{ requestTimeout?: (peer: any) => number } | null} */
+    this.peerScorer = options.peerScorer || null;
     /** @type {((entries: any[], conn?: any) => Promise<any[]>) | null} */
     this.feedSnapshotProvider = null;
     /** @type {number} */
@@ -544,18 +546,22 @@ export class PublicFeed {
     }
   }
 
-  async requestAvailabilityHints(requests, { timeoutMs = 250, maxPeers = 4 } = {}) {
+  async requestAvailabilityHints(requests, { timeoutMs = null, maxPeers = 4 } = {}) {
     const peers = Array.from(this.feedConnections).slice(0, maxPeers)
     if (!Array.isArray(requests) || requests.length === 0 || peers.length === 0) return []
 
     const perPeer = peers.map((conn) => new Promise((resolve) => {
       const channel = this.peerChannels.get(conn)
       if (!channel) return resolve([])
+      const peerKey = this._connectionPeerKeys.get(conn) || this._connectionIds.get(conn) || conn
+      const peerTimeoutMs = Number.isFinite(timeoutMs)
+        ? timeoutMs
+        : Math.max(300, Math.min(5000, Number(this.peerScorer?.requestTimeout?.(peerKey) || 3000)))
       const requestId = `${Date.now()}:${this._nextAvailabilityRequestId++}`
       const timeout = setTimeout(() => {
         this.pendingAvailabilityRequests.delete(requestId)
         resolve([])
-      }, timeoutMs)
+      }, peerTimeoutMs)
       this.pendingAvailabilityRequests.set(requestId, {
         resolve: (hints) => {
           clearTimeout(timeout)

--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -556,7 +556,9 @@ export class PublicFeed {
       const peerKey = this._connectionPeerKeys.get(conn) || this._connectionIds.get(conn) || conn
       const peerTimeoutMs = Number.isFinite(timeoutMs)
         ? timeoutMs
-        : Math.max(300, Math.min(5000, Number(this.peerScorer?.requestTimeout?.(peerKey) || 3000)))
+        : this.peerScorer?.requestTimeout
+          ? Math.max(300, Math.min(5000, Number(this.peerScorer.requestTimeout(peerKey) || 3000)))
+          : 250
       const requestId = `${Date.now()}:${this._nextAvailabilityRequestId++}`
       const timeout = setTimeout(() => {
         this.pendingAvailabilityRequests.delete(requestId)

--- a/packages/backend/src/universal-core.js
+++ b/packages/backend/src/universal-core.js
@@ -786,7 +786,7 @@ export function createUniversalCore(options = {}) {
       const createBackendContext = typeof options.createBackendContext === 'function'
         ? options.createBackendContext
         : null
-      backend = createBackendContext ? await createBackendContext(options) : { ctx: {} }
+      backend = createBackendContext ? await createBackendContext({ ...options, peerScorer }) : { ctx: {} }
       const mirrorWorker = typeof options.createMirrorSeedWorker === 'function'
         ? options.createMirrorSeedWorker({ backend, core: api })
         : {}

--- a/packages/backend/test/archive-schema-writer.test.mjs
+++ b/packages/backend/test/archive-schema-writer.test.mjs
@@ -8,7 +8,7 @@ import b4a from 'b4a'
 import Corestore from 'corestore'
 import HyperDB from 'hyperdb'
 
-import { decode, encode } from '../lib/archive-schema.js'
+import { decode, encode, encodeLegacyForTest } from '../lib/archive-schema.js'
 import { archiveKey, ensureCanonicalArchiveCore, readArchiveMapping, writeArchiveMapping } from '../lib/archive-writer.js'
 import publicDbDefinition from '../src/channel/public-hyperdb-spec/hyperdb/index.js'
 
@@ -74,6 +74,12 @@ test('archive schema rejects malformed fixed hashes and ranges', () => {
   assert.throws(() => encode(sampleMapping({ fileHash: b4a.alloc(31) })), /fileHash must be exactly 32 bytes/)
   assert.throws(() => encode(sampleMapping({ variants: [{ resolution: '720p', coreKey, startBlock: 10, endBlock: 9 }] })), /endBlock must be >= startBlock/)
   assert.throws(() => decode(b4a.concat([encode(sampleMapping()), b4a.from([0])])), /trailing bytes/)
+})
+
+test('archive schema reads legacy mappings and derives canonical hypercore key', () => {
+  const encoded = encodeLegacyForTest(sampleMapping())
+  assert.equal(encoded.byteLength, 93)
+  assert.deepEqual(decode(encoded), sampleMapping())
 })
 
 test('archive writer writes cenc records under the content-addressed archive key', async () => {

--- a/packages/backend/test/archive-schema-writer.test.mjs
+++ b/packages/backend/test/archive-schema-writer.test.mjs
@@ -9,7 +9,7 @@ import Corestore from 'corestore'
 import HyperDB from 'hyperdb'
 
 import { decode, encode } from '../lib/archive-schema.js'
-import { archiveKey, readArchiveMapping, writeArchiveMapping } from '../lib/archive-writer.js'
+import { archiveKey, ensureCanonicalArchiveCore, readArchiveMapping, writeArchiveMapping } from '../lib/archive-writer.js'
 import publicDbDefinition from '../src/channel/public-hyperdb-spec/hyperdb/index.js'
 
 const fileHash = b4a.alloc(32, 1)
@@ -19,6 +19,7 @@ const secondCoreKey = b4a.alloc(32, 3)
 function sampleMapping(overrides = {}) {
   return {
     fileHash,
+    hypercoreKey: coreKey,
     sourceId: 'youtube:dQw4w9WgXcQ',
     variants: [
       {
@@ -65,7 +66,7 @@ test('archive schema encodes compact file mappings and decodes canonical objects
   const decoded = decode(encoded)
 
   assert.ok(b4a.isBuffer(encoded))
-  assert.equal(encoded.byteLength, 93)
+  assert.equal(encoded.byteLength, 125)
   assert.deepEqual(decoded, mapping)
 })
 
@@ -162,7 +163,8 @@ test('archive writer serializes upserts and merges variants without dropping exi
     await Promise.all([
       writeArchiveMapping(db, fileHash, {
         sourceId: 'youtube:dQw4w9WgXcQ',
-        variants: [{ resolution: '720p', coreKey: secondCoreKey, startBlock: 43, endBlock: 70 }],
+        hypercoreKey: coreKey,
+        variants: [{ resolution: '720p', coreKey, startBlock: 43, endBlock: 70 }],
       }),
       writeArchiveMapping(db, fileHash, {
         sourceId: 'youtube:dQw4w9WgXcQ',
@@ -173,5 +175,91 @@ test('archive writer serializes upserts and merges variants without dropping exi
     const stored = await readArchiveMapping(db, fileHash)
     assert.equal(stored.variants.length, 3)
     assert.deepEqual(stored.variants.map((variant) => variant.resolution), ['1080p', '720p', '480p'])
+  })
+})
+
+test('archive writer rejects attempts to remap a content hash to another hypercore key', async () => {
+  await withHyperDb(async (db) => {
+    await writeArchiveMapping(db, fileHash, {
+      sourceId: 'youtube:dQw4w9WgXcQ',
+      variants: [{ resolution: '1080p', coreKey, startBlock: 7, endBlock: 42 }],
+    })
+
+    await assert.rejects(
+      writeArchiveMapping(db, fileHash, {
+        sourceId: 'youtube:dQw4w9WgXcQ',
+        hypercoreKey: secondCoreKey,
+        variants: [{ resolution: '720p', coreKey: secondCoreKey, startBlock: 43, endBlock: 70 }],
+      }),
+      /canonical hypercore key/
+    )
+  })
+})
+
+test('ensureCanonicalArchiveCore joins an existing archive core instead of creating a duplicate', async () => {
+  await withHyperDb(async (db) => {
+    await writeArchiveMapping(db, fileHash, {
+      sourceId: 'youtube:dQw4w9WgXcQ',
+      variants: [{ resolution: 'original', coreKey, startBlock: 0, endBlock: 1 }],
+    })
+
+    let created = 0
+    const joined = []
+    const store = {
+      get(opts) {
+        assert.deepEqual(opts, { key: coreKey })
+        return { key: coreKey, discoveryKey: b4a.alloc(32, 9), ready: async () => {} }
+      },
+    }
+    const swarm = {
+      join(topic, opts) {
+        joined.push({ topic, opts })
+        return { flushed: async () => {} }
+      },
+    }
+
+    const resolved = await ensureCanonicalArchiveCore(db, fileHash, {
+      store,
+      swarm,
+      createCore: async () => { created += 1; return { key: secondCoreKey, ready: async () => {} } },
+    })
+
+    assert.equal(resolved.created, false)
+    assert.equal(created, 0)
+    assert.deepEqual(resolved.mapping.hypercoreKey, coreKey)
+    assert.equal(joined.length, 1)
+    assert.deepEqual(joined[0].opts, { server: true, client: true })
+  })
+})
+
+test('ensureCanonicalArchiveCore creates and announces exactly one canonical core for new content', async () => {
+  await withHyperDb(async (db) => {
+    let created = 0
+    const joined = []
+    const canonicalCore = { key: secondCoreKey, discoveryKey: b4a.alloc(32, 8), length: 5, ready: async () => {} }
+    const store = { get() { throw new Error('store.get should not be used when createCore is supplied') } }
+    const swarm = {
+      join(topic, opts) {
+        joined.push({ topic, opts })
+        return { flushed: async () => {} }
+      },
+    }
+
+    const resolved = await ensureCanonicalArchiveCore(db, fileHash, {
+      store,
+      swarm,
+      metadata: { sourceId: 'youtube:dQw4w9WgXcQ' },
+      createCore: async ({ name }) => {
+        created += 1
+        assert.equal(name, `archives/${b4a.toString(fileHash, 'hex')}`)
+        return canonicalCore
+      },
+    })
+
+    assert.equal(resolved.created, true)
+    assert.equal(created, 1)
+    assert.deepEqual(resolved.mapping.hypercoreKey, secondCoreKey)
+    assert.deepEqual((await readArchiveMapping(db, fileHash)).hypercoreKey, secondCoreKey)
+    assert.equal(joined.length, 1)
   })
 })

--- a/packages/backend/test/archive-schema-writer.test.mjs
+++ b/packages/backend/test/archive-schema-writer.test.mjs
@@ -66,7 +66,7 @@ test('archive schema encodes compact file mappings and decodes canonical objects
   const decoded = decode(encoded)
 
   assert.ok(b4a.isBuffer(encoded))
-  assert.equal(encoded.byteLength, 125)
+  assert.equal(encoded.byteLength, 93)
   assert.deepEqual(decoded, mapping)
 })
 
@@ -80,6 +80,9 @@ test('archive schema reads legacy mappings and derives canonical hypercore key',
   const encoded = encodeLegacyForTest(sampleMapping())
   assert.equal(encoded.byteLength, 93)
   assert.deepEqual(decode(encoded), sampleMapping())
+
+  const longSource = sampleMapping({ sourceId: 'a'.repeat(129) })
+  assert.deepEqual(decode(encodeLegacyForTest(longSource)), longSource)
 })
 
 test('archive writer writes cenc records under the content-addressed archive key', async () => {

--- a/packages/backend/test/archive-schema-writer.test.mjs
+++ b/packages/backend/test/archive-schema-writer.test.mjs
@@ -198,6 +198,30 @@ test('archive writer serializes upserts and merges variants without dropping exi
   })
 })
 
+test('archive writer canonicalizes mixed legacy variants on upsert', async () => {
+  await withHyperDb(async (db) => {
+    const legacy = encodeLegacyForTest({
+      fileHash,
+      sourceId: 'legacy:mixed',
+      variants: [
+        { resolution: '1080p', coreKey, startBlock: 7, endBlock: 42 },
+        { resolution: '720p', coreKey: secondCoreKey, startBlock: 43, endBlock: 70 },
+      ],
+    })
+    await db.engine.db.put(archiveKey(fileHash), legacy)
+
+    await writeArchiveMapping(db, fileHash, {
+      sourceId: 'youtube:dQw4w9WgXcQ',
+      variants: [{ resolution: '480p', coreKey, startBlock: 71, endBlock: 99 }],
+    })
+
+    const stored = await readArchiveMapping(db, fileHash)
+    assert.deepEqual(stored.variants.map((variant) => variant.resolution), ['1080p', '480p'])
+    assert.equal(stored.variants.every((variant) => b4a.equals(variant.coreKey, coreKey)), true)
+  })
+})
+
+
 test('archive writer rejects attempts to remap a content hash to another hypercore key', async () => {
   await withHyperDb(async (db) => {
     await writeArchiveMapping(db, fileHash, {

--- a/packages/backend/test/archive-schema-writer.test.mjs
+++ b/packages/backend/test/archive-schema-writer.test.mjs
@@ -246,6 +246,15 @@ test('archive writer rejects attempts to remap a content hash to another hyperco
       }),
       /canonical hypercore key/
     )
+
+    await assert.rejects(
+      writeArchiveMapping(db, fileHash, {
+        sourceId: 'youtube:dQw4w9WgXcQ',
+        hypercoreKey: secondCoreKey,
+        variants: [{ resolution: '360p', coreKey: secondCoreKey, startBlock: 71, endBlock: 99 }],
+      }, { merge: false }),
+      /canonical hypercore key/
+    )
   })
 })
 

--- a/packages/backend/test/archive-schema-writer.test.mjs
+++ b/packages/backend/test/archive-schema-writer.test.mjs
@@ -83,6 +83,17 @@ test('archive schema reads legacy mappings and derives canonical hypercore key',
 
   const longSource = sampleMapping({ sourceId: 'a'.repeat(129) })
   assert.deepEqual(decode(encodeLegacyForTest(longSource)), longSource)
+
+  const mixedLegacy = sampleMapping({
+    hypercoreKey: undefined,
+    variants: [
+      { resolution: '1080p', coreKey, startBlock: 7, endBlock: 42 },
+      { resolution: '720p', coreKey: secondCoreKey, startBlock: 1, endBlock: 9 },
+    ],
+  })
+  const decoded = decode(encodeLegacyForTest(mixedLegacy))
+  assert.equal(b4a.toString(decoded.hypercoreKey, 'hex'), b4a.toString(coreKey, 'hex'))
+  assert.equal(b4a.toString(decoded.variants[1].coreKey, 'hex'), b4a.toString(secondCoreKey, 'hex'))
 })
 
 test('archive writer writes cenc records under the content-addressed archive key', async () => {
@@ -193,6 +204,15 @@ test('archive writer rejects attempts to remap a content hash to another hyperco
       sourceId: 'youtube:dQw4w9WgXcQ',
       variants: [{ resolution: '1080p', coreKey, startBlock: 7, endBlock: 42 }],
     })
+
+    await assert.rejects(
+      writeArchiveMapping(db, fileHash, {
+        sourceId: 'youtube:dQw4w9WgXcQ',
+        hypercoreKey: coreKey,
+        variants: [{ resolution: '720p', coreKey: secondCoreKey, startBlock: 43, endBlock: 70 }],
+      }),
+      /canonical hypercoreKey/
+    )
 
     await assert.rejects(
       writeArchiveMapping(db, fileHash, {

--- a/packages/backend/test/public-feed-manager.test.mjs
+++ b/packages/backend/test/public-feed-manager.test.mjs
@@ -1399,6 +1399,57 @@ test('requestAvailabilityHints merges playable responses from feed peers (includ
 })
 
 
+test('requestAvailabilityHints uses peer scorer dynamic timeout for connected peer keys', async () => {
+  const swarm = createSwarm()
+  const peerKey = b4a.alloc(32, 9)
+  const seenPeers = []
+  const manager = new PublicFeedManager(swarm, createMetaDb(), {
+    peerScorer: {
+      requestTimeout(peer) {
+        seenPeers.push(peer)
+        return 450
+      },
+    },
+  })
+  const conn = createConnection()
+  const sent = []
+  const delays = []
+
+  const originalFrom = Protomux.from
+  const originalSetTimeout = globalThis.setTimeout
+  Protomux.from = () => ({
+    pair() {},
+    createChannel() {
+      return {
+        messages: [{ send(msg) { sent.push(msg) } }],
+        open() {},
+      }
+    }
+  })
+  globalThis.setTimeout = (fn, delay, ...args) => {
+    delays.push(delay)
+    return originalSetTimeout(fn, 0, ...args)
+  }
+
+  try {
+    manager.handleConnection(conn, { publicKey: peerKey })
+    manager.feedConnections.add(conn)
+    const hints = await manager.requestAvailabilityHints([
+      { driveKey: DRIVE_KEY, id: 'v1', blobsCoreKey: '33'.repeat(32), blobId: '1:2:3:4' }
+    ], { maxPeers: 1 })
+
+    assert.deepEqual(hints, [])
+    assert.equal(delays[0], 450)
+    assert.equal(seenPeers[0], peerKey)
+    assert.ok(sent.find((msg) => msg.type === 'AVAILABILITY_HINT_REQUEST'))
+  } finally {
+    globalThis.setTimeout = originalSetTimeout
+    Protomux.from = originalFrom
+    manager.stop()
+  }
+})
+
+
 test('relay catalog entries stay visible and do not become published channels', async (t) => {
   const feed = new PublicFeedManager({
     connections: new Set(),

--- a/packages/backend/test/universal-core-hardening.test.mjs
+++ b/packages/backend/test/universal-core-hardening.test.mjs
@@ -185,6 +185,7 @@ test('peer scorer persists compact performance metrics and updates reactive scor
   const peer = scorer.registerPeer({ peerId: 'peer-a', identity: { validProofCount: 2 }, descriptor: { descriptorId: 'feed-a' } })
   await scorer.recordPerformance(peer.peerId, {
     latencyMs: 40,
+    srttMs: 80,
     handshakeSuccesses: 4,
     handshakes: 4,
     udxThroughputBps: 1024 * 1024,
@@ -194,6 +195,8 @@ test('peer scorer persists compact performance metrics and updates reactive scor
   assert.equal(puts[0][0], 'universal-core:peer-metric:peer-a')
   assert.equal(puts[0][1] instanceof Uint8Array, true)
   assert.equal(decodePeerMetric(puts[0][1]).udxThroughputBps, 1024 * 1024)
+  assert.equal(decodePeerMetric(puts[0][1]).srttMs, 80)
+  assert.equal(scorer.requestTimeout(peer.peerId), 300)
   assert.equal(decodePeerMetric(puts[0][1]).socketStabilityObserved, false)
   assert.equal(decodePeerMetric(encodePeerMetric({ peerId: 'peer-unknown', latencyMs: 10, socketStability: 0, socketStabilityObserved: false })).socketStabilityObserved, false)
 

--- a/packages/backend/test/universal-core-hardening.test.mjs
+++ b/packages/backend/test/universal-core-hardening.test.mjs
@@ -3,6 +3,8 @@ import assert from 'node:assert/strict'
 
 import { readFile } from 'node:fs/promises'
 
+import b4a from 'b4a'
+
 import { createUniversalCore, createUnifiedAutobaseSink } from '../src/universal-core.js'
 import { createBudgetManager, decodeBudgetState, encodeBudgetState } from '../src/budget-manager.js'
 import { createPeerScorer, decodePeerMetric, encodePeerMetric } from '../src/peer-scorer.js'
@@ -197,6 +199,13 @@ test('peer scorer persists compact performance metrics and updates reactive scor
   assert.equal(decodePeerMetric(puts[0][1]).udxThroughputBps, 1024 * 1024)
   assert.equal(decodePeerMetric(puts[0][1]).srttMs, 80)
   assert.equal(scorer.requestTimeout(peer.peerId), 300)
+
+  const peerKey = b4a.alloc(32, 9)
+  const peerKeyHex = b4a.toString(peerKey, 'hex')
+  scorer.registerPeer({ peerId: peerKeyHex, identity: { publicKey: peerKey, validProofCount: 2 } })
+  await scorer.recordPerformance(peerKeyHex, { srttMs: 200, handshakes: 1, handshakeSuccesses: 1 })
+  assert.equal(scorer.requestTimeout(peerKey), 600)
+
   assert.equal(decodePeerMetric(puts[0][1]).socketStabilityObserved, false)
   assert.equal(decodePeerMetric(encodePeerMetric({ peerId: 'peer-unknown', latencyMs: 10, socketStability: 0, socketStabilityObserved: false })).socketStabilityObserved, false)
 
@@ -232,13 +241,18 @@ test('budget manager derives dynamic peer/feed caps from bare-hc memory pressure
 test('universal core state persistence uses compact buffers and has no legacy gossip polling interval', async () => {
   const puts = []
   const observed = []
+  let backendOptions = null
   const core = createUniversalCore({
     platform: 'relay',
     storagePath: '/tmp/peartube-universal-core-test',
-    createBackendContext: async () => ({ ctx: { metaDb: { async put(key, value) { puts.push([key, value]) } } } }),
+    createBackendContext: async (opts) => {
+      backendOptions = opts
+      return { ctx: { metaDb: { async put(key, value) { puts.push([key, value]) } } } }
+    },
   })
 
   await core.init()
+  assert.equal(typeof backendOptions?.peerScorer?.requestTimeout, 'function')
   const unsubscribe = core.eventSink.onappend((record) => observed.push(record))
   await core.eventSink.append('test.compact', { ok: true })
   unsubscribe()


### PR DESCRIPTION
## Summary

- Adds canonical `/archives/<contentHash>` archive mappings with an explicit top-level `hypercoreKey`.
- Adds `ensureCanonicalArchiveCore()` so relay ingestion joins an existing canonical Hypercore/swarm for the same content hash instead of creating a duplicate core.
- Rejects attempts to remap a content hash to a different Hypercore key.
- Extends peer scoring metrics with persisted `srttMs` and exposes dynamic request timeouts using `max(300, min(5000, srtt * 3))`.
- Wires `PublicFeed.requestAvailabilityHints()` to use peer-scorer dynamic timeouts when available.

## Test Plan

- `node --test test/archive-schema-writer.test.mjs test/universal-core-hardening.test.mjs`
  - 21 pass, 0 fail
- `node --test test/public-feed-manager.test.mjs`
  - 47 pass, 0 fail
- `npm test` from `packages/backend`
  - exit code 0
- `git diff --check`
  - clean
