### PR TITLE
fix: repair Android cache quota controls

### DIFF
--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -20,6 +20,7 @@ import { getVideoToolboxDecodeSettings, setVideoToolboxDecodeEnabled, setVideoTo
 import { buildBlobRefCacheKey, normalizeBlobsCoreKey, normalizeBlobRefInput, parseBlobRef, stringifyBlobId } from './blob-ref.js';
 import { encodeIndexKey } from './index-encoder.js'
 import { NETWORK_TOPIC_STRING } from './types.js'
+import { SeedingAuthorizationError } from './seeding.js'
 
 /**
  * @typedef {import('./types.js').StorageContext} StorageContext
@@ -27,6 +28,10 @@ import { NETWORK_TOPIC_STRING } from './types.js'
  * @typedef {import('./types.js').VideoMetadata} VideoMetadata
  * @typedef {import('./types.js').ChannelMetadata} ChannelMetadata
  */
+
+function isSeedingAuthorizationError(err) {
+  return err instanceof SeedingAuthorizationError || err?.name === 'SeedingAuthorizationError'
+}
 
 /**
  * Create the API object with all shared methods
@@ -1905,31 +1910,20 @@ export function createApi({
             }).catch(err => console.log('[API] Failed to save download intent:', err?.message))
           }
 
-          if (seedingManager) {
-            await seedingManager.addSeed(driveKey, videoPath, 'watched', {
-              blockLength: totalBlocks,
-              byteLength: totalBytes,
-              publicBeeKey: publicBeeKey || v?.publicBeeKey || existingIntent?.publicBeeKey || null,
-              blobId: normalizedBlobId,
-              blobsCoreKey: blobMeta.blobsCoreKey,
-              thumbnailBlobId: v?.thumbnailBlobId || existingIntent?.thumbnailBlobId || null,
-              thumbnailBlobsCoreKey: v?.thumbnailBlobsCoreKey || existingIntent?.thumbnailBlobsCoreKey || null,
-              mimeType: v?.mimeType || existingIntent?.mimeType || null,
-              thumbnailMimeType: v?.thumbnailMimeType || existingIntent?.thumbnailMimeType || null
-            }, { protectSelf: true }).catch(err => console.log('[API] Failed to register seed intent:', err?.message))
-          }
-
           // Count initial blocks already available
           // For large videos, use sampling instead of all-or-nothing has(start, end)
           let initialAvailable = 0
+          let initialAvailabilityIsExact = false
           const fullyCached = await core.has(startBlock, endBlock)
           if (fullyCached) {
             initialAvailable = totalBlocks
+            initialAvailabilityIsExact = true
           } else if (totalBlocks <= 512) {
             // Small video: exact block-by-block count
             for (let i = startBlock; i < endBlock; i++) {
               if (await core.has(i)) initialAvailable++
             }
+            initialAvailabilityIsExact = true
           } else {
             // Large video: sample to estimate (same pattern as checkVideoSync)
             const sampleSize = Math.min(totalBlocks, 20)
@@ -1962,6 +1956,21 @@ export function createApi({
           }
 
           const bytesPerBlock = totalBlocks > 0 ? totalBytes / totalBlocks : 0
+          const initialCachedBlocksForQuota = initialAvailabilityIsExact ? initialAvailable : 0
+          const initialCachedBytes = Math.round(initialCachedBlocksForQuota * bytesPerBlock)
+          if (seedingManager) {
+            await seedingManager.addSeed(driveKey, videoPath, 'watched', {
+              blockLength: totalBlocks,
+              byteLength: initialCachedBytes,
+              publicBeeKey: publicBeeKey || v?.publicBeeKey || existingIntent?.publicBeeKey || null,
+              blobId: normalizedBlobId,
+              blobsCoreKey: blobMeta.blobsCoreKey,
+              thumbnailBlobId: v?.thumbnailBlobId || existingIntent?.thumbnailBlobId || null,
+              thumbnailBlobsCoreKey: v?.thumbnailBlobsCoreKey || existingIntent?.thumbnailBlobsCoreKey || null,
+              mimeType: v?.mimeType || existingIntent?.mimeType || null,
+              thumbnailMimeType: v?.thumbnailMimeType || existingIntent?.thumbnailMimeType || null
+            }, { protectSelf: true }).catch(err => console.log('[API] Failed to register seed intent:', err?.message))
+          }
           const headBlocks = getHeadBlockCount(totalBlocks, totalBytes)
           const tailBlocks = getTailBlockCount(totalBlocks, totalBytes)
           const midBlocks = getMidBlockCount(totalBlocks, totalBytes)
@@ -1986,7 +1995,7 @@ export function createApi({
           }
 
           let downloadedBlocks = 0
-          let downloadedBytesTotal = initialAvailable * bytesPerBlock
+          let downloadedBytesTotal = initialCachedBytes
           let downloadSpeed = 0
           let lastSpeedTime = Date.now()
           let lastSpeedBytes = downloadedBytesTotal
@@ -2030,6 +2039,9 @@ export function createApi({
             }
 
             const isComplete = totalDownloaded >= totalBlocks
+            if (seedingManager) {
+              seedingManager.updateSeedCachedBytes?.(driveKey, videoPath, Math.min(totalBytes, downloadedBytesTotal)).catch(() => {})
+            }
             if (videoStats) {
               videoStats.updateStats(driveKey, videoPath, {
                 downloadedBlocks,
@@ -2117,7 +2129,7 @@ export function createApi({
                     thumbnailBlobsCoreKey: v?.thumbnailBlobsCoreKey || null,
                     mimeType: v?.mimeType || existingIntent?.mimeType || null,
                     thumbnailMimeType: v?.thumbnailMimeType || null
-                  }).catch(err => console.log('[API] Failed to register seed:', err?.message))
+                  }, { protectSelf: true }).catch(err => console.log('[API] Failed to register seed:', err?.message))
                 }
               }).catch(err => {
                 if (err.message?.includes('closed') || ctx.store.closed) {
@@ -2215,7 +2227,7 @@ export function createApi({
                 thumbnailBlobsCoreKey: v?.thumbnailBlobsCoreKey || null,
                 mimeType: v?.mimeType || existingIntent?.mimeType || null,
                 thumbnailMimeType: v?.thumbnailMimeType || null
-              }).catch(() => {})
+              }, { protectSelf: true }).catch(() => {})
             }
           }
 
@@ -2595,7 +2607,12 @@ export function createApi({
     async pinChannel(driveKey) {
       console.log('[API] PIN_CHANNEL:', driveKey?.slice(0, 16));
       if (seedingManager && driveKey) {
-        await seedingManager.pinChannel(driveKey);
+        try {
+          await seedingManager.pinChannel(driveKey);
+        } catch (err) {
+          if (isSeedingAuthorizationError(err)) return { success: false, error: err.message };
+          throw err;
+        }
         await loadChannel(ctx, driveKey);
         return { success: true };
       }
@@ -2610,7 +2627,12 @@ export function createApi({
     async unpinChannel(driveKey) {
       console.log('[API] UNPIN_CHANNEL:', driveKey?.slice(0, 16));
       if (seedingManager && driveKey) {
-        await seedingManager.unpinChannel(driveKey);
+        try {
+          await seedingManager.unpinChannel(driveKey);
+        } catch (err) {
+          if (isSeedingAuthorizationError(err)) return { success: false, error: err.message };
+          throw err;
+        }
         return { success: true };
       }
       return { success: false, error: 'Invalid request' };
@@ -2657,7 +2679,7 @@ export function createApi({
     async setStorageLimit(maxGB) {
       console.log('[API] SET_STORAGE_LIMIT:', maxGB, 'GB');
       if (seedingManager) {
-        await seedingManager.setMaxStorageGB(maxGB);
+        await seedingManager.setMaxStorageGB(maxGB, { authorized: true });
         return { success: true };
       }
       return { success: false };
@@ -2670,7 +2692,7 @@ export function createApi({
     async clearCache() {
       console.log('[API] CLEAR_CACHE');
       if (seedingManager) {
-        const clearResult = await seedingManager.clearCache();
+        const clearResult = await seedingManager.clearCache({ authorized: true });
         return { success: true, ...clearResult };
       }
       return { success: false, clearedBytes: 0 };

--- a/packages/backend/src/mobile-handlers.js
+++ b/packages/backend/src/mobile-handlers.js
@@ -238,8 +238,8 @@ export function attachMobileHandlers(B, deps) {
 
   B.getSeedingStatus = async () => normalizeSeedingStatus(await api.getSeedingStatus())
   B.setSeedingConfig = async (r) => { await api.setSeedingConfig(r.config || {}); return { success: true } }
-  B.pinChannel = async (r) => { await api.pinChannel(r.channelKey); return { success: true } }
-  B.unpinChannel = async (r) => { await api.unpinChannel(r.channelKey); return { success: true } }
+  B.pinChannel = async (r) => api.pinChannel(r.channelKey)
+  B.unpinChannel = async (r) => api.unpinChannel(r.channelKey)
   B.getPinnedChannels = async () => ({ channels: (await api.getPinnedChannels()).channels || [] })
   B.getStorageStats = async () => api.getStorageStats()
   B.setStorageLimit = async (r) => api.setStorageLimit(r.maxGB)

--- a/packages/backend/src/seeding.js
+++ b/packages/backend/src/seeding.js
@@ -39,6 +39,16 @@ function mergeSeedReason(existingReason, nextReason) {
     : existingReason
 }
 
+function hasFiniteByteLength(blobInfo) {
+  return Number.isFinite(Number(blobInfo?.byteLength)) && Number(blobInfo.byteLength) >= 0
+}
+
+function normalizeByteLength(blobInfo, fallback = 0) {
+  return hasFiniteByteLength(blobInfo)
+    ? Math.round(Number(blobInfo.byteLength))
+    : fallback
+}
+
 export class SeedingAuthorizationError extends Error {
   constructor(message = 'Unauthorized seeding mutation') {
     super(message)
@@ -152,7 +162,7 @@ export class SeedingManager {
         ...existing,
         reason: mergeSeedReason(existing.reason, reason),
         blocks: blobInfo?.blockLength || existing.blocks || 0,
-        bytes: blobInfo?.byteLength || existing.bytes || 0,
+        bytes: normalizeByteLength(blobInfo, existing.bytes || 0),
         publicBeeKey: blobInfo?.publicBeeKey || existing.publicBeeKey || null,
         blobId: blobInfo?.blobId || existing.blobId || null,
         blobsCoreKey: blobInfo?.blobsCoreKey || existing.blobsCoreKey || null,
@@ -176,7 +186,7 @@ export class SeedingManager {
       reason,
       addedAt: Date.now(),
       blocks: blobInfo?.blockLength || 0,
-      bytes: blobInfo?.byteLength || 0,
+      bytes: normalizeByteLength(blobInfo, 0),
       publicBeeKey: blobInfo?.publicBeeKey || null,
       blobId: blobInfo?.blobId || null,
       blobsCoreKey: blobInfo?.blobsCoreKey || null,
@@ -299,6 +309,28 @@ export class SeedingManager {
       total += seed.bytes || 0;
     }
     return total;
+  }
+
+  /**
+   * Update the locally cached byte accounting for an already tracked seed.
+   * This is cache bookkeeping, not an explicit channel/seeding mutation, so it
+   * can be driven by automatic playback downloads without an active identity.
+   * @param {string} driveKey
+   * @param {string} videoPath
+   * @param {number} byteLength
+   * @param {{ persist?: boolean }} [options]
+   */
+  async updateSeedCachedBytes(driveKey, videoPath, byteLength, options = {}) {
+    const key = `${driveKey}:${videoPath}`;
+    const seed = this.activeSeeds.get(key);
+    if (!seed) return false;
+
+    const nextBytes = Math.max(0, Math.round(Number(byteLength) || 0));
+    if (nextBytes === (seed.bytes || 0)) return false;
+
+    this.activeSeeds.set(key, { ...seed, bytes: nextBytes });
+    if (options.persist === true) await this.persistSeeds();
+    return true;
   }
 
   /**
@@ -478,19 +510,22 @@ export class SeedingManager {
    */
   async setMaxStorageGB(gb, options = {}) {
     this.assertAuthorizedMutation(options)
+    const previousMaxStorageGB = this.config.maxStorageGB;
     if (gb < 1) gb = 1;
     if (gb > 100) gb = 100;
     this.config.maxStorageGB = gb;
     await this.metaDb.put('seeding-config', this.config);
     console.log('[SeedingManager] Set max storage to', gb, 'GB');
-    const partials = await this.clearDownloadIntents()
-    if (partials.clearedBlob) {
-      await collectCorestoreGarbage(this.store, {
-        label: 'partial download intent clear',
-        log: console.log
-      });
+    if (gb < previousMaxStorageGB) {
+      const partials = await this.clearDownloadIntents()
+      if (partials.clearedBlob) {
+        await collectCorestoreGarbage(this.store, {
+          label: 'partial download intent clear',
+          log: console.log
+        });
+      }
     }
-    // Enforce quota with new limit
+    // Enforce quota with the new limit after any lower-limit partial cleanup.
     await this.enforceQuota();
   }
 

--- a/packages/backend/test/seeding-auth.test.mjs
+++ b/packages/backend/test/seeding-auth.test.mjs
@@ -63,7 +63,7 @@ function createIdentityManager(activeIdentity = null) {
   }
 }
 
-test('SeedingManager rejects explicit seeding mutations without an active identity', async (t) => {
+test('SeedingManager protects explicit seeds but accepts authorized local cache controls without an active identity', async (t) => {
   const manager = new SeedingManager(createStore(), createMetaDb(), {
     identityManager: createIdentityManager(null)
   })
@@ -73,13 +73,15 @@ test('SeedingManager rejects explicit seeding mutations without an active identi
     SeedingAuthorizationError
   )
   await t.exception(
-    () => manager.setMaxStorageGB(10),
+    () => manager.addSeed('drive-a', 'videos/pinned.mp4', 'pinned', { byteLength: 1024 }),
     SeedingAuthorizationError
   )
-  await t.exception(
-    () => manager.clearCache(),
-    SeedingAuthorizationError
-  )
+
+  await manager.setMaxStorageGB(10, { authorized: true })
+  t.is(manager.config.maxStorageGB, 10)
+
+  const clearResult = await manager.clearCache({ authorized: true })
+  t.is(clearResult.clearedBytes, 0)
 })
 
 test('SeedingManager allows automatic watched seeds but requires active identity for explicit pins', async (t) => {
@@ -114,13 +116,21 @@ test('SeedingManager allows explicit seeding mutations for the active channel id
   t.is(manager.config.maxStorageGB, 8)
 })
 
-test('seeding API mutation endpoints return unauthorized without active identity', async (t) => {
+test('seeding API keeps pin auth but allows local cache controls without active identity', async (t) => {
   const manager = new SeedingManager(createStore(), createMetaDb(), {
     identityManager: createIdentityManager(null)
   })
   const api = createApi({ ctx: { store: createStore(), metaDb: createMetaDb() }, seedingManager: manager })
 
   t.alike(await api.pinChannel('aa'.repeat(32)), { success: false, error: 'Unauthorized seeding mutation' })
-  t.alike(await api.setStorageLimit(5), { success: false, error: 'Unauthorized seeding mutation' })
-  t.alike(await api.clearCache(), { success: false, clearedBytes: 0, error: 'Unauthorized seeding mutation' })
+  t.alike(await api.setStorageLimit(5), { success: true })
+  t.is(manager.config.maxStorageGB, 5)
+  t.alike(await api.clearCache(), {
+    success: true,
+    clearedBytes: 0,
+    totalStorageBytes: 0,
+    totalStorageGB: '0.00',
+    untrackedStorageBytes: 0,
+    untrackedStorageGB: '0.00'
+  })
 })

--- a/packages/backend/test/seeding-quota.test.mjs
+++ b/packages/backend/test/seeding-quota.test.mjs
@@ -100,6 +100,28 @@ test('setMaxStorageGB enforces quota and clears removed cached blob ranges', asy
   t.ok(persistedSeeds['drive-b:videos/new.mp4'])
 })
 
+test('protectSelf keeps the current watched seed through quota enforcement', async (t) => {
+  const store = createStore()
+  const manager = new SeedingManager(store, createMetaDb())
+
+  await manager.setMaxStorageGB(5)
+  await manager.addSeed('drive-a', 'videos/large.mp4', 'watched', {
+    byteLength: 1 * GB,
+    blobId: '30:1:0:1024',
+    blobsCoreKey: coreA
+  }, { protectSelf: true })
+  await manager.addSeed('drive-a', 'videos/large.mp4', 'watched', {
+    byteLength: 6 * GB,
+    blobId: '30:6:0:6144',
+    blobsCoreKey: coreA
+  }, { protectSelf: true })
+
+  t.is(manager.getStorageStatsSync().usedBytes, 6 * GB)
+  t.is(manager.getActiveSeeds().length, 1)
+  t.is(manager.getActiveSeeds()[0].videoPath, 'videos/large.mp4')
+  t.alike(store.cores.get(coreA)?.clearCalls || [], [])
+})
+
 test('clearCache clears non-pinned blob ranges and keeps pinned cached bytes', async (t) => {
   const store = createStore()
   const metaDb = createMetaDb()

--- a/packages/backend/test/storage-quota-api.test.mjs
+++ b/packages/backend/test/storage-quota-api.test.mjs
@@ -125,7 +125,7 @@ test('clearCache clears persisted partial download intents as cache bytes', asyn
   t.absent(metaDb.state.has('download-intent:drive-a:videos/partial.mp4'))
 })
 
-test('setStorageLimit clears stale partial download intents outside tracked seeds', async (t) => {
+test('setStorageLimit preserves partial download intents when the limit is unchanged or raised', async (t) => {
   const metaDb = createMetaDb({
     [`download-intent:drive-a:videos/stale.mp4`]: {
       driveKey: 'drive-a',
@@ -146,10 +146,78 @@ test('setStorageLimit clears stale partial download intents outside tracked seed
   const api = createApi({ ctx: { store, metaDb }, seedingManager })
 
   const result = await api.setStorageLimit(5)
+  const raised = await api.setStorageLimit(10)
 
   t.is(result.success, true)
+  t.is(raised.success, true)
+  t.alike(store.cores.get(coreA).clearCalls, [])
+  t.ok(metaDb.state.has('download-intent:drive-a:videos/stale.mp4'))
+})
+
+test('setStorageLimit clears partial download intents when lowering the limit', async (t) => {
+  const metaDb = createMetaDb({
+    [`download-intent:drive-a:videos/stale.mp4`]: {
+      driveKey: 'drive-a',
+      videoPath: 'videos/stale.mp4',
+      blobsCoreKey: coreA,
+      blobId: '10:3:0:4096',
+      startBlock: 10,
+      endBlock: 13,
+      totalBlocks: 3,
+      totalBytes: 3 * GB,
+      mimeType: 'video/mp4',
+      startedAt: 1
+    }
+  })
+  const store = createStore()
+  store.get(b4a.from(coreA, 'hex'))
+  const seedingManager = new SeedingManager(store, metaDb)
+  const api = createApi({ ctx: { store, metaDb }, seedingManager })
+
+  await api.setStorageLimit(10)
+  const lowered = await api.setStorageLimit(5)
+
+  t.is(lowered.success, true)
   t.alike(store.cores.get(coreA).clearCalls, [{ start: 10, end: 13 }])
   t.absent(metaDb.state.has('download-intent:drive-a:videos/stale.mp4'))
+})
+
+test('setStorageLimit clears stale partial bytes before evicting valid seeds on lower limit', async (t) => {
+  const intentKey = `download-intent:drive-a:videos/stale.mp4`
+  const metaDb = createMetaDb({
+    [intentKey]: {
+      driveKey: 'drive-a',
+      videoPath: 'videos/stale.mp4',
+      blobsCoreKey: coreA,
+      blobId: '10:3:0:4096',
+      startBlock: 10,
+      endBlock: 13,
+      totalBlocks: 3,
+      totalBytes: 2 * GB,
+      mimeType: 'video/mp4',
+      startedAt: 1
+    }
+  })
+  const store = createStore()
+  store.get(b4a.from(coreA, 'hex'))
+  const seedingManager = new SeedingManager(store, metaDb, {
+    getDiskUsageBytes: () => metaDb.state.has(intentKey) ? 6 * GB : 4 * GB
+  })
+  const api = createApi({ ctx: { store, metaDb }, seedingManager })
+
+  await api.setStorageLimit(10)
+  await seedingManager.addSeed('drive-a', 'videos/valid.mp4', 'watched', {
+    byteLength: 4 * GB,
+    blobId: '20:4:0:4096',
+    blobsCoreKey: coreA
+  })
+  const lowered = await api.setStorageLimit(5)
+
+  t.is(lowered.success, true)
+  t.absent(metaDb.state.has(intentKey))
+  t.is(seedingManager.getActiveSeeds().length, 1)
+  t.is(seedingManager.getActiveSeeds()[0]?.videoPath, 'videos/valid.mp4')
+  t.is(seedingManager.getStorageStatsSync().usedBytes, 4 * GB)
 })
 
 test('prefetchVideo registers in-flight downloads with quota tracking before completion', async (t) => {
@@ -182,7 +250,66 @@ test('prefetchVideo registers in-flight downloads with quota tracking before com
   const seeds = seedingManager.getActiveSeeds()
   t.is(seeds.length, 1)
   t.is(seeds[0]?.videoPath, 'videos/partial.mp4')
-  t.is(seedingManager.getStorageStatsSync().usedBytes, 1024 * 1024)
+  t.is(seedingManager.getStorageStatsSync().usedBytes, 65536)
+})
+
+test('prefetchVideo does not reserve the full blob size before bytes are cached', async (t) => {
+  const metaDb = createMetaDb()
+  const store = createStore()
+  const seedingManager = new SeedingManager(store, metaDb)
+  await seedingManager.init()
+  const api = createApi({ ctx: { store, metaDb, swarm: null }, seedingManager })
+
+  api.getVideoData = async () => ({
+    id: 'huge-partial',
+    path: 'videos/huge-partial.mp4',
+    blobId: '0:8:0:8589934592',
+    blobsCoreKey: coreA,
+    byteLength: 8 * GB,
+    publicBeeKey: 'bb'.repeat(32),
+    mimeType: 'video/mp4'
+  })
+
+  const result = await api.prefetchVideo('drive-a', 'videos/huge-partial.mp4')
+
+  t.is(result.success, true)
+  const seeds = seedingManager.getActiveSeeds()
+  t.is(seeds.length, 1)
+  t.is(seeds[0]?.bytes, 0)
+  t.is(seedingManager.getStorageStatsSync().usedBytes, 0)
+})
+
+test('prefetchVideo corrects stale full-size watched seed accounting downward', async (t) => {
+  const metaDb = createMetaDb()
+  const store = createStore()
+  const seedingManager = new SeedingManager(store, metaDb)
+  await seedingManager.init()
+  await seedingManager.addSeed('drive-a', 'videos/stale-huge.mp4', 'watched', {
+    blockLength: 8,
+    byteLength: 8 * GB,
+    blobId: '0:8:0:8589934592',
+    blobsCoreKey: coreA
+  }, { protectSelf: true })
+  const api = createApi({ ctx: { store, metaDb, swarm: null }, seedingManager })
+
+  api.getVideoData = async () => ({
+    id: 'stale-huge',
+    path: 'videos/stale-huge.mp4',
+    blobId: '0:8:0:8589934592',
+    blobsCoreKey: coreA,
+    byteLength: 8 * GB,
+    publicBeeKey: 'bb'.repeat(32),
+    mimeType: 'video/mp4'
+  })
+
+  t.is(seedingManager.getStorageStatsSync().usedBytes, 8 * GB)
+  const result = await api.prefetchVideo('drive-a', 'videos/stale-huge.mp4')
+
+  t.is(result.success, true)
+  const seeds = seedingManager.getActiveSeeds()
+  t.is(seeds.length, 1)
+  t.is(seeds[0]?.bytes, 0)
+  t.is(seedingManager.getStorageStatsSync().usedBytes, 0)
 })
 
 test('prefetchVideo cleans up core listeners when blob is already fully cached', async (t) => {


### PR DESCRIPTION
Summary
- allow viewer-local Android cache controls to set storage limits and clear cache without requiring a channel identity
- keep channel pin/unpin authorization intact and propagate unauthorized API results through mobile handlers
- account partial playback cache by cached bytes instead of full blob size, including stale full-size watched seed correction
- preserve partial download intents on unchanged/raised limits, but clear stale partials before quota eviction when lowering limits

Test plan
- ./packages/backend/node_modules/.bin/brittle packages/backend/test/seeding-auth.test.mjs packages/backend/test/storage-quota-api.test.mjs packages/backend/test/seeding-quota.test.mjs
  - 18/18 tests passed
  - 79/79 assertions passed

Notes
- Diagnosed from physical Android logcat showing SET_STORAGE_LIMIT/CLEAR_CACHE failing with Unauthorized seeding mutation and previous playback attempts recording oversized watched seeds against a 5 GB quota.
