### PR TITLE
fix: wait for selected blob head before playback

### DIFF
--- a/packages/app/app/video/[id].tsx
+++ b/packages/app/app/video/[id].tsx
@@ -486,9 +486,17 @@ function MobileVideoPlayerScreen() {
         if (Platform.OS !== 'web' || isPear) {
           void rpc.preparePlayback(playbackRequest).then((result: any) => {
             if (!mountedRef.current || loadGenerationRef.current !== generation) return
-            if (result?.url) {
-              if (cacheKey) setCachedVideoUrl(cacheKey, result.url, Boolean(result.selectedBlobWarmup?.readyForPlayback))
+            const selectedBlobWarmup = result?.selectedBlobWarmup
+            const waitingForSelectedBlob = Boolean(selectedBlobWarmup && selectedBlobWarmup.readyForPlayback === false)
+            if (result?.url && !waitingForSelectedBlob) {
+              if (cacheKey) setCachedVideoUrl(cacheKey, result.url, Boolean(selectedBlobWarmup?.readyForPlayback))
               loadAndPlayVideo(videoData, result.url)
+            } else if (waitingForSelectedBlob) {
+              setTimeout(() => {
+                if (mountedRef.current && loadGenerationRef.current === generation) {
+                  setVideoLoaded(false)
+                }
+              }, 1500)
             }
             if (result?.stats) {
               setLocalStats(result.stats as VideoStats)
@@ -507,8 +515,10 @@ function MobileVideoPlayerScreen() {
       const result = await rpc.preparePlayback(playbackRequest)
       if (!mountedRef.current || loadGenerationRef.current !== generation) return
 
-      if (result?.url) {
-        if (cacheKey) setCachedVideoUrl(cacheKey, result.url, Boolean(result.selectedBlobWarmup?.readyForPlayback))
+      const selectedBlobWarmup = result?.selectedBlobWarmup
+      const waitingForSelectedBlob = Boolean(selectedBlobWarmup && selectedBlobWarmup.readyForPlayback === false)
+      if (result?.url && !waitingForSelectedBlob) {
+        if (cacheKey) setCachedVideoUrl(cacheKey, result.url, Boolean(selectedBlobWarmup?.readyForPlayback))
         // Use context's loadAndPlayVideo - this uses the shared player
         loadAndPlayVideo(videoData, result.url)
 
@@ -521,6 +531,16 @@ function MobileVideoPlayerScreen() {
             scheduleStatsPolling(500)
           }
         }
+      } else if (waitingForSelectedBlob) {
+        if (result?.stats) {
+          setLocalStats(result.stats as VideoStats)
+        }
+        scheduleStatsPolling(500)
+        setTimeout(() => {
+          if (mountedRef.current && loadGenerationRef.current === generation) {
+            setVideoLoaded(false)
+          }
+        }, 1500)
       }
     } catch (err) {
       console.error('[VideoPlayer] Failed to load video:', err)

--- a/packages/backend/src/blob-playback-service.js
+++ b/packages/backend/src/blob-playback-service.js
@@ -159,7 +159,7 @@ export class BlobPlaybackService {
       const peers = getCorePeerList(blobsCore)
       diagnostics.peerCount = getCorePeerCount(blobsCore)
       diagnostics.blobPeerIds = peers.map(getPeerKey).filter(Boolean)
-      diagnostics.readyForPlayback = diagnostics.hasHeadBlock || diagnostics.peerCount > 0
+      diagnostics.readyForPlayback = diagnostics.hasHeadBlock
       return diagnostics
     } catch (err) {
       diagnostics.error = err?.message || String(err)

--- a/packages/backend/test/blob-playback-selected-warmup.test.mjs
+++ b/packages/backend/test/blob-playback-selected-warmup.test.mjs
@@ -103,3 +103,24 @@ test('preparePlayback returns URL with explicit selected blob diagnostics when n
   t.is(result.selectedBlobWarmup.hasHeadBlock, false)
   t.is(result.selectedBlobWarmup.readyForPlayback, false)
 })
+
+test('preparePlayback does not report selected blob ready from peers alone', async (t) => {
+  const { ctx } = createCtx({ peerCount: 1, hasHeadBlock: false })
+  const service = new BlobPlaybackService({ ctx })
+
+  const result = await service.preparePlayback({
+    driveKey: 'channel-key',
+    videoPath: 'videos/king.mp4',
+    publicBeeKey: 'public-bee-key',
+    blobId: VALID_BLOB,
+    blobsCoreKey: VALID_KEY,
+    mimeType: 'video/mp4',
+    warmSelectedBlob: true,
+    selectedBlobWarmupTimeoutMs: 25,
+  })
+
+  t.is(result.url, VALID_URL)
+  t.is(result.selectedBlobWarmup.peerCount, 1)
+  t.is(result.selectedBlobWarmup.hasHeadBlock, false)
+  t.is(result.selectedBlobWarmup.readyForPlayback, false)
+})


### PR DESCRIPTION
## Summary
- require selected blob head block before reporting direct blob playback ready
- keep the video screen in P2P connecting/retry mode instead of handing an unready local blob URL to ExoPlayer
- add regression coverage for peers-present/head-missing selected blob warmup

## Verification
- node packages/backend/test/blob-playback-selected-warmup.test.mjs
- node packages/backend/test/blob-playback-service-peer-warmup.test.mjs
- node packages/backend/test/playback-api.test.mjs
- ./node_modules/.bin/eslint --quiet packages/backend/src/blob-playback-service.js packages/backend/test/blob-playback-selected-warmup.test.mjs 'packages/app/app/video/[id].tsx'
- git diff --check
