### PR TITLE
fix: gossip relay cached preview feed entries

### DIFF
--- a/packages/backend/src/public-feed.js
+++ b/packages/backend/src/public-feed.js
@@ -614,13 +614,15 @@ export class PublicFeed {
         const driveKey = snapshot?.driveKey
         if (!driveKey || !byKey.has(driveKey)) continue
 
+        const previewVideos = this._sanitizePreviewVideos(snapshot.previewVideos || byKey.get(driveKey)?.previewVideos)
         const merged = {
           ...byKey.get(driveKey),
           publicBeeKey: this._resolvePublicBeeKey(snapshot) || byKey.get(driveKey)?.publicBeeKey || null,
           channelName: snapshot.channelName || byKey.get(driveKey)?.channelName || null,
           videoCount: Number(snapshot.videoCount || byKey.get(driveKey)?.videoCount || 0) || 0,
           manifestUpdatedAt: Number(snapshot.manifestUpdatedAt || byKey.get(driveKey)?.manifestUpdatedAt || 0) || 0,
-          previewVideos: this._sanitizePreviewVideos(snapshot.previewVideos || byKey.get(driveKey)?.previewVideos),
+          previewVideos,
+          previewVideosHash: hashPreviewVideos(previewVideos),
         }
         byKey.set(driveKey, merged)
         this._applyEntrySnapshot(driveKey, merged)
@@ -1713,7 +1715,7 @@ export class PublicFeed {
     // or has explicitly published, not every historical key it heard about.
     const buildAnnounceEntries = () => Array.from(this.entries.values())
       .filter((entry) => isValidKey(this._resolvePublicBeeKey(entry)))
-      .filter((entry) => this._isLocallyBackedEntry(entry))
+      .filter((entry) => this._isLocallyBackedEntry(entry) || entry?.relayServing === true || entry?.relayRole === 'cache')
       .map((entry) => this._serializeEntry(entry))
 
     const baseEntries = buildAnnounceEntries()

--- a/packages/backend/test/public-feed-signed-ingress.test.mjs
+++ b/packages/backend/test/public-feed-signed-ingress.test.mjs
@@ -180,6 +180,50 @@ test('public feed rejects inbound relay-cache-like HAVE_FEED entries without sig
   }
 })
 
+test('public feed re-sends relay-cache HAVE_FEED after snapshot enrichment', async () => {
+  const manager = new PublicFeedManager(createSwarm(), createMetaDb())
+  const conn = {}
+  const sent = []
+  try {
+    manager.peerChannels.set(conn, {
+      messages: [{
+        send(msg) { sent.push(msg) },
+      }],
+    })
+    manager.entries.set(key(14), {
+      driveKey: key(14),
+      publicBeeKey: key(15),
+      source: 'peer',
+      relayRole: 'cache',
+      relayServing: true,
+      discoveryOnly: true,
+      restoredFromCache: true,
+      requiresAvailabilityProbe: true,
+    })
+    manager.feedSnapshotProvider = async (entries) => entries.map((entry) => ({
+      ...entry,
+      previewVideos: [{
+        id: 'relay-snapshot-video',
+        blobId: '0:8:0:1024',
+        blobsCoreKey: key(16),
+        availability: 'playable',
+        byteAvailability: 'playable',
+      }],
+    }))
+
+    manager.sendHaveFeed(conn)
+    await new Promise((resolve) => setImmediate(resolve))
+
+    assert.equal(sent.length, 2)
+    assert.equal(sent[0].entries.length, 1)
+    assert.equal(sent[0].entries[0].previewVideos, undefined)
+    assert.equal(sent[1].entries.length, 1)
+    assert.equal(sent[1].entries[0].previewVideos.length, 1)
+  } finally {
+    manager.stop()
+  }
+})
+
 test('public feed counts already-known async verified HAVE_FEED entries for the peer connection', async () => {
   const manager = new PublicFeedManager(createSwarm(), createMetaDb())
   const signed = await signedDescriptor({ channelId: key(7), metadataKey: key(8), mediaKey: key(9) })


### PR DESCRIPTION
## Summary
- keep relay-cache entries in outbound HAVE_FEED even when restored from relay catalog/cache
- preserve previewVideosHash after snapshot enrichment so peers receive enriched playable previews
- add regression coverage for relay-cache HAVE_FEED re-send after enrichment

## Test plan
- npx brittle test/public-feed-signed-ingress.test.mjs