### PR TITLE
Block bare-module-lexer 1.5.1 and verify packed bundles against dropped requires

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "typescript": "~6.0.3"
   },
   "overrides": {
+    "bare-module-lexer": ">=1.5.2",
     "eslint-plugin-react-hooks": "^4.6.2",
     "@peartube/spec": "file:packages/spec"
   },

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -151,6 +151,7 @@
   },
   "overrides": {
     "@peartube/spec": "file:../spec",
+    "bare-module-lexer": ">=1.5.2",
     "bogon": "1.2.0",
     "minipass": "^7.1.2",
     "tar": {

--- a/packages/app/scripts/build-backend-bundles.js
+++ b/packages/app/scripts/build-backend-bundles.js
@@ -55,6 +55,53 @@ function runBarePack(bundle) {
   }
 }
 
+function stripComments(source) {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:'"\\])\/\/[^\n]*/g, '$1')
+}
+
+// bare-pack relies on bare-module-lexer to discover require() calls; a lexer
+// regression once silently dropped modules required from inside
+// `module.exports = { ... }` literals (bare-module-lexer 1.5.1), shipping a
+// worklet bundle without bare-rpc — the backend then never started on device.
+// Re-scan the packed output with an independent regex and fail the build if
+// any literal require() in a bundled CJS file has no resolution entry.
+async function verifyBundleRequireCoverage(bundle) {
+  const { createRequire } = await import('node:module')
+  const requireFromApp = createRequire(path.join(projectRoot, 'package.json'))
+  const Bundle = requireFromApp('bare-bundle')
+
+  const outputPath = resolveRepoPath(bundle.output)
+  const packed = Bundle.from(Buffer.from(requireFromApp(outputPath)))
+
+  const problems = []
+  for (const key of packed.keys()) {
+    if (!/\.(js|cjs)$/.test(key)) continue
+
+    const source = stripComments(packed.read(key).toString())
+    const resolutions = packed.resolutions[key] || {}
+    const requirePattern = /(?:^|[^.\w$])require\s*\(\s*['"]([^'"\n]+)['"]\s*\)/g
+
+    let match
+    while ((match = requirePattern.exec(source))) {
+      const specifier = match[1]
+      if (specifier.startsWith('bare:') || specifier.startsWith('node:')) continue
+      if (!(specifier in resolutions)) problems.push(`${key} -> ${specifier}`)
+    }
+  }
+
+  if (problems.length > 0) {
+    throw new Error(
+      `[bundle:backend] ${bundle.id}: packed bundle is missing resolutions for ` +
+      `${problems.length} require() call(s) — the module lexer likely failed to ` +
+      `see them and bare-pack dropped the modules:\n  ${problems.join('\n  ')}`
+    )
+  }
+
+  console.log(`[bundle:backend] ${bundle.id}: require() coverage verified`)
+}
+
 async function main() {
   const only = process.argv.slice(2)
   const manifest = await loadManifest()
@@ -66,7 +113,10 @@ async function main() {
     throw new Error(`No backend bundles matched: ${only.join(', ')}`)
   }
 
-  for (const bundle of bundles) runBarePack(bundle)
+  for (const bundle of bundles) {
+    runBarePack(bundle)
+    await verifyBundleRequireCoverage(bundle)
+  }
 }
 
 main().catch(err => {

--- a/packages/desktop-native/package.json
+++ b/packages/desktop-native/package.json
@@ -17,5 +17,8 @@
     "test:bridge": "npm run ensure:barekit-echo && npm run ensure:barekit-bare-fs && npm run ensure:barekit-corestore && npm run ensure:bare-runtime && npm run ensure:host-sidecar && npm run ensure:host-worklet && npm run ensure:host-worklet-frameworks && npm run ensure:bare-mpv-prebuilds && node --test scripts/bare-pack-host-flags.test.mjs scripts/barekit-build-contract.test.mjs Bridge/bridge-core.test.mjs Bridge/native-rpc.test.mjs Bridge/playback-resolution.test.mjs Bridge/sidecar-addon-roots.test.mjs Bridge/native-host-sidecar.test.mjs",
     "test": "npm run generate && npm run test:bridge && xcodebuild -project PearTubeDesktop.xcodeproj -scheme PearTubeDesktop -configuration Debug -derivedDataPath build test",
     "run": "open ./build/Build/Products/Debug/PearTubeDesktop.app"
+  },
+  "overrides": {
+    "bare-module-lexer": ">=1.5.2"
   }
 }


### PR DESCRIPTION
The v0.2.5 Android/iOS release builds shipped a backend worklet bundle
missing 54 files (all of bare-rpc, compact-encoding, varint submodules,
bare-stream, safety-catch, teex under @peartube/spec). bare-module-lexer
1.5.1 — published between the v0.2.4 and v0.2.5 CI builds and resolved
fresh because nothing pins it — failed to see require() calls inside
`module.exports = { ... }` object literals, so bare-pack silently dropped
those modules and their resolution entries. On device the worklet died
with MODULE_NOT_FOUND before HRPC came up, and the app sat in the 30s
"Backend is taking longer than expected" startup timeout forever.
Upstream fixed the lexer in 1.5.2, published 25 minutes after the v0.2.5
build ran.

- Add `"bare-module-lexer": ">=1.5.2"` overrides to every install root
  that runs bare-pack (repo root, packages/app, packages/desktop-native)
  so a floating install can never resolve the broken version again
- Make build-backend-bundles.js re-scan each packed bundle with a regex
  that is independent of the lexer and fail the build when any literal
  require() in a bundled CJS file has no resolution entry. Verified: the
  check passes on a healthy bundle and fails with all 14 dropped
  resolutions when packing with lexer 1.5.1

The v0.2.5 release artifacts themselves are unfixable in place — the
Android (and iOS) release workflows need a re-run now that 1.5.2 is
current.

