### PR TITLE
Consolidate thumbnails onto bare-ffmpeg, drop bare-media

### DIFF
--- a/docs/superpowers/plans/2026-04-05-replace-mpv-with-html5-video.md
+++ b/docs/superpowers/plans/2026-04-05-replace-mpv-with-html5-video.md
@@ -1,5 +1,13 @@
 # Replace MpvPlayer with HTML5 Video (react-native-video web) Implementation Plan
 
+> **Superseded/extended by `2026-06-11-retire-libmpv-cross-platform.md`** — this doc
+> is the Electrobun/web slice of a broader cross-platform libmpv retirement. Two
+> updates since this was written: (1) the "Known tradeoffs" codec loss below is no
+> longer accepted — `MseVideoPlayer.web.tsx` + mediabunny already remux MKV, and a
+> bare-ffmpeg audio-transcode fallback (`2026-06-11-desktop-mse-audio-transcode-fallback.md`)
+> covers AC-3/DTS, so this becomes a **regression-free** swap; (2) the desktop-native
+> app is now **in scope** of the umbrella plan, not permanently out of scope.
+
 > **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Unify all platforms on `react-native-video` by removing the MpvPlayer/bare-mpv desktop playback path and using react-native-video's built-in web implementation (which renders a standard HTML5 `<video>` tag) on Pear Desktop.

