### PR TITLE
fix: protect active playback blob ranges from quota eviction

### DIFF
--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -10,7 +10,7 @@ import crypto from 'hypercore-crypto';
 import HypercoreID from 'hypercore-id-encoding';
 import z32 from 'z32';
 import c from 'compact-encoding';
-import { getVideoUrlFromBlob, loadChannel as storageLoadChannel, loadPublicBee as storageLoadPublicBee, pairDevice as pairChannelDevice, suspendNetworking, resumeNetworking, getNetworkStats, getNetworkStatsReadable, retainSwarmDiscovery } from './storage.js';
+import { getVideoUrlFromBlob, loadChannel as storageLoadChannel, loadPublicBee as storageLoadPublicBee, pairDevice as pairChannelDevice, suspendNetworking, resumeNetworking, setPlaybackActive as storageSetPlaybackActive, getNetworkStats, getNetworkStatsReadable, retainSwarmDiscovery } from './storage.js';
 import { createBlobPlaybackService } from './blob-playback-service.js';
 import { SemanticFinder } from './search/semantic-finder.js';
 import { buildMetadataEnvelope } from './search/metadata-envelope.js';
@@ -218,6 +218,14 @@ export function createApi({
   /** @type {Map<string, Promise<any>>} */
   const prefetchInFlight = new Map()
   const activeRangeRequests = new Map() // key: `${driveKey}:${videoPath}`, value: { ranges: [], core, onDownload, onUpload }
+
+  function getActiveRangeSeedKeys() {
+    const keys = new Set()
+    for (const request of activeRangeRequests.values()) {
+      if (request?.seedKey) keys.add(request.seedKey)
+    }
+    return keys
+  }
 
   /** @type {Map<string, { ts: number, value: any[] }>} */
   const listVideosCache = new Map()
@@ -1854,6 +1862,13 @@ export function createApi({
       const existingIntent = await loadDownloadIntent(ctx, driveKey, videoPath)
       let blobMeta = null
       let v = null
+      let releasePrefetchBlobRef = null
+      const releaseProtectedPrefetchBlobRef = () => {
+        if (!releasePrefetchBlobRef) return
+        const release = releasePrefetchBlobRef
+        releasePrefetchBlobRef = null
+        release()
+      }
 
       if (existingIntent) {
         console.log('[API] Resuming download from intent:', videoPath)
@@ -1913,6 +1928,13 @@ export function createApi({
           const normalizedBlobId = typeof blobMeta.blobId === 'string'
             ? blobMeta.blobId
             : `${blobId.blockOffset}:${blobId.blockLength}:${blobId.byteOffset}:${blobId.byteLength}`
+
+          if (seedingManager?.retainBlobRef) {
+            releasePrefetchBlobRef = seedingManager.retainBlobRef({
+              blobsCoreKey: blobMeta.blobsCoreKey,
+              blobId: normalizedBlobId
+            })
+          }
 
           if (!existingIntent && blobMeta?.blobsCoreKey) {
             await saveDownloadIntent(ctx, {
@@ -1988,7 +2010,7 @@ export function createApi({
               thumbnailBlobsCoreKey: v?.thumbnailBlobsCoreKey || existingIntent?.thumbnailBlobsCoreKey || null,
               mimeType: v?.mimeType || existingIntent?.mimeType || null,
               thumbnailMimeType: v?.thumbnailMimeType || existingIntent?.thumbnailMimeType || null
-            }, { protectSelf: true }).catch(err => console.log('[API] Failed to register seed intent:', err?.message))
+            }, { protectSelf: true, protectedKeys: getActiveRangeSeedKeys() }).catch(err => console.log('[API] Failed to register seed intent:', err?.message))
           }
           const headBlocks = getHeadBlockCount(totalBlocks, totalBytes)
           const tailBlocks = getTailBlockCount(totalBlocks, totalBytes)
@@ -2114,8 +2136,8 @@ export function createApi({
             })
           }
 
-          // Initialize range tracking entry (ranges added as they're created)
-          activeRangeRequests.set(prefetchKey, { ranges: [], core, onDownload, onUpload })
+          // Initialize range tracking entry only for live downloads.
+          if (!wasCached) activeRangeRequests.set(prefetchKey, { ranges: [], core, onDownload, onUpload, seedKey: `${driveKey}:${videoPath}` })
 
           if (!wasCached) {
             let fullDownloadStarted = false
@@ -2148,7 +2170,11 @@ export function createApi({
                     thumbnailBlobsCoreKey: v?.thumbnailBlobsCoreKey || null,
                     mimeType: v?.mimeType || existingIntent?.mimeType || null,
                     thumbnailMimeType: v?.thumbnailMimeType || null
-                  }, { protectSelf: true }).catch(err => console.log('[API] Failed to register seed:', err?.message))
+                  }, { protectSelf: true, protectedKeys: getActiveRangeSeedKeys() })
+                    .catch(err => console.log('[API] Failed to register seed:', err?.message))
+                    .finally(releaseProtectedPrefetchBlobRef)
+                } else {
+                  releaseProtectedPrefetchBlobRef()
                 }
               }).catch(err => {
                 if (err.message?.includes('closed') || ctx.store.closed) {
@@ -2162,6 +2188,7 @@ export function createApi({
                   videoStats.cleanupMonitor(driveKey, videoPath)
                 }
                 activeRangeRequests.delete(prefetchKey)
+                releaseProtectedPrefetchBlobRef()
               })
             }
 
@@ -2246,10 +2273,17 @@ export function createApi({
                 thumbnailBlobsCoreKey: v?.thumbnailBlobsCoreKey || null,
                 mimeType: v?.mimeType || existingIntent?.mimeType || null,
                 thumbnailMimeType: v?.thumbnailMimeType || null
-              }, { protectSelf: true }).catch(() => {})
+              }, { protectSelf: true, protectedKeys: getActiveRangeSeedKeys() })
+                .catch(() => {})
+                .finally(releaseProtectedPrefetchBlobRef)
+            } else {
+              releaseProtectedPrefetchBlobRef()
             }
           }
 
