### PR TITLE
desktop: embed native addons in worker bundle + submodule preflight

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ npm run bundle:backend  # bare-pack → backend.bundle.js
 1. `desktop:export` - Expo web export to `.desktop-export/`
 2. `desktop:merge` - Copy to `desktop-build/`
 3. `desktop:worker` - SWC compile `workers/desktop/index.ts` → `index.mjs`
-4. `desktop:bundle` - bare-pack `index.mjs` (+ `@peartube/backend` source) into a self-contained, runnable `index.bundle` (mtime-gated). `desktop:ecopy` ships **only** this bundle into the `.app` (no `node_modules/@peartube` source tree), and the launcher (`src/bun/index.ts`) loads it — so the `.app` runs one frozen artifact. Native addons are linked (`--linked`) to the dev monorepo, not copied.
+4. `desktop:bundle` - bare-pack `index.mjs` (+ `@peartube/backend` source) into a self-contained, runnable `index.bundle` (mtime-gated). `desktop:ecopy` ships **only** this bundle into the `.app` (no `node_modules/@peartube` source tree), and the launcher (`src/bun/index.ts`) loads it — so the `.app` runs one frozen artifact. The host's prebuilt native addons (bare-os, bare-ffmpeg, …) are **embedded** in the bundle (bare-pack without `--linked`); do not add `--linked` (that emits `linked:` specifiers expecting the host to ship addon frameworks — a standalone `bare index.bundle` then fails with `ADDON_NOT_FOUND`).
 
 **Native Desktop Build (desktop:native:build):**
 1. `ensure:host-sidecar` - Bundle JS sidecar via bare-pack

--- a/packages/app/scripts/build-desktop-bundle.mjs
+++ b/packages/app/scripts/build-desktop-bundle.mjs
@@ -303,6 +303,34 @@ function verifyBundleLinks() {
   console.log('[desktop:bundle] Bundle link check passed (all named imports satisfied)')
 }
 