--- a/docs/superpowers/plans/2026-06-11-desktop-mse-audio-transcode-fallback.md
+++ b/docs/superpowers/plans/2026-06-11-desktop-mse-audio-transcode-fallback.md
@@ -1,0 +1,150 @@
+# Desktop MSE fallback: real-time bare-ffmpeg audio transcode
+
+Status: design / proposal
+Date: 2026-06-11
+Scope: Electrobun desktop (system WebView: WKWebView / WebView2 / WebKitGTK)
+
+## Problem
+
+Desktop playback is already an **MSE pipeline**: `MseVideoPlayer.web.tsx` drives a
+`MediaSource` / `SourceBuffer` and uses **mediabunny** to remux MKV/MP4 into
+fragmented MP4 (`moof`/`mdat` pairs, absolute `tfdt` timestamps) entirely in JS,
+stream-copying packets — no transcode. This works whenever the webview can
+natively decode the contained codecs.
+
+PearTube is P2P with arbitrary uploads, so we hit codecs the webview can't decode.
+The gap has two halves:
+
+1. **Audio-only gap** — video codec is supported (H.264/HEVC) but the audio track
+   isn't (AC-3, E-AC-3, DTS, Opus, Vorbis, TrueHD, …). This is the **common** case
+   for "won't play" MKVs.
+2. **Video gap** — the video codec itself is unsupported (VP8/VP9/AV1, or H.264 on a
+   WebKitGTK build without licensed decoders). Audio transcode does not help here.
+
+This doc covers (1): a cheap, real-time **audio→AAC transcode with video
+stream-copy**, delivered as fMP4 fragments into the existing SourceBuffer. (2) is
+tracked separately (see "Out of scope" below).
+
+## Why this shape
+
+- **Cheap.** Audio→AAC is real-time on any CPU; video is stream-copied (zero
+  re-encode, zero quality loss). Crucially it needs **no H.264 encoder**, which
+  matters because the `bare-ffmpeg` fork builds with `BARE_FFMPEG_ENABLE_GPL=OFF`
+  (no libx264) and has no software H.264 encoder.
+- **Reuses existing infra.** `cast-transcoder.mjs` already does
+  "video-copy + audio-to-AAC" and already muxes **fragmented MP4** with
+  `frag_keyframe+empty_moov+default_base_moof` (the `FMP4Segmenter` path). We feed
+  the same fragments to MSE instead of (or in addition to) Chromecast.
+- **Stays on MSE → portable.** Native HLS (`.m3u8`) playback is a WKWebView-only
+  trick; WebView2 and WebKitGTK don't do it reliably. MSE works across all three
+  webviews, so we keep one playback path. HLS stays Chromecast-only.
+
+## Capability gate: let the renderer decide
+
+Do **not** hardcode a per-webview codec matrix. The renderer knows its own
+capabilities. Drive the decision with `MediaSource.isTypeSupported()`:
+
+```ts
+// in MseVideoPlayer.web.tsx, after probe returns codec strings
+const videoOk = MediaSource.isTypeSupported(`video/mp4; codecs="${videoCodecStr}"`)
+const audioOk = MediaSource.isTypeSupported(`video/mp4; codecs="${audioCodecStr}"`)
+```
+
+Routing:
+
+| videoOk | audioOk | path |
+|---------|---------|------|
+| yes | yes | mediabunny stream-copy (today, unchanged) |
+| yes | no  | **bare-ffmpeg audio→AAC, copy video, fMP4 → same SourceBuffer** |
+| no  | *   | out of scope here (full transcode or "unsupported") |
+
+This automatically handles the WebKitGTK-no-H.264 case without a lookup table.
+
+The codec strings come from probe: `transcoder.probeMedia()` /
+`probeWithBareFFmpeg()` already returns `videoCodec`, `audioCodec`, profile/level,
+width/height. We need to map those to RFC 6381 codec strings
+(`avc1.<profile><level>`, `mp4a.40.2`, etc.) — a small helper, partly derivable
+from the profile/level probe already exposes.
+
+## Byte-source contract
+
+`MseVideoPlayer` currently consumes mediabunny output as: one **init segment**
+(`ftyp`+`moov`) followed by **media fragments** (`moof`+`mdat`) carrying absolute
+timestamps. The transcoding source must mirror this contract so the player's
+append loop, sliding-window buffering (~60s ahead / ~30s behind), and seek logic
+are reused unchanged.
+
+Proposed interface (a drop-in alternative to the mediabunny pipeline):
+
+```ts
+interface FragmentSource {
+  init(): Promise<Uint8Array>            // ftyp+moov init segment
+  fragments(startTime: number):          // async iterator of fMP4 fragments
+    AsyncIterable<{ time: number; data: Uint8Array }>
+  seekTo(time: number): void             // restart fragment production at keyframe <= time
+  destroy(): void
+}
+```
+
+- mediabunny path: existing implementation, refactored behind this interface.
+- transcode path: backend produces the fragments via bare-ffmpeg and streams them
+  to the renderer over the existing HRPC/IPC channel (binary relay already exists
+  in the Electrobun bridge).
+
+## Backend side
+
+Reuse `cast-transcoder.mjs`'s `runVideoCopyAudioTranscode` (video stream-copy +
+audio→AAC) with the fMP4 muxer settings it already uses
+(`frag_keyframe+empty_moov+default_base_moof` via `FMP4Segmenter`). Two deltas:
+
+1. **Don't go through the HTTP/HLS server for desktop.** Emit the init segment and
+   each `moof`/`mdat` fragment as discrete buffers pushed over IPC, rather than
+   writing `.m4s` files + playlist. (Chromecast keeps the HTTP server; desktop
+   doesn't need it.)
+2. **Absolute timestamps.** Ensure fragment `tfdt` carries absolute media time so
+   the player needs no `timestampOffset` bookkeeping (matches mediabunny today).
+
+Note: the standalone `transcodeAudioWithBareFFmpeg` in `transcoder.mjs` writes
+**plain** `'mp4'` (progressive), which is **not** appendable to a SourceBuffer.
+Use the cast-transcoder fragmented path, not that one.
+
+## Renderer / wiring
+
+- `MseVideoPlayer.web.tsx`: after probe + `isTypeSupported`, pick the
+  `FragmentSource` implementation. The SourceBuffer codec string for `addSourceBuffer`
+  becomes `video/mp4; codecs="<copied-video>, mp4a.40.2"`.
+- Desktop worker RPC: extend the playback prep path (`onWebPreparePlayback` /
+  `preparePlayback`) to optionally start a transcode session and return a handle the
+  renderer can pull fragments from, instead of only returning a blob-server URL.
+- **Seek:** on seek, the player already cancels the active pipeline and clears the
+  SourceBuffer; the transcode source must support `seekTo()` by restarting the
+  bare-ffmpeg read/transcode from the keyframe at/just before the target (the input
+  IOContext supports `onseek`).
+
+## Out of scope (tracked separately)
+
+**Unsupported video codec** (VP9/AV1/VP8, or H.264 missing in WebKitGTK). Audio
+transcode cannot fix this; options:
+
+- Full transcode to H.264. On macOS this can use `h264_videotoolbox` (HW). On
+  Windows/Linux there is **no HW H.264 encoder and no libx264** in the current
+  build, so this requires either enabling `BARE_FFMPEG_ENABLE_GPL`/x264 for those
+  platforms or surfacing "unsupported codec".
+- Decision deferred; desktop uploads hitting this are rarer than the audio gap.
+
+## Open questions
+
+- Codec-string mapping coverage: confirm probe exposes enough (profile/level) for
+  all common HEVC/H.264 variants, or extend `probeWithBareFFmpeg`.
+- IPC throughput for pushing fragment buffers vs. a localhost socket the WKWebView
+  fetches from — measure before committing to the transport.
+- Whether to keep mediabunny for the supported-codec path or unify everything
+  through the backend fragment source (simpler renderer, but moves remux off the
+  GPU-free JS path onto the worker).
+
+## Summary
+
+Keep MSE. Add a bare-ffmpeg **audio-only → AAC, video stream-copy, fMP4-fragment**
+`FragmentSource`, selected by `MediaSource.isTypeSupported`, reusing the
+cast-transcoder fragmented muxer and the player's existing append/seek/buffer
+logic. Handle unsupported *video* codecs as a separate effort.

--- a/docs/superpowers/plans/2026-06-11-desktop-mse-audio-transcode-fallback.md
+++ b/docs/superpowers/plans/2026-06-11-desktop-mse-audio-transcode-fallback.md
@@ -39,6 +39,56 @@ tracked separately (see "Out of scope" below).
   trick; WebView2 and WebKitGTK don't do it reliably. MSE works across all three
   webviews, so we keep one playback path. HLS stays Chromecast-only.
 
+## Considered: mediabunny + WebCodecs for transcode (rejected)
+
+mediabunny is already in the renderer doing remux; could it also do the audio
+transcode and avoid the worker entirely? It does support transcoding — but it
+carries **no codecs of its own**: it orchestrates the browser's **WebCodecs API**,
+and for codecs WebCodecs lacks it requires WASM extension packages. That creates
+hard gaps exactly where we need coverage:
+
+- **No WebCodecs AAC *encoder* on desktop Linux.** WebCodecs `AudioEncoder` AAC
+  exists on macOS (Safari 26+/WKWebView) and Windows (WebView2) but is unavailable
+  in any browser on desktop Linux (AAC is patent-encumbered; Linux builds omit it).
+  So mediabunny cannot produce AAC on **WebKitGTK** at all — a hard wall, mirroring
+  the H.264-on-Linux gap.
+- **AC-3 / E-AC-3 / DTS / TrueHD are not in WebCodecs.** mediabunny's answer is
+  extensions like `@mediabunny/ac3`, which are themselves "size-optimized WASM
+  builds of FFmpeg's AC-3/E-AC-3 coders" — i.e. reintroducing scoped WASM-FFmpeg
+  blobs piecemeal (and DTS/TrueHD have no extension).
+- WebCodecs draws on the **same OS codec set** as the `<video>`/MSE pipeline, so
+  for the very codecs that force a transcode, WebCodecs typically can't decode them
+  either — which is why the extensions exist.
+
+`bare-ffmpeg` already contains all of those decoders (default FFmpeg build) plus an
+AAC encoder, runs uniformly across all three webviews, and is independent of
+WebCodecs availability / OS version. Given "full codec support on every desktop" is
+a requirement, bare-ffmpeg is the dependable single fallback. mediabunny-transcode
+would at best cover macOS/Windows for WebCodecs-decodable sources — a second code
+path for a subset of what bare-ffmpeg already covers. Not worth the complexity.
+
+Refs: MDN WebCodecs codec selection; caniuse "webcodecs"; mediabunny `@mediabunny/ac3`
+extension docs.
+
+## Division of labor: keep mediabunny for remux
+
+mediabunny is **not** redundant with bare-ffmpeg and is **not** a native blob (pure
+JS/TS). The two occupy different layers and compose cleanly:
+
+- **mediabunny = container layer.** Remux / stream-copy, runs in the **renderer**,
+  reads the local blob server via HTTP range requests, appends straight to the
+  SourceBuffer. No decode, no WebCodecs, no worker, no native code. This is the
+  ~90% path (supported codecs that just need repackaging).
+- **bare-ffmpeg = codec layer.** Decode / re-encode, runs in the **worker**, used
+  only when `isTypeSupported` says the webview can't decode a track.
+
+Routing remux through bare-ffmpeg instead would push every video's full bitstream
+worker → Bun main → renderer (two IPC hops) and require SourceBuffer backpressure
+across that boundary — making the majority path more expensive to retire a
+zero-blob JS dependency. The unification we want is at the `FragmentSource`
+**interface** (one abstraction, two implementations), not by collapsing onto one
+engine.
+
 ## Capability gate: let the renderer decide
 
 Do **not** hardcode a per-webview codec matrix. The renderer knows its own

--- a/docs/superpowers/plans/2026-06-11-retire-libmpv-cross-platform.md
+++ b/docs/superpowers/plans/2026-06-11-retire-libmpv-cross-platform.md
@@ -77,6 +77,25 @@ benefit.
    `api.preparePlayback` / `getVideoUrl` (`api.js`, `blob-playback-service.js`).
 3. Reuse `probeWithBareFFmpeg` and `runVideoCopyAudioTranscode`.
 
+**Progress (2026-06-11):**
+- ✅ `playback-compat.mjs` — pure per-player capability policy
+  (`avplayer`/`exoplayer`/`webkit`/`chromecast`) + `decidePlayback` /
+  `osPlayerCanHandle`, faithful to the existing Chromecast/web checks. Unit-tested
+  (`test/playback-compat.test.mjs`, 22 cases).
+- ✅ `cast-transcoder.startCompatTranscode(sourceUrl, { player })` — generalizes
+  the dormant `startWebTranscode` to any player via the policy, reusing the proven
+  full/audio-only/remux dispatch. `startWebTranscode` now delegates (player:
+  `webkit`). Output is fMP4 HLS via the cast file server.
+- ✅ Local reachability: the cast file server binds `0.0.0.0` and
+  `getCastHlsUrl(sessionId, '127.0.0.1')` already returns a loopback URL — usable
+  by local AVPlayer, not just Chromecast. (A dedicated `127.0.0.1`-only bind can
+  be tightened later.)
+- ⏭ **Remaining:** thread the requesting `player`/capabilities through the
+  `preparePlayback` HRPC and branch there (probe → `decidePlayback` → either the
+  direct blob URL or `startCompatTranscode` + `getCastHlsUrl`). Backward-compatible
+  (absent player ⇒ today's direct-URL behavior). Needs on-device validation, so
+  staged separately from the pure/unit-tested core above.
+
 ### Phase 1 — iOS (delete dead mpv)
 4. Remove `MpvPlayerCore.swift`, `MpvPlayerView.swift`, `MpvPlayerViewManager.swift`,
    `MpvPlayerManager.m`, `MpvHttpStreamBridge.swift`, `MpvPipController.swift` and

--- a/docs/superpowers/plans/2026-06-11-retire-libmpv-cross-platform.md
+++ b/docs/superpowers/plans/2026-06-11-retire-libmpv-cross-platform.md
@@ -101,12 +101,15 @@ benefit.
   `PEARTUBE_AVPLAYER_COMPAT=1` the sidecar injects a lazy cast-transcoder +
   `player: 'avplayer'`, so AVPlayer-incompatible codecs route through local-HLS
   transcode. Off by default.
+- ✅ Mobile player threading: `rpc.native` derives the player id from `Platform.OS`
+  (iOS → `avplayer`, Android → `exoplayer`) and passes it via the worklet
+  `__peartubeLaunchOptions`; `createMobileRuntimeBackend` reads `launchOptions.player`
+  and injects `player` + a lazy cast-transcoder into the handler deps — gated by the
+  same `PEARTUBE_AVPLAYER_COMPAT` flag, inert otherwise.
 - ⏭ **Remaining (needs a device):** flip the flag and validate AVPlayer plays the
-  local-HLS output for MKV/Opus/AC-3/DTS on macOS; then **Phase 3** — drop
-  `prefersNativeMpvPlayback` so the Swift app always uses AVPlayer (no longer mpv)
-  for those, completing the desktop-native retirement. Mobile (iOS `avplayer` vs
-  Android `exoplayer`) needs the per-OS player id threaded to the worklet at launch
-  (`rpc.native` → worklet args → `attachMobileHandlers` deps) before enabling there.
+  local-HLS output for MKV/Opus/AC-3/DTS on macOS **and iOS**; then **Phase 3** —
+  drop `prefersNativeMpvPlayback` so the Swift app always uses AVPlayer (no longer
+  mpv) for those, completing the desktop-native retirement.
 
 ### Phase 1 — iOS (delete dead mpv)
 4. Remove `MpvPlayerCore.swift`, `MpvPlayerView.swift`, `MpvPlayerViewManager.swift`,

--- a/docs/superpowers/plans/2026-06-11-retire-libmpv-cross-platform.md
+++ b/docs/superpowers/plans/2026-06-11-retire-libmpv-cross-platform.md
@@ -90,11 +90,23 @@ benefit.
   `getCastHlsUrl(sessionId, '127.0.0.1')` already returns a loopback URL — usable
   by local AVPlayer, not just Chromecast. (A dedicated `127.0.0.1`-only bind can
   be tightened later.)
-- ⏭ **Remaining:** thread the requesting `player`/capabilities through the
-  `preparePlayback` HRPC and branch there (probe → `decidePlayback` → either the
-  direct blob URL or `startCompatTranscode` + `getCastHlsUrl`). Backward-compatible
-  (absent player ⇒ today's direct-URL behavior). Needs on-device validation, so
-  staged separately from the pure/unit-tested core above.
+- ✅ `playback-compat-runtime.resolveCompatPlaybackUrl()` — best-effort runtime
+  orchestration (probe/decide happens inside `startCompatTranscode`; this waits for
+  the first fragment then returns the local HLS URL, falling back to the direct URL
+  on ANY error). Unit-tested with a mock transcoder (`test/playback-compat-runtime.test.mjs`).
+- ✅ Wired into the shared `mobile-handlers.js` `B.preparePlayback`, **gated** on the
+  backend passing `castTranscoder` + `player` in deps — a strict no-op otherwise, so
+  mobile/desktop behavior is unchanged.
+- ✅ Activated (behind a flag) in the desktop-native sidecar: with
+  `PEARTUBE_AVPLAYER_COMPAT=1` the sidecar injects a lazy cast-transcoder +
+  `player: 'avplayer'`, so AVPlayer-incompatible codecs route through local-HLS
+  transcode. Off by default.
+- ⏭ **Remaining (needs a device):** flip the flag and validate AVPlayer plays the
+  local-HLS output for MKV/Opus/AC-3/DTS on macOS; then **Phase 3** — drop
+  `prefersNativeMpvPlayback` so the Swift app always uses AVPlayer (no longer mpv)
+  for those, completing the desktop-native retirement. Mobile (iOS `avplayer` vs
+  Android `exoplayer`) needs the per-OS player id threaded to the worklet at launch
+  (`rpc.native` → worklet args → `attachMobileHandlers` deps) before enabling there.
 
 ### Phase 1 — iOS (delete dead mpv)
 4. Remove `MpvPlayerCore.swift`, `MpvPlayerView.swift`, `MpvPlayerViewManager.swift`,

--- a/docs/superpowers/plans/2026-06-11-retire-libmpv-cross-platform.md
+++ b/docs/superpowers/plans/2026-06-11-retire-libmpv-cross-platform.md
@@ -1,0 +1,143 @@
+# Retire libmpv across all platforms (bare-mpv → OS-native players)
+
+Status: design / proposal
+Date: 2026-06-11
+Related: `2026-04-05-replace-mpv-with-html5-video.md` (Electrobun half — extended/superseded here),
+`2026-06-11-desktop-mse-audio-transcode-fallback.md` (web compat layer)
+
+## Goal
+
+Remove `bare-mpv` (and the iOS MPVKit/libmpv integration) entirely, so every
+platform plays through its **OS-native player** with hardware decode and ships
+**zero codec blob**. Codecs the OS player can't handle are covered by a single
+shared **bare-ffmpeg compatibility layer** (remux / audio-transcode → local
+serving). End state: **one FFmpeg in the whole product** (`bare-ffmpeg`, for
+transcode + thumbnails), no libmpv anywhere, `bare-media` already gone.
+
+`bare-mpv` statically links libmpv **and a full FFmpeg** into each prebuild, so it
+is the single largest codec blob; it lives in iOS, the Electrobun desktop, and the
+experimental desktop-native app.
+
+## Per-platform status (what's actually there today)
+
+| Platform | Player today | mpv role today | Work to retire mpv |
+|---|---|---|---|
+| **Android** | expo-video (ExoPlayer) | none | **none** — ExoPlayer is codec-complete (MKV/Opus/VP9/FLAC) |
+| **iOS** | expo-video (AVPlayer), via `PearInlineVideoView.tsx` | **dead code** — native mpv module is compiled but never referenced from JS/TS | delete dead Swift/ObjC + MPVKit pod; optionally add compat serving for AVPlayer-incompatible codecs |
+| **Electrobun desktop** | MSE + mediabunny (`MseVideoPlayer.web.tsx`); `MpvPlayer.web.tsx` canvas path still present | fallback/secondary | remove `MpvPlayer.web.tsx` path (the 2026-04-05 plan) + add MSE audio-transcode fallback (already designed) |
+| **desktop-native (macOS, experimental)** | AVPlayer is the **default**; mpv chosen only when `prefersNativeMpvPlayback` | codec-coverage + a half-wired "ffmpeg decode" stub | make AVPlayer the only path, backed by compat serving; delete mpv RPC/frame-server |
+
+Key realization: **this is mostly deleting dead/secondary mpv paths, not risky
+player swaps.** Android is done; iOS mpv is unused; desktop-native already has a
+real AVPlayer path. The only genuinely *new* engineering is the shared compat
+layer that lets AVPlayer handle the codecs mpv used to cover.
+
+## The one shared piece of new work: local bare-ffmpeg compatibility serving
+
+Today `api.preparePlayback` / `getVideoUrl` always returns a **direct blob-server
+URL** (`http://127.0.0.1:<port>/blobs/...`), and HLS exists only for Chromecast
+(`cast-transcoder.mjs`, bound `0.0.0.0`). To let the OS players cover everything
+without mpv, insert a probe-driven decision at that single backend point:
+
+```
+preparePlayback(video):
+  probe(source)                       # probeWithBareFFmpeg — already exists
+  if osPlayerCanHandle(container, videoCodec, audioCodec):
+      return directBlobUrl            # today's behavior (the ~90% MP4/H.264/AAC case)
+  else:
+      session = startCompatTranscode(source)   # bare-ffmpeg, video-copy where possible
+      return localHlsUrl(session)     # 127.0.0.1, AVPlayer-friendly
+```
+
+- **bare-ffmpeg** does the work (it already has AC-3/E-AC-3/DTS/Vorbis decoders +
+  AAC encoder + MKV demux + the fMP4/HLS muxers in `cast-transcoder.mjs`). Reuse
+  `runVideoCopyAudioTranscode` (video stream-copy + audio→AAC) for the common
+  audio-gap case; full transcode only when the *video* codec is unsupported.
+- **Serving transport per player:**
+  - **AVPlayer** (iOS + desktop-native): **local HLS** (`.m3u8` + fMP4/MPEGTS) on
+    `127.0.0.1`. AVPlayer plays local HLS natively; ATS already permits the
+    loopback HTTP the blob server uses today.
+  - **WKWebView** (Electrobun): **fMP4 fragments → MSE** (the `FragmentSource` in
+    the MSE-fallback doc). Native HLS isn't portable across webviews, so MSE.
+  - **Android**: not needed — ExoPlayer handles these directly.
+- **`osPlayerCanHandle`** is a per-platform capability predicate (the backend knows
+  the requesting platform). On the webview, the renderer refines it with
+  `MediaSource.isTypeSupported`.
+
+This is the mobile/native analog of the Electrobun MSE fallback — same engine, same
+muxers, just also exposed as a loopback HLS endpoint. Build it once, three players
+benefit.
+
+## Work breakdown
+
+### Phase 0 — shared compat layer (enables everything else)
+1. Add a **local-bound HLS endpoint** to the transcoder serving (reuse
+   `cast-transcoder.mjs` muxing; bind `127.0.0.1`, not `0.0.0.0`).
+2. Add `osPlayerCanHandle(platform, probe)` + wire the probe-driven branch into
+   `api.preparePlayback` / `getVideoUrl` (`api.js`, `blob-playback-service.js`).
+3. Reuse `probeWithBareFFmpeg` and `runVideoCopyAudioTranscode`.
+
+### Phase 1 — iOS (delete dead mpv)
+4. Remove `MpvPlayerCore.swift`, `MpvPlayerView.swift`, `MpvPlayerViewManager.swift`,
+   `MpvPlayerManager.m`, `MpvHttpStreamBridge.swift`, `MpvPipController.swift` and
+   their Xcode `project.pbxproj` refs.
+5. Remove the **MPVKit** pod/dependency.
+6. Confirm PiP + background audio are provided by expo-video (they are features of
+   AVPlayer); set expo-video PiP options. *(Verify expo-video version supports PiP.)*
+7. (Optional) route AVPlayer-incompatible codecs through Phase-0 compat serving —
+   strictly an improvement over today, where such files likely fail on iOS.
+
+### Phase 2 — Electrobun desktop (execute 2026-04-05, regression-free)
+8. Implement the MSE audio-transcode `FragmentSource` (see MSE-fallback doc).
+9. Remove `MpvPlayer.web.tsx` and its render sites in `VideoPlayerOverlayImpl.tsx` /
+   `index.web.tsx`; route everything through `MseVideoPlayer.web.tsx`.
+10. Remove the mpv handlers wired for the desktop worker.
+
+### Phase 3 — desktop-native (make AVPlayer the only path)
+11. Make `startPlaybackSession` always return `.avPlayer`; route incompatible
+    codecs to the Phase-0 local-HLS URL instead of mpv.
+12. Delete the mpv branch, the **RGBA-frame server + 30fps polling renderer**
+    (`MpvPlayerView.swift` frame polling), `mpvRenderFrame`, and the
+    `prefersNativeMpvPlayback` / `prefersFFmpegDecode` / `forceAVPlayerFallback`
+    machinery. (This also removes the inefficient frame-streaming hack.)
+
+### Phase 4 — delete bare-mpv
+13. Remove the `mpv*` HRPC methods + message types from `spec/schema.cjs`,
+    regenerate JS + Swift schema.
+14. Delete the mpv RPC handlers in `native-host-sidecar.mjs` /
+    `native-host-worklet-push.mjs`.
+15. Delete `packages/bare-mpv` submodule + `.gitmodules` entry, the committed
+    `prebuilds/`, `.github/workflows/bare-mpv-prebuilds.yml`,
+    `ensure-bare-mpv-prebuilds.mjs`, and the `packages/bare-mpv` candidate in
+    `sidecar-addon-roots.mjs` / worklet bundle watcher.
+
+## Risks / feature preservation
+
+- **PiP** — iOS: expo-video supports AVPlayer PiP; desktop-native: AVKit supports
+  PiP. The bespoke `MpvPipController` is removed; confirm expo-video PiP config
+  matches the current UX (skip ±, play/pause, auto-restore).
+- **Subtitles** — mpv renders embedded **ASS/SSA** with styling; AVPlayer/expo-video
+  do VTT/SRT + CEA-608/timed-text, not ASS styling. Potential regression for
+  ASS-subbed content. (No subtitle wiring found today, so likely already absent —
+  confirm before deleting.)
+- **Codec breadth on iOS today** — AVPlayer can't demux MKV / decode Opus/AC-3/DTS.
+  Without Phase 0, those already fail on iOS (HLS is Chromecast-only). Phase 0 is
+  what closes that gap; sequence it first if iOS MKV/Opus playback matters.
+- **desktop-native is experimental** — lowest priority; Phases 0–2 deliver the main
+  wins (iOS + Electrobun + the blob deletion is gated on Phase 3/4).
+- **Seeking** — AVPlayer seeks local HLS fine; ensure the compat session supports
+  seek (restart transcode at keyframe via the input IOContext `onseek`).
+
+## Sequencing
+
+Phase 0 first (unblocks codec coverage everywhere). Then Phase 1 (cheap, pure
+deletion) and Phase 2 (the designed MSE work) in parallel. Phase 3 once AVPlayer
+compat is validated on macOS. Phase 4 (delete bare-mpv) only after no consumer
+remains — that's the commit that removes the last libmpv/embedded-FFmpeg blob.
+
+## End state
+
+OS-native player on every platform (ExoPlayer / AVPlayer / WKWebView), one shared
+bare-ffmpeg compat layer for the long tail of codecs, **one FFmpeg total**, no
+libmpv, no bare-media. Simplest configuration that still maintains full codec
+support — achieved by deleting blobs, not adding them.

--- a/packages/app/app/(tabs)/studio.tsx
+++ b/packages/app/app/(tabs)/studio.tsx
@@ -378,8 +378,8 @@ export default function StudioScreen() {
       } else if (rpc) {
         // Native: use AppContext uploadVideo so we get streaming progress events.
         // Prefer the RN-generated thumbnail when available.
-        // Keep bare-media thumbnail generation available as a fallback on iOS only.
-        // (Android bare-media thumbnail generation has been crash-prone.)
+        // Keep backend (bare-ffmpeg) thumbnail generation available as a fallback
+        // on iOS only. (Android backend thumbnail generation has been crash-prone.)
         const skipThumbnail = Platform.OS === 'android'
           ? true
           : (thumbnailGenerating || !!thumbnailFilePath)

--- a/packages/app/backend/index.mjs
+++ b/packages/app/backend/index.mjs
@@ -170,6 +170,24 @@ async function ensureCastTranscoderModule() {
   return castTranscoderPromise
 }
 
+// Lazy cast-transcoder wrapper for the AVPlayer/OS-native compatibility layer.
+function createLazyCastTranscoder() {
+  return {
+    async startCompatTranscode(...args) {
+      const module = await ensureCastTranscoderModule()
+      return module.startCompatTranscode(...args)
+    },
+    async getCastHlsUrl(...args) {
+      const module = await ensureCastTranscoderModule()
+      return module.getCastHlsUrl(...args)
+    },
+    async getCastStatus(...args) {
+      const module = await ensureCastTranscoderModule()
+      return module.getCastStatus(...args)
+    },
+  }
+}
+
 function formatError(error) {
   if (!error) return 'Unknown error'
   if (error instanceof Error) return error.stack || error.message || String(error)
@@ -362,6 +380,15 @@ export async function createMobileRuntimeBackend(options = {}) {
   const { launchOptions, workerArgs } = parseMobileLaunchArgs(args)
   const workerBundlePath = workerArgs[0] || ''
   if (workerBundlePath) globalThis.__PEARTUBE_WORKER_PATH__ = workerBundlePath
+
+  // OS-native-player compatibility layer (off unless PEARTUBE_AVPLAYER_COMPAT=1).
+  // launchOptions.player ('avplayer' on iOS / 'exoplayer' on Android) is supplied
+  // by the RN side; when enabled it routes codecs the player can't decode through
+  // a local-HLS bare-ffmpeg transcode in preparePlayback.
+  const avplayerCompatEnabled = globalThis.process?.env?.PEARTUBE_AVPLAYER_COMPAT === '1'
+  const compatDeps = (avplayerCompatEnabled && launchOptions?.player)
+    ? { player: launchOptions.player, castTranscoder: createLazyCastTranscoder() }
+    : {}
 
   let rpc = null
   let handlersRegistered = false
@@ -608,6 +635,7 @@ function removeStaleLocks(storageDir) {
       return module.generateAndStoreThumbnail(...args)
     },
     transcoder: lazyTranscoder,
+    ...compatDeps,
     storagePath
   })
 
@@ -784,6 +812,7 @@ function removeStaleLocks(storageDir) {
         return module.generateAndStoreThumbnail(...args)
       },
       transcoder: lazyTranscoder,
+      ...compatDeps,
       storagePath
     },
     destroy

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -125,7 +125,6 @@
     "babel-plugin-module-resolver": "^5.0.2",
     "bare-build": "^0.5.3",
     "bare-fs": "^4.7.1",
-    "bare-media": "^2.6.0",
     "bare-pack": "^2.0.1",
     "bare-path": "^3.0.0",
     "blind-pairing": "^2.3.1",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -62,7 +62,6 @@
     "bare-fs": "^4.7.1",
     "bare-http1": "^4.5.6",
     "bare-https": "^2.1.3",
-    "bare-media": "^2.6.0",
     "bare-os": "^3.8.7",
     "bare-path": "^3.0.0",
     "bare-storage": "^1.1.0",

--- a/packages/backend/src/mobile-handlers.js
+++ b/packages/backend/src/mobile-handlers.js
@@ -7,6 +7,8 @@
  * symlinked node_modules layout.
  */
 
+import { resolveCompatPlaybackUrl } from './transcode/playback-compat-runtime.mjs'
+
 /**
  * @param {Object} B - Backend object to attach handlers to
  * @param {Object} deps - Dependencies from the backend context
@@ -42,7 +44,7 @@ function normalizeSeedingStatus(s) {
 }
 
 export function attachMobileHandlers(B, deps) {
-  const { api, identityManager, uploadManager, ctx, initializeIdentityFromMnemonic, rpc, fs, path, generateAndStoreThumbnail, transcoder } = deps
+  const { api, identityManager, uploadManager, ctx, initializeIdentityFromMnemonic, rpc, fs, path, generateAndStoreThumbnail, transcoder, castTranscoder, player } = deps
   const refreshPublishedChannelFeed = async (driveKey) => {
     if (!driveKey || typeof api?.isChannelPublished !== 'function' || typeof api?.submitToFeed !== 'function') return
     try {
@@ -144,14 +146,34 @@ export function attachMobileHandlers(B, deps) {
     )
     return { url: res.url }
   }
-  B.preparePlayback = async (r) => api.preparePlayback(
-    r.channelKey,
-    r.videoId,
-    r.publicBeeKey,
-    r.blobId,
-    r.blobsCoreKey,
-    r.mimeType
-  )
+  B.preparePlayback = async (r) => {
+    const prepared = await api.preparePlayback(
+      r.channelKey,
+      r.videoId,
+      r.publicBeeKey,
+      r.blobId,
+      r.blobsCoreKey,
+      r.mimeType
+    )
+    // Optional OS-native-player compatibility layer: when the backend was given
+    // a `castTranscoder` + `player`, route codecs the player can't decode through
+    // a local-HLS transcode. Best-effort — any failure keeps the direct URL.
+    if (castTranscoder && player && prepared?.url) {
+      try {
+        const sourceKey = r.blobsCoreKey && r.blobId ? `${r.blobsCoreKey}:${r.blobId}` : null
+        const compat = await resolveCompatPlaybackUrl({
+          player,
+          directUrl: prepared.url,
+          sourceKey,
+          castTranscoder,
+        })
+        if (compat?.transcoded && compat.url) {
+          return { ...prepared, url: compat.url, compatTranscoded: true, compatMode: compat.mode }
+        }
+      } catch { /* best-effort: fall through to the direct URL */ }
+    }
+    return prepared
+  }
   B.setPlaybackActive = async (r = {}) => api.setPlaybackActive(r)
   B.getVideoData = async (r) => ({ video: (await api.getVideoData(r.channelKey, r.videoId, r.publicBeeKey, r.blobId, r.blobsCoreKey, r.mimeType)) || { id: r.videoId, title: 'Unknown' } })
   B.getVideoMetadata = async (r) => ({ video: (await api.getVideoData(r.channelKey, r.videoId)) || { id: r.videoId, title: 'Unknown' } })

