### PR TITLE
Add per-stage playback timing instrumentation to preparePlayback

### DIFF
--- a/packages/app/app/video/[id].tsx
+++ b/packages/app/app/video/[id].tsx
@@ -462,7 +462,7 @@ function MobileVideoPlayerScreen() {
     statsPollingRef.current = setInterval(pollStats, 1000)
   }, [clearStatsPolling, rpc, videoData])
 
-  const scheduleStatsPolling = useCallback((delayMs = 500) => {
+  const scheduleStatsPolling = useCallback((delayMs = 0) => {
     if (statsPollingDelayRef.current) {
       clearTimeout(statsPollingDelayRef.current)
     }
@@ -516,12 +516,12 @@ function MobileVideoPlayerScreen() {
               setLocalStats(result.stats as VideoStats)
             }
             if (!isStatsComplete(result?.stats as VideoStats | null | undefined)) {
-              scheduleStatsPolling(500)
+              scheduleStatsPolling(0)
             }
           }).catch((err: any) => {
             console.error('[VideoPlayer] preparePlayback failed:', err)
             if (!mountedRef.current || loadGenerationRef.current !== generation) return
-            scheduleStatsPolling(500)
+            scheduleStatsPolling(0)
           })
         }
         return
@@ -547,14 +547,14 @@ function MobileVideoPlayerScreen() {
 
         if (Platform.OS !== 'web' || isPear) {
           if (!isStatsComplete(result?.stats as VideoStats | null | undefined)) {
-            scheduleStatsPolling(500)
+            scheduleStatsPolling(0)
           }
         }
       } else {
         if (result?.stats) {
           setLocalStats(result.stats as VideoStats)
         }
-        scheduleStatsPolling(500)
+        scheduleStatsPolling(0)
       }
     } catch (err) {
       console.error('[VideoPlayer] Failed to load video:', err)

--- a/packages/app/components/native-diagnostics/DiagnosticsPanel.android.tsx
+++ b/packages/app/components/native-diagnostics/DiagnosticsPanel.android.tsx
@@ -60,6 +60,7 @@ export default function DiagnosticsPanel({
   const feedConnections = network?.feed?.feedConnections ?? swarmStatus?.feedConnections ?? 0
   const dht = network?.dht
   const lastHaveFeed = network?.feed?.lastHaveFeed
+  const lastPlayback = network?.playback?.lastPreparePlayback
 
   return (
     <View style={styles.root}>
@@ -123,6 +124,29 @@ export default function DiagnosticsPanel({
           </Text>
         ) : null}
       </View>
+
+      {lastPlayback ? (
+        <View style={styles.card}>
+          <Text style={styles.cardTitle}>Playback timing</Text>
+          <Text style={styles.statusText}>
+            {lastPlayback.videoId || 'unknown video'}
+            {lastPlayback.readyForPlayback === true ? ' • ready' : lastPlayback.readyForPlayback === false ? ' • not ready' : ''}
+          </Text>
+          <View style={styles.metricRow}>
+            <Metric label="Total" value={`${lastPlayback.stages?.totalMs ?? '—'} ms`} />
+            <Metric label="URL" value={`${lastPlayback.stages?.urlResolvedMs ?? '—'} ms`} />
+            <Metric label="Head block" value={`${lastPlayback.stages?.headBlockMs ?? '—'} ms`} />
+          </View>
+          <Text style={styles.detailText}>
+            Hints: {lastPlayback.stages?.hintsMs ?? '—'} ms • Core ready: {lastPlayback.stages?.blobCoreReadyMs ?? '—'} ms
+            {' '}• Peers retained: {lastPlayback.stages?.peersRetainedMs ?? '—'} ms
+          </Text>
+          <Text style={styles.detailText}>
+            First blob peer: {lastPlayback.stages?.firstBlobPeerMs ?? '—'} ms • Warmup done: {lastPlayback.stages?.warmupDoneMs ?? '—'} ms
+            {' '}• Blob peers: {lastPlayback.peerCount ?? '—'}
+          </Text>
+        </View>
+      ) : null}
 
       <View style={styles.card}>
         <Text style={styles.cardTitle}>Network info</Text>

--- a/packages/app/components/native-diagnostics/types.ts
+++ b/packages/app/components/native-diagnostics/types.ts
@@ -29,7 +29,7 @@ export interface PlaybackTimingRecord {
     blobCoreReadyMs?: number
     peersRetainedMs?: number
     hintsPromotedMs?: number
-    updateWaitMs?: number
+    hintsArrivedMs?: number
     firstBlobPeerMs?: number
     headBlockMs?: number
     warmupDoneMs?: number

--- a/packages/app/components/native-diagnostics/types.ts
+++ b/packages/app/components/native-diagnostics/types.ts
@@ -16,6 +16,28 @@ export interface SeedingStatus {
   } | null
 }
 
+export interface PlaybackTimingRecord {
+  at?: number
+  driveKey?: string | null
+  videoId?: string | null
+  readyForPlayback?: boolean | null
+  peerCount?: number | null
+  hasHeadBlock?: boolean | null
+  stages?: {
+    hintsMs?: number
+    urlResolvedMs?: number
+    blobCoreReadyMs?: number
+    peersRetainedMs?: number
+    hintsPromotedMs?: number
+    updateWaitMs?: number
+    firstBlobPeerMs?: number
+    headBlockMs?: number
+    warmupDoneMs?: number
+    returnedMs?: number
+    totalMs?: number
+  } | null
+}
+
 export interface SwarmStatus {
   connected?: boolean
   peerCount?: number
@@ -58,6 +80,10 @@ export interface SwarmStatus {
         lastRejectReason?: string | null
       } | null
     }
+    playback?: {
+      lastPreparePlayback?: PlaybackTimingRecord | null
+      recentPreparePlayback?: PlaybackTimingRecord[]
+    } | null
     recommendedBoundary?: string | null
   } | null
   swarmOffline?: boolean

--- a/packages/app/lib/thumbnail.ts
+++ b/packages/app/lib/thumbnail.ts
@@ -18,8 +18,8 @@ const READY_ATTEMPTS = 5
 const READY_TIMEOUT_MS = 1_500
 const READY_RETRY_DELAY_MS = 250
 
-const THUMBNAIL_ATTEMPTS = 4
-const THUMBNAIL_TIMEOUT_MS = 2_500
+const THUMBNAIL_ATTEMPTS = 3
+const THUMBNAIL_TIMEOUT_MS = 1_500
 const THUMBNAIL_RETRY_DELAY_MS = 300
 
 const readinessCache = new WeakMap<object, { checkedAt: number; ready: boolean }>()
@@ -94,6 +94,20 @@ export async function ensureThumbnailBackendReady(
   }
 }
 
+async function attemptThumbnailFetch(
+  rpc: ThumbnailRPC,
+  channelKey: string,
+  videoId: string,
+  timeoutMs: number
+): Promise<string | null> {
+  try {
+    const response = await withTimeout(rpc.getVideoThumbnail({ channelKey, videoId }), timeoutMs)
+    const url = response?.dataUrl || response?.url
+    if (response?.exists && url) return url
+  } catch {}
+  return null
+}
+
 export async function fetchThumbnailUrlWithRetry(args: {
   rpc: ThumbnailRPC | null | undefined
   channelKey: string
@@ -103,24 +117,24 @@ export async function fetchThumbnailUrlWithRetry(args: {
   const { rpc, channelKey, videoId, expectedPort } = args
   if (!rpc || !channelKey || !videoId) return null
 
+  // Fast path: fetch immediately. Feed previews already carry thumbnail refs
+  // backend-side, so the first attempt usually succeeds without paying for a
+  // readiness probe first.
+  const firstUrl = await attemptThumbnailFetch(rpc, channelKey, videoId, THUMBNAIL_TIMEOUT_MS)
+  if (firstUrl) {
+    readinessCache.set(rpc as object, { checkedAt: Date.now(), ready: true })
+    return firstUrl
+  }
+
+  // Slow path: the immediate fetch failed — gate the remaining retries on
+  // backend readiness so we don't hammer a worklet that is still booting.
   const backendReady = await ensureThumbnailBackendReady(rpc, expectedPort)
   if (!backendReady) return null
 
-  for (let attempt = 0; attempt < THUMBNAIL_ATTEMPTS; attempt += 1) {
-    try {
-      const response = await withTimeout(
-        rpc.getVideoThumbnail({ channelKey, videoId }),
-        THUMBNAIL_TIMEOUT_MS + attempt * 500
-      )
-      const url = response?.dataUrl || response?.url
-      if (response?.exists && url) {
-        return url
-      }
-    } catch {}
-
-    if (attempt < THUMBNAIL_ATTEMPTS - 1) {
-      await sleep(THUMBNAIL_RETRY_DELAY_MS * (attempt + 1))
-    }
+  for (let attempt = 1; attempt < THUMBNAIL_ATTEMPTS; attempt += 1) {
+    await sleep(THUMBNAIL_RETRY_DELAY_MS * attempt)
+    const url = await attemptThumbnailFetch(rpc, channelKey, videoId, THUMBNAIL_TIMEOUT_MS + attempt * 500)
+    if (url) return url
   }
 
   return null

--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -110,6 +110,18 @@ export function createApi({
   const signedDescriptorCache = new Map()
 
   /**
+   * Recent preparePlayback timing breakdowns (per-stage ms offsets from request
+   * start). Surfaced via getSwarmStatus doctor.playback so the on-device
+   * diagnostics panel can show where time-to-first-frame goes.
+   */
+  const recentPlaybackTimings = []
+  const trackPlaybackTiming = (record) => {
+    recentPlaybackTimings.push(record)
+    while (recentPlaybackTimings.length > 8) recentPlaybackTimings.shift()
+    return record
+  }
+
+  /**
    * Ensure SemanticFinder is initialized with persistence
    * YouTube-Fast: loads persisted index on first use for instant search
    */
@@ -1128,6 +1140,16 @@ export function createApi({
      */
     async preparePlayback(driveKey, videoPath, publicBeeKey, blobId, blobsCoreKey, mimeType) {
       console.log('[API] preparePlayback:', driveKey?.slice(0, 16), videoPath)
+      const startedAt = Date.now()
+      const timingRecord = trackPlaybackTiming({
+        at: startedAt,
+        driveKey: driveKey ? String(driveKey).slice(0, 16) : null,
+        videoId: videoPath || null,
+        stages: {},
+        readyForPlayback: null,
+        peerCount: null,
+        hasHeadBlock: null,
+      })
 
       const playbackBlobRef = resolvePlaybackBlobRef(driveKey, videoPath, publicBeeKey, blobId, blobsCoreKey, mimeType)
       let sourcePeerDiagnostics = { sourceFeedPeerIds: [], sourceRelayPeerIds: [] }
@@ -1149,6 +1171,7 @@ export function createApi({
             : []
           sourcePeerDiagnostics = collectHintPeerIds(matchingHints)
         } catch { /* best effort */ }
+        timingRecord.stages.hintsMs = Date.now() - startedAt
       }
       const promotePeerHints = publicFeed?.promoteAvailabilityHintPeers
         ? (peerIds, topic) => publicFeed.promoteAvailabilityHintPeers(peerIds, topic)
@@ -1165,10 +1188,16 @@ export function createApi({
         sourceFeedPeerIds: sourcePeerDiagnostics.sourceFeedPeerIds,
         sourceRelayPeerIds: sourcePeerDiagnostics.sourceRelayPeerIds,
         promotePeerHints,
+        timingBaseMs: startedAt,
         warmup: (...args) => this.prefetchVideo(...args),
         resolveUrl: (...args) => this.getVideoUrl(...args),
         getStats: (...args) => this.getVideoStats(...args),
       })
+      Object.assign(timingRecord.stages, prepared?.timing || {})
+      timingRecord.stages.totalMs = Date.now() - startedAt
+      timingRecord.readyForPlayback = prepared?.selectedBlobWarmup?.readyForPlayback ?? null
+      timingRecord.peerCount = prepared?.selectedBlobWarmup?.peerCount ?? null
+      timingRecord.hasHeadBlock = prepared?.selectedBlobWarmup?.hasHeadBlock ?? null
       if (prepared?.selectedBlobWarmup && prepared.selectedBlobWarmup.readyForPlayback !== true) {
         const warm = prepared.selectedBlobWarmup
         console.log(
@@ -2932,6 +2961,10 @@ export function createApi({
           feedEntries: publicFeed?.entries?.size || 0,
           directPeerDial: feedStats.directPeerDial || null,
           lastHaveFeed: feedStats.lastHaveFeed || null,
+        },
+        playback: {
+          lastPreparePlayback: recentPlaybackTimings[recentPlaybackTimings.length - 1] || null,
+          recentPreparePlayback: recentPlaybackTimings.slice(-5),
         },
         recommendedBoundary: null,
       }

--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -1153,25 +1153,31 @@ export function createApi({
 
       const playbackBlobRef = resolvePlaybackBlobRef(driveKey, videoPath, publicBeeKey, blobId, blobsCoreKey, mimeType)
       let sourcePeerDiagnostics = { sourceFeedPeerIds: [], sourceRelayPeerIds: [] }
+      // Fire the availability-hint request without blocking playback prep.
+      // Hints feed peer promotion inside the blob warmup as they arrive.
+      let peerHintsPromise = null
       if (playbackBlobRef?.blobId && playbackBlobRef?.blobsCoreKey && publicFeed?.requestAvailabilityHints) {
-        try {
-          const hints = await publicFeed.requestAvailabilityHints([{
-            driveKey,
-            publicBeeKey,
-            id: videoPath,
-            blobsCoreKey: playbackBlobRef.blobsCoreKey,
-            blobId: playbackBlobRef.blobId,
-          }], { timeoutMs: 500, maxPeers: 4 })
-          const matchingHints = Array.isArray(hints)
-            ? hints.filter((hint) => hintMatchesBlobRef(hint, {
+        peerHintsPromise = (async () => {
+          try {
+            const hints = await publicFeed.requestAvailabilityHints([{
+              driveKey,
+              publicBeeKey,
               id: videoPath,
               blobsCoreKey: playbackBlobRef.blobsCoreKey,
               blobId: playbackBlobRef.blobId,
-            }))
-            : []
-          sourcePeerDiagnostics = collectHintPeerIds(matchingHints)
-        } catch { /* best effort */ }
-        timingRecord.stages.hintsMs = Date.now() - startedAt
+            }], { timeoutMs: 500, maxPeers: 4 })
+            const matchingHints = Array.isArray(hints)
+              ? hints.filter((hint) => hintMatchesBlobRef(hint, {
+                id: videoPath,
+                blobsCoreKey: playbackBlobRef.blobsCoreKey,
+                blobId: playbackBlobRef.blobId,
+              }))
+              : []
+            sourcePeerDiagnostics = collectHintPeerIds(matchingHints)
+          } catch { /* best effort */ }
+          timingRecord.stages.hintsMs = Date.now() - startedAt
+          return sourcePeerDiagnostics
+        })()
       }
       const promotePeerHints = publicFeed?.promoteAvailabilityHintPeers
         ? (peerIds, topic) => publicFeed.promoteAvailabilityHintPeers(peerIds, topic)
@@ -1188,6 +1194,7 @@ export function createApi({
         sourceFeedPeerIds: sourcePeerDiagnostics.sourceFeedPeerIds,
         sourceRelayPeerIds: sourcePeerDiagnostics.sourceRelayPeerIds,
         promotePeerHints,
+        peerHintsPromise,
         timingBaseMs: startedAt,
         warmup: (...args) => this.prefetchVideo(...args),
         resolveUrl: (...args) => this.getVideoUrl(...args),

--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -1510,19 +1510,29 @@ export function createApi({
             try { ctx.swarm.join(blobsCore.discoveryKey) } catch { /* best effort */ }
           }
 
-          try {
-            await Promise.race([
-              blobsCore.update({ wait: true }),
-              new Promise((_, reject) => setTimeout(() => reject(new Error('thumbnail core update timeout')), 10000))
-            ]);
-          } catch { /* best effort */ }
-
           const blob = normalizeBlobRefInput(meta.thumbnailBlobId) || parseBlobRef({
             blobsCoreKey: meta.thumbnailBlobsCoreKey,
             blobId: meta.thumbnailBlobId,
           })?.blob
           if (!blob) {
             return { exists: false, error: 'Invalid thumbnail blob ID format' }
+          }
+
+          // Serve immediately when the thumbnail bytes are already local;
+          // update({wait: true}) would otherwise block on the network (it
+          // used to stall thumbnail loads for up to 10s). The blob server
+          // fetches missing bytes on demand anyway.
+          let thumbnailLocal = false
+          try {
+            thumbnailLocal = Boolean(await blobsCore.has(blob.blockOffset, blob.blockOffset + Math.max(1, blob.blockLength || 1)))
+          } catch { /* best effort */ }
+          if (!thumbnailLocal) {
+            try {
+              await Promise.race([
+                blobsCore.update({ wait: true }),
+                new Promise((_, reject) => setTimeout(() => reject(new Error('thumbnail core update timeout')), 1500))
+              ]);
+            } catch { /* best effort */ }
           }
 
           const thumbnailMimeType = typeof meta.thumbnailMimeType === 'string' && meta.thumbnailMimeType.length > 0

--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -103,7 +103,21 @@ export function createApi({
   }
 
   const loadChannelBounded = async (channelKey, timeoutMs = 2500) => {
-    return withTimeout(loadChannel(ctx, channelKey), timeoutMs, `loadChannel ${channelKey?.slice?.(0, 16) || ''}`)
+    const label = `loadChannel ${channelKey?.slice?.(0, 16) || ''}`
+    // Already-loaded channels resolve from the in-memory cache — no timeout needed.
+    if (ctx.channels?.has?.(channelKey)) {
+      return loadChannel(ctx, channelKey)
+    }
+    try {
+      return await withTimeout(loadChannel(ctx, channelKey), timeoutMs, label)
+    } catch (err) {
+      if (!/timeout/i.test(err?.message || '')) throw err
+      // Slow networks routinely blow the first deadline while the underlying
+      // load keeps going (loadChannel dedupes concurrent loads), so retry once
+      // with a doubled budget instead of failing hard.
+      console.warn(`[API] ${label} timed out after ${timeoutMs}ms, retrying once`)
+      return withTimeout(loadChannel(ctx, channelKey), timeoutMs * 2, `${label} retry`)
+    }
   }
 
   /** @type {Map<string, {value: object|null, at: number}>} driveKey → cached signed channel root descriptor (misses retried after 60s) */

--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -961,21 +961,35 @@ export function createApi({
         }
 
         const attachVideoAvailability = async (videos) => {
-          return await Promise.all(cloneArrayOfObjects(videos).map(async (video) => {
-            const localHint = await getLocalVideoAvailabilityHint(video)
-            let peerHint = null
-            if (publicFeed && typeof publicFeed.requestAvailabilityHints === 'function') {
-              try {
-                const hints = await publicFeed.requestAvailabilityHints([{
-                  driveKey,
-                  publicBeeKey,
-                  id: video?.id,
-                  blobsCoreKey: video?.blobsCoreKey,
-                  blobId: video?.blobId,
-                }])
-                peerHint = Array.isArray(hints) ? hints.find((hint) => hintMatchesBlobRef(hint, video)) || null : null
-              } catch { /* best effort */ }
-            }
+          const cloned = cloneArrayOfObjects(videos)
+          const localHints = await Promise.all(cloned.map((video) => getLocalVideoAvailabilityHint(video)))
+
+          // One bounded, batched hint round trip for videos that still lack
+          // local byte proof — instead of a per-video network RPC (each riding
+          // the peer scorer's multi-second timeout) across the whole list.
+          const MAX_NETWORK_HINTS = 12
+          let peerHints = []
+          const hintRequests = cloned
+            .filter((video, index) => !hasPlayableByteProof(localHints[index]) &&
+              extractVideoId(video) && video?.blobsCoreKey && video?.blobId)
+            .slice(0, MAX_NETWORK_HINTS)
+            .map((video) => ({
+              driveKey,
+              publicBeeKey,
+              id: extractVideoId(video),
+              blobsCoreKey: video.blobsCoreKey,
+              blobId: video.blobId,
+            }))
+          if (hintRequests.length > 0 && publicFeed && typeof publicFeed.requestAvailabilityHints === 'function') {
+            try {
+              const hints = await publicFeed.requestAvailabilityHints(hintRequests, { timeoutMs: 600, maxPeers: 4 })
+              peerHints = Array.isArray(hints) ? hints : []
+            } catch { /* best effort */ }
+          }
+
+          return cloned.map((video, index) => {
+            const localHint = localHints[index]
+            const peerHint = peerHints.find((hint) => hintMatchesBlobRef(hint, video)) || null
             const availability = resolveExplicitVideoAvailability({ localHint, peerHint, video })
             const proofHint = hasPlayableByteProof(localHint)
               ? localHint
@@ -992,7 +1006,7 @@ export function createApi({
               hasHeadBlock: Boolean(proofHint?.hasHeadBlock),
               readyForPlayback: availability === 'playable' && Boolean(proofHint),
             }
-          }))
+          })
         }
 
         const cached = listVideosCache.get(driveKey)

--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -1153,10 +1153,18 @@ export function createApi({
 
       const playbackBlobRef = resolvePlaybackBlobRef(driveKey, videoPath, publicBeeKey, blobId, blobsCoreKey, mimeType)
       let sourcePeerDiagnostics = { sourceFeedPeerIds: [], sourceRelayPeerIds: [] }
+      const hasDirectBlobRef = Boolean(playbackBlobRef?.blobId && playbackBlobRef?.blobsCoreKey)
+      // Known feed peers that announced this channel are available synchronously
+      // — promote them right away instead of waiting on any hint round trip.
+      if (hasDirectBlobRef && typeof publicFeed?.getEntryFeedPeerIds === 'function') {
+        try {
+          sourcePeerDiagnostics.sourceFeedPeerIds = publicFeed.getEntryFeedPeerIds(driveKey) || []
+        } catch { /* best effort */ }
+      }
       // Fire the availability-hint request without blocking playback prep.
       // Hints feed peer promotion inside the blob warmup as they arrive.
       let peerHintsPromise = null
-      if (playbackBlobRef?.blobId && playbackBlobRef?.blobsCoreKey && publicFeed?.requestAvailabilityHints) {
+      if (hasDirectBlobRef && publicFeed?.requestAvailabilityHints) {
         peerHintsPromise = (async () => {
           try {
             const hints = await publicFeed.requestAvailabilityHints([{
@@ -1173,7 +1181,11 @@ export function createApi({
                 blobId: playbackBlobRef.blobId,
               }))
               : []
-            sourcePeerDiagnostics = collectHintPeerIds(matchingHints)
+            const hinted = collectHintPeerIds(matchingHints)
+            sourcePeerDiagnostics = {
+              sourceFeedPeerIds: Array.from(new Set([...sourcePeerDiagnostics.sourceFeedPeerIds, ...hinted.sourceFeedPeerIds])),
+              sourceRelayPeerIds: Array.from(new Set([...sourcePeerDiagnostics.sourceRelayPeerIds, ...hinted.sourceRelayPeerIds])),
+            }
           } catch { /* best effort */ }
           timingRecord.stages.hintsMs = Date.now() - startedAt
           return sourcePeerDiagnostics

--- a/packages/backend/src/blob-playback-service.js
+++ b/packages/backend/src/blob-playback-service.js
@@ -253,18 +253,16 @@ export class BlobPlaybackService {
       }
 
       const startedAt = Date.now()
-      try {
-        await Promise.race([
-          blobsCore.update({ wait: true }),
-          wait(Math.max(1, Math.min(timeoutMs, 250))),
-        ])
-      } catch { /* best effort */ }
-      markTiming('updateWaitMs')
+      // Kick a DHT/network update without blocking the head-block wait —
+      // known peers were already promoted above, so replication can start
+      // over existing connections while discovery catches up.
+      try { blobsCore.update({ wait: true }).catch(() => {}) } catch { /* best effort */ }
 
       updatePeerDiagnostics()
       await updateHeadAvailability()
-      while (!diagnostics.hasHeadBlock && Date.now() - startedAt < timeoutMs) {
-        await wait(Math.min(100, Math.max(1, timeoutMs - (Date.now() - startedAt))))
+      if (!diagnostics.hasHeadBlock) {
+        const deadline = startedAt + timeoutMs
+        await this._waitForHeadBlock(blobsCore, ref.blob.blockOffset, deadline)
         updatePeerDiagnostics()
         await updateHeadAvailability()
       }
@@ -277,6 +275,54 @@ export class BlobPlaybackService {
       markTiming('warmupDoneMs')
       return diagnostics
     }
+  }
+
+  /**
+   * Wait for the head block of the selected blob to become available, bounded
+   * by `deadline`. Prefers requesting the block directly (hypercore downloads
+   * it from any connected peer and resolves the moment it lands) over passive
+   * polling.
+   */
+  async _waitForHeadBlock(blobsCore, blockIndex, deadline) {
+    const remaining = () => deadline - Date.now()
+    if (remaining() <= 0) return false
+
+    if (typeof blobsCore.get === 'function') {
+      try {
+        const block = await blobsCore.get(blockIndex, { wait: true, timeout: Math.max(1, remaining()) })
+        return block != null
+      } catch {
+        return false
+      }
+    }
+
+    // Event-driven fallback for cores without get(): resolve on append/download.
+    if (typeof blobsCore.on === 'function' && typeof blobsCore.off === 'function') {
+      return await new Promise((resolve) => {
+        let settled = false
+        const finish = (value) => {
+          if (settled) return
+          settled = true
+          clearTimeout(timer)
+          try { blobsCore.off('append', onEvent) } catch { /* best effort */ }
+          try { blobsCore.off('download', onEvent) } catch { /* best effort */ }
+          resolve(value)
+        }
+        const onEvent = () => {
+          Promise.resolve(blobsCore.has?.(blockIndex, blockIndex + 1))
+            .then((has) => { if (has) finish(true) })
+            .catch(() => {})
+        }
+        const timer = setTimeout(() => finish(false), Math.max(1, remaining()))
+        blobsCore.on('append', onEvent)
+        blobsCore.on('download', onEvent)
+        onEvent()
+      })
+    }
+
+    // Last resort (minimal cores/mocks): single bounded sleep, caller rechecks.
+    await wait(Math.max(1, remaining()))
+    return false
   }
 
   async resolveFromMetadata(meta, { channel } = {}) {

--- a/packages/backend/src/blob-playback-service.js
+++ b/packages/backend/src/blob-playback-service.js
@@ -148,11 +148,17 @@ export class BlobPlaybackService {
     sourceFeedPeerIds = [],
     sourceRelayPeerIds = [],
     promotePeerHints = null,
+    timingBaseMs = Date.now(),
   }) {
     const ref = parseBlobRef({ blobsCoreKey, blobId, mimeType: 'video/mp4' })
     const feedIds = uniquePeerIds(sourceFeedPeerIds)
     const relayIds = uniquePeerIds(sourceRelayPeerIds)
+    const timing = {}
+    const markTiming = (name) => {
+      if (timing[name] === undefined) timing[name] = Date.now() - timingBaseMs
+    }
     const diagnostics = {
+      timing,
       blobsCoreKey: ref?.blobsCoreKey || blobsCoreKey || null,
       blobId: blobId ? String(blobId) : null,
       peerCount: 0,
@@ -184,6 +190,7 @@ export class BlobPlaybackService {
       diagnostics.blobPeerIds = peerIds
       diagnostics.blobPeerIdsJson = JSON.stringify(peerIds)
       diagnostics.feedRelayAlsoBlobPeer = relayIds.some((id) => peerIds.includes(id)) || feedIds.some((id) => peerIds.includes(id))
+      if (diagnostics.peerCount > 0) markTiming('firstBlobPeerMs')
     }
 
     const updateHeadAvailability = async () => {
@@ -198,7 +205,9 @@ export class BlobPlaybackService {
 
     try {
       await blobsCore.ready()
+      markTiming('blobCoreReadyMs')
       const retained = await this.retainBlobCorePeers(ref.blobsCoreKey, blobsCore)
+      markTiming('peersRetainedMs')
       diagnostics.retainedDiscoveryLabel = retained.retainedDiscoveryLabel || diagnostics.retainedDiscoveryLabel
       diagnostics.retainedDiscoveryStatus = retained.retainedDiscoveryStatus || (retained.retained ? 'retained' : 'not-retained')
       updatePeerDiagnostics()
@@ -214,6 +223,7 @@ export class BlobPlaybackService {
         } catch (err) {
           diagnostics.promotedPeerHintsJson = JSON.stringify([{ error: err?.message || String(err) }])
         }
+        markTiming('hintsPromotedMs')
       }
 
       const startedAt = Date.now()
@@ -223,6 +233,7 @@ export class BlobPlaybackService {
           wait(Math.max(1, Math.min(timeoutMs, 250))),
         ])
       } catch { /* best effort */ }
+      markTiming('updateWaitMs')
 
       updatePeerDiagnostics()
       await updateHeadAvailability()
@@ -231,10 +242,13 @@ export class BlobPlaybackService {
         updatePeerDiagnostics()
         await updateHeadAvailability()
       }
+      if (diagnostics.hasHeadBlock) markTiming('headBlockMs')
+      markTiming('warmupDoneMs')
 
       return diagnostics
     } catch (err) {
       diagnostics.error = err?.message || String(err)
+      markTiming('warmupDoneMs')
       return diagnostics
     }
   }
@@ -285,12 +299,14 @@ export class BlobPlaybackService {
     sourceFeedPeerIds = [],
     sourceRelayPeerIds = [],
     promotePeerHints = null,
+    timingBaseMs = Date.now(),
   }) {
     let warmupStarted = false
 
     const result = resolveUrl
       ? await resolveUrl(driveKey, videoPath, publicBeeKey, blobId, blobsCoreKey, mimeType)
       : this.resolveDirectBlobUrl({ blobsCoreKey, blobId, mimeType })
+    const urlResolvedMs = Date.now() - timingBaseMs
 
     try {
       if (warmup) {
@@ -312,6 +328,7 @@ export class BlobPlaybackService {
           sourceFeedPeerIds,
           sourceRelayPeerIds,
           promotePeerHints,
+          timingBaseMs,
         })
         : null
       const peerWarmup = this.waitForBlobCorePeers(blobsCoreKey, { minPeers: 1, timeoutMs: 1500, pollMs: 100 }).catch((err) => {
@@ -324,6 +341,11 @@ export class BlobPlaybackService {
         warmupStarted,
         peerWarmupStarted: true,
         selectedBlobWarmup,
+        timing: {
+          urlResolvedMs,
+          ...(selectedBlobWarmup?.timing || {}),
+          returnedMs: Date.now() - timingBaseMs,
+        },
         peerWarmup: await Promise.race([
           peerWarmup,
           wait(0).then(() => ({ peerCount: 0, blobPeerIds: [], retained: false, timedOut: false })),
@@ -336,6 +358,10 @@ export class BlobPlaybackService {
       stats: typeof getStats === 'function' ? getStats(driveKey, videoPath) : undefined,
       warmupStarted,
       peerWarmupStarted: false,
+      timing: {
+        urlResolvedMs,
+        returnedMs: Date.now() - timingBaseMs,
+      },
     }
   }
 }

--- a/packages/backend/src/blob-playback-service.js
+++ b/packages/backend/src/blob-playback-service.js
@@ -148,6 +148,7 @@ export class BlobPlaybackService {
     sourceFeedPeerIds = [],
     sourceRelayPeerIds = [],
     promotePeerHints = null,
+    peerHintsPromise = null,
     timingBaseMs = Date.now(),
   }) {
     const ref = parseBlobRef({ blobsCoreKey, blobId, mimeType: 'video/mp4' })
@@ -203,6 +204,27 @@ export class BlobPlaybackService {
       diagnostics.readyForPlayback = diagnostics.hasHeadBlock
     }
 
+    const promotedPeerSummaries = []
+    const promoteHintIds = (ids) => {
+      const merged = uniquePeerIds(ids)
+      if (merged.length === 0 || typeof promotePeerHints !== 'function') return
+      try {
+        const promoted = promotePeerHints(merged, blobsCore.discoveryKey)
+        if (Array.isArray(promoted)) {
+          promotedPeerSummaries.push(...promoted.map((peer) => ({
+            key: typeof peer?.key === 'string' ? peer.key.slice(0, 16) : null,
+            connected: Boolean(peer?.connected),
+            explicit: Boolean(peer?.explicit),
+            relayAddresses: Number(peer?.relayAddresses || 0),
+          })))
+        }
+      } catch (err) {
+        promotedPeerSummaries.push({ error: err?.message || String(err) })
+      }
+      diagnostics.promotedPeerHintsJson = JSON.stringify(promotedPeerSummaries)
+      markTiming('hintsPromotedMs')
+    }
+
     try {
       await blobsCore.ready()
       markTiming('blobCoreReadyMs')
@@ -211,19 +233,23 @@ export class BlobPlaybackService {
       diagnostics.retainedDiscoveryLabel = retained.retainedDiscoveryLabel || diagnostics.retainedDiscoveryLabel
       diagnostics.retainedDiscoveryStatus = retained.retainedDiscoveryStatus || (retained.retained ? 'retained' : 'not-retained')
       updatePeerDiagnostics()
-      if (typeof promotePeerHints === 'function' && (feedIds.length > 0 || relayIds.length > 0)) {
-        try {
-          const promoted = promotePeerHints(uniquePeerIds([...feedIds, ...relayIds]), blobsCore.discoveryKey)
-          diagnostics.promotedPeerHintsJson = JSON.stringify(Array.isArray(promoted) ? promoted.map((peer) => ({
-            key: typeof peer?.key === 'string' ? peer.key.slice(0, 16) : null,
-            connected: Boolean(peer?.connected),
-            explicit: Boolean(peer?.explicit),
-            relayAddresses: Number(peer?.relayAddresses || 0),
-          })) : [])
-        } catch (err) {
-          diagnostics.promotedPeerHintsJson = JSON.stringify([{ error: err?.message || String(err) }])
-        }
-        markTiming('hintsPromotedMs')
+      promoteHintIds([...feedIds, ...relayIds])
+      // Late-arriving availability hints (the request is fired without
+      // blocking playback prep) still get promoted as soon as they resolve,
+      // even if the warmup below has already returned.
+      if (peerHintsPromise && typeof peerHintsPromise.then === 'function') {
+        peerHintsPromise.then((hintIds) => {
+          const newFeed = uniquePeerIds(hintIds?.sourceFeedPeerIds).filter((id) => !feedIds.includes(id))
+          const newRelay = uniquePeerIds(hintIds?.sourceRelayPeerIds).filter((id) => !relayIds.includes(id))
+          if (newFeed.length === 0 && newRelay.length === 0) return
+          feedIds.push(...newFeed)
+          relayIds.push(...newRelay)
+          diagnostics.sourceFeedPeerIdsJson = jsonArray(feedIds)
+          diagnostics.sourceRelayPeerIdsJson = jsonArray(relayIds)
+          markTiming('hintsArrivedMs')
+          promoteHintIds([...newFeed, ...newRelay])
+          updatePeerDiagnostics()
+        }).catch(() => {})
       }
 
       const startedAt = Date.now()
@@ -299,6 +325,7 @@ export class BlobPlaybackService {
     sourceFeedPeerIds = [],
     sourceRelayPeerIds = [],
     promotePeerHints = null,
+    peerHintsPromise = null,
     timingBaseMs = Date.now(),
   }) {
     let warmupStarted = false
@@ -328,6 +355,7 @@ export class BlobPlaybackService {
           sourceFeedPeerIds,
           sourceRelayPeerIds,
           promotePeerHints,
+          peerHintsPromise,
           timingBaseMs,
         })
         : null

--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -1045,6 +1045,24 @@ export class PublicFeed {
     return true
   }
 
+  /**
+   * Peer ids (noise key hex) of currently connected feed peers that announced
+   * the given drive key. Lets playback prep promote/dial known seeders
+   * immediately instead of waiting for an availability-hint round trip.
+   * @param {string} driveKey
+   * @returns {string[]}
+   */
+  getEntryFeedPeerIds(driveKey) {
+    if (!driveKey || !this.peerFeedKeys) return []
+    const ids = new Set()
+    for (const [conn, keys] of this.peerFeedKeys) {
+      if (!keys?.has?.(driveKey)) continue
+      const keyHex = this._connectionPeerKeyHex(conn)
+      if (keyHex) ids.add(keyHex)
+    }
+    return Array.from(ids)
+  }
+
   promoteAvailabilityHintPeers(peerIds = [], topic = null) {
     const ids = Array.isArray(peerIds) ? peerIds : [peerIds]
     const promoted = []

--- a/packages/backend/test/blob-playback-selected-warmup.test.mjs
+++ b/packages/backend/test/blob-playback-selected-warmup.test.mjs
@@ -114,6 +114,35 @@ test('preparePlayback promotes source relay hints and reports blob bridge diagno
   t.is(JSON.parse(result.selectedBlobWarmup.promotedPeerHintsJson)[0].key, sourcePeer.slice(0, 16))
 })
 
+test('warmSelectedBlobRef promotes late-arriving availability hints without blocking', async (t) => {
+  const sourcePeer = '2'.repeat(64)
+  const { ctx } = createCtx({ peerCount: 0, hasHeadBlock: true })
+  const promoted = []
+  const service = new BlobPlaybackService({ ctx })
+  let resolveHints
+  const peerHintsPromise = new Promise((resolve) => { resolveHints = resolve })
+
+  const result = await service.warmSelectedBlobRef({
+    blobsCoreKey: VALID_KEY,
+    blobId: VALID_BLOB,
+    timeoutMs: 25,
+    promotePeerHints(peerIds, topic) {
+      promoted.push({ peerIds, topic })
+      return []
+    },
+    peerHintsPromise,
+  })
+
+  t.is(result.hasHeadBlock, true)
+  t.is(promoted.length, 0, 'no promotion before hints resolve')
+
+  resolveHints({ sourceFeedPeerIds: [sourcePeer], sourceRelayPeerIds: [] })
+  await new Promise((resolve) => setImmediate(resolve))
+
+  t.alike(promoted[0]?.peerIds, [sourcePeer], 'late hints promoted after warmup returned')
+  t.is(result.sourceFeedPeerIdsJson, JSON.stringify([sourcePeer]))
+})
+
 test('preparePlayback returns URL with explicit selected blob diagnostics when no blob peer arrives', async (t) => {
   const { ctx } = createCtx({ peerCount: 0, hasHeadBlock: false })
   const service = new BlobPlaybackService({ ctx })


### PR DESCRIPTION
Record ms offsets for each preparePlayback stage (availability hints, URL
resolution, blob core ready, peer retention, hint promotion, first blob
peer, head block, warmup done) and keep the last few records in memory.
Surface them through getSwarmStatus doctor.playback (already JSON-encoded
into doctorJson on the wire) and render a Playback timing card in the
Android diagnostics panel so on-device TTFF regressions are measurable.