### PR TITLE
ci: add x86 Android release APKs

### DIFF
--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        abi: [arm64-v8a]
+        abi: [arm64-v8a, x86, x86_64]
 
     steps:
       - name: Checkout

--- a/packages/app/tests/ci-workflow-split-regression.test.mjs
+++ b/packages/app/tests/ci-workflow-split-regression.test.mjs
@@ -62,19 +62,19 @@ test('build workflows stay separate from publish workflows', () => {
   )
 })
 
-test('tagged Android releases only build the arm64-v8a APK', () => {
+test('tagged Android releases build arm64 and x86 APKs', () => {
   const releaseAndroid = readFile('.github/workflows/release-android.yml')
   const abiSplitsPlugin = readFile('packages/app/plugins/withAndroidAbiSplits.js')
 
   assert.match(
     releaseAndroid,
-    /abi:\s*\[arm64-v8a\]/,
-    'release-android should only build the arm64-v8a APK for tagged releases',
+    /abi:\s*\[arm64-v8a, x86, x86_64\]/,
+    'release-android should build arm64-v8a, x86, and x86_64 APKs for tagged releases',
   )
   assert.doesNotMatch(
     releaseAndroid,
-    /abi:\s*\[[^\]]*(armeabi-v7a|x86|x86_64)/,
-    'release-android should skip armv7 and emulator APK builds for tagged releases',
+    /abi:\s*\[[^\]]*armeabi-v7a/,
+    'release-android should skip armv7 APK builds for tagged releases',
   )
   assert.match(
     releaseAndroid,


### PR DESCRIPTION
## Summary
- Adds x86 and x86_64 to the Android release APK matrix while keeping arm64-v8a
- Keeps armv7 excluded from tagged Android release builds
- Updates the workflow regression test to lock the new release ABI contract

## Test Plan
- `node --test packages/app/tests/ci-workflow-split-regression.test.mjs`
- `git diff --check`
