### PR TITLE
desktop: fail-fast if the worker bundle packs stale @peartube source

### DIFF
--- a/packages/app/scripts/build-desktop-bundle.mjs
+++ b/packages/app/scripts/build-desktop-bundle.mjs
@@ -23,7 +23,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { spawnSync } from 'node:child_process'
 import { createRequire } from 'node:module'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const projectRoot = path.resolve(__dirname, '..')
@@ -187,6 +187,122 @@ function verifyBundleFreshness() {
   console.log(`[desktop:bundle] Verified ${checked} packed @peartube file(s) match live source`)
 }
 
+// ── Static link check of the packed artifact ────────────────────────────────
+// verifyBundleFreshness proves the bundle matches the live working tree — but
+// if the working tree ITSELF is inconsistent (e.g. a locally-modified, stale
+// universal-core.js next to an up-to-date runtime.js that imports a newer
+// export), the freshness check passes and the worker still dies at link time
+// with "does not provide an export named 'X'". Catch that at build time by
+// verifying every named ESM import between packed @peartube files is satisfied
+// by the target file's exports. The parser is intentionally conservative: it
+// only flags a missing name when the target has no `export *` escape hatch.
+// Validated against the real backend source (365 named imports, 0 false
+// positives). Skip with PEARTUBE_SKIP_BUNDLE_LINK_CHECK=1 if it ever
+// misfires.
+
+function parseEsmExports(source) {
+  const names = new Set()
+  let starReexport = false
+  for (const m of source.matchAll(/^\s*export\s+(?:async\s+)?(?:function|class)\s*\*?\s*([\w$]+)/mg)) names.add(m[1])
+  for (const m of source.matchAll(/^\s*export\s+(?:const|let|var)\s+([\w$]+)/mg)) names.add(m[1])
+  for (const m of source.matchAll(/^\s*export\s*\*\s*as\s+([\w$]+)/mg)) names.add(m[1])
+  if (/^\s*export\s+default\b/m.test(source)) names.add('default')
+  for (const m of source.matchAll(/^\s*export\s*\{([^}]*)\}/mg)) {
+    for (const part of m[1].split(',')) {
+      const token = part.trim()
+      if (!token) continue
+      const asMatch = token.match(/^([\w$]+)\s+as\s+([\w$]+)$/)
+      names.add(asMatch ? asMatch[2] : token)
+    }
+  }
+  if (/^\s*export\s*\*\s*from/m.test(source)) starReexport = true
+  return { names, starReexport }
+}
+
+function parseEsmNamedImports(source) {
+  const imports = []
+  const collect = (clause, specifier) => {
+    const names = clause.split(',').map(s => s.trim()).filter(Boolean).map(token => {
+      const asMatch = token.match(/^([\w$]+)\s+as\s+[\w$]+$/)
+      return asMatch ? asMatch[1] : token
+    })
+    if (names.length > 0) imports.push({ names, specifier })
+  }
+  for (const m of source.matchAll(/^\s*import\s+(?:[\w$]+\s*,\s*)?\{([^}]*)\}\s*from\s*['"]([^'"]+)['"]/mg)) collect(m[1], m[2])
+  for (const m of source.matchAll(/^\s*export\s*\{([^}]*)\}\s*from\s*['"]([^'"]+)['"]/mg)) collect(m[1], m[2])
+  return imports
+}
+
+function describeWorkingTreeState() {
+  const result = spawnSync('git', ['status', '--porcelain', '--', 'packages/backend', 'packages/host', 'packages/core', 'packages/protocol'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  })
+  const status = (result.stdout || '').trim()
+  if (result.status !== 0) return ''
+  return status
+    ? `git reports locally modified files (a stale local edit is the usual culprit):\n  ${status.split('\n').join('\n  ')}`
+    : 'git reports a clean working tree for the shared packages — the inconsistency may be in an unmerged/diverged checkout (compare `git log -1` with origin/main).'
+}
+
+function isOwnSourceKey(key) {
+  return /@peartube\/|\/packages\//.test(key)
+}
+
+export function checkBundleLinks(packed) {
+  const problems = []
+  for (const key of packed.keys()) {
+    if (!isOwnSourceKey(key) || !/\.(js|mjs)$/.test(key)) continue
+    const source = packed.read(key).toString('utf8')
+    const resolutions = packed.resolutions[key] || {}
+    for (const { names, specifier } of parseEsmNamedImports(source)) {
+      if (!specifier.startsWith('.')) continue
+      const targetKey = resolutions[specifier]
+      if (!targetKey || typeof targetKey !== 'string') continue
+      if (!isOwnSourceKey(targetKey) || /\.cjs$/.test(targetKey)) continue
+      let targetSource
+      try {
+        targetSource = packed.read(targetKey).toString('utf8')
+      } catch {
+        continue
+      }
+      const { names: exported, starReexport } = parseEsmExports(targetSource)
+      if (starReexport) continue
+      for (const name of names) {
+        if (!exported.has(name)) {
+          problems.push(`${key}\n    imports '${name}' from '${specifier}' but ${targetKey} does not export it`)
+        }
+      }
+    }
+  }
+  return problems
+}
+
+function verifyBundleLinks() {
+  if (process.env.PEARTUBE_SKIP_BUNDLE_LINK_CHECK === '1') {
+    console.warn('[desktop:bundle] Skipping bundle link check (PEARTUBE_SKIP_BUNDLE_LINK_CHECK=1)')
+    return
+  }
+  const require = createRequire(path.join(projectRoot, 'package.json'))
+  const Bundle = require('bare-bundle')
+  const packed = Bundle.from(fs.readFileSync(bundleFile))
+
+  const problems = checkBundleLinks(packed)
+  if (problems.length > 0) {
+    throw new Error(
+      `[desktop:bundle] Bundle FAILS to link — the worker would crash at startup (${problems.length} unresolved import(s)):\n` +
+      `  ${problems.join('\n  ')}\n\n` +
+      'This means the source tree itself is internally inconsistent (an importer expects an export\n' +
+      'the target file does not have). ' + describeWorkingTreeState() + '\n' +
+      'Fix: restore the stale file(s) from git, e.g.\n' +
+      '  git checkout origin/main -- packages/backend/src\n' +
+      'then rebuild with PEARTUBE_FORCE_DESKTOP_BUNDLE=1 npm run desktop:bundle.\n' +
+      '(Escape hatch if this check misfires: PEARTUBE_SKIP_BUNDLE_LINK_CHECK=1)',
+    )
+  }
+  console.log('[desktop:bundle] Bundle link check passed (all named imports satisfied)')
+}
+
 function runBarePack() {
   if (!fs.existsSync(entryFile)) {
     throw new Error(
@@ -213,18 +329,23 @@ function runBarePack() {
   if (result.status !== 0) process.exit(result.status || 1)
 }
 
-const forced = process.env.PEARTUBE_FORCE_DESKTOP_BUNDLE === '1'
-const sourceNewest = getSourceNewestMtimeMs()
-const bundleMtime = getMtimeMs(bundleFile)
-const missingBundle = bundleMtime === 0
-const staleBundle = !missingBundle && bundleMtime < sourceNewest
+// Only run the build when executed directly (the test imports checkBundleLinks).
+const isMain = process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url
+if (isMain) {
+  const forced = process.env.PEARTUBE_FORCE_DESKTOP_BUNDLE === '1'
+  const sourceNewest = getSourceNewestMtimeMs()
+  const bundleMtime = getMtimeMs(bundleFile)
+  const missingBundle = bundleMtime === 0
+  const staleBundle = !missingBundle && bundleMtime < sourceNewest
 
-if (forced || missingBundle || staleBundle) {
-  const reason = forced ? 'forced rebuild' : missingBundle ? 'missing bundle' : 'stale bundle'
-  console.log(`[desktop:bundle] Rebuilding desktop worker bundle (${reason})`)
-  runBarePack()
-  verifyBundleFreshness()
-  console.log(`[desktop:bundle] Wrote ${path.relative(projectRoot, bundleFile)}`)
-} else {
-  console.log('[desktop:bundle] Desktop worker bundle is up to date')
+  if (forced || missingBundle || staleBundle) {
+    const reason = forced ? 'forced rebuild' : missingBundle ? 'missing bundle' : 'stale bundle'
+    console.log(`[desktop:bundle] Rebuilding desktop worker bundle (${reason})`)
+    runBarePack()
+    verifyBundleFreshness()
+    verifyBundleLinks()
+    console.log(`[desktop:bundle] Wrote ${path.relative(projectRoot, bundleFile)}`)
+  } else {
+    console.log('[desktop:bundle] Desktop worker bundle is up to date')
+  }
 }

--- a/packages/app/scripts/build-desktop-bundle.mjs
+++ b/packages/app/scripts/build-desktop-bundle.mjs
@@ -20,9 +20,9 @@
  * launch and self-heal a stale bundle after a source change.
  */
 import fs from 'node:fs'
-import os from 'node:os'
 import path from 'node:path'
 import { spawnSync } from 'node:child_process'
+import { createRequire } from 'node:module'
 import { fileURLToPath } from 'node:url'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -112,6 +112,81 @@ function getBundleHosts() {
   return [`${process.platform}-${process.arch}`]
 }
 
+const peartubeWorkspacePackages = ['backend', 'host', 'core', 'protocol', 'spec', 'platform']
+
+// bare-pack resolves `@peartube/*` through node_modules. With npm `file:`
+// deps those entries are symlinks to the live packages/ source, so the pack
+// traces fresh code. But a stale *physical copy* (left by an older install
+// state or a different package manager) would be silently inlined into the
+// bundle and resurrect "does not provide an export named X" with up-to-date
+// source on disk. Detect that and re-link to the live package.
+function ensureLiveWorkspaceLinks() {
+  const scopeDirs = [
+    path.join(projectRoot, 'node_modules', '@peartube'),
+    path.join(repoRoot, 'node_modules', '@peartube'),
+  ]
+  for (const scopeDir of scopeDirs) {
+    if (!fs.existsSync(scopeDir)) continue
+    for (const name of peartubeWorkspacePackages) {
+      const linkPath = path.join(scopeDir, name)
+      const livePath = path.join(repoRoot, 'packages', name)
+      if (!fs.existsSync(linkPath) || !fs.existsSync(livePath)) continue
+      let resolved
+      try {
+        resolved = fs.realpathSync(linkPath)
+      } catch {
+        continue
+      }
+      if (resolved === fs.realpathSync(livePath)) continue
+      console.warn(
+        `[desktop:bundle] ${linkPath} resolves to ${resolved} instead of the live ` +
+        `${livePath} — replacing the stale copy with a symlink to live source`,
+      )
+      fs.rmSync(linkPath, { recursive: true, force: true })
+      fs.symlinkSync(livePath, linkPath, 'dir')
+    }
+  }
+}
+
+// Belt-and-braces: after packing, prove the bundle actually contains the live
+// source. Any packed @peartube file whose bytes differ from packages/<pkg>/...
+// means bare-pack traced a stale copy — fail loudly instead of shipping a
+// bundle that crashes the worker at link time.
+function verifyBundleFreshness() {
+  const require = createRequire(path.join(projectRoot, 'package.json'))
+  const Bundle = require('bare-bundle')
+  const packed = Bundle.from(fs.readFileSync(bundleFile))
+
+  const problems = []
+  let checked = 0
+  for (const key of packed.keys()) {
+    const match = key.match(/node_modules\/@peartube\/([^/]+)\/(.+)$/)
+    if (!match) continue
+    const livePath = path.join(repoRoot, 'packages', match[1], match[2])
+    let liveSource
+    try {
+      liveSource = fs.readFileSync(livePath)
+    } catch {
+      continue
+    }
+    checked++
+    if (!packed.read(key).equals(liveSource)) {
+      problems.push(`${key}\n    differs from ${livePath}`)
+    }
+  }
+
+  if (problems.length > 0) {
+    throw new Error(
+      `[desktop:bundle] Packed bundle contains STALE @peartube source (${problems.length} file(s)):\n` +
+      `  ${problems.join('\n  ')}\n` +
+      'A stale physical copy of @peartube/* shadowed the live packages/ source during the pack.\n' +
+      'Fix: rm -rf packages/app/node_modules/@peartube && npm run install:all, then rebuild.',
+    )
+  }
+
+  console.log(`[desktop:bundle] Verified ${checked} packed @peartube file(s) match live source`)
+}
+
 function runBarePack() {
   if (!fs.existsSync(entryFile)) {
     throw new Error(
@@ -121,6 +196,7 @@ function runBarePack() {
   }
 
   fs.mkdirSync(path.dirname(bundleFile), { recursive: true })
+  ensureLiveWorkspaceLinks()
 
   const barePackBin = findBarePackBin()
   const args = ['--out', bundleFile, '--format', 'bundle', '--linked']
@@ -147,6 +223,7 @@ if (forced || missingBundle || staleBundle) {
   const reason = forced ? 'forced rebuild' : missingBundle ? 'missing bundle' : 'stale bundle'
   console.log(`[desktop:bundle] Rebuilding desktop worker bundle (${reason})`)
   runBarePack()
+  verifyBundleFreshness()
   console.log(`[desktop:bundle] Wrote ${path.relative(projectRoot, bundleFile)}`)
 } else {
   console.log('[desktop:bundle] Desktop worker bundle is up to date')

--- a/packages/app/tests/desktop-bundle-script-regression.test.mjs
+++ b/packages/app/tests/desktop-bundle-script-regression.test.mjs
@@ -88,6 +88,91 @@ test('desktop bundle builder packs a runnable, linked bare bundle', () => {
     /verifyBundleFreshness\(\)/,
     'should verify packed @peartube files match live source after packing',
   )
+  assert.match(
+    source,
+    /verifyBundleLinks\(\)/,
+    'should statically link-check the packed bundle after packing',
+  )
+})
+
+test('bundle link check catches a stale universal-core missing an export', async () => {
+  const { checkBundleLinks } = await import('../scripts/build-desktop-bundle.mjs')
+
+  // Minimal Bundle-shaped fixture: keys() + read() + resolutions, mirroring
+  // bare-bundle's surface that checkBundleLinks consumes.
+  function makeBundle(files, resolutions) {
+    return {
+      keys: () => Object.keys(files),
+      read: (key) => Buffer.from(files[key]),
+      resolutions,
+    }
+  }
+
+  const entryKey = '/x/node_modules/@peartube/backend/src/backend-entry.js'
+  const coreKey = '/x/node_modules/@peartube/backend/src/universal-core.js'
+  const importer = "import { createUniversalCore, createUniversalHrpcSurface } from './universal-core.js'\nexport function createBackend() {}\n"
+  const freshCore = 'export function createUniversalCore() {}\nexport function createUniversalHrpcSurface() {}\nexport default {}\n'
+  const staleCore = 'export function createUniversalCore() {}\nexport default {}\n'
+  const resolutions = { [entryKey]: { './universal-core.js': coreKey } }
+
+  const fresh = checkBundleLinks(makeBundle({ [entryKey]: importer, [coreKey]: freshCore }, resolutions))
+  assert.equal(fresh.length, 0, `fresh bundle should link cleanly, got: ${fresh.join('; ')}`)
+
+  const stale = checkBundleLinks(makeBundle({ [entryKey]: importer, [coreKey]: staleCore }, resolutions))
+  assert.equal(stale.length, 1, 'stale bundle should produce exactly one problem')
+  assert.match(stale[0], /createUniversalHrpcSurface/, 'problem should name the missing export')
+  assert.match(stale[0], /universal-core\.js/, 'problem should name the stale file')
+
+  // `export *` disables verification for that target (cannot check statically).
+  const starCore = "export * from './elsewhere.js'\n"
+  const star = checkBundleLinks(makeBundle({ [entryKey]: importer, [coreKey]: starCore }, resolutions))
+  assert.equal(star.length, 0, 'export * targets should be skipped, not flagged')
+})
+
+test('bundle link check has zero false positives across the real backend source', async () => {
+  const { checkBundleLinks } = await import('../scripts/build-desktop-bundle.mjs')
+  const repoRoot = path.resolve(appRoot, '..', '..')
+
+  // Build a synthetic bundle from the actual live source tree: every relative
+  // import between files maps through resolutions exactly like bare-pack
+  // records them. The real tree must link cleanly.
+  const files = {}
+  const resolutions = {}
+  const roots = ['packages/backend/src', 'packages/backend/lib', 'packages/host/src', 'packages/protocol/src', 'packages/core/src']
+
+  function walk(dir) {
+    let entries
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true })
+    } catch {
+      return
+    }
+    for (const entry of entries) {
+      if (entry.name === 'node_modules') continue
+      const full = path.join(dir, entry.name)
+      if (entry.isDirectory()) walk(full)
+      else if (/\.(js|mjs)$/.test(entry.name)) files[full] = fs.readFileSync(full, 'utf8')
+    }
+  }
+  for (const root of roots) walk(path.join(repoRoot, root))
+
+  for (const key of Object.keys(files)) {
+    const map = {}
+    for (const m of files[key].matchAll(/from\s*['"](\.[^'"]+)['"]/g)) {
+      const resolved = path.resolve(path.dirname(key), m[1])
+      if (files[resolved]) map[m[1]] = resolved
+    }
+    resolutions[key] = map
+  }
+
+  const bundle = {
+    keys: () => Object.keys(files),
+    read: (key) => Buffer.from(files[key]),
+    resolutions,
+  }
+  const problems = checkBundleLinks(bundle)
+  assert.equal(problems.length, 0, `live source should link cleanly, got:\n${problems.join('\n')}`)
+  assert.ok(Object.keys(files).length > 50, 'sanity: should have scanned the real source tree')
 })
 
 test('desktop launcher prefers the bare bundle over the loose worker', () => {

--- a/packages/app/tests/desktop-bundle-script-regression.test.mjs
+++ b/packages/app/tests/desktop-bundle-script-regression.test.mjs
@@ -75,6 +75,19 @@ test('desktop bundle builder packs a runnable, linked bare bundle', () => {
   assert.match(source, /index\.bundle/, 'should write index.bundle')
   // Must be mtime-gated so desktop:start stays cheap when nothing changed.
   assert.match(source, /staleBundle|getSourceNewestMtimeMs/, 'should be mtime-gated')
+  // Must guard against a stale physical copy of @peartube/* shadowing live
+  // source during the pack (the silent path back to "does not provide an
+  // export named X"), and prove post-pack that bundled bytes match live source.
+  assert.match(
+    source,
+    /ensureLiveWorkspaceLinks\(\)/,
+    'should re-link stale @peartube node_modules copies before packing',
+  )
+  assert.match(
+    source,
+    /verifyBundleFreshness\(\)/,
+    'should verify packed @peartube files match live source after packing',
+  )
 })
 
 test('desktop launcher prefers the bare bundle over the loose worker', () => {


### PR DESCRIPTION
## Why

Last follow-up in the desktop stale-`universal-core` saga. After the bundle pipeline (#429) and the self-healing launch (#431), one silent path to `does not provide an export named 'createUniversalHrpcSurface'` remained: **bare-pack resolves `@peartube/*` through `node_modules`**, and if a *stale physical copy* of `@peartube/backend` is sitting there (from an older install state or a different package manager) instead of npm's `file:` symlink to live `packages/`, that stale source gets silently inlined into the bundle — reproducing the crash even with correct source on disk and the new pipeline active.

## What

Two guards in `scripts/build-desktop-bundle.mjs`:

1. **`ensureLiveWorkspaceLinks()` (pre-pack)** — for each `node_modules/@peartube/<pkg>` (in both `packages/app` and repo-root `node_modules`), if its realpath isn't the live `packages/<pkg>`, replace the stale copy with a symlink to live source (with a warning).
2. **`verifyBundleFreshness()` (post-pack)** — parse the produced bundle with `bare-bundle` and byte-compare every packed `@peartube` file against `packages/<pkg>/...`. On any mismatch, **fail the build** naming the stale files and how to fix (`rm -rf packages/app/node_modules/@peartube && npm run install:all`), instead of shipping a bundle that crashes the worker at link time.

So the stale-export error can no longer happen silently: the bundle is provably fresh, or the build stops and tells you exactly which file is stale.

## Verification

`bare-bundle`'s parse/compare mechanism validated against synthetic bundles — a stale variant (export stripped) is detected and named; a fresh one passes. `bare-bundle` is already a transitive dep of `bare-pack` (the mobile bundler requires it the same way). Regression test asserts both guards are wired.

Couldn't run the macOS/Electrobun build in CI here.

