### PR TITLE
fix: stream blob playback in play order for large archives

### DIFF
--- a/packages/app/components/video-player/PearInlineVideoView.tsx
+++ b/packages/app/components/video-player/PearInlineVideoView.tsx
@@ -43,6 +43,14 @@ const ANDROID_BUFFER_OPTIONS = {
   preferredForwardBufferDuration: 20,
   waitsToMinimizeStalling: true,
 }
+// iOS (AVPlayer) was using the default forward buffer, so for large P2P-streamed
+// archives it would only read a little ahead and stall whenever the relay peers
+// lagged. Match Android's 20s forward buffer and let AVPlayer wait to minimize
+// stalling so it refills before resuming instead of stuttering block-by-block.
+const IOS_BUFFER_OPTIONS = {
+  preferredForwardBufferDuration: 20,
+  waitsToMinimizeStalling: true,
+}
 const SEEK_PLAYBACK_RECOVERY_MS = 6000
 
 function getExpoEventDurationMs(data: any, player?: VideoPlayer | null) {
@@ -125,12 +133,12 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
     nextPlayer.playbackRate = playbackRate
     nextPlayer.showNowPlayingNotification = showNotificationControls
     nextPlayer.staysActiveInBackground = showNotificationControls
-    if (Platform.OS === 'android') {
-      try {
-        nextPlayer.bufferOptions = ANDROID_BUFFER_OPTIONS as any
-      } catch {
-        // Some Expo Video versions expose bufferOptions as read-only before source load.
-      }
+    try {
+      nextPlayer.bufferOptions = (Platform.OS === 'android'
+        ? ANDROID_BUFFER_OPTIONS
+        : IOS_BUFFER_OPTIONS) as any
+    } catch {
+      // Some Expo Video versions expose bufferOptions as read-only before source load.
     }
   })
 

--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -2230,7 +2230,11 @@ export function createApi({
             const startFullDownload = () => {
               if (fullDownloadStarted) return
               fullDownloadStarted = true
-              const downloadRange = core.download({ start: startBlock, end: endBlock })
+              // Stream the body in play order. Without `linear`, hypercore pulls
+              // blocks in rarest/availability order, so the background fill races
+              // ahead into the middle/end of the file while the player stalls
+              // waiting for the contiguous bytes right after its current position.
+              const downloadRange = core.download({ start: startBlock, end: endBlock, linear: true })
               activeRangeRequests.get(prefetchKey)?.ranges.push(downloadRange)
               downloadRange.done().then(async () => {
                 console.log('[API] Download complete (blobs)')
@@ -2283,7 +2287,7 @@ export function createApi({
               if (headBlocks > 0 && headBlocks < totalBlocks) {
                 const headEnd = Math.min(endBlock, startBlock + headBlocks)
                 console.log('[API] Prefetch head range (blobs):', (headEnd - startBlock), 'blocks')
-                const headRange = core.download({ start: startBlock, end: headEnd })
+                const headRange = core.download({ start: startBlock, end: headEnd, linear: true })
                 activeRangeRequests.get(prefetchKey).ranges.push(headRange)
                 let headTimeout = null
                 headTimeout = setTimeout(() => {

--- a/packages/backend/src/blob-range-priority.js
+++ b/packages/backend/src/blob-range-priority.js
@@ -2,7 +2,13 @@ import c from 'compact-encoding'
 import HypercoreID from 'hypercore-id-encoding'
 import z32 from 'z32'
 
-const DEFAULT_BLOB_RANGE_READ_AHEAD_BYTES = 2 * 1024 * 1024
+// Keep the prioritized read-ahead window comfortably larger than the player's
+// forward buffer (ExoPlayer/AVPlayer buffer ~20s ahead). A 2MB window was only
+// ~2s of video for large archived files, so the player constantly outran the
+// prioritized region on bandwidth-constrained mobile links. 16MB keeps the
+// front of the stream prioritized ahead of the player without flooding the
+// scheduler with the whole file.
+const DEFAULT_BLOB_RANGE_READ_AHEAD_BYTES = 16 * 1024 * 1024
 const DEFAULT_BLOB_RANGE_PRIORITY_TIMEOUT_MS = 15000
 
 const blobIdEncoding = {
@@ -152,10 +158,15 @@ export async function prioritizeBlobServerRangeRequest(blobServer, req, options 
   }, true)
   if (!core || typeof core.download !== 'function') return null
 
+  // Video playback reads bytes sequentially from the seek point forward, so the
+  // prioritized region must download in play order. `linear: false` let
+  // hypercore fetch blocks in rarest/availability order, which leaves gaps the
+  // player reaches before they land -> rebuffering on large files. `linear: true`
+  // fills the window front-to-back so the player keeps draining contiguous bytes.
   const range = core.download({
     start: downloadRange.start,
     end: downloadRange.end,
-    linear: false
+    linear: true
   })
   const timeoutMs = Math.max(
     1000,

--- a/packages/backend/test/blob-range-priority.test.mjs
+++ b/packages/backend/test/blob-range-priority.test.mjs
@@ -84,7 +84,7 @@ function createRangeRequest({ method = 'GET', token = 'test-token' } = {}) {
   return { key, blob, req }
 }
 
-test('prioritizeBlobServerRangeRequest starts a non-linear core download for the requested HTTP GET range', async (t) => {
+test('prioritizeBlobServerRangeRequest starts a linear core download for the requested HTTP GET range', async (t) => {
   const calls = []
   const { key, blob, req } = createRangeRequest()
   const blobServer = {
@@ -112,7 +112,7 @@ test('prioritizeBlobServerRangeRequest starts a non-linear core download for the
 
   t.alike(result, { start: 14, end: 15, blocks: 1 })
   t.alike(calls[0], ['_getCore', key.toString('hex'), blob, true])
-  t.alike(calls[1], ['download', { start: 14, end: 15, linear: false }])
+  t.alike(calls[1], ['download', { start: 14, end: 15, linear: true }])
   // The shared serving core must NOT be closed on cleanup by default: it is the
   // same core hypercore-blob-server streams playback ranges from. Closing it
   // mid-stream causes constant playback stalls.


### PR DESCRIPTION
Large archived videos streamed slowly to mobile peers because every
hypercore download in the playback path fetched blocks in rarest/
availability order instead of play order:

- Full background prefetch download (api.js) had no `linear` flag, so it
  raced into the middle/end of the file while the player stalled waiting
  for the contiguous bytes right after its position.
- The blob-server range-priority download used `linear: false` and only a
  2MB read-ahead window (~2s of video), so the player's 20s forward buffer
  constantly outran the prioritized region on bandwidth-constrained links.

Changes:
- linear: true on the full download, head prefetch, and range-priority
  download so blocks arrive front-to-back from the seek point.
- Raise the prioritized read-ahead window from 2MB to 16MB to stay ahead
  of the player buffer.
- Apply a 20s forward buffer + waitsToMinimizeStalling on iOS (was
  Android-only), so AVPlayer reads further ahead from relay peers.

Update blob-range-priority test to assert the linear download.

