### PR TITLE
fix: gossip relay cached playable feed entries

### DIFF
--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -426,11 +426,18 @@ export class PublicFeed {
   _isLocallyBackedEntry(entry) {
     if (!entry || typeof entry !== 'object') return false
     const driveKey = entry.driveKey || entry.channelKey
+    const relayBackedPreview = Boolean(entry.relayServing || entry.relayRole === 'cache') &&
+      Array.isArray(entry.previewVideos) &&
+      entry.previewVideos.some((video) => {
+        const availability = String(video?.byteAvailability || video?.availability || '').toLowerCase()
+        return availability === 'playable' && Boolean(video?.blobId && video?.blobsCoreKey)
+      })
     return (
       entry.source === 'local' ||
       entry.source === 'relay-cache' ||
       (driveKey && this.publishedChannels.has(driveKey)) ||
-      this._entryHasPlayablePreview(entry)
+      this._entryHasPlayablePreview(entry) ||
+      relayBackedPreview
     )
   }
 
@@ -573,13 +580,15 @@ export class PublicFeed {
         const driveKey = snapshot?.driveKey
         if (!driveKey || !byKey.has(driveKey)) continue
 
+        const previewVideos = this._sanitizePreviewVideos(snapshot.previewVideos || byKey.get(driveKey)?.previewVideos)
         const merged = {
           ...byKey.get(driveKey),
           publicBeeKey: this._resolvePublicBeeKey(snapshot) || byKey.get(driveKey)?.publicBeeKey || null,
           channelName: snapshot.channelName || byKey.get(driveKey)?.channelName || null,
           videoCount: Number(snapshot.videoCount || byKey.get(driveKey)?.videoCount || 0) || 0,
           manifestUpdatedAt: Number(snapshot.manifestUpdatedAt || byKey.get(driveKey)?.manifestUpdatedAt || 0) || 0,
-          previewVideos: this._sanitizePreviewVideos(snapshot.previewVideos || byKey.get(driveKey)?.previewVideos),
+          previewVideos,
+          previewVideosHash: hashPreviewVideos(previewVideos),
         }
         byKey.set(driveKey, merged)
         this._applyEntrySnapshot(driveKey, merged)
@@ -1672,7 +1681,7 @@ export class PublicFeed {
     // or has explicitly published, not every historical key it heard about.
     const buildAnnounceEntries = () => Array.from(this.entries.values())
       .filter((entry) => isValidKey(this._resolvePublicBeeKey(entry)))
-      .filter((entry) => this._isLocallyBackedEntry(entry))
+      .filter((entry) => this._isLocallyBackedEntry(entry) || entry?.relayServing === true || entry?.relayRole === 'cache')
       .map((entry) => this._serializeEntry(entry))
 
     const baseEntries = buildAnnounceEntries()

--- a/packages/backend/test/public-feed-signed-ingress.test.mjs
+++ b/packages/backend/test/public-feed-signed-ingress.test.mjs
@@ -180,6 +180,78 @@ test('public feed rejects inbound relay-cache-like HAVE_FEED entries without sig
   }
 })
 
+test('public feed treats relay-served playable preview entries as locally backed for outbound gossip', () => {
+  const manager = new PublicFeedManager(createSwarm(), createMetaDb())
+  try {
+    assert.equal(manager._isLocallyBackedEntry({
+      driveKey: key(11),
+      publicBeeKey: key(12),
+      source: 'peer',
+      relayRole: 'cache',
+      relayServing: true,
+      discoveryOnly: true,
+      restoredFromCache: true,
+      requiresAvailabilityProbe: true,
+      previewVideos: [{
+        id: 'relay-restored-playable',
+        blobId: '0:8:0:1024',
+        blobsCoreKey: key(13),
+        availability: 'playable',
+        byteAvailability: 'playable',
+        readyForPlayback: false,
+        hasHeadBlock: false,
+        contiguousBlocks: 0,
+      }],
+    }), true)
+  } finally {
+    manager.stop()
+  }
+})
+
+test('public feed re-sends relay-cache HAVE_FEED after snapshot enrichment', async () => {
+  const manager = new PublicFeedManager(createSwarm(), createMetaDb())
+  const conn = {}
+  const sent = []
+  try {
+    manager.peerChannels.set(conn, {
+      messages: [{
+        send(msg) { sent.push(msg) },
+      }],
+    })
+    manager.entries.set(key(14), {
+      driveKey: key(14),
+      publicBeeKey: key(15),
+      source: 'peer',
+      relayRole: 'cache',
+      relayServing: true,
+      discoveryOnly: true,
+      restoredFromCache: true,
+      requiresAvailabilityProbe: true,
+    })
+    manager.feedSnapshotProvider = async (entries) => entries.map((entry) => ({
+      ...entry,
+      previewVideos: [{
+        id: 'relay-snapshot-video',
+        blobId: '0:8:0:1024',
+        blobsCoreKey: key(16),
+        availability: 'playable',
+        byteAvailability: 'playable',
+      }],
+    }))
+
+    manager.sendHaveFeed(conn)
+    await new Promise((resolve) => setImmediate(resolve))
+
+    assert.equal(sent.length, 2)
+    assert.equal(sent[0].entries.length, 1)
+    assert.equal(sent[0].entries[0].previewVideos, undefined)
+    assert.equal(sent[1].entries.length, 1)
+    assert.equal(sent[1].entries[0].previewVideos.length, 1)
+  } finally {
+    manager.stop()
+  }
+})
+
 test('public feed counts already-known async verified HAVE_FEED entries for the peer connection', async () => {
   const manager = new PublicFeedManager(createSwarm(), createMetaDb())
   const signed = await signedDescriptor({ channelId: key(7), metadataKey: key(8), mediaKey: key(9) })


### PR DESCRIPTION
## Summary
- advertise relay-cache entries marked relayServing/cache even before snapshot enrichment
- preserve previewVideosHash during feed snapshot enrichment so HAVE_FEED is resent with playable preview refs
- cover restored relay-cache playable preview gossip with backend tests

## Test plan
- npx brittle test/public-feed-signed-ingress.test.mjs