### PR TITLE
fix: persist relay archive catalog entries

### DIFF
--- a/packages/cli/src/archive-manager.js
+++ b/packages/cli/src/archive-manager.js
@@ -433,14 +433,19 @@ export function createArchivePublisher({ identityManager, uploadManager, api, ru
           catalogVersion: 1,
           driveKey: channelKey,
           publicBeeKey,
-          source: 'relay-cache',
+          source: 'archive-job',
+          retentionClass: 'private',
           relayRole: 'cache',
           relayServing: true,
           previewVideos: playablePreviews,
           videoCount: playablePreviews.length,
           manifestUpdatedAt: Date.now()
         }
-        await runtime?.publishRelayCatalogEntry?.(catalogEntry).catch(() => {})
+        await runtime?.publishRelayCatalogEntry?.({
+          ...catalogEntry,
+          source: 'archive-job',
+          retentionClass: 'private'
+        }).catch(() => {})
       }
     }
   }

--- a/packages/cli/src/catalog.js
+++ b/packages/cli/src/catalog.js
@@ -10,6 +10,11 @@ function ensureDir(path) {
   mkdirSync(path, { recursive: true })
 }
 
+function ensureParentDir(path) {
+  const separatorIndex = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'))
+  if (separatorIndex > 0) ensureDir(path.slice(0, separatorIndex))
+}
+
 function readCatalog(path) {
   if (!existsSync(path)) {
     return {
@@ -31,12 +36,14 @@ export class RelayCatalog {
 
   static async open({ storagePath, catalogPath = join(storagePath, RELAY_CATALOG_FILENAME) }) {
     ensureDir(storagePath)
+    ensureParentDir(catalogPath)
     const data = readCatalog(catalogPath)
     return new RelayCatalog({ storagePath, catalogPath, data })
   }
 
   async persist() {
     this.data.updatedAt = Date.now()
+    ensureParentDir(this.catalogPath)
     writeFileSync(this.catalogPath, JSON.stringify(this.data, null, 2))
   }
 

--- a/packages/cli/src/config.js
+++ b/packages/cli/src/config.js
@@ -608,9 +608,10 @@ export function resolveRelayConfig(input = {}, { env = process.env || {} } = {})
 
   config.archive = resolveArchiveConfig(config.archive, { storagePath: config.storage.path })
 
+  const runtimeDbPath = join(config.storage.path, 'db')
   config.paths = {
-    catalog: join(config.storage.path, RELAY_CATALOG_FILENAME),
-    status: join(config.storage.path, RELAY_STATUS_FILENAME),
+    catalog: join(runtimeDbPath, RELAY_CATALOG_FILENAME),
+    status: join(runtimeDbPath, RELAY_STATUS_FILENAME),
     corestore: join(config.storage.path, 'corestore'),
     archiveTmpPath: config.archive.tmpPath
   }

--- a/packages/cli/src/service.js
+++ b/packages/cli/src/service.js
@@ -152,6 +152,56 @@ export async function createRelayService({
     return currentStatus
   }
 
+  const basePublishRelayCatalogEntry = typeof runtime.publishRelayCatalogEntry === 'function'
+    ? runtime.publishRelayCatalogEntry.bind(runtime)
+    : null
+
+  async function persistRuntimeRelayCatalogEntry(entry = {}) {
+    const channelKey = entry.channelKey || entry.driveKey
+    const publicBeeKey = entry.publicBeeKey || null
+    if (!channelKey || !publicBeeKey) return null
+    const existing = relayCatalog.getChannel(channelKey)
+
+    const previewVideos = Array.isArray(entry.previewVideos) ? entry.previewVideos : []
+    const unavailableVideos = Array.isArray(entry.unavailableVideos) ? entry.unavailableVideos : []
+    const manifestUpdatedAt = Number(entry.manifestUpdatedAt || entry.mirroredAt || entry.lastSeenAt || nowFn()) || Date.now()
+    const source = entry.source === 'relay-cache' && existing?.source === 'archive-job'
+      ? existing.source
+      : (entry.source || existing?.source || 'relay-cache')
+    const retentionClass = entry.retentionClass || existing?.retentionClass || (source === 'archive-job' ? 'private' : 'discovery')
+    const record = {
+      ...entry,
+      channelKey,
+      driveKey: entry.driveKey || channelKey,
+      publicBeeKey,
+      source,
+      retentionClass,
+      relayRole: entry.relayRole || 'cache',
+      relayServing: entry.relayServing !== false,
+      lastSeenAt: Number(entry.lastSeenAt || manifestUpdatedAt) || manifestUpdatedAt,
+      mirroredAt: Number(entry.mirroredAt || manifestUpdatedAt) || manifestUpdatedAt,
+      previewVideos,
+      unavailableVideos,
+      videoCount: Number(entry.videoCount || previewVideos.length || unavailableVideos.length || 0) || 0,
+      manifestUpdatedAt
+    }
+
+    const persisted = await relayCatalog.upsertChannel(record)
+    await persistStatus()
+    return persisted
+  }
+
+  runtime.publishRelayCatalogEntry = async (entry = {}) => {
+    const published = basePublishRelayCatalogEntry
+      ? await basePublishRelayCatalogEntry(entry)
+      : entry
+    const catalogEntry = published && typeof published === 'object'
+      ? { ...entry, ...published }
+      : entry
+    const persisted = await persistRuntimeRelayCatalogEntry(catalogEntry)
+    return published || persisted
+  }
+
   async function processCandidate(candidate) {
     if (closed) {
       return { accepted: false, reason: 'closed' }
@@ -168,11 +218,14 @@ export async function createRelayService({
 
     if (refreshDecision.skip) {
       const retentionClass = existingChannel.retentionClass || resolved.retentionClass || 'discovery'
+      const source = existingChannel.source === 'archive-job' && (!resolved.source || resolved.source === 'discovered' || resolved.source === 'relay-cache')
+        ? existingChannel.source
+        : (resolved.source || existingChannel.source || 'discovered')
       await relayCatalog.upsertChannel({
         channelKey: resolved.channelKey,
         ownerKey: resolved.ownerKey || existingChannel.ownerKey || null,
         publicBeeKey: resolved.publicBeeKey || existingChannel.publicBeeKey || null,
-        source: resolved.source || existingChannel.source || 'discovered',
+        source,
         retentionClass,
         lastDecisionReason: refreshDecision.reason,
         lastSeenAt: now
@@ -210,11 +263,14 @@ export async function createRelayService({
       return decision
     }
 
+    const acceptedSource = existingChannel?.source === 'archive-job' && (!resolved.source || resolved.source === 'discovered' || resolved.source === 'relay-cache')
+      ? existingChannel.source
+      : (resolved.source || 'discovered')
     const baseRecord = {
       channelKey: resolved.channelKey,
       ownerKey: resolved.ownerKey || null,
       publicBeeKey: resolved.publicBeeKey || null,
-      source: resolved.source || 'discovered',
+      source: acceptedSource,
       retentionClass: decision.retentionClass,
       lastDecisionReason: decision.reason,
       lastSeenAt: now
@@ -296,18 +352,23 @@ export async function createRelayService({
           publicBeeKey: resolved.publicBeeKey,
           previewVideos: seedPreviewVideos
         }).catch(() => null)
-        const catalogEntry = seedStats?.catalogEntry || {
-          schema: 'peartube.relayCatalog',
-          catalogVersion: 1,
-          driveKey: resolved.channelKey,
-          publicBeeKey: resolved.publicBeeKey,
-          source: 'relay-cache',
-          relayRole: 'cache',
-          relayServing: true,
-          previewVideos: persistedPreviewVideos,
-          unavailableVideos: mirrorUnavailableVideos,
-          videoCount: Number(mirrorStats?.videoCount || mirrorStats?.videosDownloaded || mirrorStats?.videosFound || persistedPreviewVideos.length || 0) || 0,
-          manifestUpdatedAt: now
+        const catalogEntry = {
+          ...(seedStats?.catalogEntry || {
+            schema: 'peartube.relayCatalog',
+            catalogVersion: 1,
+            driveKey: resolved.channelKey,
+            publicBeeKey: resolved.publicBeeKey,
+            source: 'relay-cache',
+            relayRole: 'cache',
+            relayServing: true,
+            previewVideos: persistedPreviewVideos,
+            unavailableVideos: mirrorUnavailableVideos,
+            videoCount: Number(mirrorStats?.videoCount || mirrorStats?.videosDownloaded || mirrorStats?.videosFound || persistedPreviewVideos.length || 0) || 0,
+            manifestUpdatedAt: now
+          }),
+          ...(baseRecord.source === 'archive-job'
+              ? { source: 'archive-job', retentionClass: 'private' }
+              : {})
         }
         await runtime.publishRelayCatalogEntry?.(catalogEntry).catch(() => {})
       }
@@ -399,7 +460,8 @@ export async function createRelayService({
       catalogVersion: 1,
       driveKey: job.channelKey,
       publicBeeKey: job.publicBeeKey,
-      source: 'relay-cache',
+      source: 'archive-job',
+      retentionClass: 'private',
       relayRole: 'cache',
       relayServing: true,
       previewVideos,
@@ -407,7 +469,11 @@ export async function createRelayService({
       videoCount: previewVideos.length,
       manifestUpdatedAt
     }
-    await runtime.publishRelayCatalogEntry?.(catalogEntry).catch(() => {})
+    await runtime.publishRelayCatalogEntry?.({
+      ...catalogEntry,
+      source: 'archive-job',
+      retentionClass: 'private'
+    }).catch(() => {})
     await persistStatus()
     return { published: true, previewVideos: previewVideos.length }
   }

--- a/packages/cli/src/status.js
+++ b/packages/cli/src/status.js
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync } from '#fs'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from '#fs'
 import { retentionClassPriority } from './admission.js'
 
 function sortEvictionCandidates(channels) {
@@ -71,6 +71,10 @@ export function buildRelayStatus({ config, catalog, runtimeStats = {} }) {
 }
 
 export function writeRelayStatus(statusPath, status) {
+  if (statusPath) {
+    const separatorIndex = Math.max(statusPath.lastIndexOf('/'), statusPath.lastIndexOf('\\'))
+    if (separatorIndex > 0) mkdirSync(statusPath.slice(0, separatorIndex), { recursive: true })
+  }
   writeFileSync(statusPath, JSON.stringify(status, null, 2))
 }
 

--- a/packages/cli/test/config.test.mjs
+++ b/packages/cli/test/config.test.mjs
@@ -17,6 +17,8 @@ test('resolveRelayConfig defaults to public discovery mode', async (t) => {
   t.is(config.discovery.enabled, true)
   t.is(config.storage.path, './peartube-relay')
   t.is(config.paths.corestore, 'peartube-relay/corestore')
+  t.is(config.paths.catalog, 'peartube-relay/db/relay-catalog.json')
+  t.is(config.paths.status, 'peartube-relay/db/relay-status.json')
 })
 
 
@@ -82,6 +84,8 @@ test('loadRelayConfig parses yaml-like config files', async (t) => {
     t.is(config.policy, 'allowlist')
     t.is(config.storage.path, './relay-data')
     t.is(config.paths.corestore, 'relay-data/corestore')
+    t.is(config.paths.catalog, 'relay-data/db/relay-catalog.json')
+    t.is(config.paths.status, 'relay-data/db/relay-status.json')
     t.is(config.storage.maxBytes, 4096)
     t.alike(config.admission.channels, ['chan-1', 'chan-2'])
     t.alike(config.admission.owners, ['owner-1'])
@@ -98,6 +102,8 @@ test('loadRelayConfig uses built-in defaults without a config file', async (t) =
   t.is(config.policy, 'discovery')
   t.is(config.storage.path, './peartube-relay')
   t.is(config.paths.corestore, 'peartube-relay/corestore')
+  t.is(config.paths.catalog, 'peartube-relay/db/relay-catalog.json')
+  t.is(config.paths.status, 'peartube-relay/db/relay-status.json')
   t.is(config.paths.config, undefined)
 })
 
@@ -127,6 +133,8 @@ test('loadRelayConfig supports env-only relay configuration', async (t) => {
   t.is(config.policy, 'allowlist')
   t.is(config.storage.path, '/var/lib/peartube-relay')
   t.is(config.paths.corestore, '/var/lib/peartube-relay/corestore')
+  t.is(config.paths.catalog, '/var/lib/peartube-relay/db/relay-catalog.json')
+  t.is(config.paths.status, '/var/lib/peartube-relay/db/relay-status.json')
   t.is(config.storage.maxBytes, 2048)
   t.alike(config.admission.channels, ['chan-a', 'chan-b'])
   t.alike(config.admission.owners, ['owner-a'])

--- a/packages/cli/test/service.test.mjs
+++ b/packages/cli/test/service.test.mjs
@@ -1,8 +1,9 @@
 import test from 'brittle'
-import { mkdtempSync, rmSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import { resolveRelayConfig } from '../src/config.js'
 import { createRelayService } from '../src/service.js'
 
 function makeTempDir(prefix) {
@@ -1118,6 +1119,123 @@ test('createRelayService marks timed-out preview refs unavailable instead of pre
     t.is(channel.videosDownloaded, 0)
     t.is(published[published.length - 1].previewVideos.length, 0)
     t.is(published[published.length - 1].unavailableVideos.length, 1)
+    await service.close()
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('createRelayService persists catalog and status under resolved runtime db path', async (t) => {
+  const dir = makeTempDir('peartube-relay-service-status-db-')
+  const runtime = createFakeRuntime()
+
+  try {
+    const config = resolveRelayConfig({
+      storage: { path: dir, maxBytes: 10_000 },
+      admission: { channels: ['configured-channel'] }
+    })
+    const service = await createRelayService({
+      config,
+      logger: createFakeLogger(),
+      runtimeFactory: async () => runtime,
+      mirrorChannel: async () => ({ bytesDownloaded: 1024, videosFound: 1, videosDownloaded: 1 })
+    })
+
+    await service.start()
+
+    t.ok(existsSync(join(dir, 'db', 'relay-catalog.json')))
+    t.ok(existsSync(join(dir, 'db', 'relay-status.json')))
+    const catalog = JSON.parse(readFileSync(join(dir, 'db', 'relay-catalog.json'), 'utf8'))
+    const status = JSON.parse(readFileSync(join(dir, 'db', 'relay-status.json'), 'utf8'))
+    t.ok(catalog.channels['configured-channel'])
+    t.is(status.storage.path, dir)
+    t.is(status.summary.totalChannels, 1)
+    await service.close()
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('createRelayService preserves archive-job catalog source after completed archive publish', async (t) => {
+  const dir = makeTempDir('peartube-relay-service-archive-catalog-')
+  const runtime = createFakeRuntime()
+  const published = []
+  const statuses = []
+  runtime.publishRelayCatalogEntry = async (entry) => {
+    published.push(entry)
+    return {
+      schema: 'peartube.relayCatalog',
+      catalogVersion: 1,
+      source: 'relay-cache',
+      relayRole: 'cache',
+      relayServing: true,
+      ...entry
+    }
+  }
+
+  try {
+    const service = await createRelayService({
+      config: {
+        mode: 'public',
+        policy: 'discovery',
+        storage: { path: dir, maxBytes: 10_000 },
+        paths: {
+          catalog: join(dir, 'relay-catalog.json'),
+          status: join(dir, 'relay-status.json')
+        },
+        admission: { channels: [], owners: [] },
+        discovery: { enabled: true, maxChannels: 5, maxChannelsPerOwner: 2 }
+      },
+      logger: createFakeLogger(),
+      runtimeFactory: async () => runtime,
+      mirrorChannel: async () => ({ bytesDownloaded: 0, videosFound: 0, videosDownloaded: 0 }),
+      writeStatusFile: async (_path, status) => { statuses.push(status) },
+      nowFn: () => 12345
+    })
+
+    await service.start()
+    const result = await service.publishArchiveJobToFeed({
+      status: 'completed',
+      channelKey: 'archive-channel',
+      publicBeeKey: 'archive-public-bee',
+      completedAt: 67890,
+      previewVideo: {
+        id: 'archive-video',
+        title: 'Archived Video',
+        blobId: '0:1:0:10',
+        blobsCoreKey: 'aa'.repeat(32),
+        mimeType: 'video/webm',
+        availability: 'playable'
+      }
+    })
+
+    t.is(result.published, true)
+    t.is(published.length, 1)
+    t.is(published[0].source, 'archive-job')
+    t.is(published[0].retentionClass, 'private')
+    const channel = service.catalog.getChannel('archive-channel')
+    t.is(channel.publicBeeKey, 'archive-public-bee')
+    t.is(channel.source, 'archive-job')
+    t.is(channel.retentionClass, 'private')
+    t.is(channel.previewVideos[0].mimeType, 'video/webm')
+    t.is(channel.videoCount, 1)
+
+    await runtime.emit({
+      channelKey: 'archive-channel',
+      publicBeeKey: 'archive-public-bee',
+      source: 'discovered',
+      previewVideos: [{
+        id: 'archive-video',
+        blobId: '0:1:0:10',
+        blobsCoreKey: 'aa'.repeat(32)
+      }]
+    })
+    const refreshedChannel = service.catalog.getChannel('archive-channel')
+    t.is(refreshedChannel.source, 'archive-job')
+    t.is(refreshedChannel.retentionClass, 'private')
+    t.is(published.at(-1).source, 'archive-job')
+    t.is(published.at(-1).retentionClass, 'private')
+    t.is(statuses.at(-1).summary.totalChannels, 1)
     await service.close()
   } finally {
     rmSync(dir, { recursive: true, force: true })


### PR DESCRIPTION
## Summary
- move relay status/catalog JSON defaults under the runtime `db/` directory and ensure parent directories exist before writing
- persist runtime-published relay catalog entries into the local relay catalog/status path
- keep archive-imported channels marked `archive-job` / `private`, including later discovered refreshes and relay catalog publish payloads

## Validation
- `npm exec -- brittle test/config.test.mjs test/service.test.mjs` from `packages/cli` — 30/30 pass, 166/166 assertions
- `node --check packages/cli/src/catalog.js packages/cli/src/status.js packages/cli/src/archive-manager.js packages/cli/src/service.js packages/cli/src/config.js`
- `git diff --check`
- `npm run lint:changed` — no changed files detected before commit, so direct ESLint was run
- `./node_modules/.bin/eslint --quiet packages/cli/src/archive-manager.js packages/cli/src/catalog.js packages/cli/src/config.js packages/cli/src/service.js packages/cli/src/status.js packages/cli/test/config.test.mjs packages/cli/test/service.test.mjs`

## OMP Review
- Used `omp` to review the follow-up changes.
- Fixed all OMP blockers around missing catalog parent dirs and archive-job source downgrades.
- Final OMP review: `No blockers.`
