### PR TITLE
Fix permanent freeze when seeking into uncached video regions

### DIFF
--- a/packages/app/components/video-player/MseVideoPlayer.web.tsx
+++ b/packages/app/components/video-player/MseVideoPlayer.web.tsx
@@ -1,23 +1,29 @@
-/* eslint-disable no-empty, no-constant-condition, jsx-a11y/media-has-caption */
+/* eslint-disable no-empty, jsx-a11y/media-has-caption */
 /**
- * MseVideoPlayer — streaming MSE player with sliding buffer window.
+ * MseVideoPlayer — seek-aware streaming MSE player.
  *
- * Uses mediabunny to remux MKV→fMP4 and feeds segments to MSE SourceBuffer.
- * Only keeps a window of data buffered around the playback position:
- *   - ~60s ahead of current position
- *   - ~30s behind current position
- * Removes old segments to stay within WebKit's SourceBuffer memory quota (~200MB).
- * Supports seeking by clearing the buffer and re-appending from the target position.
+ * Remuxes (MKV→fMP4) ON DEMAND using mediabunny's random-access packet API
+ * instead of a single linear Conversion. Seeking looks up the keyframe before
+ * the target through the container index (fetched via HTTP range requests
+ * against the local P2P blob server) and starts a fresh remux pipeline from
+ * there — so seeking into an uncached region of a streamed file only
+ * downloads bytes around the seek target instead of everything before it.
+ *
+ * Fragments carry absolute timestamps (fMP4 tfdt), so they land at the right
+ * place on the MSE timeline without timestampOffset bookkeeping. Only a
+ * sliding window is kept buffered (~60s ahead / ~30s behind) to stay within
+ * WebKit's SourceBuffer memory quota.
  */
 
 import { memo, useCallback, useRef } from 'react'
 
-const BUFFER_AHEAD_SEC = 60   // Buffer 60s ahead of current position
-const BUFFER_BEHIND_SEC = 30  // Keep 30s behind current position
-const POLL_MS = 500           // Main loop poll interval
+const BUFFER_AHEAD_SEC = 60   // Remux/buffer this far ahead of playback
+const BUFFER_BEHIND_SEC = 30  // Keep this much behind playback
+const POLL_MS = 250           // Pump idle poll interval
+const MAX_PENDING_SEGMENTS = 64 // Hard cap on segments awaiting append
 
 interface Segment {
-  time: number       // Timestamp in seconds from mediabunny onMoof
+  time: number       // Fragment start timestamp in seconds (absolute)
   data: Uint8Array   // moof+mdat combined
 }
 
@@ -37,22 +43,14 @@ type MseVideoPlayerProps = {
   playerRef?: React.RefObject<PlayerPort | null>
 }
 
