### PR TITLE
Fix Android background playback resume: notification tap lands on player page, no seek gap

### DIFF
--- a/packages/app/lib/VideoPlayerContext.tsx
+++ b/packages/app/lib/VideoPlayerContext.tsx
@@ -723,6 +723,13 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
         const suppressWindow = suppressForegroundRestoreUntilRef.current > now
         const shouldSuppressRestore = suppressOnce || suppressWindow || wasInPip
 
+        // The native player kept playing through the background period
+        // (staysActiveInBackground + media notification). Reopening the app —
+        // most commonly by tapping the playback notification — should surface
+        // the player page rather than leave the session in the mini player.
+        const resumedWithBackgroundPlayback =
+          !wasInPip && Boolean(currentVideoRef.current) && wasPlayingWhenBackgroundedRef.current
+
         const skipLifecycleDispatchForSplitAndroid =
           Platform.OS === 'android' && ENABLE_ANDROID_SPLIT_PLAYER_ACTIVITY
         const skipAppForegroundDispatchForPip = Platform.OS === 'android' && wasInPip
@@ -743,6 +750,7 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
             appState: 'active',
             wasInPip,
             suppressRestore: shouldSuppressRestore,
+            resumedWithBackgroundPlayback,
           })
         }
 
@@ -760,9 +768,12 @@ export function VideoPlayerProvider({ children }: VideoPlayerProviderProps) {
           }
         }
 
-         // Foreground seek "nudge" is useful after backgrounding, but it can cause
-         // audible/visible stutter when returning from PiP (single-player continues).
-         if (!wasInPip && wasPlayingWhenBackgroundedRef.current && durationRef.current > 0) {
+         // Foreground seek "nudge" re-syncs the native player after backgrounding,
+         // but only when background playback actually stopped. If the player kept
+         // playing the whole time (background audio via the media notification),
+         // seeking forces ExoPlayer to rebuffer the P2P stream — an audible gap on
+         // resume — and can jump backwards when the JS-side position is stale.
+         if (!wasInPip && wasPlayingWhenBackgroundedRef.current && !isPlayingRef.current && durationRef.current > 0) {
            const seekValue = currentTimeRef.current / durationRef.current
            setSeekPosition(seekValue)
            setTimeout(() => setSeekPosition(undefined), 100)

--- a/packages/app/lib/playerStateMachine.ts
+++ b/packages/app/lib/playerStateMachine.ts
@@ -116,6 +116,11 @@ export type PlayerEvent =
       appState: 'active'
       wasInPip: boolean
       suppressRestore: boolean
+      // True when the native player kept playing through the background period
+      // (background audio via the media notification). Reopening the app then —
+      // most commonly by tapping the playback notification — should land on the
+      // player page, not on whatever screen hosted the mini player.
+      resumedWithBackgroundPlayback: boolean
     }
   | {
       type: 'REMOTE_PLAY'
@@ -604,7 +609,7 @@ function playerReducerInternal(state: PlayerState, event: PlayerEvent): PlayerSt
           }
           return {
             ...state,
-            mode: event.wasInPip ? 'fullscreen' : 'mini',
+            mode: event.wasInPip || event.resumedWithBackgroundPlayback ? 'fullscreen' : 'mini',
           }
         case 'REMOTE_PLAY':
           return {

--- a/packages/app/tests/android-background-playback-foreground-regression.test.mjs
+++ b/packages/app/tests/android-background-playback-foreground-regression.test.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { test } from 'node:test'
+
+const contextPath = new URL('../lib/VideoPlayerContext.tsx', import.meta.url)
+const stateMachinePath = new URL('../lib/playerStateMachine.ts', import.meta.url)
+
+test('foreground return does not seek-nudge while background playback kept running', async () => {
+  const src = await readFile(contextPath, 'utf8')
+
+  // The nudge seeks the native player to the JS-side position. When the player
+  // kept playing in the background (media notification / staysActiveInBackground),
+  // that seek forces a P2P rebuffer — an audible gap on resume — and can jump
+  // backwards when the JS position is stale. It must only run when background
+  // playback actually stopped.
+  assert.match(
+    src,
+    /!wasInPip && wasPlayingWhenBackgroundedRef\.current && !isPlayingRef\.current && durationRef\.current > 0/,
+    'foreground seek nudge must be gated on background playback having stopped (!isPlayingRef.current)',
+  )
+})
+
+test('reopening the app during background playback surfaces the player page', async () => {
+  const stateMachine = await readFile(stateMachinePath, 'utf8')
+  const context = await readFile(contextPath, 'utf8')
+
+  // Tapping the media playback notification resumes MainActivity with no extra
+  // signal, so APP_FOREGROUND must carry whether the session kept playing in the
+  // background and restore the fullscreen player page from mini mode.
+  assert.match(
+    stateMachine,
+    /resumedWithBackgroundPlayback: boolean/,
+    'APP_FOREGROUND event must carry resumedWithBackgroundPlayback',
+  )
+  assert.match(
+    stateMachine,
+    /event\.wasInPip \|\| event\.resumedWithBackgroundPlayback \? 'fullscreen' : 'mini'/,
+    'mini + APP_FOREGROUND must restore fullscreen when playback continued in background',
+  )
+  assert.match(
+    context,
+    /resumedWithBackgroundPlayback =\s*\n?\s*!wasInPip && Boolean\(currentVideoRef\.current\) && wasPlayingWhenBackgroundedRef\.current/,
+    'AppState foreground handler must compute resumedWithBackgroundPlayback from the backgrounded playback state',
+  )
+})


### PR DESCRIPTION
Two fixes for returning to the app while a video keeps playing in the
background via the media notification (staysActiveInBackground):

1. Tapping the playback notification (or reopening the app) while the
   session was backgrounded from the mini player now restores the
   fullscreen player page instead of leaving the video in the mini
   player on whatever screen was open. APP_FOREGROUND carries a new
   resumedWithBackgroundPlayback flag and the mini-mode reducer
   transitions to fullscreen when it is set.

2. The foreground seek "nudge" no longer fires when the native player
   kept playing through the background period. Seeking an already-
   playing ExoPlayer to the JS-side position forced a rebuffer of the
   P2P stream (audible gap on resume) and could jump backwards when the
   JS position was stale (e.g. iOS JS suspension). The nudge is now
   gated on background playback having actually stopped.