+// Native-addon deps (e.g. bare-ffmpeg, imported by backend/src/thumbnail.js)
+// ship as git submodules under packages/. If a submodule isn't initialized its
+// `file:` dep can't link and bare-pack dies tracing it with a cryptic
+// "MODULE_NOT_FOUND: Cannot find module 'bare-ffmpeg'". Catch it up front with
+// an actionable message.
+function ensureNativeAddonSubmodules() {
+  let gitmodules = ''
+  try {
+    gitmodules = fs.readFileSync(path.join(repoRoot, '.gitmodules'), 'utf8')
+  } catch {
+    return
+  }
+  const missing = []
+  for (const m of gitmodules.matchAll(/path\s*=\s*(packages\/bare-[^\s]+)/g)) {
+    const subPath = m[1]
+    if (!fs.existsSync(path.join(repoRoot, subPath, 'package.json'))) missing.push(subPath)
+  }
+  if (missing.length > 0) {
+    throw new Error(
+      `[desktop:bundle] Native addon submodule(s) not initialized: ${missing.join(', ')}\n` +
+      'bare-pack needs them on disk to trace the backend (bare-ffmpeg is imported by\n' +
+      'packages/backend/src/thumbnail.js). They are git submodules, untouched by git pull/checkout.\n' +
+      `Fix: git submodule update --init ${missing.join(' ')} && npm run install:all\n` +
+      'then rebuild with PEARTUBE_FORCE_DESKTOP_BUNDLE=1 npm run desktop:bundle.',
+    )
+  }
+}
+
 function runBarePack() {
   if (!fs.existsSync(entryFile)) {
     throw new Error(
@@ -312,6 +340,7 @@ function runBarePack() {
   }
 
   fs.mkdirSync(path.dirname(bundleFile), { recursive: true })
+  ensureNativeAddonSubmodules()
   ensureLiveWorkspaceLinks()
 
   const barePackBin = findBarePackBin()

--- a/packages/app/scripts/build-desktop-bundle.mjs
+++ b/packages/app/scripts/build-desktop-bundle.mjs
@@ -89,7 +89,10 @@ function getSourceNewestMtimeMs() {
   // entry: `desktop:worker` rewrites index.mjs on every build, so keying off it
   // would force a rebundle every launch. The bundle content only depends on the
   // traced source, and `workers/desktop` is included below.
-  let newest = 0
+  // Include this script's own mtime: when the packing logic/flags change (e.g.
+  // dropping --linked), the bundle must be rebuilt even if no source changed —
+  // otherwise a mtime-fresh bundle from the old logic is silently kept.
+  let newest = getMtimeMs(fileURLToPath(import.meta.url))
   for (const root of sourceRoots) newest = Math.max(newest, walkNewestMtimeMs(root))
   for (const filePath of sourceFiles) newest = Math.max(newest, getMtimeMs(filePath))
   return newest

--- a/packages/app/scripts/build-desktop-bundle.mjs
+++ b/packages/app/scripts/build-desktop-bundle.mjs
@@ -107,7 +107,8 @@ function findBarePackBin() {
 }
 
 // Hosts to pack native addons for. In dev we only need the host the developer
-// is running on; bare-pack records linked addon resolutions for it.
+// is running on; without --linked, bare-pack embeds that host's prebuilt
+// addons into the bundle so it is self-contained.
 function getBundleHosts() {
   return [`${process.platform}-${process.arch}`]
 }
@@ -344,7 +345,12 @@ function runBarePack() {
   ensureLiveWorkspaceLinks()
 
   const barePackBin = findBarePackBin()
-  const args = ['--out', bundleFile, '--format', 'bundle', '--linked']
+  // No --linked: embed the host's prebuilt native addons (bare-os, bare-ffmpeg,
+  // …) into the bundle so a standalone `bare index.bundle` is self-contained.
+  // --linked would emit `linked:` specifiers expecting the host to provide the
+  // addon frameworks (the mobile/native-sidecar model) — which a plain bare
+  // subprocess does not, so it would fail with ADDON_NOT_FOUND at startup.
+  const args = ['--out', bundleFile, '--format', 'bundle']
   for (const host of getBundleHosts()) args.push('--host', host)
   args.push(entryFile)
 

--- a/packages/app/tests/desktop-bundle-script-regression.test.mjs
+++ b/packages/app/tests/desktop-bundle-script-regression.test.mjs
@@ -71,7 +71,10 @@ test('desktop bundle builder packs a runnable, linked bare bundle', () => {
   const source = fs.readFileSync(path.join(appRoot, 'scripts', 'build-desktop-bundle.mjs'), 'utf8')
 
   assert.match(source, /'--format', 'bundle'/, 'should emit a runnable bare bundle')
-  assert.match(source, /'--linked'/, 'should link native addons')
+  // Must NOT pass --linked: a standalone `bare index.bundle` needs the prebuilt
+  // addons embedded, not referenced as external linked: frameworks.
+  assert.doesNotMatch(source, /'--linked'/, 'should embed addons, not link them externally')
+  assert.match(source, /'--host'/, 'should target the host so the right prebuilt addons embed')
   assert.match(source, /index\.bundle/, 'should write index.bundle')
   // Must be mtime-gated so desktop:start stays cheap when nothing changed.
   assert.match(source, /staleBundle|getSourceNewestMtimeMs/, 'should be mtime-gated')

--- a/packages/app/tests/desktop-bundle-script-regression.test.mjs
+++ b/packages/app/tests/desktop-bundle-script-regression.test.mjs
@@ -93,6 +93,11 @@ test('desktop bundle builder packs a runnable, linked bare bundle', () => {
     /verifyBundleLinks\(\)/,
     'should statically link-check the packed bundle after packing',
   )
+  assert.match(
+    source,
+    /ensureNativeAddonSubmodules\(\)/,
+    'should preflight native-addon submodules (bare-ffmpeg) before packing',
+  )
 })
 
 test('bundle link check catches a stale universal-core missing an export', async () => {


### PR DESCRIPTION
## Why

Continues the desktop bundle work (#429, #431, #432). With those merged, a real `npm run desktop` on a clean machine got past the export error and the bundle now spawns — surfacing two more concrete blockers and one ergonomics gap. This PR fixes the ones that stop the app from launching.

## What

- **Embed native addons (drop `--linked`)** — *the one that actually makes it launch.* The bundle was crashing at startup with `ADDON_NOT_FOUND: linked:bare-os.3.9.1.framework/...`. Per bare-pack's docs, `--linked` emits `linked:` specifiers expecting the **host** to ship addon frameworks ahead of time (the mobile/BareKit + native-sidecar model). The Electrobun worker runs as a plain `bare index.bundle` subprocess via pear-runtime, which ships nothing. Dropping `--linked` makes bare-pack **embed** the host's prebuilt addons into the bundle (`file:` specifiers) → self-contained. `--host` is kept so the right arch prebuilt embeds.
- **Preflight native-addon submodules** — if `packages/bare-ffmpeg` (a git submodule, imported by `backend/src/thumbnail.js`) isn't initialized, bare-pack dies with a cryptic `MODULE_NOT_FOUND`. The build now checks `.gitmodules` for `packages/bare-*` submodules up front and fails with the fix (`git submodule update --init … && npm run install:all`).
- **Rebundle when the build script changes** — the bundle staleness gate now includes `build-desktop-bundle.mjs`'s own mtime, so a change to the packing logic/flags (like dropping `--linked`) forces a rebuild instead of silently keeping a mtime-fresh bundle from the old logic.

## Verification

Regression tests updated (assert `--linked` absent + `--host` present, submodule preflight wired); 5/5 green. bare-pack flag semantics confirmed against its README. Couldn't run the macOS/Electrobun build here — on a dev machine, after `git submodule update --init packages/bare-ffmpeg && npm run install:all`, `npm run desktop` should spawn `index.bundle` and launch. Remaining unknown: if `bare-ffmpeg` lacks a `darwin-arm64` prebuild, bare-pack will need an addon-build step (separate follow-up).

https://claude.ai/code/session_01GLy5xKAXzeBLawqmn16Hb9

---
_Generated by [Claude Code](https://claude.ai/code/session_01GLy5xKAXzeBLawqmn16Hb9)_