### PR TITLE
fix: refresh native video card press handlers

### DIFF
--- a/packages/app/components/video/VideoCard.tsx
+++ b/packages/app/components/video/VideoCard.tsx
@@ -204,6 +204,7 @@ function arePropsEqual(prevProps: VideoCardProps, nextProps: VideoCardProps): bo
     prev.channelKey === next.channelKey &&
     prev.driveKey === next.driveKey &&
     prev.channel?.name === next.channel?.name &&
+    prevProps.onPress === nextProps.onPress &&
     prevProps.showChannelInfo === nextProps.showChannelInfo &&
     prevProps.onChannelPress === nextProps.onChannelPress
   )

--- a/packages/app/tests/video-card-native-onpress-memo-regression.test.mjs
+++ b/packages/app/tests/video-card-native-onpress-memo-regression.test.mjs
@@ -1,0 +1,30 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const appRoot = path.resolve(__dirname, '..')
+
+test('native VideoCard memo comparison treats onPress changes as render-relevant after video data matches', () => {
+  const source = fs.readFileSync(
+    path.join(appRoot, 'components/video/VideoCard.tsx'),
+    'utf8',
+  )
+
+  const comparisonStart = source.indexOf('function arePropsEqual')
+  assert.notEqual(comparisonStart, -1, 'VideoCard should define a custom memo comparator')
+  const comparisonSource = source.slice(comparisonStart, source.indexOf('export const VideoCard', comparisonStart))
+
+  const deepReturnStart = comparisonSource.indexOf('// Deep comparison of video data that affects rendering')
+  assert.notEqual(deepReturnStart, -1, 'VideoCard comparator should have a deep comparison branch')
+  const deepComparisonSource = comparisonSource.slice(deepReturnStart)
+
+  assert.match(
+    deepComparisonSource,
+    /prevProps\.onPress\s*===\s*nextProps\.onPress/,
+    'the deep memo comparison must return false when onPress changes; otherwise cards can keep a stale no-op press handler from before rpc readiness',
+  )
+})


### PR DESCRIPTION
## Summary
- Fixes native `VideoCard` memoization so card press handlers refresh when `onPress` changes.
- Adds a regression test for the stale handler case that can leave visible Android feed cards with no-op taps after RPC readiness changes.

## Runtime evidence
- Reproduced on Android x86_64 emulator with `v0.1.191`: Discover/feed cards visible, but tapping a card stayed on the feed and produced no playback/open-player log signal.
- Built a local x86_64 release APK from this branch and installed it on the emulator.
- After the fix, tapping a visible feed card opens the video detail/player surface and shows active download/peer status.

## Test Plan
- `node --test packages/app/tests/video-card-native-onpress-memo-regression.test.mjs` failed before the fix.
- `node --test packages/app/tests/video-card-native-onpress-memo-regression.test.mjs packages/app/tests/video-card-web-channel-handlers-regression.test.mjs packages/app/tests/playback-url-instant-regression.test.mjs packages/app/tests/playback-url-cache-readiness-regression.test.mjs packages/app/tests/feed-hydration.test.mjs packages/app/tests/home-feed-virtualization.test.mjs packages/app/tests/feed-preview-restoration-red.test.mjs`
- `git diff --check`
- Local Android build: `./gradlew assembleRelease -PtargetAbis=x86_64 -PreactNativeArchitectures=x86_64`
- Emulator install + tap smoke test with `adb install -r -d .../app-x86_64-release.apk`