### PR TITLE
fix: resolve resource leaks and config loss found in architecture audit

### DIFF
--- a/packages/backend/src/orchestrator.js
+++ b/packages/backend/src/orchestrator.js
@@ -284,7 +284,9 @@ export async function createBackendContext(config) {
       blobServerHost,
       blobServerBindHost,
       primaryKey: null,
-      corestoreWaitForLock
+      corestoreWaitForLock,
+      network,
+      swarmOptions
     })
 
     try {

--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -32,6 +32,7 @@ import {
 const log = logger('PublicFeed')
 const PUBLIC_FEED_CATALOG_VERSION = 1
 const PUBLIC_FEED_RELAY_CATALOG_KEY = 'public-feed-relay-catalog-v1'
+const PUBLIC_FEED_HIDDEN_CHANNELS_KEY = 'hidden-channels-v1'
 const NETWORK_TOPIC = crypto.data(b4a.from(NETWORK_TOPIC_STRING, 'utf-8'))
 const NETWORK_TOPIC_HEX = b4a.toString(NETWORK_TOPIC, 'hex')
 
@@ -844,15 +845,18 @@ export class PublicFeed {
   }
 
   _enforceFeedEntryLimit() {
-    while (this.entries.size > this._persistMaxEntries) {
-      const oldestKey = this.entries.keys().next().value
-      if (!oldestKey) break
-      const entry = this.entries.get(oldestKey)
-      if (entry?.source === 'local') break
-      this.entries.delete(oldestKey)
-      this.entryPeerCounts.delete(oldestKey)
+    if (this.entries.size <= this._persistMaxEntries) return
+    // Evict oldest non-local entries. Local entries are skipped (never break:
+    // a local entry at the head of the Map must not disable eviction entirely,
+    // or peer-discovered entries grow unbounded).
+    for (const key of this.entries.keys()) {
+      if (this.entries.size <= this._persistMaxEntries) break
+      const entry = this.entries.get(key)
+      if (entry?.source === 'local') continue
+      this.entries.delete(key)
+      this.entryPeerCounts.delete(key)
       for (const peerKeys of this.peerFeedKeys.values()) {
-        peerKeys.delete(oldestKey)
+        peerKeys.delete(key)
       }
     }
   }
@@ -930,16 +934,15 @@ export class PublicFeed {
   }
 
   _recordPeerConnectionOutcome(conn, reason = 'closed') {
+    // A failing connection emits both 'error' and 'close'. _forgetConnection
+    // clears the conn maps after the first event, so bail here to avoid
+    // scoring the same connection outcome twice (the connected-stat decrement
+    // is owned by _forgetConnection).
+    if (!this._connectionPeerKeys.has(conn)) return
     const remoteKey = this._connectionPeerKeys.get(conn) || conn?.remotePublicKey || conn?.publicKey || null
     const keyHex = this._peerKeyHex(remoteKey)
     const record = keyHex ? this._peerDirectory.get(keyHex) : null
-    const hadRemoteKey = Boolean(remoteKey)
-    if (!record) {
-      if (hadRemoteKey && this._directPeerDialStats.connected > 0) {
-        this._directPeerDialStats.connected = Math.max(0, this._directPeerDialStats.connected - 1)
-      }
-      return
-    }
+    if (!record) return
     const ageMs = this._connectionAgeMs(conn)
     const swarmState = this._swarmDialState(keyHex, remoteKey)
     record.lastConnectionAt = this._now()
@@ -1200,6 +1203,24 @@ export class PublicFeed {
       this.handleConnection(conn, {});
     }
 
+    // Restore hidden channels before any cached entries so addEntry() filters
+    // them out — otherwise channels the user hid reappear on every restart.
+    if (this.metaDb) {
+      try {
+        const hidden = await this.metaDb.get(PUBLIC_FEED_HIDDEN_CHANNELS_KEY).catch(() => null)
+        if (Array.isArray(hidden?.value)) {
+          for (const key of hidden.value) {
+            if (typeof key === 'string' && /^[a-f0-9]{64}$/i.test(key)) this.hiddenKeys.add(key)
+          }
+          if (this.hiddenKeys.size > 0) {
+            console.log('[PublicFeed] Restored', this.hiddenKeys.size, 'hidden channels from db')
+          }
+        }
+      } catch (err) {
+        console.log('[PublicFeed] Hidden-channel restore skipped:', err?.message)
+      }
+    }
+
     // Load persisted published channels from database
     // Try new format first (with publicBeeKey), fall back to legacy format
     if (this.metaDb) {
@@ -1445,7 +1466,7 @@ export class PublicFeed {
     try {
       mux = Protomux.from(conn);
     } catch (err) {
-      this.wiredConnections.delete(conn);
+      this._forgetConnection(conn);
       console.error('[PublicFeed] Protomux.from failed during handshake:', label, err?.message || err, err?.stack || '')
       return;
     }
@@ -1459,7 +1480,7 @@ export class PublicFeed {
         }
       });
     } catch (err) {
-      this.wiredConnections.delete(conn);
+      this._forgetConnection(conn);
       console.error('[PublicFeed] mux.pair failed during handshake:', label, err?.message || err, err?.stack || '')
       return
     }
@@ -1467,7 +1488,7 @@ export class PublicFeed {
     try {
       this.setupFeedProtocol(conn, mux);
     } catch (err) {
-      this.wiredConnections.delete(conn);
+      this._forgetConnection(conn);
       console.error('[PublicFeed] setupFeedProtocol failed during handshake:', label, err?.message || err, err?.stack || '')
     }
   }
@@ -1707,11 +1728,14 @@ export class PublicFeed {
         let announcedKeys = []
         let receivedCount = 0
 
-        // Prefer new entries format (with publicBeeKey)
+        // Prefer new entries format (with publicBeeKey).
+        // Cap processed entries per message: each verified entry costs a
+        // signature check, and a hostile peer must not be able to pin the CPU
+        // or balloon memory with one oversized HAVE_FEED.
         if (msg.entries && Array.isArray(msg.entries)) {
           log.debug('HAVE_FEED received (entries)', { count: msg.entries.length })
           receivedCount = msg.entries.length
-          for (const entry of msg.entries) {
+          for (const entry of msg.entries.slice(0, this._persistMaxEntries)) {
             if (!entry?.driveKey) continue
             const entrySource = 'peer'
             const resolvedPublicBeeKey = this._resolvePublicBeeKey(entry)
@@ -1727,7 +1751,9 @@ export class PublicFeed {
         else if (msg.keys && Array.isArray(msg.keys)) {
           log.debug('HAVE_FEED received (legacy keys)', { count: msg.keys.length })
           receivedCount = msg.keys.length
-          announcedKeys = msg.keys.filter((key) => typeof key === 'string' && key.length > 0)
+          announcedKeys = msg.keys
+            .filter((key) => typeof key === 'string' && key.length > 0)
+            .slice(0, this._persistMaxEntries)
         }
 
         let peerSetChanged = this._applyPeerFeedKeys(conn, announcedKeys)
@@ -1781,7 +1807,7 @@ export class PublicFeed {
       console.log('[PublicFeed] FEED_RESPONSE received with', msg.keys?.length || 0, 'keys');
       let added = 0;
       const announcedKeys = Array.isArray(msg.keys)
-        ? msg.keys.filter((key) => typeof key === 'string' && key.length > 0)
+        ? msg.keys.filter((key) => typeof key === 'string' && key.length > 0).slice(0, this._persistMaxEntries)
         : []
       const peerSetChanged = this._applyPeerFeedKeys(conn, announcedKeys)
       try {
@@ -2102,7 +2128,17 @@ export class PublicFeed {
     this.hiddenKeys.add(driveKey);
     this.entries.delete(driveKey);
     console.log('[PublicFeed] Hidden channel:', driveKey.slice(0, 16));
+    this._persistHiddenChannels().catch(() => {})
     this._schedulePersistDiscovered()
+  }
+
+  async _persistHiddenChannels() {
+    if (!this.metaDb) return
+    try {
+      await this.metaDb.put(PUBLIC_FEED_HIDDEN_CHANNELS_KEY, Array.from(this.hiddenKeys))
+    } catch (err) {
+      console.log('[PublicFeed] Failed to persist hidden channels:', err?.message)
+    }
   }
 
   /**

--- a/packages/backend/src/seeding.js
+++ b/packages/backend/src/seeding.js
@@ -444,8 +444,9 @@ export class SeedingManager {
     const ref = normalizeSeedBlobRef(seed);
     if (!ref) return false;
 
+    let core = null;
     try {
-      const core = this.store.get(Buffer.from(ref.blobsCoreKey, 'hex'));
+      core = this.store.get(Buffer.from(ref.blobsCoreKey, 'hex'));
       await core.ready?.();
       const start = ref.blob.blockOffset;
       const end = ref.blob.blockOffset + ref.blob.blockLength;
@@ -456,6 +457,10 @@ export class SeedingManager {
       }
     } catch (err) {
       console.log('[SeedingManager] Failed to clear cached blob range:', err?.message);
+    } finally {
+      // store.get() opened a fresh session for this clear; release it so
+      // evictions don't accumulate open core sessions.
+      try { await core?.close?.(); } catch { /* best effort */ }
     }
 
     return false;

--- a/packages/backend/src/storage.js
+++ b/packages/backend/src/storage.js
@@ -2111,6 +2111,13 @@ export async function shutdownBackend(ctx) {
   ctx._isShutdown = true
   ctx.isShuttingDown = true
 
+  // The cast watchdog probes the blob server on an interval and force-resumes
+  // it; left running past shutdown it targets a closed server forever.
+  if (watchdogTimer) {
+    clearInterval(watchdogTimer)
+    watchdogTimer = null
+  }
+
   async function runShutdownStep(label, fn, timeoutMs = 5000) {
     let timeoutId = null
     let timedOut = false

--- a/packages/platform/src/rpc.native.ts
+++ b/packages/platform/src/rpc.native.ts
@@ -722,13 +722,20 @@ export async function startTranscodeWorklet(config: {
   const FS = normalizeFsModule(require('expo-file-system'));
   const FSLegacy = normalizeFsModule(require('expo-file-system/legacy'));
 
-  // Terminate any existing transcode worklet
+  // Terminate any existing transcode worklet, settling its pending promise
+  // so the previous caller is not left hanging forever.
   if (transcodeWorklet) {
     console.log('[Platform RPC] Terminating existing transcode worklet');
     try {
       transcodeWorklet.terminate();
     } catch {}
     transcodeWorklet = null;
+    if (_transcodeReject) {
+      _transcodeReject(new Error('Transcode superseded by a new request'));
+    }
+    _transcodeResolve = null;
+    _transcodeReject = null;
+    _transcodeCallbacks = {};
   }
 
   return new Promise((resolve, reject) => {
@@ -882,6 +889,11 @@ export function terminateTranscodeWorklet(): void {
       console.error('[Platform RPC] Failed to terminate transcode worklet:', err);
       transcodeWorklet = null;
     }
+  }
+  // Settle a still-pending transcode promise (no-op after complete/error,
+  // which clear these before terminating).
+  if (_transcodeReject) {
+    _transcodeReject(new Error('Transcode terminated'));
   }
   _transcodeCallbacks = {};
   _transcodeResolve = null;

--- a/packages/platform/src/rpc.web.ts
+++ b/packages/platform/src/rpc.web.ts
@@ -51,6 +51,7 @@ function createBridgePipe(specifier: string) {
   const listeners = new Map<string, Array<(...args: any[]) => void>>();
   let destroyed = false;
   let unsubscribe: (() => void) | null = null;
+  let offOutput: (() => void) | null = null;
 
   const pipe: any = {
     write(data: any) {
@@ -79,6 +80,7 @@ function createBridgePipe(specifier: string) {
       pipe.emit('close');
       listeners.clear();
       if (unsubscribe) unsubscribe();
+      if (offOutput) offOutput();
     },
     get destroyed() { return destroyed; },
     get writable() { return !destroyed; },
@@ -99,9 +101,13 @@ function createBridgePipe(specifier: string) {
   });
   const offExit = bridge.onWorkerExit(specifier, (code: number) => {
     console.log('[Worker] Exited with code:', code);
-    offStdout(); offStderr(); offExit();
     if (!destroyed) pipe.destroy();
   });
+  offOutput = () => {
+    offStdout();
+    offStderr();
+    offExit();
+  };
 
   return pipe;
 }


### PR DESCRIPTION
- orchestrator: preserve network/swarmOptions when retrying storage init
  after a Corestore seed mismatch fallback (previously dropped, leaving
  the swarm misconfigured after recovery)
- storage: clear the cast watchdog interval in shutdownBackend so it
  stops probing the blob server after the backend closes
- rpc.web: remove worker stdout/stderr/exit bridge listeners when the
  bridge pipe is destroyed before the worker exits
- rpc.native: reject pending transcode promises when a transcode is
  superseded or terminated instead of leaving callers hung forever

