### PR TITLE
fix: do not close shared serving core on range-priority cleanup

### DIFF
--- a/packages/backend/src/blob-range-priority.js
+++ b/packages/backend/src/blob-range-priority.js
@@ -166,10 +166,17 @@ export async function prioritizeBlobServerRangeRequest(blobServer, req, options 
     if (cleanedUp) return
     cleanedUp = true
     try { range?.destroy?.() } catch { /* best effort */ }
-    try {
-      const closeResult = core.close?.()
-      if (closeResult && typeof closeResult.catch === 'function') closeResult.catch(() => {})
-    } catch { /* best effort */ }
+    // Do NOT close the shared serving core by default: `_getCore` returns the
+    // core that hypercore-blob-server is actively streaming byte ranges from to
+    // the player. Closing it on range-priority cleanup tears down playback
+    // mid-stream, causing constant stalls. Only close when a caller explicitly
+    // owns the core lifecycle for this request.
+    if (options.closeCoreOnCleanup === true) {
+      try {
+        const closeResult = core.close?.()
+        if (closeResult && typeof closeResult.catch === 'function') closeResult.catch(() => {})
+      } catch { /* best effort */ }
+    }
   }
   const timer = setTimeout(cleanup, timeoutMs)
   const done = typeof range?.done === 'function'

--- a/packages/backend/test/blob-range-priority.test.mjs
+++ b/packages/backend/test/blob-range-priority.test.mjs
@@ -113,7 +113,38 @@ test('prioritizeBlobServerRangeRequest starts a non-linear core download for the
   t.alike(result, { start: 14, end: 15, blocks: 1 })
   t.alike(calls[0], ['_getCore', key.toString('hex'), blob, true])
   t.alike(calls[1], ['download', { start: 14, end: 15, linear: false }])
-  t.ok(calls.some((call) => call[0] === 'close'))
+  // The shared serving core must NOT be closed on cleanup by default: it is the
+  // same core hypercore-blob-server streams playback ranges from. Closing it
+  // mid-stream causes constant playback stalls.
+  t.absent(calls.some((call) => call[0] === 'close'), 'shared serving core is not closed on default cleanup')
+})
+
+test('prioritizeBlobServerRangeRequest closes the core when closeCoreOnCleanup is set', async (t) => {
+  const calls = []
+  const { req } = createRangeRequest()
+  const blobServer = {
+    token: 'test-token',
+    async _getCore() {
+      return {
+        download(options) {
+          calls.push(['download', options])
+          return {
+            done: () => Promise.resolve(),
+            destroy: () => calls.push(['destroy']),
+          }
+        },
+        close() {
+          calls.push(['close'])
+        },
+      }
+    },
+  }
+
+  await prioritizeBlobServerRangeRequest(blobServer, req, { readAheadBytes: 0, closeCoreOnCleanup: true })
+  await Promise.resolve()
+  await Promise.resolve()
+
+  t.ok(calls.some((call) => call[0] === 'close'), 'core is closed when caller opts in')
 })
 
 test('prioritizeBlobServerRangeRequest ignores HEAD range probes', async (t) => {


### PR DESCRIPTION
## Problem
Playback on Android is slow and stalls constantly even when a relay is seeding full episodes. Root cause: `prioritizeBlobServerRangeRequest` borrows the shared serving core via `blobServer._getCore(...)` — the same core `hypercore-blob-server` streams playback byte ranges from — and its `cleanup()` unconditionally called `core.close()` on completion or the ~1s timeout. Each prioritized range tears the serving core down mid-stream, so the player stalls, re-requests, briefly recovers, and stalls again.

This is the mid-playback continuation failure left unaddressed by #399 (which only hardened startup byte-readiness). #397 carried a version of this gate but also overlapped other areas; this is the minimal isolated fix cherry-picked onto current main.

## Fix
Gate `core.close()` behind an explicit `options.closeCoreOnCleanup === true` (default off). Range prioritization no longer destroys the borrowed playback core; callers that genuinely own the core lifecycle can still opt in.

## Verification
- `npx brittle test/blob-range-priority.test.mjs` — 6/6 pass
  - updated existing test to assert the shared core is **not** closed on default cleanup
  - added a test asserting `close` fires when `closeCoreOnCleanup: true`
- `npx brittle test/blob-playback-selected-warmup.test.mjs test/blob-playback-service-peer-warmup.test.mjs test/playback-service.test.mjs` — pass

Based on current main `4a72d219` (v0.1.197 merge commit).