+          if (wasCached && !videoStats) {
+            releaseProtectedPrefetchBlobRef()
+          }
           await playbackReady
 
           return {
@@ -2270,6 +2304,7 @@ export function createApi({
           videoStats.updateStats(driveKey, videoPath, { status: 'error', error: err.message });
           videoStats.cleanupMonitor(driveKey, videoPath);
         }
+        releaseProtectedPrefetchBlobRef()
         activeRangeRequests.delete(prefetchKey)
         return { success: false, error: err.message };
       }
@@ -3405,6 +3440,19 @@ export function createApi({
       } catch (err) {
         console.error('[API] resumeNetwork error:', err.message)
         return { success: false, error: err.message }
+      }
+    },
+
+    /**
+     * Mirror app playback state into the backend so cache cleanup does not
+     * clear blob ranges while a player or blob-server reader is active.
+     * @param {{active?: boolean, ttlMs?: number}} [options]
+     * @returns {{success: boolean, active: boolean, updatedAt: number, expiresAt: number}}
+     */
+    setPlaybackActive(options = {}) {
+      return {
+        success: true,
+        ...storageSetPlaybackActive(Boolean(options.active), { ttlMs: options.ttlMs })
       }
     },
 

--- a/packages/backend/src/orchestrator.js
+++ b/packages/backend/src/orchestrator.js
@@ -9,7 +9,7 @@
  *   const { ctx, api, identityManager, uploadManager, publicFeed, seedingManager, videoStats } = backend;
  */
 
-import { initializeStorage, loadChannel, retainPublicBeeContentDiscovery, retainSwarmDiscovery } from './storage.js';
+import { initializeStorage, isPlaybackActive, loadChannel, retainPublicBeeContentDiscovery, retainSwarmDiscovery } from './storage.js';
 import { PublicFeedManager } from './public-feed.js';
 import { VideoStatsTracker } from './video-stats.js';
 import { SeedingManager } from './seeding.js';
@@ -340,7 +340,8 @@ export async function createBackendContext(config) {
   const identityManager = createIdentityManager({ ctx });
   const seedingManager = new SeedingManager(ctx.store, ctx.metaDb, {
     identityManager,
-    getDiskUsageBytes: createStorageUsageMeasurer(storagePath)
+    getDiskUsageBytes: createStorageUsageMeasurer(storagePath),
+    isCacheClearBlocked: isPlaybackActive
   });
   const uploadManager = createUploadManager({ ctx });
 

--- a/packages/backend/src/seeding.js
+++ b/packages/backend/src/seeding.js
@@ -32,6 +32,10 @@ function normalizeProtectedSeedKeys(keys) {
   return new Set()
 }
 
+function createNoopRelease() {
+  return () => {}
+}
+
 function mergeSeedReason(existingReason, nextReason) {
   const priority = { watched: 1, subscribed: 2, pinned: 3 }
   return (priority[nextReason] || 0) > (priority[existingReason] || 0)
@@ -64,7 +68,7 @@ export class SeedingManager {
   /**
    * @param {import('corestore')} store - Corestore instance
    * @param {import('hyperbee')} metaDb - Metadata database
-   * @param {{ getDiskUsageBytes?: () => number | Promise<number> }} [options]
+   * @param {{ getDiskUsageBytes?: () => number | Promise<number>, isCacheClearBlocked?: () => boolean }} [options]
    */
   constructor(store, metaDb, options = {}) {
     this.store = store;
@@ -74,8 +78,13 @@ export class SeedingManager {
     this.getDiskUsageBytes = typeof options.getDiskUsageBytes === 'function'
       ? options.getDiskUsageBytes
       : (typeof store?.getDiskUsageBytes === 'function' ? () => store.getDiskUsageBytes() : null);
+    this.isCacheClearBlocked = typeof options.isCacheClearBlocked === 'function'
+      ? options.isCacheClearBlocked
+      : null;
     /** @type {Map<string, SeedInfo>} key: `${driveKey}:${videoPath}` -> seed info */
     this.activeSeeds = new Map();
+    /** @type {Map<string, number>} blobsCoreKey -> active playback/prefetch retain count */
+    this.protectedBlobCores = new Map();
     /** @type {Set<string>} driveKeys that are pinned (always seed) */
     this.pinnedChannels = new Set();
     /** @type {SeedingConfig} */
@@ -103,6 +112,43 @@ export class SeedingManager {
   assertAuthorizedForSeed(driveKey, reason, options = {}) {
     if (reason === 'watched' && options.userInitiated !== true) return
     this.assertAuthorizedMutation(options)
+  }
+
+  retainBlobRef(blobInfo) {
+    const ref = normalizeSeedBlobRef(blobInfo)
+    if (!ref) return createNoopRelease()
+
+    const key = ref.blobsCoreKey
+    this.protectedBlobCores.set(key, (this.protectedBlobCores.get(key) || 0) + 1)
+
+    let released = false
+    return () => {
+      if (released) return
+      released = true
+      const nextCount = (this.protectedBlobCores.get(key) || 0) - 1
+      if (nextCount > 0) {
+        this.protectedBlobCores.set(key, nextCount)
+      } else {
+        this.protectedBlobCores.delete(key)
+      }
+    }
+  }
+
+  isSeedBlobProtected(seed) {
+    const ref = normalizeSeedBlobRef(seed)
+    return Boolean(ref && this.protectedBlobCores.has(ref.blobsCoreKey))
+  }
+
+  isCacheClearBlockedNow() {
+    try {
+      return Boolean(this.isCacheClearBlocked?.())
+    } catch {
+      return false
+    }
+  }
+
+  shouldSkipSeedClear(seed) {
+    return this.isCacheClearBlockedNow() || this.isSeedBlobProtected(seed)
   }
 
   /**
@@ -369,7 +415,7 @@ export class SeedingManager {
     for (const seed of seeds) {
       if (quotaBytes <= maxBytes) break;
       if (seed.reason === 'pinned') continue; // Never remove pinned
-      if (protectedKeys.has(seed.key)) continue;
+      if (protectedKeys.has(seed.key) || this.shouldSkipSeedClear(seed)) continue;
 
       this.activeSeeds.delete(seed.key);
       clearedBlob = (await this.clearSeedBlob(seed)) || clearedBlob;
@@ -432,7 +478,7 @@ export class SeedingManager {
       const intent = entry?.value
       if (!intent?.driveKey || !intent?.videoPath) continue
       const seedKey = `${intent.driveKey}:${intent.videoPath}`
-      if (excludeKeys.has(seedKey)) continue
+      if (excludeKeys.has(seedKey) || this.shouldSkipSeedClear(intent)) continue
       entries.push({ key: entry.key, seedKey, intent })
     }
 
@@ -584,7 +630,7 @@ export class SeedingManager {
     let clearedBlob = false;
 
     for (const [key, seed] of this.activeSeeds.entries()) {
-      if (seed.reason !== 'pinned') {
+      if (seed.reason !== 'pinned' && !this.shouldSkipSeedClear(seed)) {
         clearedBytes += seed.bytes || 0;
         toRemove.push(key);
       }

--- a/packages/backend/test/seeding-quota.test.mjs
+++ b/packages/backend/test/seeding-quota.test.mjs
@@ -122,6 +122,90 @@ test('protectSelf keeps the current watched seed through quota enforcement', asy
   t.alike(store.cores.get(coreA)?.clearCalls || [], [])
 })
 
+test('quota enforcement skips retained in-flight blob cores', async (t) => {
+  const store = createStore()
+  const metaDb = createMetaDb()
+  const manager = new SeedingManager(store, metaDb)
+
+  await manager.setMaxStorageGB(10)
+  manager.activeSeeds.set('drive-a:videos/in-flight.mp4', {
+    driveKey: 'drive-a',
+    videoPath: 'videos/in-flight.mp4',
+    reason: 'watched',
+    addedAt: 1,
+    blocks: 4,
+    bytes: 4 * GB,
+    blobId: '10:4:0:4096',
+    blobsCoreKey: coreA
+  })
+  manager.activeSeeds.set('drive-b:videos/evictable.mp4', {
+    driveKey: 'drive-b',
+    videoPath: 'videos/evictable.mp4',
+    reason: 'watched',
+    addedAt: 2,
+    blocks: 4,
+    bytes: 4 * GB,
+    blobId: '20:4:0:4096',
+    blobsCoreKey: coreB
+  })
+  await manager.persistSeeds()
+
+  const release = manager.retainBlobRef({ blobId: '10:4:0:4096', blobsCoreKey: coreA })
+  await manager.setMaxStorageGB(5)
+
+  t.is(manager.getActiveSeeds().length, 1)
+  t.is(manager.getActiveSeeds()[0].videoPath, 'videos/in-flight.mp4')
+  t.alike(store.cores.get(coreA)?.clearCalls || [], [])
+  t.alike(store.cores.get(coreB).clearCalls, [{ start: 20, end: 24 }])
+
+  release()
+  t.absent(manager.isSeedBlobProtected({ blobId: '10:4:0:4096', blobsCoreKey: coreA }))
+})
+
+test('quota enforcement defers clears while playback is active', async (t) => {
+  const store = createStore()
+  const metaDb = createMetaDb()
+  let playbackActive = true
+  const manager = new SeedingManager(store, metaDb, {
+    isCacheClearBlocked: () => playbackActive
+  })
+
+  await manager.setMaxStorageGB(10)
+  manager.activeSeeds.set('drive-a:videos/old.mp4', {
+    driveKey: 'drive-a',
+    videoPath: 'videos/old.mp4',
+    reason: 'watched',
+    addedAt: 1,
+    blocks: 4,
+    bytes: 4 * GB,
+    blobId: '10:4:0:4096',
+    blobsCoreKey: coreA
+  })
+  manager.activeSeeds.set('drive-b:videos/new.mp4', {
+    driveKey: 'drive-b',
+    videoPath: 'videos/new.mp4',
+    reason: 'watched',
+    addedAt: 2,
+    blocks: 4,
+    bytes: 4 * GB,
+    blobId: '20:4:0:4096',
+    blobsCoreKey: coreB
+  })
+  await manager.persistSeeds()
+
+  await manager.setMaxStorageGB(5)
+
+  t.is(manager.getActiveSeeds().length, 2)
+  t.is(store.calls.length, 0)
+
+  playbackActive = false
+  await manager.enforceQuota()
+
+  t.is(manager.getActiveSeeds().length, 1)
+  t.is(manager.getActiveSeeds()[0].videoPath, 'videos/new.mp4')
+  t.alike(store.cores.get(coreA).clearCalls, [{ start: 10, end: 14 }])
+})
+
 test('clearCache clears non-pinned blob ranges and keeps pinned cached bytes', async (t) => {
   const store = createStore()
   const metaDb = createMetaDb()

--- a/packages/backend/test/storage-quota-api.test.mjs
+++ b/packages/backend/test/storage-quota-api.test.mjs
@@ -94,6 +94,7 @@ class FakeCore extends EventEmitter {
 
 const GB = 1024 * 1024 * 1024
 const coreA = 'aa'.repeat(32)
+const coreB = 'bb'.repeat(32)
 
 test('clearCache clears persisted partial download intents as cache bytes', async (t) => {
   const metaDb = createMetaDb({
@@ -310,6 +311,53 @@ test('prefetchVideo corrects stale full-size watched seed accounting downward', 
   t.is(seeds.length, 1)
   t.is(seeds[0]?.bytes, 0)
   t.is(seedingManager.getStorageStatsSync().usedBytes, 0)
+})
+
+test('prefetchVideo quota enforcement preserves active range downloads', async (t) => {
+  const metaDb = createMetaDb()
+  const store = createStore()
+  const seedingManager = new SeedingManager(store, metaDb)
+  await seedingManager.init()
+  await seedingManager.setMaxStorageGB(5)
+  const api = createApi({ ctx: { store, metaDb, swarm: null }, seedingManager })
+
+  api.getVideoData = async (_driveKey, videoPath) => {
+    if (videoPath === 'videos/active.mp4') {
+      return {
+        id: 'active',
+        path: 'videos/active.mp4',
+        blobId: '0:8:0:4294967296',
+        blobsCoreKey: coreA,
+        byteLength: 4 * GB,
+        mimeType: 'video/mp4'
+      }
+    }
+
+    return {
+      id: 'cached',
+      path: 'videos/cached.mp4',
+      blobId: '10:8:0:4294967296',
+      blobsCoreKey: coreB,
+      byteLength: 4 * GB,
+      mimeType: 'video/mp4'
+    }
+  }
+
+  const activePrefetch = api.prefetchVideo('drive-a', 'videos/active.mp4')
+  await new Promise((resolve) => setImmediate(resolve))
+  const activeCore = store.cores.get(coreA)
+  activeCore.emit('download', 0, 2 * GB)
+  await activePrefetch
+
+  const cachedCore = store.get(b4a.from(coreB, 'hex'))
+  cachedCore.has = async () => true
+  const cachedResult = await api.prefetchVideo('drive-b', 'videos/cached.mp4')
+
+  t.is(cachedResult.success, true)
+  t.is(cachedResult.cached, true)
+  t.alike(activeCore.clearCalls, [])
+  t.is(seedingManager.getActiveSeeds().length, 2)
+  t.is(seedingManager.getStorageStatsSync().usedBytes, 6 * GB)
 })
 
 test('prefetchVideo cleans up core listeners when blob is already fully cached', async (t) => {


### PR DESCRIPTION
## Summary
- Prevent quota/cache cleanup from clearing blob ranges while playback or prefetch is active.
- Track active prefetch seed keys and pass them into quota enforcement.
- Add retained blob-core protection in `SeedingManager` and wire it to backend playback activity.
- Expose the already-wired mobile `setPlaybackActive` backend method so active playback can block destructive cache clears.

## Runtime evidence
Observed emulator launch/feed playback failure before the fix:
- Feed/PublicBee metadata resolved successfully and peers/feed entries were present.
- Startup resumed multiple blob downloads from intents.
- `SeedingManager` immediately exceeded quota and cleared cached blob ranges for multi-GB videos.
- App then crashed with `SIGSEGV` in `librocksdb-native.3.15.2.so` from a `libuv-worker` via `libbare-kit.so`.

This separates feed peer discovery from playable blob availability: peers/seeders can show up while cache eviction is destroying active blob ranges underneath playback/prefetch.

## Tests
- `packages/backend/node_modules/.bin/brittle packages/backend/test/storage-quota-api.test.mjs`
  - 11/11 pass, 48/48 assertions
- `packages/backend/node_modules/.bin/brittle packages/backend/test/seeding-quota.test.mjs packages/backend/test/seeding-storage-accounting.test.mjs packages/backend/test/blob-playback-selected-warmup.test.mjs`
  - 11/11 pass, 58/58 assertions
- `npm test --prefix packages/backend`
  - exit 0
- `node --check packages/backend/src/api.js && node --check packages/backend/src/seeding.js && node --check packages/backend/src/orchestrator.js`
  - exit 0

## Note
`npm run typecheck --prefix packages/backend` is currently blocked by repo/package config: `tsc` resolves the root `/tsconfig.json`, whose `include` is `src/**/*`, and reports `TS18003: No inputs were found`. This appears pre-existing and unrelated to this patch.
