### PR TITLE
fix: preserve feed playback blob refs

### DIFF
--- a/packages/app/lib/discover-feed-controller.js
+++ b/packages/app/lib/discover-feed-controller.js
@@ -19,7 +19,8 @@ export function mergeUniqueFeedVideos(previousVideos = [], incomingVideos = [], 
     const channelKey = video.channelKey || video.driveKey || ''
     const identifier = video.id || video.path || ''
     if (!identifier) continue
-    byKey.set(`${channelKey}:${identifier}`, video)
+    const key = `${channelKey}:${identifier}`
+    byKey.set(key, mergeVideoPlaybackIdentity(byKey.get(key), video))
   }
 
   return Array.from(byKey.values()).slice(0, limit)
@@ -32,6 +33,19 @@ function hasNonEmpty(value) {
 
 function getEntryKey(entry) {
   return entry?.channelKey || entry?.driveKey || ''
+}
+
+function mergeVideoPlaybackIdentity(previous, incoming) {
+  if (!previous) return incoming
+  if (!incoming) return previous
+  return {
+    ...incoming,
+    path: incoming.path || previous.path,
+    publicBeeKey: incoming.publicBeeKey || previous.publicBeeKey,
+    blobId: incoming.blobId || previous.blobId,
+    blobsCoreKey: incoming.blobsCoreKey || previous.blobsCoreKey,
+    mimeType: incoming.mimeType || previous.mimeType,
+  }
 }
 
 export function getVerticalFeedHydrationKey(entry) {

--- a/packages/app/lib/feed-hydration.js
+++ b/packages/app/lib/feed-hydration.js
@@ -68,6 +68,19 @@ function hasDirectBlobRef(video) {
     typeof video?.blobsCoreKey === 'string' && /^[a-f0-9]{64}$/i.test(video.blobsCoreKey)
 }
 
+function mergeVideoPlaybackIdentity(previous, incoming) {
+  if (!previous) return incoming
+  if (!incoming) return previous
+  return {
+    ...incoming,
+    path: incoming.path || previous.path,
+    publicBeeKey: incoming.publicBeeKey || previous.publicBeeKey,
+    blobId: incoming.blobId || previous.blobId,
+    blobsCoreKey: incoming.blobsCoreKey || previous.blobsCoreKey,
+    mimeType: incoming.mimeType || previous.mimeType,
+  }
+}
+
 function canUseFeedPreviewVideos(entry, identityDriveKey) {
   const channelKey = entry?.channelKey || entry?.driveKey || null
   if (!channelKey) return false
@@ -222,7 +235,7 @@ export function mergeHydratedFeedVideos({
     if (!identifier) continue
     const key = `${channelKey || ''}:${identifier}`
     byKey.set(key, {
-      ...video,
+      ...mergeVideoPlaybackIdentity(byKey.get(key), video),
       __feedSource: video?.__feedSource === 'preview' ? 'preview' : 'hydrated',
     })
   }

--- a/packages/app/tests/discover-feed-controller.test.mjs
+++ b/packages/app/tests/discover-feed-controller.test.mjs
@@ -36,6 +36,29 @@ test('vertical feed controller dedupes preview and hydrated videos by channel/vi
   ])
 })
 
+test('vertical feed controller preserves preview blob refs when hydration updates metadata only', () => {
+  const merged = mergeUniqueFeedVideos([
+    {
+      id: 'a',
+      channelKey: 'one',
+      title: 'preview',
+      blobId: '0:2:0:512',
+      blobsCoreKey: 'aa'.repeat(32),
+      mimeType: 'video/mp4',
+      publicBeeKey: 'bee-preview',
+    },
+  ], [
+    { id: 'a', channelKey: 'one', title: 'hydrated' },
+  ])
+
+  assert.equal(merged.length, 1)
+  assert.equal(merged[0].title, 'hydrated')
+  assert.equal(merged[0].blobId, '0:2:0:512')
+  assert.equal(merged[0].blobsCoreKey, 'aa'.repeat(32))
+  assert.equal(merged[0].mimeType, 'video/mp4')
+  assert.equal(merged[0].publicBeeKey, 'bee-preview')
+})
+
 test('vertical feed controller preserves rich cached entries during partial feed hydration', () => {
   const cached = [{
     channelKey: 'one',

--- a/packages/app/tests/feed-hydration.test.mjs
+++ b/packages/app/tests/feed-hydration.test.mjs
@@ -371,6 +371,51 @@ test('mergeHydratedFeedVideos preserves preview-backed cards when channel hydrat
   ])
 })
 
+test('mergeHydratedFeedVideos preserves feed preview blob refs when hydration omits them', () => {
+  const merged = mergeHydratedFeedVideos({
+    previousVideos: [
+      {
+        id: 'shared-video',
+        channelKey: 'remote-a',
+        uploadedAt: 30,
+        availability: 'playable',
+        blobId: '0:4:0:1024',
+        blobsCoreKey: 'aa'.repeat(32),
+        mimeType: 'video/mp4',
+        publicBeeKey: 'bee-preview',
+        __feedSource: 'preview',
+      },
+    ],
+    incomingVideos: [
+      {
+        id: 'shared-video',
+        channelKey: 'remote-a',
+        uploadedAt: 40,
+        availability: 'playable',
+        title: 'Hydrated title',
+      },
+    ],
+    refreshedChannelKeys: ['remote-a'],
+    feedEntries: [
+      {
+        driveKey: 'remote-a',
+        manifestUpdatedAt: 123,
+        previewVideos: [{ id: 'shared-video', availability: 'playable' }],
+      },
+    ],
+    identityDriveKey: 'local',
+    limit: 50,
+  })
+
+  assert.equal(merged.length, 1)
+  assert.equal(merged[0].title, 'Hydrated title')
+  assert.equal(merged[0].blobId, '0:4:0:1024')
+  assert.equal(merged[0].blobsCoreKey, 'aa'.repeat(32))
+  assert.equal(merged[0].mimeType, 'video/mp4')
+  assert.equal(merged[0].publicBeeKey, 'bee-preview')
+  assert.equal(merged[0].__feedSource, 'hydrated')
+})
+
 test('isConfirmedFeedHydrationResult only treats empty results as authoritative when the feed manifest explicitly resolved empty', () => {
   assert.equal(isConfirmedFeedHydrationResult({
     entry: { manifestUpdatedAt: 0, previewVideos: [] },

--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -380,6 +380,23 @@ export function createApi({
     return previews.find((video) => normalizeVideoId(video?.id || video?.path) === targetId) || null
   }
 
+  function resolvePlaybackBlobRef(driveKey, videoId, publicBeeKey, blobId, blobsCoreKey, mimeType) {
+    if (blobId && blobsCoreKey) {
+      return { blobId, blobsCoreKey, mimeType: mimeType || 'video/mp4' }
+    }
+
+    const previewVideo = getPreviewVideoFromFeed(driveKey, videoId, publicBeeKey)
+    if (!previewVideo?.blobId || !previewVideo?.blobsCoreKey) {
+      return { blobId, blobsCoreKey, mimeType }
+    }
+
+    return {
+      blobId: previewVideo.blobId,
+      blobsCoreKey: previewVideo.blobsCoreKey,
+      mimeType: mimeType || previewVideo.mimeType || 'video/mp4',
+    }
+  }
+
   // ============================================
   // Download Intent Persistence Helpers
   // ============================================
@@ -1017,13 +1034,13 @@ export function createApi({
     async getVideoUrl(driveKey, videoPath, publicBeeKey, blobId, blobsCoreKey, mimeType) {
       console.log('[API] getVideoUrl:', driveKey?.slice(0, 16), videoPath);
 
-      // INSTANT PATH: If we already have blobId and blobsCoreKey, skip metadata fetch entirely.
-      if (blobId && blobsCoreKey) {
+      const playbackBlobRef = resolvePlaybackBlobRef(driveKey, videoPath, publicBeeKey, blobId, blobsCoreKey, mimeType)
+      if (playbackBlobRef?.blobId && playbackBlobRef?.blobsCoreKey) {
         console.log('[API] getVideoUrl: INSTANT - using direct blobId/blobsCoreKey');
         return blobPlayback.resolveDirectBlobUrl({
-          blobsCoreKey,
-          blobId,
-          mimeType: mimeType || 'video/mp4',
+          blobsCoreKey: playbackBlobRef.blobsCoreKey,
+          blobId: playbackBlobRef.blobId,
+          mimeType: playbackBlobRef.mimeType || 'video/mp4',
         })
       }
 
@@ -1053,14 +1070,16 @@ export function createApi({
     async preparePlayback(driveKey, videoPath, publicBeeKey, blobId, blobsCoreKey, mimeType) {
       console.log('[API] preparePlayback:', driveKey?.slice(0, 16), videoPath)
 
+      const playbackBlobRef = resolvePlaybackBlobRef(driveKey, videoPath, publicBeeKey, blobId, blobsCoreKey, mimeType)
+
       return blobPlayback.preparePlayback({
         driveKey,
         videoPath,
         publicBeeKey,
-        blobId,
-        blobsCoreKey,
-        mimeType,
-        warmSelectedBlob: Boolean(blobId && blobsCoreKey),
+        blobId: playbackBlobRef?.blobId,
+        blobsCoreKey: playbackBlobRef?.blobsCoreKey,
+        mimeType: playbackBlobRef?.mimeType,
+        warmSelectedBlob: Boolean(playbackBlobRef?.blobId && playbackBlobRef?.blobsCoreKey),
         warmup: (...args) => this.prefetchVideo(...args),
         resolveUrl: (...args) => this.getVideoUrl(...args),
         getStats: (...args) => this.getVideoStats(...args),

--- a/packages/backend/test/playback-api.test.mjs
+++ b/packages/backend/test/playback-api.test.mjs
@@ -73,6 +73,98 @@ test('preparePlayback returns a playable URL before warmup settles or fails', as
   ])
 })
 
+test('preparePlayback resolves feed preview blob refs when playback request omits direct identity', async (t) => {
+  const driveKey = '12'.repeat(32)
+  const publicBeeKey = '34'.repeat(32)
+  const blobsCoreKey = '56'.repeat(32)
+  const blobId = '0:4:0:2048'
+  const calls = []
+  const core = {
+    discoveryKey: Buffer.from('discovery-key'),
+    peers: [{ remotePublicKey: Buffer.from('peer-key') }],
+    async ready() {
+      calls.push(['core.ready'])
+    },
+    update() {
+      calls.push(['core.update'])
+      return Promise.resolve()
+    },
+    async has(start, end) {
+      calls.push(['core.has', start, end])
+      return start === 0 && end === 1
+    },
+  }
+
+  const api = createApi({
+    ctx: {
+      blobServer: {
+        port: 60023,
+        getLink(_keyBuffer, options) {
+          calls.push(['getLink', options.blob, options.type])
+          return 'http://127.0.0.1:60023/feed-video.webm'
+        },
+      },
+      store: {
+        get() {
+          calls.push(['store.get'])
+          return core
+        },
+      },
+      swarm: {
+        join(discoveryKey) {
+          calls.push(['swarm.join', discoveryKey])
+          return { flushed: () => Promise.resolve() }
+        },
+      },
+    },
+    publicFeed: {
+      getFeed() {
+        return [{
+          driveKey,
+          publicBeeKey,
+          source: 'peer',
+          peerCount: 2,
+          previewVideos: [{
+            id: 'feed-video',
+            title: 'Feed video',
+            blobId,
+            blobsCoreKey,
+            mimeType: 'video/webm',
+            availability: 'playable',
+          }],
+        }]
+      },
+      getStats() {
+        return { totalEntries: 1, hiddenCount: 0, peerCount: 2 }
+      },
+    },
+    loadPublicBee: async () => {
+      throw new Error('public bee should not be required for preview playback')
+    },
+    loadChannel: async () => {
+      throw new Error('channel should not be required for preview playback')
+    },
+  })
+
+  api.prefetchVideo = async (...args) => {
+    calls.push(['prefetchVideo', args])
+  }
+  api.getVideoStats = (...args) => {
+    calls.push(['getVideoStats', args])
+    return { peerCount: 1 }
+  }
+
+  const result = await api.preparePlayback(driveKey, 'feed-video', publicBeeKey)
+
+  t.is(result.url, 'http://127.0.0.1:60023/feed-video.webm')
+  t.is(result.peerWarmupStarted, true)
+  t.is(result.selectedBlobWarmup.blobId, blobId)
+  t.is(result.selectedBlobWarmup.blobsCoreKey, blobsCoreKey)
+  t.is(result.selectedBlobWarmup.readyForPlayback, true)
+  t.ok(calls.some((call) => call[0] === 'getLink' && call[2] === 'video/webm'), 'uses feed preview mime type for the blob-server URL')
+  t.ok(calls.some((call) => call[0] === 'swarm.join'), 'joins selected blob discovery before returning playback diagnostics')
+})
+
 test('prefetchNextVideos lists channel videos with the correct signature', async (t) => {
   const api = createApi({ ctx: {} })
   const calls = []


### PR DESCRIPTION
## Summary
- preserve feed preview playback blob refs when hydration/vertical-feed metadata updates omit direct blob identity
- let backend playback recover direct blob refs from canonical feed previews before falling back to PublicBee/channel metadata
- add app and backend regressions for feed-card playback with active peers/seeders

## Test Plan
- node packages/app/tests/feed-hydration.test.mjs
- node packages/app/tests/discover-feed-controller.test.mjs
- packages/backend/node_modules/.bin/brittle packages/backend/test/playback-api.test.mjs
- ./node_modules/.bin/eslint --quiet packages/app/lib/discover-feed-controller.js packages/app/lib/feed-hydration.js packages/app/tests/discover-feed-controller.test.mjs packages/app/tests/feed-hydration.test.mjs packages/backend/src/api.js packages/backend/test/playback-api.test.mjs
- git diff --check

OMP-assisted implementation: OMP produced the initial patch in a clean worktree; Hermes independently reviewed, linted, tested, committed, and owns this PR lifecycle.