--- a/packages/backend/src/thumbnail.js
+++ b/packages/backend/src/thumbnail.js
@@ -1,39 +1,72 @@
 /**
  * Unified Thumbnail Generation
  *
- * Uses bare-media for video frame extraction across all platforms:
- * - Desktop (Pear): via pear-run worker
- * - Mobile (iOS/Android): via BareKit worklet
+ * Uses bare-ffmpeg for video frame extraction and image encoding across all
+ * platforms running the Bare runtime (desktop Pear worker + mobile BareKit
+ * worklet).
  *
- * This replaces platform-specific solutions:
- * - Previous: bare-ffmpeg on desktop, expo-video-thumbnails on mobile
- * - Now: bare-media everywhere (runs on Bare runtime)
+ * This intentionally reuses the SAME bare-ffmpeg native addon that the
+ * transcoder already depends on, instead of pulling in `bare-media` (which
+ * bundled its own second copy of FFmpeg just for thumbnails). One FFmpeg blob,
+ * full codec coverage.
+ *
+ * Pipeline: open file -> decode the target frame -> scale/convert -> encode.
+ * Output is JPEG (via the always-available `mjpeg` encoder). WebP is NOT in the
+ * bare-ffmpeg build (no libwebp), so a requested `image/webp` transparently
+ * falls back to JPEG. PNG is used when explicitly requested and available.
  */
 
