### PR TITLE
fix: seed relay feed entries natively

### DIFF
--- a/docs/holepunchto-ecosystem.md
+++ b/docs/holepunchto-ecosystem.md
@@ -435,15 +435,10 @@ Compact encoding schemes for building small and fast parsers/serializers.
 
 Bridging the gap between buffers and typed arrays.
 
-### simple-seeder
+### simple-seeder (historical reference only)
 **Stars:** 23 | **Status:** Active | [GitHub](https://github.com/holepunchto/simple-seeder)
 
-Dead simple Hypercore seeder. CLI and programmatic.
-
-```bash
-simple-seeder -c <key> -c <another-key>
-simple-seeder --file ./seeds.txt
-```
+Historical Hypercore seeder utility. Do not run it as a PearTube relay or operator sidecar; PearTube relay discovery and content-core seeding live in the native relay/backend runtime path.
 
 ---
 

--- a/docs/plans/2026-05-08-relay-stability-contract.md
+++ b/docs/plans/2026-05-08-relay-stability-contract.md
@@ -25,7 +25,7 @@ The structural fix is not to revive legacy topics. It is to make relay availabil
 
 ## Task 1: Backend content discovery retention helper
 
-**Objective:** Restore the old simple seeding behavior as a shared backend primitive.
+**Objective:** Restore content-core discovery retention as a shared PearTube backend primitive; do not revive standalone/simple seeder operation.
 
 **Files:**
 - Modify: `packages/backend/src/storage.js`

--- a/packages/cli/src/runtime.js
+++ b/packages/cli/src/runtime.js
@@ -128,11 +128,24 @@ export async function createRelayRuntime({ config, logger } = {}) {
     return true
   }
 
+  function getFeedEntries() {
+    return Array.from(publicFeed.getFeed?.() || publicFeed.entries.values())
+  }
+
+  function seedFeedEntries(reason) {
+    return seeder.seedFeedEntries(getFeedEntries()).catch((err) => {
+      logger.runtime?.warn('Relay feed-entry seeding refresh failed', {
+        reason,
+        error: err?.message || String(err)
+      })
+    })
+  }
+
   function emitFeedEntries() {
     if (typeof candidateHandler !== 'function') return
     if (!discoveryAcceptsCandidates()) return
 
-    for (const entry of publicFeed.getFeed?.() || publicFeed.entries.values()) {
+    for (const entry of getFeedEntries()) {
       if (!entry?.driveKey || !entry?.publicBeeKey) continue
       candidateHandler({
         channelKey: entry.driveKey,
@@ -164,6 +177,7 @@ export async function createRelayRuntime({ config, logger } = {}) {
           }).catch(() => {})
         }
       }
+      seedFeedEntries('feed-update')
       emitFeedEntries()
     } catch (err) {
       logger.runtime?.error('Feed update failed', { error: err?.message || String(err) })
@@ -231,6 +245,7 @@ export async function createRelayRuntime({ config, logger } = {}) {
       await seeder.seedCachedChannels(cacheManager).catch((err) => {
         logger.runtime?.warn('Relay seeding refresh failed', { error: err?.message || String(err) })
       })
+      await seedFeedEntries('startup')
       emitFeedEntries()
     },
     requestFeedSync() {

--- a/packages/cli/src/seeding.js
+++ b/packages/cli/src/seeding.js
@@ -338,6 +338,25 @@ export function createRelaySeeder({ ctx, loadPublicBee, logger = {}, blindPeer =
     return getStats()
   }
 
+  async function seedFeedEntries(entries = []) {
+    const seen = new Set()
+    for (const entry of entries || []) {
+      const driveKey = entry?.driveKey || entry?.channelKey
+      const publicBeeKey = entry?.publicBeeKey || null
+      if (!driveKey || !publicBeeKey || seen.has(driveKey)) continue
+      seen.add(driveKey)
+      await seedChannel({
+        driveKey,
+        publicBeeKey,
+        previewVideos: Array.isArray(entry?.previewVideos) ? entry.previewVideos : [],
+        feedEntry: entry,
+        catalogEntry: entry?.schema === 'peartube.relayCatalog' ? entry : entry?.catalogEntry
+      })
+    }
+    return getStats()
+  }
+
+
   function getStats() {
     const stats = emptyStats()
     stats.channels = seededChannels.size
@@ -378,6 +397,7 @@ export function createRelaySeeder({ ctx, loadPublicBee, logger = {}, blindPeer =
     retainDiscovery,
     seedChannel,
     seedCachedChannels,
+    seedFeedEntries,
     getStats,
     close
   }

--- a/packages/cli/test/relay-seeding.test.mjs
+++ b/packages/cli/test/relay-seeding.test.mjs
@@ -376,6 +376,57 @@ test('relay seeder also seeds preview/catalog blob refs when PublicBee is sparse
   ])
 })
 
+test('native relay seeding retains public-feed entries as they arrive', async (t) => {
+  const publicBeeCore = createCore('41')
+  const videoCore = createCore('42')
+  const thumbnailCore = createCore('43')
+  const swarm = createSwarm()
+  const ctx = {
+    swarm,
+    store: {
+      get(key) {
+        const keyHex = Buffer.isBuffer(key) ? key.toString('hex') : String(key)
+        if (keyHex.startsWith('42')) return videoCore
+        if (keyHex.startsWith('43')) return thumbnailCore
+        throw new Error(`unexpected core key ${keyHex}`)
+      }
+    }
+  }
+  const seeding = createRelaySeeder({
+    ctx,
+    loadPublicBee: async () => ({
+      core: publicBeeCore,
+      async listVideos() {
+        return []
+      }
+    }),
+    logger: { info() {}, warn() {}, debug() {} }
+  })
+
+  const stats = await seeding.seedFeedEntries([{
+    driveKey: 'aa'.padEnd(64, '0'),
+    publicBeeKey: 'bb'.padEnd(64, '0'),
+    source: 'relay-cache',
+    previewVideos: [{
+      id: 'feed-video',
+      blobId: '0:1:0:10',
+      blobsCoreKey: '42'.padEnd(64, '0'),
+      thumbnailBlobId: '1:1:0:5',
+      thumbnailBlobsCoreKey: '43'.padEnd(64, '0')
+    }]
+  }])
+
+  t.is(stats.channels, 1)
+  t.is(stats.publicBeeCores, 1)
+  t.is(stats.blobCores, 2)
+  t.is(stats.discoveryHandles, 3)
+  t.alike(swarm.joins.map((join) => join.discoveryKey), [
+    publicBeeCore.discoveryKey,
+    videoCore.discoveryKey,
+    thumbnailCore.discoveryKey
+  ])
+})
+
 test('relay seeder registers mirrored cores with relay blind peer', async (t) => {
   const publicBeeCore = createCore('66')
   const videoCore = createCore('77')


### PR DESCRIPTION
Summary
- Add native relay feed-entry seeding so public-feed entries retain PublicBee/blob/thumbnail discovery from the relay runtime path.
- Refresh native seeding on relay startup and feed updates instead of relying on standalone simple-seeder sidecars.
- Reframe docs so simple-seeder is historical-only, not an operator path.

Test plan
- npm exec -- brittle-node test/relay-seeding.test.mjs
  - 10/10 tests pass
  - 57/57 asserts pass
- npm exec -- brittle-node test/admission.test.mjs test/archive-ui.test.mjs test/archive.test.mjs test/blob-downloader.test.mjs test/cli.test.mjs test/config.test.mjs test/local-drive-mirror.test.mjs test/relay-seeding.test.mjs test/service.test.mjs test/status.test.mjs test/runtime-no-relay-catalog.test.mjs
  - 114/114 tests pass
  - 647/647 asserts pass
- npm test --prefix packages/cli
  - 112/112 tests pass
  - 639/639 asserts pass
- git diff --check

Notes
- The initial RED test failed as expected before implementation with TypeError: seeding.seedFeedEntries is not a function.
- Remaining simple-seeder doc mentions are historical references explicitly warning not to run it as a PearTube relay/operator sidecar.