-/** Binary search for the segment whose time is <= target */
-function findSegmentIndex(segments: Segment[], target: number): number {
-  let lo = 0
-  let hi = segments.length - 1
-  let result = 0
-  while (lo <= hi) {
-    const mid = (lo + hi) >>> 1
-    if (segments[mid].time <= target) {
-      result = mid
-      lo = mid + 1
-    } else {
-      hi = mid - 1
-    }
-  }
-  return result
+function concatBytes(a: Uint8Array, b: Uint8Array): Uint8Array {
+  const combined = new Uint8Array(a.length + b.length)
+  combined.set(a, 0)
+  combined.set(b, a.length)
+  return combined
 }
+
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
 
 export const MseVideoPlayer = memo(function MseVideoPlayer({
   videoUrl,
@@ -68,9 +66,15 @@ export const MseVideoPlayer = memo(function MseVideoPlayer({
 }: MseVideoPlayerProps) {
   const initStarted = useRef(false)
   const videoElRef = useRef<HTMLVideoElement | null>(null)
+  const disposeRef = useRef<(() => void) | null>(null)
 
   const videoRefCallback = useCallback((el: HTMLVideoElement | null) => {
-    if (!el || initStarted.current) return
+    if (!el) {
+      disposeRef.current?.()
+      disposeRef.current = null
+      return
+    }
+    if (initStarted.current) return
     initStarted.current = true
     videoElRef.current = el
 
@@ -79,7 +83,7 @@ export const MseVideoPlayer = memo(function MseVideoPlayer({
     }
 
     // Progress reporting
-    setInterval(() => {
+    const progressTimer = setInterval(() => {
       if (el.duration && !isNaN(el.duration)) {
         onProgress?.({
           currentTime: Math.round(el.currentTime * 1000),
@@ -92,7 +96,16 @@ export const MseVideoPlayer = memo(function MseVideoPlayer({
     ;(async () => {
       try {
         const mb = await import('mediabunny')
-        const { Input, Output, Conversion, UrlSource, Mp4OutputFormat, NullTarget } = mb
+        const {
+          Input,
+          Output,
+          UrlSource,
+          Mp4OutputFormat,
+          NullTarget,
+          EncodedPacketSink,
+          EncodedVideoPacketSource,
+          EncodedAudioPacketSource,
+        } = mb
         const ALL_FORMATS = mb.ALL_FORMATS || [mb.MatroskaInputFormat, mb.Mp4InputFormat].filter(Boolean)
 
         const source = new UrlSource(videoUrl, {
@@ -101,46 +114,37 @@ export const MseVideoPlayer = memo(function MseVideoPlayer({
         })
         const input = new Input({ source, formats: ALL_FORMATS, prefetchProfile: 'network' })
 
-        // Collect fMP4 segments (ftyp+moov init + moof+mdat pairs)
-        let initSegment: Uint8Array | null = null
-        let moofTimestamp = 0
-        let lastMoof: Uint8Array | null = null
-        const segments: Segment[] = []
-
-        const output = new Output({
-          target: new NullTarget(),
-          format: new Mp4OutputFormat({
-            fastStart: 'fragmented',
-            onFtyp: (data: Uint8Array) => {
-              initSegment = new Uint8Array(data)
-            },
-            onMoov: (data: Uint8Array) => {
-              if (initSegment) {
-                const combined = new Uint8Array(initSegment.length + data.length)
-                combined.set(initSegment, 0)
-                combined.set(data, initSegment.length)
-                initSegment = combined
-              }
-            },
-            onMoof: (data: Uint8Array, _pos: number, timestamp: number) => {
-              lastMoof = new Uint8Array(data)
-              moofTimestamp = timestamp // seconds from mediabunny
-            },
-            onMdat: (data: Uint8Array) => {
-              if (!lastMoof) return
-              const segment = new Uint8Array(lastMoof.length + data.length)
-              segment.set(lastMoof, 0)
-              segment.set(data, lastMoof.length)
-              segments.push({ time: moofTimestamp, data: segment })
-              lastMoof = null
-            },
-          }),
-        })
-
-        const conversion = await Conversion.init({ input, output })
-        if (!conversion.isValid) {
-          onError?.({ message: 'Incompatible tracks' })
+        const videoTrack = await input.getPrimaryVideoTrack()
+        if (!videoTrack) {
+          onError?.({ message: 'No video track' })
           return
+        }
+        const videoCodec = await videoTrack.getCodec()
+        const videoDecoderConfig = videoCodec ? await videoTrack.getDecoderConfig() : null
+        const mp4Codecs = new Mp4OutputFormat({ fastStart: 'fragmented' }).getSupportedCodecs()
+        if (!videoCodec || !videoDecoderConfig || !mp4Codecs.includes(videoCodec)) {
+          onError?.({ message: `Unsupported video codec: ${videoCodec || 'unknown'}` })
+          return
+        }
+
+        const audioTrack = await input.getPrimaryAudioTrack()
+        const audioCodec = audioTrack ? await audioTrack.getCodec() : null
+        const audioDecoderConfig = audioTrack && audioCodec ? await audioTrack.getDecoderConfig() : null
+        const audioUsable = Boolean(audioCodec && audioDecoderConfig && mp4Codecs.includes(audioCodec))
+
+        // Build the SourceBuffer MIME from the precise codec strings, falling
+        // back to the legacy hardcoded candidates.
+        const videoCodecString = await videoTrack.getCodecParameterString()
+        const audioCodecString = audioUsable ? await audioTrack!.getCodecParameterString() : null
+        const mimeCandidates: Array<{ mime: string; withAudio: boolean }> = []
+        if (videoCodecString) {
+          if (audioCodecString) {
+            mimeCandidates.push({ mime: `video/mp4; codecs="${videoCodecString}, ${audioCodecString}"`, withAudio: true })
+          }
+          mimeCandidates.push({ mime: `video/mp4; codecs="${videoCodecString}"`, withAudio: false })
+        }
+        for (const legacy of ['video/mp4; codecs="hev1.1.6.L150.B0"', 'video/mp4; codecs="avc1.640032"', 'video/mp4']) {
+          mimeCandidates.push({ mime: legacy, withAudio: audioUsable })
         }
 
         // Create MediaSource
@@ -148,17 +152,15 @@ export const MseVideoPlayer = memo(function MseVideoPlayer({
         el.src = URL.createObjectURL(ms)
         await new Promise<void>(r => { ms.onsourceopen = () => r() })
 
-        // Add SourceBuffer
-        const mimes = [
-          'video/mp4; codecs="hev1.1.6.L150.B0"',
-          'video/mp4; codecs="avc1.640032"',
-          'video/mp4',
-        ]
         let sb: SourceBuffer | null = null
-        for (const m of mimes) {
-          if (MediaSource.isTypeSupported(m)) {
-            try { sb = ms.addSourceBuffer(m); break }
-            catch {}
+        let includeAudio = false
+        for (const candidate of mimeCandidates) {
+          if (MediaSource.isTypeSupported(candidate.mime)) {
+            try {
+              sb = ms.addSourceBuffer(candidate.mime)
+              includeAudio = candidate.withAudio
+              break
+            } catch {}
           }
         }
         if (!sb) { onError?.({ message: 'No MSE MIME support' }); return }
@@ -184,7 +186,7 @@ export const MseVideoPlayer = memo(function MseVideoPlayer({
               console.warn('[MsePlayer] QuotaExceeded, evicting')
               try {
                 await waitForUpdate()
-                sb!.remove(0, el.currentTime)
+                sb!.remove(0, Math.max(0, el.currentTime - 1))
                 await waitForUpdate()
                 sb!.appendBuffer(data)
                 await waitForUpdate()
@@ -208,164 +210,215 @@ export const MseVideoPlayer = memo(function MseVideoPlayer({
           } catch {}
         }
 
-        // --- Conversion runs in background ---
-        let conversionDone = false
-        const conversionPromise = (async () => {
-          await conversion.execute()
-          conversionDone = true
-        })()
-
-        // Wait for init segment + first few media segments
-        while (!initSegment || segments.length < 2) {
-          await new Promise(r => setTimeout(r, 100))
-          if (conversionDone && segments.length === 0) {
-            onError?.({ message: 'No segments produced' })
-            return
+        const isBuffered = (time: number) => {
+          for (let i = 0; i < sb!.buffered.length; i++) {
+            if (time >= sb!.buffered.start(i) && time <= sb!.buffered.end(i)) return true
           }
+          return false
         }
 
-        // Append init segment
-        await safeAppend(initSegment)
+        // Real duration is known up front from the container index — report it
+        // and size the MediaSource so the whole timeline is seekable
+        // immediately (the old linear conversion only grew the seekable range
+        // as it progressed through the file).
+        const duration = await input.computeDuration()
+        if (duration > 0) {
+          await waitForUpdate()
+          try { ms.duration = duration } catch {}
+          onLoad?.({ duration, durationMs: Math.round(duration * 1000) })
+        }
 
-        // --- State for sliding window ---
-        // Track which segments are currently in the SourceBuffer
-        let windowStart = 0  // Index of first segment currently appended
-        let windowEnd = 0    // Index past last segment appended (exclusive)
-        let seekGeneration = 0  // Increments on seek to abort stale appends
+        const videoSink = new EncodedPacketSink(videoTrack)
+        const audioSink = includeAudio && audioTrack ? new EncodedPacketSink(audioTrack) : null
 
-        /** Append segments from `from` to cover up to `targetTime` seconds ahead */
-        const fillWindow = async (from: number, targetTime: number, gen: number): Promise<number> => {
-          let idx = from
-          while (idx < segments.length && segments[idx].time < targetTime) {
-            if (gen !== seekGeneration) return idx // Abort if seek happened
-            const ok = await safeAppend(segments[idx].data)
-            if (!ok) break // Quota still exceeded, stop
-            idx++
+        // --- On-demand remux pipeline ---
+        let generation = 0
+        let activeOutput: any = null
+        let playbackStarted = false
+        let disposed = false
+
+        disposeRef.current = () => {
+          disposed = true
+          generation++
+          clearInterval(progressTimer)
+          try { activeOutput?.cancel?.()?.catch?.(() => {}) } catch {}
+          activeOutput = null
+          try { (input as any).dispose?.() } catch {}
+        }
+
+        /**
+         * Remux from the keyframe at/before `fromTime` and feed fragments into
+         * the SourceBuffer until end of file, a newer generation supersedes
+         * this one, or the component is disposed. Stays ~BUFFER_AHEAD_SEC
+         * ahead of playback and evicts ~BUFFER_BEHIND_SEC behind it.
+         */
+        const runPipeline = async (fromTime: number, gen: number) => {
+          const stale = () => disposed || gen !== generation
+
+          let startPacket = await videoSink.getKeyPacket(Math.max(0, fromTime), { verifyKeyPackets: true })
+          if (!startPacket) startPacket = await videoSink.getFirstKeyPacket({ verifyKeyPackets: true })
+          if (!startPacket || stale()) return
+          const startTime = startPacket.timestamp
+
+          const pending: Segment[] = []
+          let ftyp: Uint8Array | null = null
+          let initSegment: Uint8Array | null = null
+          let initAppended = false
+          let lastMoof: { data: Uint8Array; time: number } | null = null
+
+          const output = new Output({
+            target: new NullTarget(),
+            format: new Mp4OutputFormat({
+              fastStart: 'fragmented',
+              onFtyp: (data: Uint8Array) => { ftyp = new Uint8Array(data) },
+              onMoov: (data: Uint8Array) => {
+                initSegment = ftyp ? concatBytes(ftyp, new Uint8Array(data)) : new Uint8Array(data)
+              },
+              onMoof: (data: Uint8Array, _pos: number, timestamp: number) => {
+                lastMoof = { data: new Uint8Array(data), time: timestamp }
+              },
+              onMdat: (data: Uint8Array) => {
+                if (!lastMoof) return
+                pending.push({ time: lastMoof.time, data: concatBytes(lastMoof.data, new Uint8Array(data)) })
+                lastMoof = null
+              },
+            }),
+          })
+          const videoOut = new EncodedVideoPacketSource(videoCodec)
+          output.addVideoTrack(videoOut)
+          let audioOut: any = null
+          if (audioSink && audioCodec) {
+            audioOut = new EncodedAudioPacketSource(audioCodec)
+            output.addAudioTrack(audioOut)
           }
-          return idx
-        }
+          await output.start()
+          if (stale()) { output.cancel().catch(() => {}); return }
+          activeOutput = output
 
-        // Append initial batch — enough to start playback
-        const initialEnd = Math.min(segments.length, 10)
-        for (let i = 0; i < initialEnd; i++) {
-          await safeAppend(segments[i].data)
-        }
-        windowStart = 0
-        windowEnd = initialEnd
-
-        el.play().catch(() => {})
-        onLoad?.({ duration: 0, durationMs: 0 })
-
-        // --- Seek handler ---
-        let seekPending = false
-
-        el.onseeking = async () => {
-          const target = el.currentTime
-
-          // Check if target is within the currently buffered range
-          if (sb!.buffered.length > 0) {
-            for (let i = 0; i < sb!.buffered.length; i++) {
-              if (target >= sb!.buffered.start(i) && target <= sb!.buffered.end(i)) {
-                return // Already buffered, nothing to do
+          /** Append the init segment (once ready) and any finalized fragments */
+          const drain = async (): Promise<boolean> => {
+            while (pending.length > 0) {
+              if (stale()) return false
+              if (!initAppended) {
+                if (!initSegment) return true // moov not written yet, fragments can't precede it for long
+                if (!(await safeAppend(initSegment))) return false
+                if (stale()) return false
+                initAppended = true
               }
+              const segment = pending.shift()!
+              if (!(await safeAppend(segment.data))) return false
+              if (stale()) return false
+              if (!playbackStarted) {
+                playbackStarted = true
+                el.play().catch(() => {})
+              }
+            }
+            return true
+          }
+
+          // Pump packets in timestamp order across tracks
+          const videoIter: AsyncGenerator<any, void, unknown> = videoSink.packets(startPacket, undefined, { verifyKeyPackets: true })
+          let nextVideo: IteratorResult<any> = await videoIter.next()
+          let audioIter: AsyncGenerator<any, void, unknown> | null = null
+          let nextAudio: IteratorResult<any> | null = null
+          if (audioSink) {
+            const audioStart = (await audioSink.getPacket(startTime)) ?? (await audioSink.getFirstPacket())
+            if (audioStart) {
+              audioIter = audioSink.packets(audioStart)
+              nextAudio = await audioIter.next()
             }
           }
 
-          // Target is outside buffered range — need to clear and re-fill
-          seekPending = true
-          const gen = ++seekGeneration
-
+          let firstVideo = true
+          let firstAudio = true
           try {
-            // Abort any pending operation
-            if (sb!.updating) {
-              sb!.abort()
+            while (!stale()) {
+              if (!(await drain())) break
+
+              const videoDone = nextVideo.done === true
+              const audioDone = !nextAudio || nextAudio.done === true
+              if (videoDone && audioDone) {
+                await output.finalize() // flushes the trailing fragment via callbacks
+                if (activeOutput === output) activeOutput = null
+                await drain()
+                if (!stale()) {
+                  await waitForUpdate()
+                  if (ms.readyState === 'open') {
+                    try { ms.endOfStream() } catch {}
+                  }
+                }
+                return
+              }
+
+              // Throttle: stay BUFFER_AHEAD_SEC ahead of the playhead, evict behind
+              const headTimestamp = Math.min(
+                videoDone ? Infinity : nextVideo.value.timestamp,
+                audioDone ? Infinity : nextAudio!.value.timestamp
+              )
+              if (
+                pending.length > MAX_PENDING_SEGMENTS ||
+                (headTimestamp > el.currentTime + BUFFER_AHEAD_SEC && isBuffered(el.currentTime))
+              ) {
+                const evictEnd = el.currentTime - BUFFER_BEHIND_SEC
+                if (sb!.buffered.length > 0 && sb!.buffered.start(0) < evictEnd) {
+                  await removeRange(sb!.buffered.start(0), evictEnd)
+                }
+                await sleep(POLL_MS)
+                continue
+              }
+
+              // Feed whichever track is furthest behind
+              if (audioDone || (!videoDone && nextVideo.value.timestamp <= nextAudio!.value.timestamp)) {
+                await videoOut.add(nextVideo.value, firstVideo ? { decoderConfig: videoDecoderConfig } : undefined)
+                firstVideo = false
+                nextVideo = await videoIter.next()
+              } else {
+                await audioOut.add(nextAudio!.value, firstAudio ? { decoderConfig: audioDecoderConfig } : undefined)
+                firstAudio = false
+                nextAudio = await audioIter!.next()
+              }
             }
-
-            // Clear entire SourceBuffer
-            await removeRange(0, Infinity)
-
-            // Re-append init segment
-            await safeAppend(initSegment!)
-
-            // Find segment closest to seek target
-            const startIdx = findSegmentIndex(segments, Math.max(0, target - 1))
-            const endTime = target + BUFFER_AHEAD_SEC
-
-            windowStart = startIdx
-            windowEnd = await fillWindow(startIdx, endTime, gen)
           } catch (err: any) {
-            console.warn('[MsePlayer] Seek error:', err?.message)
-          }
-
-          seekPending = false
-        }
-
-        // --- Main streaming loop ---
-        const streamLoop = async () => {
-          while (true) {
-            await new Promise(r => setTimeout(r, POLL_MS))
-
-            // Skip if a seek is in progress
-            if (seekPending) continue
-
-            const currentGen = seekGeneration
-            const now = el.currentTime
-
-            // 1. Evict old buffer behind playback
-            if (now > BUFFER_BEHIND_SEC && sb!.buffered.length > 0) {
-              const evictEnd = now - BUFFER_BEHIND_SEC
-              if (sb!.buffered.start(0) < evictEnd) {
-                await removeRange(sb!.buffered.start(0), evictEnd)
-                // Update windowStart to reflect evicted segments
-                while (windowStart < windowEnd && segments[windowStart].time < evictEnd) {
-                  windowStart++
-                }
-              }
+            if (!stale()) {
+              console.warn('[MsePlayer] Pipeline error:', err?.message)
+              onError?.({ message: err?.message || 'Remux pipeline error' })
             }
-
-            // 2. Append ahead of playback (only within window)
-            if (currentGen === seekGeneration) {
-              const targetTime = now + BUFFER_AHEAD_SEC
-              if (windowEnd < segments.length && segments[windowEnd].time < targetTime) {
-                windowEnd = await fillWindow(windowEnd, targetTime, currentGen)
-              }
+          } finally {
+            if (activeOutput === output) activeOutput = null
+            if (output.state === 'pending' || output.state === 'started') {
+              output.cancel().catch(() => {})
             }
-
-            // 3. Report duration if available
-            if (el.duration && isFinite(el.duration) && el.duration > 0) {
-              onLoad?.({ duration: el.duration, durationMs: Math.round(el.duration * 1000) })
-            }
-
-            // 4. Set MediaSource duration once conversion is done
-            if (conversionDone && ms.readyState === 'open' && segments.length > 0) {
-              const lastSeg = segments[segments.length - 1]
-              // Estimate: last segment time + typical segment duration
-              const estDuration = lastSeg.time + (segments.length > 1
-                ? lastSeg.time - segments[segments.length - 2].time
-                : 4)
-              try {
-                await waitForUpdate()
-                ms.duration = estDuration
-              } catch {}
-              onLoad?.({ duration: estDuration, durationMs: Math.round(estDuration * 1000) })
-            }
-
-            // 5. End of stream when all segments have been seen
-            // (but only if playback is near the end — don't end prematurely)
-            if (conversionDone && windowEnd >= segments.length) {
-              const lastSegTime = segments[segments.length - 1]?.time ?? 0
-              if (now >= lastSegTime - 10) {
-                await waitForUpdate()
-                if (ms.readyState === 'open') {
-                  try { ms.endOfStream() } catch {}
-                }
-                break
-              }
-            }
+            try { videoIter.return?.(undefined) } catch {}
+            try { audioIter?.return?.(undefined) } catch {}
           }
         }
 
-        await Promise.all([conversionPromise, streamLoop()])
+        // --- Seek handler: restart the pipeline from the seek target ---
+        el.onseeking = () => {
+          const target = el.currentTime
+          if (isBuffered(target)) return // Data already present, the element recovers on its own
+
+          generation++
+          const gen = generation
+          const oldOutput = activeOutput
+          activeOutput = null
+          try { oldOutput?.cancel?.()?.catch?.(() => {}) } catch {}
+
+          ;(async () => {
+            try {
+              if (sb!.updating) {
+                try { sb!.abort() } catch {}
+              }
+              await removeRange(0, Infinity)
+              if (gen !== generation) return
+              await runPipeline(Math.max(0, target - 0.5), gen)
+            } catch (err: any) {
+              console.warn('[MsePlayer] Seek error:', err?.message)
+            }
+          })()
+        }
+
+        await runPipeline(0, generation)
       } catch (err: any) {
         console.error('[MsePlayer] Error:', err?.message)
         onError?.({ message: err?.message || 'MSE error' })

--- a/packages/app/components/video-player/PearInlineVideoView.tsx
+++ b/packages/app/components/video-player/PearInlineVideoView.tsx
@@ -52,6 +52,15 @@ const IOS_BUFFER_OPTIONS = {
   waitsToMinimizeStalling: true,
 }
 const SEEK_PLAYBACK_RECOVERY_MS = 6000
+// Fatal player errors used to leave the surface frozen forever. The common
+// trigger is seeking into an uncached region of a P2P-streamed file: the blob
+// server resets the HTTP range request when peers don't deliver the blocks in
+// time, and the native player gives up with a network error. Re-attach the
+// source and resume from the last position a few times before surfacing the
+// error — by then the prioritized download usually has the seek target cached.
+const PLAYBACK_ERROR_RECOVERY_MAX_ATTEMPTS = 4
+const PLAYBACK_ERROR_RECOVERY_BASE_DELAY_MS = 1000
+const PLAYBACK_ERROR_RECOVERY_PROGRESS_SEC = 2
 
 function getExpoEventDurationMs(data: any, player?: VideoPlayer | null) {
   const rawDurationSeconds = Number(data?.duration ?? player?.duration ?? 0)
@@ -116,6 +125,10 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
   const notificationControlsRef = useRef(showNotificationControls)
   const onErrorRef = useRef(onError)
   const sourceReplaceGenerationRef = useRef(0)
+  const lastPlaybackPositionSecRef = useRef(0)
+  const errorRecoveryAttemptsRef = useRef(0)
+  const errorRecoveryResumePositionRef = useRef(0)
+  const errorRecoveryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const videoSource = useMemo<VideoSource>(() => ({
     uri: videoUrl,
@@ -152,8 +165,22 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
     lastAppliedSeekRef.current = null
     previousStatusRef.current = null
     seekPlaybackRecoveryUntilRef.current = 0
+    lastPlaybackPositionSecRef.current = 0
+    errorRecoveryAttemptsRef.current = 0
+    errorRecoveryResumePositionRef.current = 0
+    if (errorRecoveryTimerRef.current) {
+      clearTimeout(errorRecoveryTimerRef.current)
+      errorRecoveryTimerRef.current = null
+    }
     playerRefForCallbacks.current = player
   }, [player, videoUrl, playbackSession, currentVideoKey])
+
+  useEffect(() => () => {
+    if (errorRecoveryTimerRef.current) {
+      clearTimeout(errorRecoveryTimerRef.current)
+      errorRecoveryTimerRef.current = null
+    }
+  }, [])
 
   useEffect(() => {
     isPlayingRef.current = isPlaying
@@ -238,6 +265,60 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
     seekPlaybackRecoveryUntilRef.current = Date.now() + SEEK_PLAYBACK_RECOVERY_MS
     player.currentTime = Math.max(0, targetSeconds)
   }, [player])
+
+  /**
+   * Re-attach the current source and resume from the last playback position.
+   * Returns false once the attempt budget is exhausted (attempts reset when
+   * playback advances past the recovery point), letting the caller surface
+   * the error instead.
+   */
+  const tryRecoverFromPlaybackError = useCallback(() => {
+    if (errorRecoveryAttemptsRef.current >= PLAYBACK_ERROR_RECOVERY_MAX_ATTEMPTS) return false
+    errorRecoveryAttemptsRef.current += 1
+    const attempt = errorRecoveryAttemptsRef.current
+    // Rewind slightly so resume lands on data that was already playable.
+    const resumeAt = Math.max(0, lastPlaybackPositionSecRef.current - 0.5)
+    errorRecoveryResumePositionRef.current = resumeAt
+    const generation = sourceReplaceGenerationRef.current
+    onBuffering?.({ isBuffering: true })
+    if (errorRecoveryTimerRef.current) clearTimeout(errorRecoveryTimerRef.current)
+    errorRecoveryTimerRef.current = setTimeout(() => {
+      errorRecoveryTimerRef.current = null
+      if (sourceReplaceGenerationRef.current !== generation) return
+      void (async () => {
+        try {
+          if (typeof player.replaceAsync === 'function') {
+            await player.replaceAsync(videoSource)
+          } else {
+            player.replace(videoSource)
+          }
+          if (sourceReplaceGenerationRef.current !== generation) return
+          player.playbackRate = playbackRateRef.current
+          if (resumeAt > 0) {
+            seekPlaybackRecoveryUntilRef.current = Date.now() + SEEK_PLAYBACK_RECOVERY_MS
+            player.currentTime = resumeAt
+          }
+          if (isPlayingRef.current) {
+            player.play()
+          }
+        } catch (recoveryError) {
+          if (sourceReplaceGenerationRef.current !== generation) return
+          if (!tryRecoverFromPlaybackErrorRef.current()) {
+            onErrorRef.current?.({
+              message: recoveryError instanceof Error ? recoveryError.message : 'Playback recovery failed',
+              engine: 'expo-video',
+            })
+          }
+        }
+      })()
+    }, PLAYBACK_ERROR_RECOVERY_BASE_DELAY_MS * attempt)
+    return true
+  }, [onBuffering, player, videoSource])
+
+  const tryRecoverFromPlaybackErrorRef = useRef(tryRecoverFromPlaybackError)
+  useEffect(() => {
+    tryRecoverFromPlaybackErrorRef.current = tryRecoverFromPlaybackError
+  }, [tryRecoverFromPlaybackError])
 
   const adapter = useMemo(
     () => createPlayerPort(
@@ -397,6 +478,15 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
     if (durationMs > 0) durationMsRef.current = durationMs
 
     const currentTime = Math.max(0, Number(event.currentTime || 0))
+    lastPlaybackPositionSecRef.current = currentTime
+    if (
+      errorRecoveryAttemptsRef.current > 0 &&
+      currentTime > errorRecoveryResumePositionRef.current + PLAYBACK_ERROR_RECOVERY_PROGRESS_SEC
+    ) {
+      // Playback advanced past the recovery point — the stall is over, so a
+      // future error gets a fresh attempt budget.
+      errorRecoveryAttemptsRef.current = 0
+    }
     const suppressStuckRecovery = shouldSuppressStuckPlaybackRecovery()
     if (suppressStuckRecovery && playbackStartedAtRef.current !== null) {
       playbackStartedAtRef.current = Date.now()
@@ -461,6 +551,7 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
     }
     if (status === 'error') {
       console.error('[PearInlineVideoView] error:', error)
+      if (tryRecoverFromPlaybackError()) return
       onError?.({
         message: error?.message || 'Unknown error',
         code: (error as any)?.code,

--- a/packages/app/components/video-player/PearInlineVideoView.tsx
+++ b/packages/app/components/video-player/PearInlineVideoView.tsx
@@ -70,6 +70,19 @@ function getExpoEventDurationMs(data: any, player?: VideoPlayer | null) {
   return 0
 }
 
+/**
+ * Format/codec errors are deterministic — reloading the same source can never
+ * succeed, and on desktop web the watch page uses the surfaced error (code 4,
+ * MEDIA_ERR_SRC_NOT_SUPPORTED) to fall back to the MSE remux player. Those
+ * must bypass the stall-recovery retries and surface immediately.
+ */
+function isUnrecoverableSourceError(error: any) {
+  const code = Number(error?.code ?? error?.error?.code)
+  if (code === 4) return true
+  const message = String(error?.message || '')
+  return /not supported|MEDIA_ERR_SRC_NOT_SUPPORTED|cannot be played|unsupported/i.test(message)
+}
+
 function getExpoEventVideoSize(data: any, player?: VideoPlayer | null) {
   const track = data?.videoTrack ?? player?.videoTrack
   const width = Number(data?.videoSize?.width ?? data?.width ?? data?.naturalSize?.width ?? track?.size?.width ?? track?.width)
@@ -551,7 +564,7 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
     }
     if (status === 'error') {
       console.error('[PearInlineVideoView] error:', error)
-      if (tryRecoverFromPlaybackError()) return
+      if (!isUnrecoverableSourceError(error) && tryRecoverFromPlaybackError()) return
       onError?.({
         message: error?.message || 'Unknown error',
         code: (error as any)?.code,

--- a/packages/app/tests/mse-player-seek-regression.test.mjs
+++ b/packages/app/tests/mse-player-seek-regression.test.mjs
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { test } from 'node:test'
+
+const msePlayerPath = new URL('../components/video-player/MseVideoPlayer.web.tsx', import.meta.url)
+const inlineViewPath = new URL('../components/video-player/PearInlineVideoView.tsx', import.meta.url)
+
+async function source(url) {
+  return readFile(url, 'utf8')
+}
+
+test('MSE player remuxes on demand instead of linearly converting the whole file', async () => {
+  const src = await source(msePlayerPath)
+
+  assert.doesNotMatch(src, /Conversion\.init|conversion\.execute/, 'the linear Conversion pipeline must not come back — it forces seeks to wait for everything before the target')
+  assert.match(src, /EncodedPacketSink/, 'random-access packet reading is required for seek-on-demand')
+  assert.match(src, /getKeyPacket\(/, 'seeks must start from the keyframe at/before the target')
+  assert.match(src, /verifyKeyPackets: true/, 'key packet flags must be verified (Matroska key flags are unreliable)')
+})
+
+test('MSE player restarts the remux pipeline from the seek target', async () => {
+  const src = await source(msePlayerPath)
+  const seekStart = src.indexOf('el.onseeking')
+  assert.notEqual(seekStart, -1, 'expected onseeking handler')
+  const handler = src.slice(seekStart, src.indexOf('await runPipeline(0, generation)', seekStart))
+
+  assert.match(handler, /generation\+\+/, 'seeking must invalidate the previous pipeline generation')
+  assert.match(handler, /cancel/, 'the superseded output must be canceled so it stops consuming bandwidth')
+  assert.match(handler, /runPipeline\(Math\.max\(0, target - 0\.5\), gen\)/, 'a new pipeline must start from the seek target')
+})
+
+test('MSE player reports the full duration up front so the whole timeline is seekable', async () => {
+  const src = await source(msePlayerPath)
+  assert.match(src, /input\.computeDuration\(\)/, 'duration must come from the container index, not from conversion progress')
+  assert.match(src, /ms\.duration = duration/, 'MediaSource duration must be set before playback so seeks anywhere are possible')
+})
+
+test('format errors skip stall recovery so the desktop MSE fallback still triggers promptly', async () => {
+  const src = await source(inlineViewPath)
+  assert.match(src, /isUnrecoverableSourceError/, 'unrecoverable source errors must be detected')
+  assert.match(
+    src,
+    /!isUnrecoverableSourceError\(error\) && tryRecoverFromPlaybackError\(\)/,
+    'recovery must be skipped for format errors (code 4) so the watch page can fall back to the MSE player immediately'
+  )
+})

--- a/packages/app/tests/mse-seek-remux-smoke.test.mjs
+++ b/packages/app/tests/mse-seek-remux-smoke.test.mjs
@@ -1,0 +1,197 @@
+/**
+ * Validates the on-demand seek-remux approach used by MseVideoPlayer.web.tsx
+ * against the installed mediabunny version:
+ *
+ * - random access into a media file via EncodedPacketSink.getKeyPacket
+ * - restarting a remux pipeline mid-file (the seek path)
+ * - fMP4 fragments carrying ABSOLUTE timestamps, so they land at the correct
+ *   position on an MSE timeline without timestampOffset bookkeeping
+ * - audio/video packet interleaving through separate packet sources
+ *
+ * Skips when mediabunny is not installed (source-pattern tests still run).
+ */
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+let mb = null
+try {
+  mb = await import('mediabunny')
+} catch {
+  // node_modules not installed in this environment
+}
+
+const FPS = 30
+const GOP = 30
+const SECONDS = 10
+
+function makeAvcPacketData(key) {
+  const nal = new Uint8Array([key ? 0x65 : 0x41, 0x88, 0x84, 0x00, 0x00, 0x00, 0x00, 0x00])
+  const data = new Uint8Array(4 + nal.length)
+  new DataView(data.buffer).setUint32(0, nal.length)
+  data.set(nal, 4)
+  return data
+}
+
+function makeVideoDecoderConfig() {
+  const sps = new Uint8Array([0x67, 0x64, 0x00, 0x28, 0xac, 0xd9, 0x40, 0x78, 0x02, 0x27, 0xe5, 0x84, 0x00, 0x00, 0x03, 0x00, 0x04, 0x00, 0x00, 0x03, 0x00, 0xf0, 0x3c, 0x60, 0xc6, 0x58])
+  const pps = new Uint8Array([0x68, 0xeb, 0xe3, 0xcb, 0x22, 0xc0])
+  const avcC = new Uint8Array([
+    1, 0x64, 0x00, 0x28, 0xff, 0xe1,
+    (sps.length >> 8) & 0xff, sps.length & 0xff, ...sps,
+    1,
+    (pps.length >> 8) & 0xff, pps.length & 0xff, ...pps,
+  ])
+  return { codec: 'avc1.640028', codedWidth: 640, codedHeight: 360, description: avcC }
+}
+
+async function buildSourceFile({ withAudio = false } = {}) {
+  const { Output, BufferTarget, Mp4OutputFormat, EncodedVideoPacketSource, EncodedAudioPacketSource, EncodedPacket } = mb
+  const target = new BufferTarget()
+  const output = new Output({ target, format: new Mp4OutputFormat({ fastStart: 'fragmented' }) })
+  const videoSource = new EncodedVideoPacketSource('avc')
+  output.addVideoTrack(videoSource)
+  let audioSource = null
+  if (withAudio) {
+    audioSource = new EncodedAudioPacketSource('aac')
+    output.addAudioTrack(audioSource)
+  }
+  await output.start()
+
+  const audioDecoderConfig = {
+    codec: 'mp4a.40.2',
+    numberOfChannels: 2,
+    sampleRate: 48000,
+    description: new Uint8Array([0x11, 0x90]),
+  }
+  const audioFrameDuration = 1024 / 48000
+  let audioTime = 0
+  for (let i = 0; i < FPS * SECONDS; i++) {
+    const key = i % GOP === 0
+    const packet = new EncodedPacket(makeAvcPacketData(key), key ? 'key' : 'delta', i / FPS, 1 / FPS)
+    await videoSource.add(packet, i === 0 ? { decoderConfig: makeVideoDecoderConfig() } : undefined)
+    if (audioSource) {
+      let firstAudio = audioTime === 0
+      while (audioTime <= (i + 1) / FPS) {
+        const aPacket = new EncodedPacket(new Uint8Array([0x21, 0x10, 0x05, 0x00]), 'key', audioTime, audioFrameDuration)
+        await audioSource.add(aPacket, firstAudio ? { decoderConfig: audioDecoderConfig } : undefined)
+        firstAudio = false
+        audioTime += audioFrameDuration
+      }
+    }
+  }
+  await output.finalize()
+  return target.buffer
+}
+
+test('seek-remux: keyframe lookup + mid-file remux emits fragments at absolute timestamps', { skip: !mb && 'mediabunny not installed' }, async () => {
+  const { Input, Output, BufferSource, Mp4OutputFormat, NullTarget, EncodedPacketSink, EncodedVideoPacketSource, ALL_FORMATS } = mb
+  const fileBuffer = await buildSourceFile()
+
+  const input = new Input({ source: new BufferSource(fileBuffer), formats: ALL_FORMATS })
+  const duration = await input.computeDuration()
+  assert.ok(Math.abs(duration - SECONDS) < 0.5, `full duration known up front (got ${duration})`)
+
+  const track = await input.getPrimaryVideoTrack()
+  const sink = new EncodedPacketSink(track)
+
+  const startPacket = await sink.getKeyPacket(7.4, { verifyKeyPackets: true })
+  assert.equal(startPacket.type, 'key')
+  assert.ok(Math.abs(startPacket.timestamp - 7) < 0.01, `keyframe at 7s (got ${startPacket.timestamp})`)
+
+  const moofTimestamps = []
+  const output = new Output({
+    target: new NullTarget(),
+    format: new Mp4OutputFormat({
+      fastStart: 'fragmented',
+      onMoof: (_data, _pos, timestamp) => moofTimestamps.push(timestamp),
+    }),
+  })
+  const videoOut = new EncodedVideoPacketSource('avc')
+  output.addVideoTrack(videoOut)
+  await output.start()
+
+  const decoderConfig = await track.getDecoderConfig()
+  let first = true
+  let count = 0
+  for await (const packet of sink.packets(startPacket, undefined, { verifyKeyPackets: true })) {
+    await videoOut.add(packet, first ? { decoderConfig } : undefined)
+    first = false
+    count++
+  }
+  await output.finalize()
+
+  assert.equal(count, FPS * (SECONDS - 7), 'remux consumed exactly the packets from the seek keyframe to EOF')
+  assert.ok(moofTimestamps.length > 0, 'fragments were emitted')
+  assert.ok(Math.abs(moofTimestamps[0] - 7) < 0.05, `first fragment lands at ~7s absolute (got ${moofTimestamps[0]})`)
+})
+
+test('seek-remux: canceling an in-flight pipeline and restarting at a new position works', { skip: !mb && 'mediabunny not installed' }, async () => {
+  const { Input, Output, BufferSource, Mp4OutputFormat, NullTarget, EncodedPacketSink, EncodedVideoPacketSource, EncodedAudioPacketSource, ALL_FORMATS } = mb
+  const fileBuffer = await buildSourceFile({ withAudio: true })
+
+  const input = new Input({ source: new BufferSource(fileBuffer), formats: ALL_FORMATS })
+  const videoTrack = await input.getPrimaryVideoTrack()
+  const audioTrack = await input.getPrimaryAudioTrack()
+  assert.ok(audioTrack, 'audio track found')
+  const videoSink = new EncodedPacketSink(videoTrack)
+  const audioSink = new EncodedPacketSink(audioTrack)
+  const videoDecoderConfig = await videoTrack.getDecoderConfig()
+  const audioDecoderConfig = await audioTrack.getDecoderConfig()
+
+  const runPipeline = async (fromTime, { stopAfterFragments = Infinity } = {}) => {
+    const moofTimestamps = []
+    const output = new Output({
+      target: new NullTarget(),
+      format: new Mp4OutputFormat({
+        fastStart: 'fragmented',
+        onMoof: (_data, _pos, timestamp) => moofTimestamps.push(timestamp),
+      }),
+    })
+    const videoOut = new EncodedVideoPacketSource('avc')
+    output.addVideoTrack(videoOut)
+    const audioOut = new EncodedAudioPacketSource('aac')
+    output.addAudioTrack(audioOut)
+    await output.start()
+
+    const startPacket = await videoSink.getKeyPacket(fromTime, { verifyKeyPackets: true })
+    const videoIter = videoSink.packets(startPacket, undefined, { verifyKeyPackets: true })
+    let nextVideo = await videoIter.next()
+    const audioStart = (await audioSink.getPacket(startPacket.timestamp)) ?? (await audioSink.getFirstPacket())
+    const audioIter = audioSink.packets(audioStart)
+    let nextAudio = await audioIter.next()
+
+    let firstVideo = true
+    let firstAudio = true
+    while (!nextVideo.done || !nextAudio.done) {
+      if (moofTimestamps.length >= stopAfterFragments) {
+        await output.cancel()
+        return { moofTimestamps, canceled: true }
+      }
+      // Feed whichever track is furthest behind (same logic as the player)
+      if (nextAudio.done || (!nextVideo.done && nextVideo.value.timestamp <= nextAudio.value.timestamp)) {
+        await videoOut.add(nextVideo.value, firstVideo ? { decoderConfig: videoDecoderConfig } : undefined)
+        firstVideo = false
+        nextVideo = await videoIter.next()
+      } else {
+        await audioOut.add(nextAudio.value, firstAudio ? { decoderConfig: audioDecoderConfig } : undefined)
+        firstAudio = false
+        nextAudio = await audioIter.next()
+      }
+    }
+    await output.finalize()
+    return { moofTimestamps, canceled: false }
+  }
+
+  // Play from the start, then "seek": cancel and restart at 6s
+  const firstRun = await runPipeline(0, { stopAfterFragments: 2 })
+  assert.equal(firstRun.canceled, true)
+  assert.ok(Math.abs(firstRun.moofTimestamps[0] - 0) < 0.05, 'initial pipeline starts at 0')
+
+  const secondRun = await runPipeline(6.2)
+  assert.equal(secondRun.canceled, false)
+  assert.ok(secondRun.moofTimestamps.length > 0, 'post-seek pipeline emits fragments')
+  assert.ok(
+    Math.abs(secondRun.moofTimestamps[0] - 6) < 0.2,
+    `post-seek fragments start at the 6s keyframe (got ${secondRun.moofTimestamps[0]})`
+  )
+})

--- a/packages/app/tests/video-error-recovery-regression.test.mjs
+++ b/packages/app/tests/video-error-recovery-regression.test.mjs
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { test } from 'node:test'
+
+const inlineViewPath = new URL('../components/video-player/PearInlineVideoView.tsx', import.meta.url)
+
+async function source(url) {
+  return readFile(url, 'utf8')
+}
+
+test('fatal playback errors trigger automatic source recovery instead of freezing', async () => {
+  const src = await source(inlineViewPath)
+  const handlerStart = src.indexOf("useEventListener(player, 'statusChange'")
+  assert.notEqual(handlerStart, -1, 'expected expo-video statusChange handler')
+  const handler = src.slice(handlerStart, src.indexOf("useEventListener(player, 'playToEnd'", handlerStart))
+
+  assert.match(
+    handler,
+    /status === 'error'[\s\S]*if \(tryRecoverFromPlaybackError\(\)\) return/,
+    'a fatal player error (e.g. blob server resetting an uncached seek range request) must attempt recovery before surfacing onError'
+  )
+})
+
+test('error recovery re-attaches the source and resumes from the last playback position', async () => {
+  const src = await source(inlineViewPath)
+  const recoveryStart = src.indexOf('const tryRecoverFromPlaybackError')
+  assert.notEqual(recoveryStart, -1, 'expected tryRecoverFromPlaybackError callback')
+  const recovery = src.slice(recoveryStart, src.indexOf('const tryRecoverFromPlaybackErrorRef', recoveryStart))
+
+  assert.match(recovery, /PLAYBACK_ERROR_RECOVERY_MAX_ATTEMPTS/, 'recovery attempts must be bounded')
+  assert.match(recovery, /replaceAsync\(videoSource\)/, 'recovery must re-attach the current video source')
+  assert.match(recovery, /player\.currentTime = resumeAt/, 'recovery must resume from the last playback position')
+  assert.match(recovery, /isPlayingRef\.current/, 'recovery must only auto-play when playback was desired')
+  assert.match(recovery, /sourceReplaceGenerationRef\.current !== generation/, 'recovery must abort when a newer source replaced the failed one')
+})
+
+test('recovery attempt budget refills once playback advances past the stall', async () => {
+  const src = await source(inlineViewPath)
+  const handlerStart = src.indexOf("useEventListener(player, 'timeUpdate'")
+  assert.notEqual(handlerStart, -1, 'expected expo-video timeUpdate handler')
+  const handler = src.slice(handlerStart, src.indexOf("useEventListener(player, 'playingChange'", handlerStart))
+
+  assert.match(
+    handler,
+    /errorRecoveryResumePositionRef\.current \+ PLAYBACK_ERROR_RECOVERY_PROGRESS_SEC[\s\S]*errorRecoveryAttemptsRef\.current = 0/,
+    'advancing past the recovery point must reset the attempt budget so later stalls can recover again'
+  )
+})

--- a/packages/app/tests/video-error-recovery-regression.test.mjs
+++ b/packages/app/tests/video-error-recovery-regression.test.mjs
@@ -16,7 +16,7 @@ test('fatal playback errors trigger automatic source recovery instead of freezin
 
   assert.match(
     handler,
-    /status === 'error'[\s\S]*if \(tryRecoverFromPlaybackError\(\)\) return/,
+    /status === 'error'[\s\S]*tryRecoverFromPlaybackError\(\)\) return/,
     'a fatal player error (e.g. blob server resetting an uncached seek range request) must attempt recovery before surfacing onError'
   )
 })

--- a/packages/backend/src/blob-range-priority.js
+++ b/packages/backend/src/blob-range-priority.js
@@ -10,6 +10,54 @@ import z32 from 'z32'
 // scheduler with the whole file.
 const DEFAULT_BLOB_RANGE_READ_AHEAD_BYTES = 16 * 1024 * 1024
 const DEFAULT_BLOB_RANGE_PRIORITY_TIMEOUT_MS = 15000
+// Progressive playback re-requests ranges that land inside the window we just
+// started downloading (connection churn, players probing ahead). Reuse that
+// in-flight download instead of restarting it, but only while it is fresh so
+// the window still advances with playback.
+const PRIORITY_RANGE_REUSE_WINDOW_MS = 5000
+// Bound how many blob core sessions the priority registry keeps alive for
+// reuse across range requests.
+const MAX_TRACKED_PRIORITY_BLOBS = 8
+
+// One entry per blob currently being prioritized for playback:
+// registryKey -> { core, range, timer, createdAt, start, end }
+const activePriorityRanges = new Map()
+
+function getPriorityRegistryKey(key, blob) {
+  return `${key.toString('hex')}:${blob.blockOffset}:${blob.blockLength}`
+}
+
+function destroyPriorityRange(entry) {
+  if (!entry) return
+  if (entry.timer) {
+    clearTimeout(entry.timer)
+    entry.timer = null
+  }
+  if (entry.range) {
+    try { entry.range.destroy?.() } catch { /* best effort */ }
+    entry.range = null
+  }
+}
+
+function closePriorityCore(core) {
+  if (!core) return
+  try {
+    const closing = core.close?.()
+    if (closing && typeof closing.catch === 'function') closing.catch(() => {})
+  } catch { /* best effort */ }
+}
+
+function releasePriorityEntry(entry) {
+  destroyPriorityRange(entry)
+  if (!entry?.core) return
+  closePriorityCore(entry.core)
+  entry.core = null
+}
+
+export function releaseAllPrioritizedBlobRanges() {
+  for (const entry of activePriorityRanges.values()) releasePriorityEntry(entry)
+  activePriorityRanges.clear()
+}
 
 const blobIdEncoding = {
   preencode(state, blob) {
@@ -151,12 +199,45 @@ export async function prioritizeBlobServerRangeRequest(blobServer, req, options 
   const downloadRange = getPrioritizedBlobDownloadRange(request.blob, request.byteRange, options)
   if (!downloadRange) return null
 
-  const core = await blobServer._getCore(request.key, {
-    key: request.key,
-    blob: request.blob,
-    range: request.byteRange
-  }, true)
-  if (!core || typeof core.download !== 'function') return null
+  // Transient callers own the core session lifecycle for this single request
+  // and bypass the shared registry entirely.
+  const transient = options.closeCoreOnCleanup === true
+  const registryKey = getPriorityRegistryKey(request.key, request.blob)
+  const existing = activePriorityRanges.get(registryKey) || null
+
+  if (
+    !transient &&
+    existing?.range &&
+    downloadRange.start >= existing.start &&
+    downloadRange.start < existing.end &&
+    Date.now() - existing.createdAt < PRIORITY_RANGE_REUSE_WINDOW_MS
+  ) {
+    return downloadRange
+  }
+
+  // Anything outside the fresh window is a seek (or the window advancing with
+  // playback): drop the stale prioritized range immediately so replication
+  // bandwidth refocuses on the bytes the player is about to block on, instead
+  // of letting up to 16MB of pre-seek window keep competing for peers for the
+  // rest of its timeout lifetime. This is what makes seeks into uncached
+  // regions start delivering quickly.
+  destroyPriorityRange(existing)
+
+  let core = !transient && existing?.core && existing.core.closed !== true ? existing.core : null
+  if (!core) {
+    core = await blobServer._getCore(request.key, {
+      key: request.key,
+      blob: request.blob,
+      range: request.byteRange
+    }, true)
+  }
+  if (!core || typeof core.download !== 'function') {
+    if (existing) {
+      activePriorityRanges.delete(registryKey)
+      releasePriorityEntry(existing)
+    }
+    return null
+  }
 
   // Video playback reads bytes sequentially from the seek point forward, so the
   // prioritized region must download in play order. `linear: false` let
@@ -168,6 +249,32 @@ export async function prioritizeBlobServerRangeRequest(blobServer, req, options 
     end: downloadRange.end,
     linear: true
   })
+
+  const entry = {
+    core,
+    range,
+    timer: null,
+    createdAt: Date.now(),
+    start: downloadRange.start,
+    end: downloadRange.end
+  }
+
+  if (!transient) {
+    // The session moves to the new entry; make sure no stale reference can
+    // close it underneath the active download.
+    if (existing) existing.core = null
+    activePriorityRanges.delete(registryKey)
+    activePriorityRanges.set(registryKey, entry)
+    // Keep the session pool bounded (Map preserves insertion order = LRU).
+    while (activePriorityRanges.size > MAX_TRACKED_PRIORITY_BLOBS) {
+      const oldestKey = activePriorityRanges.keys().next().value
+      if (oldestKey === registryKey) break
+      const oldest = activePriorityRanges.get(oldestKey)
+      activePriorityRanges.delete(oldestKey)
+      releasePriorityEntry(oldest)
+    }
+  }
+
   const timeoutMs = Math.max(
     1000,
     Number(options.timeoutMs ?? DEFAULT_BLOB_RANGE_PRIORITY_TIMEOUT_MS) || DEFAULT_BLOB_RANGE_PRIORITY_TIMEOUT_MS
@@ -176,20 +283,17 @@ export async function prioritizeBlobServerRangeRequest(blobServer, req, options 
   const cleanup = () => {
     if (cleanedUp) return
     cleanedUp = true
-    try { range?.destroy?.() } catch { /* best effort */ }
-    // Do NOT close the shared serving core by default: `_getCore` returns the
-    // core that hypercore-blob-server is actively streaming byte ranges from to
-    // the player. Closing it on range-priority cleanup tears down playback
-    // mid-stream, causing constant stalls. Only close when a caller explicitly
-    // owns the core lifecycle for this request.
-    if (options.closeCoreOnCleanup === true) {
-      try {
-        const closeResult = core.close?.()
-        if (closeResult && typeof closeResult.catch === 'function') closeResult.catch(() => {})
-      } catch { /* best effort */ }
+    destroyPriorityRange(entry)
+    if (entry.range !== range) {
+      try { range?.destroy?.() } catch { /* best effort */ }
     }
+    // Do NOT close the registry-held core session here: it stays pooled so the
+    // next range request for this blob reuses it instead of leaking a fresh
+    // session per request. Transient callers opted into owning the lifecycle.
+    if (transient) closePriorityCore(core)
   }
-  const timer = setTimeout(cleanup, timeoutMs)
+  entry.timer = setTimeout(cleanup, timeoutMs)
+
   const done = typeof range?.done === 'function'
     ? range.done()
     : typeof range?.downloaded === 'function'
@@ -198,10 +302,7 @@ export async function prioritizeBlobServerRangeRequest(blobServer, req, options 
 
   Promise.resolve(done)
     .catch(() => {})
-    .finally(() => {
-      clearTimeout(timer)
-      cleanup()
-    })
+    .finally(cleanup)
 
   return downloadRange
 }

--- a/packages/backend/src/storage.js
+++ b/packages/backend/src/storage.js
@@ -26,7 +26,7 @@ import {
 import { NETWORK_TOPIC_STRING } from './types.js'
 import { normalizeBlobRefInput } from './blob-ref.js'
 import { createKnownPeerCache } from './known-peers.js'
-import { prioritizeBlobServerRangeRequest } from './blob-range-priority.js'
+import { prioritizeBlobServerRangeRequest, releaseAllPrioritizedBlobRanges } from './blob-range-priority.js'
 
 function resolveDebugLogPath() {
   return globalThis?.process?.env?.PEARTUBE_NATIVE_WORKLET_DEBUG_LOG || null
@@ -2208,6 +2208,9 @@ export async function shutdownBackend(ctx) {
 
     if (ctx.blobServer) {
       console.log('[Backend] Shutdown: closing blobServer...')
+      try {
+        releaseAllPrioritizedBlobRanges()
+      } catch { /* best effort */ }
       await runShutdownStep('blobServer close', async () => {
         await ctx.blobServer.close()
       }, 2000)

--- a/packages/backend/test/blob-range-priority.test.mjs
+++ b/packages/backend/test/blob-range-priority.test.mjs
@@ -10,6 +10,7 @@ import {
   getPrioritizedBlobDownloadRange,
   parseHttpByteRange,
   prioritizeBlobServerRangeRequest,
+  releaseAllPrioritizedBlobRanges,
 } from '../src/blob-range-priority.js'
 
 const blobIdEncoding = {
@@ -65,7 +66,7 @@ test('getPrioritizedBlobDownloadRange maps a seek byte range to the matching blo
   )
 })
 
-function createRangeRequest({ method = 'GET', token = 'test-token' } = {}) {
+function createRangeRequest({ method = 'GET', token = 'test-token', rangeStart = 4 * 65536, rangeEnd = (5 * 65536) - 1 } = {}) {
   const key = Buffer.from('b'.repeat(64), 'hex')
   const blob = {
     blockOffset: 10,
@@ -78,25 +79,24 @@ function createRangeRequest({ method = 'GET', token = 'test-token' } = {}) {
     method,
     url: `/?key=${HypercoreID.encode(key)}&blob=${encodedBlob}&type=video%2Fmp4&token=${token}`,
     headers: {
-      range: `bytes=${4 * 65536}-${(5 * 65536) - 1}`,
+      range: `bytes=${rangeStart}-${rangeEnd}`,
     },
   }
   return { key, blob, req }
 }
 
-test('prioritizeBlobServerRangeRequest starts a linear core download for the requested HTTP GET range', async (t) => {
-  const calls = []
-  const { key, blob, req } = createRangeRequest()
-  const blobServer = {
+function createMockBlobServer(calls, { resolveDone = true } = {}) {
+  return {
     token: 'test-token',
     async _getCore(requestKey, info, active) {
       calls.push(['_getCore', requestKey.toString('hex'), info.blob, active])
       return {
+        closed: false,
         download(options) {
           calls.push(['download', options])
           return {
-            done: () => Promise.resolve(),
-            destroy: () => calls.push(['destroy']),
+            done: () => (resolveDone ? Promise.resolve() : new Promise(() => {})),
+            destroy: () => calls.push(['destroy', options.start]),
           }
         },
         close() {
@@ -105,6 +105,13 @@ test('prioritizeBlobServerRangeRequest starts a linear core download for the req
       }
     },
   }
+}
+
+test('prioritizeBlobServerRangeRequest starts a linear core download for the requested HTTP GET range', async (t) => {
+  releaseAllPrioritizedBlobRanges()
+  const calls = []
+  const { key, blob, req } = createRangeRequest()
+  const blobServer = createMockBlobServer(calls)
 
   const result = await prioritizeBlobServerRangeRequest(blobServer, req, { readAheadBytes: 0 })
   await Promise.resolve()
@@ -113,10 +120,57 @@ test('prioritizeBlobServerRangeRequest starts a linear core download for the req
   t.alike(result, { start: 14, end: 15, blocks: 1 })
   t.alike(calls[0], ['_getCore', key.toString('hex'), blob, true])
   t.alike(calls[1], ['download', { start: 14, end: 15, linear: true }])
-  // The shared serving core must NOT be closed on cleanup by default: it is the
-  // same core hypercore-blob-server streams playback ranges from. Closing it
-  // mid-stream causes constant playback stalls.
-  t.absent(calls.some((call) => call[0] === 'close'), 'shared serving core is not closed on default cleanup')
+  // The pooled core session must NOT be closed on default cleanup: it is kept
+  // in the registry so the next range request reuses it instead of opening a
+  // fresh session per request.
+  t.absent(calls.some((call) => call[0] === 'close'), 'pooled core session is not closed on default cleanup')
+})
+
+test('a seek outside the active window drops the stale prioritized range and reuses the core session', async (t) => {
+  releaseAllPrioritizedBlobRanges()
+  const calls = []
+  const blobServer = createMockBlobServer(calls, { resolveDone: false })
+
+  const first = createRangeRequest({ rangeStart: 4 * 65536, rangeEnd: (5 * 65536) - 1 })
+  const firstRange = await prioritizeBlobServerRangeRequest(blobServer, first.req, { readAheadBytes: 0 })
+  t.alike(firstRange, { start: 14, end: 15, blocks: 1 })
+
+  // Seek far ahead of the prioritized window while its download is in flight.
+  const second = createRangeRequest({ rangeStart: 90 * 65536, rangeEnd: (91 * 65536) - 1 })
+  const secondRange = await prioritizeBlobServerRangeRequest(blobServer, second.req, { readAheadBytes: 0 })
+  t.alike(secondRange, { start: 100, end: 101, blocks: 1 })
+
+  const downloads = calls.filter((call) => call[0] === 'download')
+  const destroys = calls.filter((call) => call[0] === 'destroy')
+  const getCores = calls.filter((call) => call[0] === '_getCore')
+
+  t.is(getCores.length, 1, 'core session is reused across range requests for the same blob')
+  t.is(downloads.length, 2, 'the seek starts a new prioritized download')
+  t.alike(destroys, [['destroy', 14]], 'the pre-seek prioritized range is destroyed so the seek target gets the bandwidth')
+  t.ok(calls.findIndex((call) => call[0] === 'destroy') < calls.lastIndexOf(downloads[1]), 'stale range is dropped before the new download starts')
+
+  releaseAllPrioritizedBlobRanges()
+})
+
+test('requests inside a fresh prioritized window reuse the in-flight download', async (t) => {
+  releaseAllPrioritizedBlobRanges()
+  const calls = []
+  const blobServer = createMockBlobServer(calls, { resolveDone: false })
+
+  const first = createRangeRequest({ rangeStart: 4 * 65536, rangeEnd: (5 * 65536) - 1 })
+  await prioritizeBlobServerRangeRequest(blobServer, first.req, { readAheadBytes: 4 * 65536 })
+
+  // Progressive playback re-requests a couple of blocks ahead, still inside
+  // the prioritized window that was just created.
+  const second = createRangeRequest({ rangeStart: 6 * 65536, rangeEnd: (7 * 65536) - 1 })
+  const secondRange = await prioritizeBlobServerRangeRequest(blobServer, second.req, { readAheadBytes: 4 * 65536 })
+
+  t.ok(secondRange, 'contained request still resolves a download range')
+  t.is(calls.filter((call) => call[0] === 'download').length, 1, 'in-flight window download is not restarted')
+  t.is(calls.filter((call) => call[0] === 'destroy').length, 0, 'in-flight window download is not destroyed')
+  t.is(calls.filter((call) => call[0] === '_getCore').length, 1, 'no extra core session is opened')
+
+  releaseAllPrioritizedBlobRanges()
 })
 
 test('prioritizeBlobServerRangeRequest closes the core when closeCoreOnCleanup is set', async (t) => {
@@ -165,13 +219,22 @@ test('prioritizeBlobServerRangeRequest ignores HEAD range probes', async (t) => 
 })
 
 test('storage wires blob range prioritization before delegating blob-server requests', (t) => {
-  const importIndex = storageSource.indexOf("import { prioritizeBlobServerRangeRequest } from './blob-range-priority.js'")
+  const importIndex = storageSource.indexOf("import { prioritizeBlobServerRangeRequest, releaseAllPrioritizedBlobRanges } from './blob-range-priority.js'")
   const wrapperIndex = storageSource.indexOf('blobServer._onrequest = async function (req, res)')
   const priorityIndex = storageSource.indexOf('await prioritizeBlobServerRangeRequest(blobServer, req)')
   const delegateIndex = storageSource.indexOf('return origOnRequest(req, res)')
 
-  t.ok(importIndex >= 0, 'storage imports range priority helper')
+  t.ok(importIndex >= 0, 'storage imports range priority helpers')
   t.ok(wrapperIndex >= 0, 'storage wraps blob-server requests')
   t.ok(priorityIndex > wrapperIndex, 'range priority runs inside the request wrapper')
   t.ok(priorityIndex < delegateIndex, 'range priority runs before blob-server serves the range')
+})
+
+test('storage releases pooled priority ranges during backend shutdown', (t) => {
+  const releaseIndex = storageSource.indexOf('releaseAllPrioritizedBlobRanges()')
+  const blobServerCloseIndex = storageSource.indexOf("runShutdownStep('blobServer close'")
+
+  t.ok(releaseIndex >= 0, 'shutdown releases pooled priority ranges')
+  t.ok(blobServerCloseIndex >= 0, 'shutdown closes the blob server')
+  t.ok(releaseIndex < blobServerCloseIndex, 'priority ranges are released before the blob server closes')
 })


### PR DESCRIPTION
Seeking into a part of a video that wasn't cached locally could freeze
playback permanently, for two compounding reasons:

1. Stale prioritized download windows kept competing for bandwidth.
   Every HTTP range request spawned a fresh 16MB linear core.download()
   that lived up to 15s. After a seek, the pre-seek windows kept pulling
   blocks the player no longer needed, starving the seek target. The
   blob server's byte stream then hit its 30s core.get timeout, errored,
   and reset the player's range request mid-response.

2. The native player treated that reset as a fatal error. expo-video
   surfaced statusChange 'error', the app's onError handler only logged
   it, and the surface stayed frozen forever.

Fixes:

- blob-range-priority now keeps a per-blob registry of the active
  prioritized range. A request outside the current window (a seek)
  destroys the stale range immediately so replication bandwidth
  refocuses on the bytes the player is blocking on; requests inside a
  fresh window reuse the in-flight download instead of restarting it.
  The registry also pools the blob core session per blob (previously
  every range request leaked a new session) and is released on backend
  shutdown.

- PearInlineVideoView now auto-recovers from fatal playback errors:
  it re-attaches the source, seeks back to the last playback position,
  and resumes, with a bounded attempt budget (refilled once playback
  advances past the stall) and backoff before surfacing onError.