+import fs from 'bare-fs'
+
 import { logger } from './logger.js'
+import { safeDestroy, ResourceTracker } from './transcode/ffmpeg-utils.mjs'
 
 const log = logger('Thumbnail')
 
-let bareMediaRuntime = null
-let bareMediaLoadFailed = false
+let ffmpegRuntime = null
+let ffmpegLoadFailed = false
 
-async function getBareMediaRuntime() {
-  if (bareMediaRuntime) return bareMediaRuntime
-  if (bareMediaLoadFailed) return null
+async function getFfmpegRuntime() {
+  if (ffmpegRuntime) return ffmpegRuntime
+  if (ffmpegLoadFailed) return null
 
-  try {
-    const mod = await import('bare-media')
-    if (typeof mod?.video !== 'function' || typeof mod?.image?.encode !== 'function') {
-      bareMediaLoadFailed = true
+  let mod = null
+  // Prefer require when available (matches transcoder loader), fall back to
+  // dynamic import for environments without a CJS require.
+  if (typeof require === 'function') {
+    try {
+      mod = require('bare-ffmpeg')
+    } catch {
+      mod = null
+    }
+  }
+  if (!mod) {
+    try {
+      mod = await import('bare-ffmpeg')
+    } catch (err) {
+      ffmpegLoadFailed = true
+      log.warn('bare-ffmpeg unavailable; thumbnail generation disabled', { error: err?.message || String(err) })
       return null
     }
-    bareMediaRuntime = { video: mod.video, image: mod.image }
-    return bareMediaRuntime
-  } catch (err) {
-    bareMediaLoadFailed = true
-    log.warn('bare-media unavailable; thumbnail generation disabled', { error: err?.message || String(err) })
+  }
+
+  const ff = mod?.default ?? mod
+  if (
+    !ff ||
+    typeof ff.InputFormatContext !== 'function' ||
+    typeof ff.IOContext !== 'function' ||
+    typeof ff.Scaler !== 'function' ||
+    typeof ff.Frame !== 'function' ||
+    typeof ff.Packet !== 'function' ||
+    !ff.constants
+  ) {
+    ffmpegLoadFailed = true
+    log.warn('bare-ffmpeg loaded but missing required API; thumbnail generation disabled')
     return null
   }
+
+  ffmpegRuntime = ff
+  return ff
 }
 
 /**
@@ -47,32 +80,138 @@ const THUMBNAIL_CONFIG = {
   // Output dimensions
   maxWidth: 640,
   maxHeight: 360,
-  // Output format
-  mimeType: 'image/webp',
+  // Output format. WebP is unsupported by the bare-ffmpeg build and falls back
+  // to JPEG (see selectImageEncoder).
+  mimeType: 'image/jpeg',
   // Quality (0-100)
   quality: 80
 }
 
 /**
+ * Create a streaming IOContext that reads from a file via fs.readSync.
+ * Avoids loading the entire video into memory; the demuxer reads sequentially.
+ * (Mirrors the transcoder's createFileReadIOContext.)
+ */
+function createFileReadIOContext(ff, filePath, fileSize) {
+  const fd = fs.openSync(filePath, 'r')
+  let currentPos = 0
+
+  const ioContext = new ff.IOContext(16384, {
+    onread: (buffer) => {
+      if (currentPos >= fileSize) return 0 // EOF
+      const bytesToRead = Math.min(buffer.length, fileSize - currentPos)
+      const bytesRead = fs.readSync(fd, buffer, 0, bytesToRead, currentPos)
+      currentPos += bytesRead
+      return bytesRead
+    },
+
+    onseek: (offset, whence) => {
+      const SEEK_SET = 0
+      const SEEK_CUR = 1
+      const SEEK_END = 2
+      const AVSEEK_SIZE = 0x10000
+
+      if (whence === AVSEEK_SIZE) return fileSize
+      if (whence === SEEK_SET) currentPos = offset
+      else if (whence === SEEK_CUR) currentPos += offset
+      else if (whence === SEEK_END) currentPos = fileSize + offset
+
+      currentPos = Math.max(0, Math.min(currentPos, fileSize))
+      return currentPos
+    }
+  })
+
+  ioContext._cleanup = () => {
+    try { fs.closeSync(fd) } catch {}
+  }
+
+  return ioContext
+}
+
+/**
+ * Pick an image encoder for the requested mime type.
+ * - image/png  -> 'png' encoder (RGB24) when available
+ * - everything else (incl. unsupported image/webp) -> 'mjpeg' (YUVJ420P)
+ *
+ * @returns {{ encoder, pixelFormat: number, mimeType: string } | null}
+ */
+function selectImageEncoder(ff, mimeType) {
+  const want = String(mimeType || 'image/jpeg').toLowerCase()
+
+  const findByName = (name) => {
+    try {
+      const e = ff.findEncoderByName?.(name)
+      if (e && e._handle) return e
+    } catch {}
+    return null
+  }
+
+  if (want === 'image/png') {
+    const png = findByName('png')
+    if (png) return { encoder: png, pixelFormat: ff.constants.pixelFormats.RGB24, mimeType: 'image/png' }
+    log.debug('PNG encoder unavailable, falling back to JPEG')
+  } else if (want === 'image/webp') {
+    log.debug('WebP encoding unsupported by bare-ffmpeg build, using JPEG')
+  }
+
+  let mjpeg = findByName('mjpeg')
+  if (!mjpeg) {
+    try { mjpeg = ff.Codec?.for?.(ff.constants.codecs.MJPEG)?.encoder } catch {}
+  }
+  if (mjpeg && mjpeg._handle) {
+    return { encoder: mjpeg, pixelFormat: ff.constants.pixelFormats.YUVJ420P, mimeType: 'image/jpeg' }
+  }
+  return null
+}
+
+/**
+ * Compute output dimensions that fit within max bounds while preserving aspect
+ * ratio. Never upscales. Rounds to even dimensions (required by YUV 4:2:0).
+ */
+function fitDimensions(srcW, srcH, maxW, maxH) {
+  if (!srcW || !srcH || srcW <= 0 || srcH <= 0) {
+    return { width: maxW, height: maxH }
+  }
+  let w = srcW
+  let h = srcH
+  if (w > maxW || h > maxH) {
+    const ratio = Math.min(maxW / w, maxH / h)
+    w = Math.round(w * ratio)
+    h = Math.round(h * ratio)
+  }
+  w = Math.max(2, w - (w % 2))
+  h = Math.max(2, h - (h % 2))
+  return { width: w, height: h }
+}
+
+/**
  * Generate a thumbnail from a video file.
  *
- * Uses bare-media for frame extraction and image encoding.
- * Works on all platforms running Bare runtime.
+ * Uses bare-ffmpeg for frame extraction, scaling and image encoding.
+ * Works on all platforms running the Bare runtime.
  *
  * @param {string} filePath - Path to video file
  * @param {object} [options] - Thumbnail options
  * @param {number} [options.frameIndex=300] - Frame index to extract (~10s at 30fps)
  * @param {number} [options.maxWidth=640] - Maximum width
  * @param {number} [options.maxHeight=360] - Maximum height
- * @param {string} [options.mimeType='image/webp'] - Output format (image/webp, image/jpeg, image/png)
+ * @param {string} [options.mimeType='image/jpeg'] - Output format (image/jpeg, image/png)
  * @param {number} [options.quality=80] - Output quality (0-100)
  * @returns {Promise<{buffer: Buffer, mimeType: string} | null>}
  */
 export async function generateThumbnail(filePath, options = {}) {
   const config = { ...THUMBNAIL_CONFIG, ...options }
-  const runtime = await getBareMediaRuntime()
-  if (!runtime) return null
-  const { video, image } = runtime
+  const ff = await getFfmpegRuntime()
+  if (!ff) return null
+
+  let fileSize = 0
+  try {
+    fileSize = fs.statSync(filePath).size
+  } catch (err) {
+    log.warn('Could not stat video file for thumbnail', { filePath, error: err?.message })
+    return null
+  }
+  if (!fileSize) return null
 
   log.debug('Generating thumbnail', {
     filePath,
@@ -80,65 +219,154 @@ export async function generateThumbnail(filePath, options = {}) {
     maxWidth: config.maxWidth
   })
 
-  try {
-    // Extract frame at target index
-    let frame
-    try {
-      frame = video(filePath).extractFrames({ frameIndex: config.frameIndex })
-      log.debug('Frame extracted at target index', {
-        frameIndex: config.frameIndex,
-        width: frame.width,
-        height: frame.height
-      })
-    } catch (err) {
-      // Frame not available, try fallback
-      log.debug('Target frame not available, using fallback', {
-        error: err?.message,
-        fallbackIndex: config.fallbackFrameIndex
-      })
-      frame = video(filePath).extractFrames({ frameIndex: config.fallbackFrameIndex })
-    }
+  const imageSel = selectImageEncoder(ff, config.mimeType)
+  if (!imageSel) {
+    log.warn('No image encoder available; thumbnail generation disabled')
+    return null
+  }
 
-    if (!frame || !frame.data) {
-      log.warn('No frame data extracted from video')
+  const tracker = new ResourceTracker()
+  let ioContext = null
+
+  try {
+    ioContext = createFileReadIOContext(ff, filePath, fileSize)
+    const input = tracker.track(new ff.InputFormatContext(ioContext), 'input')
+
+    const videoStream = input.getBestStream(ff.constants.mediaTypes.VIDEO)
+    if (!videoStream) {
+      log.warn('No video stream found for thumbnail')
       return null
     }
 
-    // Resize if needed
-    let resizedFrame = frame
-    if (frame.width > config.maxWidth || frame.height > config.maxHeight) {
-      resizedFrame = await image.resize(frame, {
-        maxWidth: config.maxWidth,
-        maxHeight: config.maxHeight
-      })
-      log.debug('Frame resized', {
-        originalWidth: frame.width,
-        originalHeight: frame.height,
-        newWidth: resizedFrame.width,
-        newHeight: resizedFrame.height
-      })
+    const decoder = tracker.track(videoStream.decoder(), 'decoder')
+    decoder.timeBase = videoStream.timeBase
+    decoder.open()
+
+    const packet = tracker.track(new ff.Packet(), 'packet')
+    const frame = tracker.track(new ff.Frame(), 'frame')
+
+    const targetIndex = Math.max(0, config.frameIndex | 0)
+    let decodedCount = 0
+    let captured = false
+    let hitTarget = false
+    let scaler = null
+    let scaledFrame = null
+    let outW = 0
+    let outH = 0
+
+    const ensureScaler = (srcFormat, srcW, srcH) => {
+      const NONE = ff.constants.pixelFormats.NONE
+      let inFmt = srcFormat
+      if (inFmt == null || inFmt === NONE || inFmt < 0) {
+        inFmt = ff.constants.pixelFormats.YUV420P
+      }
+      const dims = fitDimensions(srcW, srcH, config.maxWidth, config.maxHeight)
+      outW = dims.width
+      outH = dims.height
+      // Scaler args: srcPixelFormat, srcW, srcH, dstPixelFormat, dstW, dstH
+      scaler = tracker.track(
+        new ff.Scaler(inFmt, srcW, srcH, imageSel.pixelFormat, outW, outH),
+        'scaler'
+      )
+      scaledFrame = tracker.track(new ff.Frame(), 'scaledFrame')
+      scaledFrame.width = outW
+      scaledFrame.height = outH
+      scaledFrame.format = imageSel.pixelFormat
+      scaledFrame.alloc()
     }
 
-    // Encode to target format
-    const encoded = await image.encode(resizedFrame, {
-      mimetype: config.mimeType,
-      quality: config.quality
-    })
+    // Capture the current decoder `frame` into `scaledFrame` (scaling/converting).
+    const captureCurrentFrame = () => {
+      const srcW = frame.width || videoStream.codecParameters.width
+      const srcH = frame.height || videoStream.codecParameters.height
+      if (!scaler) ensureScaler(frame.format, srcW, srcH)
+      scaler.scale(frame, scaledFrame)
+      scaledFrame.pts = 0
+      captured = true
+    }
+
+    // Decode until we reach the target frame. Always keep the first decoded
+    // frame as a fallback (covers videos shorter than the target index).
+    const consumeDecodedFrames = () => {
+      while (decoder.receiveFrame(frame)) {
+        if (decodedCount === 0 || decodedCount === targetIndex) {
+          captureCurrentFrame()
+          if (decodedCount === targetIndex) {
+            hitTarget = true
+            return
+          }
+        }
+        decodedCount++
+      }
+    }
+
+    while (input.readFrame(packet)) {
+      if (packet.streamIndex === videoStream.index && decoder.sendPacket(packet)) {
+        consumeDecodedFrames()
+      }
+      packet.unref()
+      if (hitTarget) break
+    }
+
+    // Flush the decoder for any buffered frames if we haven't hit the target.
+    if (!hitTarget) {
+      decoder.sendPacket(null)
+      consumeDecodedFrames()
+    }
+
+    if (!captured || !scaledFrame) {
+      log.warn('No frame could be extracted from video')
+      return null
+    }
+
+    // Encode the captured frame to a still image.
+    const encoder = tracker.track(new ff.CodecContext(imageSel.encoder), 'encoder')
+    encoder.width = outW
+    encoder.height = outH
+    encoder.pixelFormat = imageSel.pixelFormat
+    encoder.timeBase = { numerator: 1, denominator: 25 }
+
+    // Best-effort quality control for MJPEG (qscale 2=best .. 31=worst).
+    const qscale = Math.max(2, Math.min(31, Math.round(31 - (Math.max(1, Math.min(100, config.quality)) / 100) * 29)))
+    try { encoder.setOption('qscale', String(qscale)) } catch {}
+    try { encoder.setOption('q:v', String(qscale)) } catch {}
+
+    encoder.open()
+
+    const outPacket = tracker.track(new ff.Packet(), 'outPacket')
+    let encoded = null
+    if (encoder.sendFrame(scaledFrame) && encoder.receivePacket(outPacket)) {
+      encoded = Buffer.from(outPacket.data)
+      outPacket.unref()
+    }
+    if (!encoded) {
+      // Flush the encoder (single intra frame may emit on flush).
+      encoder.sendFrame(null)
+      if (encoder.receivePacket(outPacket)) {
+        encoded = Buffer.from(outPacket.data)
+        outPacket.unref()
+      }
+    }
+
+    if (!encoded || !encoded.length) {
+      log.warn('Encoder produced no thumbnail data')
+      return null
+    }
 
     log.info('Thumbnail generated', {
       size: encoded.length,
-      mimeType: config.mimeType,
-      width: resizedFrame.width,
-      height: resizedFrame.height
+      mimeType: imageSel.mimeType,
+      width: outW,
+      height: outH
     })
 
-    return {
-      buffer: Buffer.from(encoded),
-      mimeType: config.mimeType
-    }
+    return { buffer: encoded, mimeType: imageSel.mimeType }
   } catch (err) {
     log.error('Thumbnail generation failed', err)
     return null
+  } finally {
+    tracker.destroyAll()
+    try { ioContext?._cleanup?.() } catch {}
   }
 }
 

--- a/packages/backend/src/transcode/cast-transcoder.mjs
+++ b/packages/backend/src/transcode/cast-transcoder.mjs
@@ -1,6 +1,7 @@
 import http from 'bare-http1'
 
-import { probeMedia, loadBareFfmpeg, checkWebTranscodeNeeded } from './transcoder.mjs'
+import { probeMedia, loadBareFfmpeg } from './transcoder.mjs'
+import { decidePlayback } from './playback-compat.mjs'
 import { safeDestroy, safeUnref, copyCodecParameters } from './ffmpeg-utils.mjs'
 import { TempFileReader } from './temp-file-reader.mjs'
 import { getHttpFileSize } from './http-file-size.mjs'
@@ -1254,8 +1255,22 @@ async function runVideoCopyAudioTranscode(session, sourceUrl, onProgress, { isVi
  * Probes the source and only transcodes what's needed for Chromium playback.
  * If only audio needs transcoding (AC3/EAC3/DTS → AAC), uses fast video-copy path.
  */
-async function startWebTranscode(sourceUrl, options = {}) {
-  const { sourceKey = null, onProgress, isVideoComplete = true } = options
+/**
+ * Start a transcode session targeting a specific OS-native player, using the
+ * per-player capability policy in playback-compat.mjs. Produces fMP4 HLS served
+ * by the cast file server (bound 0.0.0.0, so reachable at 127.0.0.1 for local
+ * device/AVPlayer playback as well as Chromecast).
+ *
+ * @param {string} sourceUrl
+ * @param {object} [options]
+ * @param {string} [options.player='webkit'] - avplayer | exoplayer | webkit | chromecast
+ * @param {string|null} [options.sourceKey]
+ * @param {Function} [options.onProgress]
+ * @param {boolean} [options.isVideoComplete=true]
+ * @returns {Promise<{success:boolean, sessionId:string, mode?:string, reused?:boolean, reason?:string, error?:string}>}
+ */
+async function startCompatTranscode(sourceUrl, options = {}) {
+  const { player = 'webkit', sourceKey = null, onProgress, isVideoComplete = true } = options
 
   if (sourceKey) {
     const existing = findSessionBySourceKey(sourceKey)
@@ -1274,32 +1289,30 @@ async function startWebTranscode(sourceUrl, options = {}) {
     await ensureFfmpegLoaded()
     const probeResult = await probeMedia(sourceUrl)
 
-    // Use web-specific codec check (broader than Chromecast)
-    checkWebTranscodeNeeded(probeResult)
-    const needsVideoTranscode = !!probeResult.needsVideoTranscode
-    const needsAudioTranscode = !!probeResult.needsAudioTranscode
+    const decision = decidePlayback({
+      player,
+      videoCodec: probeResult.videoCodec,
+      audioCodec: probeResult.audioCodec,
+      container: probeResult.container,
+      videoProfile: probeResult.videoProfile,
+      videoLevel: probeResult.videoLevel,
+    })
 
-    // Also check container — MKV needs remux even if codecs are web-compatible
-    const needsRemux = probeResult.container && (
-      probeResult.container.includes('matroska') || probeResult.container.includes('mkv')
-    )
-
-    if (!needsVideoTranscode && !needsAudioTranscode && !needsRemux) {
+    if (decision.mode === 'direct') {
       session.status = 'complete'
       return { success: false, sessionId: session.id, reason: 'no-transcode-needed' }
     }
 
-    const mode = needsVideoTranscode ? 'full' : needsAudioTranscode ? 'audio-only' : 'remux'
-    console.log('[WebTranscode] Starting:', mode, '|', probeResult.reason || `container: ${probeResult.container}`)
+    console.log('[CompatTranscode] Starting:', decision.mode, 'for', player, '|', decision.reason)
 
     ;(async () => {
       try {
-        if (needsVideoTranscode) {
+        if (decision.mode === 'full') {
           await runFullTranscodeCast(session, sourceUrl, { isVideoComplete })
-        } else if (needsAudioTranscode) {
+        } else if (decision.mode === 'audio-only') {
           await runVideoCopyAudioTranscode(session, sourceUrl, onProgress, { isVideoComplete })
         } else {
-          // Remux only (MKV → MP4, no re-encoding)
+          // Remux only (e.g. MKV → fMP4, no re-encoding)
           await runRemuxCast(session, sourceUrl, onProgress, { isVideoComplete })
         }
       } catch (err) {
@@ -1308,19 +1321,27 @@ async function startWebTranscode(sourceUrl, options = {}) {
           session.error = session.error || 'cancelled'
         } else {
           session.status = 'error'
-          session.error = err?.message || 'Web transcode failed'
-          console.error('[WebTranscode] Error:', err?.message || err)
+          session.error = err?.message || 'Compat transcode failed'
+          console.error('[CompatTranscode] Error:', err?.message || err)
         }
         try { session.segmentStore?.setFinished?.() } catch {}
       }
     })()
 
-    return { success: true, sessionId: session.id, reused: false }
+    return { success: true, sessionId: session.id, mode: decision.mode, reused: false }
   } catch (err) {
     session.status = 'error'
-    session.error = err?.message || 'Web transcode startup failed'
+    session.error = err?.message || 'Compat transcode startup failed'
     return { success: false, error: session.error, sessionId: session.id }
   }
+}
+
+/**
+ * Back-compat entry for Electrobun/web (WKWebView/Chromium) playback.
+ * Delegates to startCompatTranscode with the webkit policy.
+ */
+async function startWebTranscode(sourceUrl, options = {}) {
+  return startCompatTranscode(sourceUrl, { ...options, player: 'webkit' })
 }
 
 async function startCastTranscode(sourceUrl, options = {}) {
@@ -1395,3 +1416,4 @@ export { createCastSession, getCastSession, findSessionBySourceKey, getCastStatu
 export { generatePlaylist }
 export { startCastTranscode }
 export { startWebTranscode }
+export { startCompatTranscode }

--- a/packages/backend/src/transcode/playback-compat-runtime.mjs
+++ b/packages/backend/src/transcode/playback-compat-runtime.mjs
@@ -1,0 +1,98 @@
+/**
+ * Runtime orchestration for the playback compatibility layer (Phase 0).
+ *
+ * Best-effort: given a direct blob URL and the target OS-native player, decide
+ * whether to route playback through the bare-ffmpeg compat transcoder (returning
+ * a local HLS URL the player can consume) or play the source directly. ANY
+ * failure falls back to the direct URL — playback must never break because the
+ * compat path errored or bare-ffmpeg was unavailable.
+ *
+ * This is pure orchestration over an injected `castTranscoder`
+ * (startCompatTranscode / getCastHlsUrl / getCastStatus), so it is fully
+ * unit-testable with a mock. The per-player policy itself lives in
+ * playback-compat.mjs and is applied inside startCompatTranscode.
+ *
+ * See: docs/superpowers/plans/2026-06-11-retire-libmpv-cross-platform.md
+ */
+
+const DEFAULT_READY_TIMEOUT_MS = 8000
+const READY_POLL_INTERVAL_MS = 200
+
+// Players routed through this HLS-based compat path. WKWebView/Chromium
+// (`webkit`) is handled by the renderer-side MSE/mediabunny path instead, and
+// ExoPlayer is codec-complete, so neither routes here by default.
+const HLS_COMPAT_PLAYERS = new Set(['avplayer'])
+
+/**
+ * @param {object} opts
+ * @param {string} opts.player - target player id (e.g. 'avplayer')
+ * @param {string} opts.directUrl - the direct blob-server URL
+ * @param {string|null} [opts.sourceKey] - stable key for session reuse
+ * @param {object} [opts.castTranscoder] - injected transcoder
+ *   (startCompatTranscode / getCastHlsUrl / getCastStatus)
+ * @param {{log?:Function,warn?:Function}|null} [opts.logger]
+ * @param {number} [opts.readyTimeoutMs]
+ * @returns {Promise<{url: string, transcoded: boolean, mode: string, sessionId?: string}>}
+ */
+export async function resolveCompatPlaybackUrl({
+  player,
+  directUrl,
+  sourceKey = null,
+  castTranscoder,
+  logger = null,
+  readyTimeoutMs = DEFAULT_READY_TIMEOUT_MS,
+} = {}) {
+  const passthrough = { url: directUrl, transcoded: false, mode: 'direct' }
+
+  if (!directUrl || !player || !castTranscoder || !HLS_COMPAT_PLAYERS.has(player)) {
+    return passthrough
+  }
+  if (typeof castTranscoder.startCompatTranscode !== 'function' ||
+      typeof castTranscoder.getCastHlsUrl !== 'function') {
+    return passthrough
+  }
+
+  try {
+    const result = await castTranscoder.startCompatTranscode(directUrl, { player, sourceKey })
+    if (!result || !result.success) {
+      // 'no-transcode-needed' (already compatible) or a startup failure → direct.
+      return passthrough
+    }
+
+    // Wait for the first fragment so the player doesn't open an empty playlist.
+    if (!result.reused && typeof castTranscoder.getCastStatus === 'function') {
+      await waitForFirstFragment(castTranscoder, result.sessionId, readyTimeoutMs)
+    }
+
+    const url = await castTranscoder.getCastHlsUrl(result.sessionId, '127.0.0.1')
+    if (!url) return passthrough
+
+    logger?.log?.(`[compat-playback] routing ${player} through ${result.mode || 'transcode'} transcode`)
+    return { url, transcoded: true, mode: result.mode || 'transcode', sessionId: result.sessionId }
+  } catch (err) {
+    logger?.warn?.(`[compat-playback] compat path failed, using direct URL: ${err?.message || err}`)
+    return passthrough
+  }
+}
+
+async function waitForFirstFragment(castTranscoder, sessionId, timeoutMs) {
+  const deadline = Date.now() + Math.max(0, timeoutMs || 0)
+  // Always poll at least once even with a zero/negative timeout.
+  do {
+    let status = null
+    try { status = await castTranscoder.getCastStatus(sessionId) } catch { status = null }
+    if (status) {
+      if (status.status === 'error') return false
+      if ((status.fragmentCount ?? 0) >= 1) return true
+    }
+    if (Date.now() >= deadline) break
+    await delay(READY_POLL_INTERVAL_MS)
+  } while (Date.now() < deadline)
+  return false
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+export default { resolveCompatPlaybackUrl }

--- a/packages/backend/src/transcode/playback-compat.mjs
+++ b/packages/backend/src/transcode/playback-compat.mjs
@@ -1,0 +1,194 @@
+/**
+ * Playback compatibility policy (Phase 0 of cross-platform libmpv retirement).
+ *
+ * Pure, dependency-free decision logic: given a probe result and the target
+ * OS-native player, decide whether the source can play directly or needs the
+ * bare-ffmpeg compatibility layer (remux / audio-transcode / full transcode),
+ * served as local HLS/fMP4.
+ *
+ * This is the per-player generalization of the existing Chromecast/web checks in
+ * transcoder.mjs (`checkTranscodeNeeded` / `checkWebTranscodeNeeded`). The
+ * `webkit` and `chromecast` tables below are kept faithful to those so the
+ * existing web/cast paths keep their behavior when routed through here.
+ *
+ * Codec/container lists are deliberately conservative (better to transcode than
+ * to fail playback) and are intended to be tuned with on-device validation.
+ *
+ * See: docs/superpowers/plans/2026-06-11-retire-libmpv-cross-platform.md
+ */
+
+// ─── Codec name normalization ───────────────────────────────────────────────
+// Probe names come from mapCodecIdToName (h264, hevc, vp9, aac, ac3, …) but may
+// also arrive as container-level aliases (avc1, h265, ec-3, dca, …).
+const VIDEO_ALIASES = {
+  avc1: 'h264', avc: 'h264', x264: 'h264',
+  h265: 'hevc', hev1: 'hevc', hvc1: 'hevc',
+}
+const AUDIO_ALIASES = {
+  'ac-3': 'ac3',
+  'ec-3': 'eac3', 'e-ac-3': 'eac3', 'eac-3': 'eac3',
+  dca: 'dts',
+  'mp4a': 'aac',
+}
+
+function normVideo(codec) {
+  if (!codec) return null
+  const c = String(codec).toLowerCase().trim()
+  return VIDEO_ALIASES[c] || c
+}
+
+function normAudio(codec) {
+  if (!codec) return null
+  const c = String(codec).toLowerCase().trim()
+  return AUDIO_ALIASES[c] || c
+}
+
+// H.264 profiles that browsers/Chromecast (and conservatively, AVPlayer) can't
+// reliably decode — 10-bit (High 10) and 4:4:4 (High 4:4:4).
+const H264_UNSUPPORTED_PROFILES = ['high 10', 'high 4:4:4', 'high422', 'high444', '10', '4:4:4']
+
+/**
+ * Per-player capability tables. A codec/container NOT listed here is treated as
+ * "needs the compatibility layer".
+ *
+ * - video / audio: Sets of normalized codec names the player decodes natively.
+ * - remuxContainerPatterns: substrings that force a remux when present in the
+ *   (possibly comma-joined) ffmpeg container string. A deny-list, because
+ *   ffmpeg reports both .mkv and .webm as the shared format "matroska,webm" —
+ *   so we can't allow-list "webm" without also passing MKV. This mirrors the
+ *   existing checkTranscodeNeeded / checkWebTranscodeNeeded container checks.
+ * - h264MaxLevel: if set, H.264 above this level needs transcode (Chromecast).
+ * - rejectHiProfileH264: reject 10-bit / 4:4:4 H.264.
+ */
+export const PLAYER_POLICIES = {
+  // iOS + macOS AVFoundation. Conservative: HW H.264/HEVC + AAC/MP3/ALAC/FLAC.
+  // Opus/Vorbis/AC-3/E-AC-3/DTS and MKV/WebM go through the compat layer.
+  avplayer: {
+    video: new Set(['h264', 'hevc']),
+    audio: new Set(['aac', 'mp3', 'alac', 'flac']),
+    remuxContainerPatterns: ['matroska', 'mkv', 'webm', 'avi', 'flv', 'ogg'],
+    rejectHiProfileH264: true,
+  },
+
+  // Android ExoPlayer — codec-complete; only DTS / odd containers need help.
+  exoplayer: {
+    video: new Set(['h264', 'hevc', 'vp8', 'vp9', 'av1']),
+    audio: new Set(['aac', 'mp3', 'opus', 'vorbis', 'flac', 'ac3', 'eac3']),
+    remuxContainerPatterns: ['avi', 'flv'],
+    rejectHiProfileH264: false,
+  },
+
+  // WKWebView / Chromium (Electrobun). Faithful to checkWebTranscodeNeeded:
+  // video h264/vp8/vp9/av1/hevc, audio aac/mp3/opus/vorbis/flac, MKV → remux.
+  // (Pure WebM over-remuxes since it shares the matroska format name, matching
+  // the existing web check; on Electrobun mediabunny remuxes in the renderer.)
+  webkit: {
+    video: new Set(['h264', 'vp8', 'vp9', 'av1', 'hevc']),
+    audio: new Set(['aac', 'mp3', 'opus', 'vorbis', 'flac']),
+    remuxContainerPatterns: ['matroska', 'mkv', 'avi', 'flv', 'ogg'],
+    rejectHiProfileH264: true,
+  },
+
+  // Chromecast. Faithful to checkTranscodeNeeded (audio AAC-only).
+  chromecast: {
+    video: new Set(['h264', 'vp8', 'vp9', 'av1']),
+    audio: new Set(['aac']),
+    remuxContainerPatterns: ['matroska', 'mkv', 'avi', 'flv'],
+    h264MaxLevel: 4.2,
+    rejectHiProfileH264: true,
+  },
+}
+
+function containerNeedsRemux(policy, container) {
+  if (!container) return false // unknown container → don't force remux blindly
+  const c = String(container).toLowerCase()
+  return policy.remuxContainerPatterns.some((pat) => c.includes(pat))
+}
+
+/**
+ * Decide how to play a source on a given OS-native player.
+ *
+ * @param {object} input
+ * @param {string} input.player - one of PLAYER_POLICIES keys
+ * @param {string|null} input.videoCodec
+ * @param {string|null} input.audioCodec
+ * @param {string|null} [input.container]
+ * @param {string|null} [input.videoProfile]
+ * @param {number} [input.videoLevel]
+ * @returns {{ mode: 'direct'|'remux'|'audio-only'|'full',
+ *            needsVideoTranscode: boolean, needsAudioTranscode: boolean,
+ *            needsRemux: boolean, reason: string, player: string }}
+ */
+export function decidePlayback({ player, videoCodec, audioCodec, container, videoProfile, videoLevel } = {}) {
+  const policy = PLAYER_POLICIES[player]
+  // Unknown player → don't second-guess; play directly.
+  if (!policy) {
+    return {
+      mode: 'direct',
+      needsVideoTranscode: false,
+      needsAudioTranscode: false,
+      needsRemux: false,
+      reason: player ? `Unknown player '${player}', passthrough` : 'No player specified, passthrough',
+      player: player || null,
+    }
+  }
+
+  const reasons = []
+  const v = normVideo(videoCodec)
+  const a = normAudio(audioCodec)
+
+  let needsVideoTranscode = false
+  if (v) {
+    if (!policy.video.has(v)) {
+      needsVideoTranscode = true
+      reasons.push(`video ${v} unsupported on ${player}`)
+    } else if (v === 'h264' && policy.rejectHiProfileH264 && videoProfile) {
+      const profile = String(videoProfile).toLowerCase()
+      if (H264_UNSUPPORTED_PROFILES.some((p) => profile.includes(p))) {
+        needsVideoTranscode = true
+        reasons.push(`H.264 profile '${videoProfile}' unsupported (10-bit/4:4:4)`)
+      }
+    }
+    if (!needsVideoTranscode && v === 'h264' && policy.h264MaxLevel && videoLevel && videoLevel > policy.h264MaxLevel) {
+      needsVideoTranscode = true
+      reasons.push(`H.264 level ${videoLevel} > ${policy.h264MaxLevel}`)
+    }
+  }
+
+  let needsAudioTranscode = false
+  if (a && !policy.audio.has(a)) {
+    needsAudioTranscode = true
+    reasons.push(`audio ${a} unsupported on ${player}`)
+  }
+
+  // Container remux only matters when we're otherwise stream-copying — a video
+  // or audio transcode already rewrites into the output (HLS/fMP4) container.
+  let needsRemux = false
+  if (!needsVideoTranscode && !needsAudioTranscode && containerNeedsRemux(policy, container)) {
+    needsRemux = true
+    reasons.push(`container '${container}' needs remux for ${player}`)
+  }
+
+  let mode = 'direct'
+  if (needsVideoTranscode) mode = 'full'
+  else if (needsAudioTranscode) mode = 'audio-only'
+  else if (needsRemux) mode = 'remux'
+
+  return {
+    mode,
+    needsVideoTranscode,
+    needsAudioTranscode,
+    needsRemux,
+    reason: reasons.join('; ') || 'Compatible',
+    player,
+  }
+}
+
+/**
+ * Convenience: does the player play this source as-is (no compat layer)?
+ */
+export function osPlayerCanHandle(input) {
+  return decidePlayback(input).mode === 'direct'
+}
+
+export default { PLAYER_POLICIES, decidePlayback, osPlayerCanHandle }

--- a/packages/backend/test/playback-compat-runtime.test.mjs
+++ b/packages/backend/test/playback-compat-runtime.test.mjs
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { resolveCompatPlaybackUrl } from '../src/transcode/playback-compat-runtime.mjs'
+
+const DIRECT = 'http://127.0.0.1:9000/blobs/abc/0?byteOffset=0&byteLength=10'
+
+function mockTranscoder(overrides = {}) {
+  const calls = { start: [], hls: [], status: [] }
+  return {
+    calls,
+    async startCompatTranscode(url, opts) {
+      calls.start.push({ url, opts })
+      return overrides.startResult ?? { success: true, sessionId: 'sess1', mode: 'audio-only' }
+    },
+    getCastStatus(sessionId) {
+      calls.status.push(sessionId)
+      return overrides.status ?? { status: 'transcoding', fragmentCount: 1 }
+    },
+    getCastHlsUrl(sessionId, host) {
+      calls.hls.push({ sessionId, host })
+      return overrides.hlsUrl ?? `http://${host}:9000/cast/${sessionId}/master.m3u8`
+    },
+    ...overrides.methods,
+  }
+}
+
+test('non-compat player passes through with no transcoder calls', async () => {
+  for (const player of ['webkit', 'exoplayer', undefined]) {
+    const t = mockTranscoder()
+    const r = await resolveCompatPlaybackUrl({ player, directUrl: DIRECT, castTranscoder: t })
+    assert.equal(r.transcoded, false)
+    assert.equal(r.url, DIRECT)
+    assert.equal(t.calls.start.length, 0)
+  }
+})
+
+test('avplayer without a transcoder passes through', async () => {
+  const r = await resolveCompatPlaybackUrl({ player: 'avplayer', directUrl: DIRECT, castTranscoder: null })
+  assert.equal(r.transcoded, false)
+  assert.equal(r.url, DIRECT)
+})
+
+test('avplayer + compatible source (no-transcode-needed) plays directly', async () => {
+  const t = mockTranscoder({ startResult: { success: false, reason: 'no-transcode-needed', sessionId: 's' } })
+  const r = await resolveCompatPlaybackUrl({ player: 'avplayer', directUrl: DIRECT, castTranscoder: t })
+  assert.equal(r.transcoded, false)
+  assert.equal(r.url, DIRECT)
+  assert.equal(t.calls.hls.length, 0)
+})
+
+test('avplayer + incompatible source returns local HLS url', async () => {
+  const t = mockTranscoder()
+  const r = await resolveCompatPlaybackUrl({ player: 'avplayer', directUrl: DIRECT, sourceKey: 'k1', castTranscoder: t, readyTimeoutMs: 1000 })
+  assert.equal(r.transcoded, true)
+  assert.equal(r.mode, 'audio-only')
+  assert.equal(r.url, 'http://127.0.0.1:9000/cast/sess1/master.m3u8')
+  assert.equal(t.calls.start[0].opts.player, 'avplayer')
+  assert.equal(t.calls.start[0].opts.sourceKey, 'k1')
+  assert.deepEqual(t.calls.hls[0], { sessionId: 'sess1', host: '127.0.0.1' })
+})
+
+test('reused session skips the fragment wait', async () => {
+  const t = mockTranscoder({ startResult: { success: true, sessionId: 'reuse', mode: 'remux', reused: true } })
+  const r = await resolveCompatPlaybackUrl({ player: 'avplayer', directUrl: DIRECT, castTranscoder: t })
+  assert.equal(r.transcoded, true)
+  assert.equal(t.calls.status.length, 0)
+})
+
+test('startCompatTranscode throwing falls back to direct url', async () => {
+  const t = mockTranscoder()
+  t.startCompatTranscode = async () => { throw new Error('ffmpeg unavailable') }
+  const r = await resolveCompatPlaybackUrl({ player: 'avplayer', directUrl: DIRECT, castTranscoder: t })
+  assert.equal(r.transcoded, false)
+  assert.equal(r.url, DIRECT)
+})
+
+test('transcode error status still yields the HLS url (best-effort)', async () => {
+  const t = mockTranscoder({ status: { status: 'error' } })
+  const r = await resolveCompatPlaybackUrl({ player: 'avplayer', directUrl: DIRECT, castTranscoder: t, readyTimeoutMs: 500 })
+  assert.equal(r.transcoded, true)
+  assert.equal(r.url, 'http://127.0.0.1:9000/cast/sess1/master.m3u8')
+})
+
+test('missing getCastHlsUrl falls back to direct', async () => {
+  const t = mockTranscoder()
+  delete t.getCastHlsUrl
+  const r = await resolveCompatPlaybackUrl({ player: 'avplayer', directUrl: DIRECT, castTranscoder: t })
+  assert.equal(r.transcoded, false)
+  assert.equal(r.url, DIRECT)
+})
+
+test('null directUrl passes through', async () => {
+  const t = mockTranscoder()
+  const r = await resolveCompatPlaybackUrl({ player: 'avplayer', directUrl: null, castTranscoder: t })
+  assert.equal(r.url, null)
+  assert.equal(t.calls.start.length, 0)
+})

--- a/packages/backend/test/playback-compat.test.mjs
+++ b/packages/backend/test/playback-compat.test.mjs
@@ -1,0 +1,138 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { decidePlayback, osPlayerCanHandle, PLAYER_POLICIES } from '../src/transcode/playback-compat.mjs'
+
+// ─── AVPlayer (iOS + macOS-native) ──────────────────────────────────────────
+
+test('avplayer: plain MP4/H.264/AAC plays directly', () => {
+  const d = decidePlayback({ player: 'avplayer', container: 'mov,mp4,m4a,3gp,3g2,mj2', videoCodec: 'h264', audioCodec: 'aac' })
+  assert.equal(d.mode, 'direct')
+  assert.equal(d.needsRemux, false)
+})
+
+test('avplayer: HEVC/AAC in MP4 plays directly', () => {
+  const d = decidePlayback({ player: 'avplayer', container: 'mp4', videoCodec: 'hevc', audioCodec: 'aac' })
+  assert.equal(d.mode, 'direct')
+})
+
+test('avplayer: MKV container with supported codecs needs remux', () => {
+  const d = decidePlayback({ player: 'avplayer', container: 'matroska,webm', videoCodec: 'h264', audioCodec: 'aac' })
+  assert.equal(d.mode, 'remux')
+  assert.equal(d.needsRemux, true)
+})
+
+test('avplayer: AC-3 audio needs audio-only transcode (video copied)', () => {
+  const d = decidePlayback({ player: 'avplayer', container: 'mp4', videoCodec: 'h264', audioCodec: 'ac3' })
+  assert.equal(d.mode, 'audio-only')
+  assert.equal(d.needsAudioTranscode, true)
+  assert.equal(d.needsVideoTranscode, false)
+})
+
+test('avplayer: Opus audio needs audio-only transcode', () => {
+  const d = decidePlayback({ player: 'avplayer', container: 'mp4', videoCodec: 'h264', audioCodec: 'opus' })
+  assert.equal(d.mode, 'audio-only')
+})
+
+test('avplayer: VP9 video needs full transcode', () => {
+  const d = decidePlayback({ player: 'avplayer', container: 'webm', videoCodec: 'vp9', audioCodec: 'opus' })
+  assert.equal(d.mode, 'full')
+  assert.equal(d.needsVideoTranscode, true)
+})
+
+test('avplayer: MKV + AC-3 collapses to audio-only (transcode subsumes remux)', () => {
+  const d = decidePlayback({ player: 'avplayer', container: 'matroska', videoCodec: 'h264', audioCodec: 'ac3' })
+  assert.equal(d.mode, 'audio-only')
+  assert.equal(d.needsRemux, false)
+})
+
+test('avplayer: 10-bit H.264 needs full transcode', () => {
+  const d = decidePlayback({ player: 'avplayer', container: 'mp4', videoCodec: 'h264', audioCodec: 'aac', videoProfile: 'High 10' })
+  assert.equal(d.mode, 'full')
+})
+
+// ─── ExoPlayer (Android) — codec-complete ───────────────────────────────────
+
+test('exoplayer: MKV/VP9/Opus plays directly (no compat layer)', () => {
+  const d = decidePlayback({ player: 'exoplayer', container: 'matroska,webm', videoCodec: 'vp9', audioCodec: 'opus' })
+  assert.equal(d.mode, 'direct')
+})
+
+test('exoplayer: AC-3 plays directly', () => {
+  const d = decidePlayback({ player: 'exoplayer', container: 'matroska', videoCodec: 'h264', audioCodec: 'ac3' })
+  assert.equal(d.mode, 'direct')
+})
+
+test('exoplayer: DTS audio still needs transcode', () => {
+  const d = decidePlayback({ player: 'exoplayer', container: 'mp4', videoCodec: 'h264', audioCodec: 'dts' })
+  assert.equal(d.mode, 'audio-only')
+})
+
+// ─── WKWebView / Chromium (Electrobun) — faithful to checkWebTranscodeNeeded ──
+
+test('webkit: Opus/Vorbis/FLAC audio plays directly', () => {
+  for (const audioCodec of ['opus', 'vorbis', 'flac', 'mp3', 'aac']) {
+    const d = decidePlayback({ player: 'webkit', container: 'mp4', videoCodec: 'h264', audioCodec })
+    assert.equal(d.mode, 'direct', `expected direct for ${audioCodec}`)
+  }
+})
+
+test('webkit: AC-3 / E-AC-3 / DTS need audio transcode', () => {
+  for (const audioCodec of ['ac3', 'eac3', 'dts']) {
+    const d = decidePlayback({ player: 'webkit', container: 'mp4', videoCodec: 'h264', audioCodec })
+    assert.equal(d.mode, 'audio-only', `expected audio-only for ${audioCodec}`)
+  }
+})
+
+test('webkit: MKV needs remux', () => {
+  const d = decidePlayback({ player: 'webkit', container: 'matroska,webm', videoCodec: 'h264', audioCodec: 'aac' })
+  assert.equal(d.mode, 'remux')
+})
+
+// ─── Chromecast — faithful to checkTranscodeNeeded (AAC-only) ────────────────
+
+test('chromecast: Opus needs audio transcode (cast supports AAC only)', () => {
+  const d = decidePlayback({ player: 'chromecast', container: 'mp4', videoCodec: 'h264', audioCodec: 'opus' })
+  assert.equal(d.mode, 'audio-only')
+})
+
+test('chromecast: H.264 level above cap needs full transcode', () => {
+  const d = decidePlayback({ player: 'chromecast', container: 'mp4', videoCodec: 'h264', audioCodec: 'aac', videoLevel: 5.1 })
+  assert.equal(d.mode, 'full')
+})
+
+// ─── Normalization + edge cases ─────────────────────────────────────────────
+
+test('codec aliases normalize (avc1→h264, h265→hevc, ec-3→eac3)', () => {
+  assert.equal(decidePlayback({ player: 'avplayer', container: 'mp4', videoCodec: 'avc1', audioCodec: 'aac' }).mode, 'direct')
+  assert.equal(decidePlayback({ player: 'avplayer', container: 'mp4', videoCodec: 'h265', audioCodec: 'aac' }).mode, 'direct')
+  assert.equal(decidePlayback({ player: 'webkit', container: 'mp4', videoCodec: 'h264', audioCodec: 'ec-3' }).mode, 'audio-only')
+})
+
+test('unknown player → passthrough direct', () => {
+  const d = decidePlayback({ player: 'roku', container: 'mp4', videoCodec: 'h264', audioCodec: 'ac3' })
+  assert.equal(d.mode, 'direct')
+})
+
+test('missing codec info → direct', () => {
+  const d = decidePlayback({ player: 'avplayer', container: 'mp4' })
+  assert.equal(d.mode, 'direct')
+})
+
+test('unknown container does not force remux', () => {
+  const d = decidePlayback({ player: 'avplayer', container: null, videoCodec: 'h264', audioCodec: 'aac' })
+  assert.equal(d.needsRemux, false)
+})
+
+test('osPlayerCanHandle mirrors decidePlayback direct mode', () => {
+  assert.equal(osPlayerCanHandle({ player: 'avplayer', container: 'mp4', videoCodec: 'h264', audioCodec: 'aac' }), true)
+  assert.equal(osPlayerCanHandle({ player: 'avplayer', container: 'mkv', videoCodec: 'h264', audioCodec: 'dts' }), false)
+})
+
+test('every policy exposes the expected shape', () => {
+  for (const [name, p] of Object.entries(PLAYER_POLICIES)) {
+    assert.ok(p.video instanceof Set, `${name}.video`)
+    assert.ok(p.audio instanceof Set, `${name}.audio`)
+    assert.ok(Array.isArray(p.remuxContainerPatterns), `${name}.remuxContainerPatterns`)
+  }
+})

--- a/packages/desktop-native/Bridge/native-host-sidecar.mjs
+++ b/packages/desktop-native/Bridge/native-host-sidecar.mjs
@@ -170,6 +170,50 @@ function createLazyTranscoder() {
   }
 }
 
+let castTranscoderModule = null
+let castTranscoderModulePromise = null
+
+async function ensureCastTranscoderModule() {
+  if (castTranscoderModule) return castTranscoderModule
+  if (!castTranscoderModulePromise) {
+    castTranscoderModulePromise = import('../../backend/src/transcode/cast-transcoder.mjs')
+      .then((module) => {
+        castTranscoderModule = module?.default ?? module
+        return castTranscoderModule
+      })
+      .catch((error) => {
+        castTranscoderModulePromise = null
+        throw error
+      })
+  }
+
+  return castTranscoderModulePromise
+}
+
+// Lazy cast-transcoder wrapper used by the AVPlayer compatibility layer. Methods
+// are async so the underlying module loads on first use; the runtime helper
+// awaits them all.
+function createLazyCastTranscoder() {
+  return {
+    async startCompatTranscode(...args) {
+      const module = await ensureCastTranscoderModule()
+      return module.startCompatTranscode(...args)
+    },
+    async getCastHlsUrl(...args) {
+      const module = await ensureCastTranscoderModule()
+      return module.getCastHlsUrl(...args)
+    },
+    async getCastStatus(...args) {
+      const module = await ensureCastTranscoderModule()
+      return module.getCastStatus(...args)
+    },
+    async stopCastTranscode(...args) {
+      const module = await ensureCastTranscoderModule()
+      return module.stopCastTranscode(...args)
+    },
+  }
+}
+
 function createKeepAliveCleanup() {
   let keepAliveTimer = setInterval(() => {}, 1 << 30)
 
@@ -481,6 +525,11 @@ async function createNativeSidecarBackend(options = {}) {
     const generateAndStoreThumbnail = thumbnailModule?.generateAndStoreThumbnail
     const transcoder = createLazyTranscoder()
 
+    // Experimental: route AVPlayer-incompatible codecs (MKV/Opus/AC-3/DTS, …)
+    // through a local-HLS bare-ffmpeg transcode so the macOS app can drop bare-mpv.
+    // Off by default — enable with PEARTUBE_AVPLAYER_COMPAT=1 for on-device validation.
+    const avplayerCompatEnabled = globalThis.process?.env?.PEARTUBE_AVPLAYER_COMPAT === '1'
+
     attachMobileHandlers(backend, {
       api: backend.api,
       identityManager: backend.identityManager,
@@ -493,8 +542,10 @@ async function createNativeSidecarBackend(options = {}) {
       path,
       generateAndStoreThumbnail,
       transcoder,
+      ...(avplayerCompatEnabled ? { castTranscoder: createLazyCastTranscoder(), player: 'avplayer' } : {}),
       storagePath: options.storagePath,
     })
+    if (avplayerCompatEnabled) console.log(`[${runtimeLabel}] AVPlayer compatibility layer enabled`)
 
     console.log(`[${runtimeLabel}] Attached shared app handler layer`)
   }

--- a/packages/desktop-native/Bridge/sidecar-addon-roots.test.mjs
+++ b/packages/desktop-native/Bridge/sidecar-addon-roots.test.mjs
@@ -15,7 +15,7 @@ test('resolves bare-ffmpeg addon roots for native sidecar packaging', () => {
   assert.ok(roots.length > 0, 'expected at least one addon root')
   assert.ok(
     roots.some((root) =>
-      root.includes(path.join('bare-media', 'node_modules', 'bare-ffmpeg')) ||
+      root.endsWith(path.join('node_modules', 'bare-ffmpeg')) ||
       root.endsWith(path.join('packages', 'bare-ffmpeg'))
     ),
     `expected bare-ffmpeg to be included in ${roots.join(', ')}`

--- a/packages/desktop-native/scripts/sidecar-addon-roots.mjs
+++ b/packages/desktop-native/scripts/sidecar-addon-roots.mjs
@@ -11,7 +11,6 @@ function isDirectory(dirPath) {
 
 export function getSidecarAddonRoots(repoRoot) {
   const candidates = [
-    path.join(repoRoot, 'packages', 'backend', 'node_modules', 'bare-media', 'node_modules', 'bare-ffmpeg'),
     path.join(repoRoot, 'packages', 'backend', 'node_modules', 'bare-ffmpeg'),
     path.join(repoRoot, 'packages', 'bare-ffmpeg'),
     path.join(repoRoot, 'packages', 'bare-mpv'),

--- a/packages/platform/src/rpc.native.ts
+++ b/packages/platform/src/rpc.native.ts
@@ -514,6 +514,7 @@ export async function initPlatformRPC(config: {
   launchOptions?: {
     network?: Record<string, unknown>;
     swarmOptions?: Record<string, unknown>;
+    player?: string;
   };
 } = {}): Promise<void> {
   if (_isInitialized && mainBridge.isInitialized()) {
@@ -601,11 +602,22 @@ export async function initPlatformRPC(config: {
 
     nativeRuntimeConfig.backendPath = backendPath;
     nativeRuntimeConfig.backendSource = backendPath ? '' : backendSource;
-    const launchOptionsArg = config.launchOptions
+    // OS-native player id for the playback compatibility layer (consumed by the
+    // worklet only when PEARTUBE_AVPLAYER_COMPAT is enabled; harmless otherwise).
+    let derivedPlayer: string | null = config.launchOptions?.player ?? null;
+    if (!derivedPlayer) {
+      try {
+        const os = require('react-native')?.Platform?.OS;
+        if (os === 'ios') derivedPlayer = 'avplayer';
+        else if (os === 'android') derivedPlayer = 'exoplayer';
+      } catch { /* Platform unavailable — leave player unset */ }
+    }
+    const launchOptionsArg = (config.launchOptions || derivedPlayer)
       ? JSON.stringify({
         __peartubeLaunchOptions: true,
-        network: config.launchOptions.network,
-        swarmOptions: config.launchOptions.swarmOptions,
+        network: config.launchOptions?.network,
+        swarmOptions: config.launchOptions?.swarmOptions,
+        player: derivedPlayer ?? undefined,
       })
       : null;
     nativeRuntimeConfig.workerArgs = [


### PR DESCRIPTION
bare-media was a convenience wrapper that bundled its own second copy of
FFmpeg (bare-media/node_modules/bare-ffmpeg) purely to make three thumbnail
calls. Reimplement thumbnail generation directly against the bare-ffmpeg
addon the transcoder already depends on, removing the duplicate native blob.

- thumbnail.js: open file via streaming IOContext -> decode target frame
  -> Scaler convert/resize -> encode. Output is JPEG via the always-built
  mjpeg encoder (the bare-ffmpeg build has no libwebp, so image/webp now
  transparently falls back to JPEG; PNG used when requested/available).
  Public API (generateThumbnail / generateAndStoreThumbnail) unchanged.
- Remove bare-media dependency from backend + app package.json.
- Drop the bare-media nested addon-root candidate and update its test.
- Refresh the now-stale bare-media comment in studio.tsx (behavior unchanged).