### PR TITLE
[codex] Fix Electrobun desktop Bare worker startup

### DIFF
--- a/packages/app/scripts/build-desktop-bundle.mjs
+++ b/packages/app/scripts/build-desktop-bundle.mjs
@@ -10,11 +10,12 @@
  * partial copy) could run a stale `universal-core.js` and fail to link a newly
  * added export (e.g. `createUniversalHrpcSurface`).
  *
- * This script bare-packs the compiled worker into a single self-contained
- * `.bundle` (the same runnable format the native macOS sidecar uses), traced
- * from the real `packages/app/node_modules` graph. `pear-runtime` runs the
- * worker via `bare <entry>`, and `bare` loads `.bundle` files natively, so the
- * launcher can point at one artifact instead of a copied source tree.
+ * This script bare-packs the compiled worker into a runnable `.bundle`, traced
+ * from the real `packages/app/node_modules` graph. Native `.bare` addons are
+ * offloaded beside the bundle because the PearRuntime sidecar dlopens them
+ * from filesystem paths. `pear-runtime` runs the worker via `bare <entry>`, so
+ * the launcher can point at one JS artifact plus its sibling native addon tree
+ * instead of a copied source tree.
  *
  * The build is mtime-gated so `desktop:start` can call it cheaply on every
  * launch and self-heal a stale bundle after a source change.
@@ -119,8 +120,8 @@ function findBarePackBin() {
 }
 
 // Hosts to pack native addons for. In dev we only need the host the developer
-// is running on; without --linked, bare-pack embeds that host's prebuilt
-// addons into the bundle so it is self-contained.
+// is running on; bare-pack uses this to choose the right prebuilt addons to
+// offload beside the bundle.
 function getBundleHosts() {
   return [`${process.platform}-${process.arch}`]
 }
@@ -316,6 +317,59 @@ function verifyBundleLinks() {
   console.log('[desktop:bundle] Bundle link check passed (all named imports satisfied)')
 }
 
+function collectStrings(value, output) {
+  if (typeof value === 'string') {
+    output.push(value)
+    return
+  }
+  if (!value || typeof value !== 'object') return
+  for (const child of Object.values(value)) collectStrings(child, output)
+}
+
+function getOffloadedNativeAddonPaths(packed) {
+  const values = []
+  for (const resolutions of Object.values(packed.resolutions)) collectStrings(resolutions, values)
+
+  const relativePaths = new Set()
+  for (const value of values) {
+    if (!/^\/\.\.\/node_modules\/.+\.(?:bare|node)$/.test(value)) continue
+    relativePaths.add(value.slice('/../'.length))
+  }
+
+  return [...relativePaths].sort().map((relativePath) => path.join(bundleOutDir, relativePath))
+}
+
+function readPackedBundle() {
+  const require = createRequire(path.join(projectRoot, 'package.json'))
+  const Bundle = require('bare-bundle')
+  return Bundle.from(fs.readFileSync(bundleFile))
+}
+
+function findMissingOffloadedNativeAddons() {
+  if (!fs.existsSync(bundleFile)) return []
+  const packed = readPackedBundle()
+  const addonPaths = getOffloadedNativeAddonPaths(packed)
+  if (addonPaths.length === 0) return ['<no offloaded native addon resolutions in bundle>']
+  return addonPaths.filter((addonPath) => !fs.existsSync(addonPath))
+}
+
+function verifyOffloadedNativeAddons() {
+  const missing = findMissingOffloadedNativeAddons()
+  if (missing.length > 0) {
+    const lines = missing.map((addonPath) => (
+      addonPath.startsWith('<') ? addonPath : path.relative(projectRoot, addonPath)
+    ))
+    throw new Error(
+      `[desktop:bundle] Missing offloaded native addon file(s) needed by ${path.relative(projectRoot, bundleFile)}:\n` +
+      `  ${lines.join('\n  ')}\n` +
+      'PearRuntime dlopens desktop native addons from the filesystem, so the worker bundle must be built with\n' +
+      '`bare-pack --offload-addons` and the generated node_modules directory must be copied beside index.bundle.\n' +
+      'Fix: PEARTUBE_FORCE_DESKTOP_BUNDLE=1 npm run desktop:bundle.',
+    )
+  }
+  console.log('[desktop:bundle] Offloaded native addon check passed')
+}
+
 // Native-addon deps (e.g. bare-ffmpeg, imported by backend/src/thumbnail.js)
 // ship as git submodules under packages/. Two failure modes bare-pack reports
 // only cryptically, caught here up front:
@@ -503,15 +557,18 @@ if (isMain) {
   const bundleMtime = getMtimeMs(bundleFile)
   const missingBundle = bundleMtime === 0
   const staleBundle = !missingBundle && bundleMtime < sourceNewest
+  const missingOffloadedAddons = !missingBundle && findMissingOffloadedNativeAddons().length > 0
 
-  if (forced || missingBundle || staleBundle) {
-    const reason = forced ? 'forced rebuild' : missingBundle ? 'missing bundle' : 'stale bundle'
+  if (forced || missingBundle || staleBundle || missingOffloadedAddons) {
+    const reason = forced ? 'forced rebuild' : missingBundle ? 'missing bundle' : staleBundle ? 'stale bundle' : 'missing offloaded native addons'
     console.log(`[desktop:bundle] Rebuilding desktop worker bundle (${reason})`)
     runBarePack()
     verifyBundleFreshness()
     verifyBundleLinks()
+    verifyOffloadedNativeAddons()
     console.log(`[desktop:bundle] Wrote ${path.relative(projectRoot, bundleFile)}`)
   } else {
+    verifyOffloadedNativeAddons()
     console.log('[desktop:bundle] Desktop worker bundle is up to date')
   }
 }

--- a/packages/app/tests/desktop-bundle-script-regression.test.mjs
+++ b/packages/app/tests/desktop-bundle-script-regression.test.mjs
@@ -80,7 +80,7 @@ test('desktop:bundle is wired into the desktop build + launch pipeline', () => {
   )
 })
 
-test('desktop bundle builder packs a runnable, linked bare bundle', () => {
+test('desktop bundle builder packs a runnable bare bundle with filesystem native addons', () => {
   const source = fs.readFileSync(path.join(appRoot, 'scripts', 'build-desktop-bundle.mjs'), 'utf8')
 
   assert.match(source, /'--format', 'bundle'/, 'should emit a runnable bare bundle')
@@ -93,6 +93,7 @@ test('desktop bundle builder packs a runnable, linked bare bundle', () => {
   // die with ENOTDIR (the bundle is a file, not a dir).
   assert.match(source, /'--offload-addons'/, 'should offload native addons to disk beside the bundle')
   assert.match(source, /'--host'/, 'should target the host so the right prebuilt addons offload')
+  assert.match(source, /'--base'/, 'should set the bundle base so offloaded addon paths resolve beside index.bundle')
   assert.match(source, /index\.bundle/, 'should write index.bundle')
   // Must be mtime-gated so desktop:start stays cheap when nothing changed.
   assert.match(source, /staleBundle|getSourceNewestMtimeMs/, 'should be mtime-gated')
@@ -126,6 +127,16 @@ test('desktop bundle builder packs a runnable, linked bare bundle', () => {
   assert.match(source, /'--base', projectRoot/, 'should pin --base to the app root so offload writes to disk and keys are unchanged')
   assert.match(source, /stagingDir/, 'should pack into a staging dir outside --base')
   assert.match(source, /relocateStagingToOutDir/, 'should relocate the bundle + offloaded addons into the out dir')
+  assert.match(
+    source,
+    /verifyOffloadedNativeAddons\(\)/,
+    'should verify the native addons needed at runtime were offloaded',
+  )
+  assert.match(
+    source,
+    /verifyOffloadedAddons\(\)/,
+    'should fail if no native addon prebuilds were relocated beside the bundle',
+  )
 })
 
 test('bundle link check catches a stale universal-core missing an export', async () => {
@@ -241,5 +252,30 @@ test('packaged desktop app ships the sibling hypercore reader worker with the ba
     workerSource,
     /const workerBaseDir = runtimeStorage \|\| os\.cwd\(\)/,
     'desktop worker must not derive bundled code paths from mutable storage',
+  )
+})
+
+test('desktop worker boots the universal backend with the real backend context', () => {
+  const workerSource = fs.readFileSync(path.join(appRoot, 'workers', 'desktop', 'index.ts'), 'utf8')
+
+  assert.match(
+    workerSource,
+    /import\s+\{\s*createBackendContext\s*\}\s+from\s+['"]@peartube\/backend\/orchestrator['"]/,
+    'desktop worker should import the real backend context factory',
+  )
+  assert.match(
+    workerSource,
+    /createBackend\(\{[\s\S]*createBackendContext,/,
+    'desktop worker should pass createBackendContext into createBackend',
+  )
+  assert.match(
+    workerSource,
+    /Backend context did not initialize required desktop services/,
+    'desktop worker should fail fast before exposing identity handlers without the real context',
+  )
+  assert.match(
+    workerSource,
+    /typeof identityManager\.getIdentities !== 'function'/,
+    'desktop worker should verify identityManager before getIdentities can be called',
   )
 })

--- a/packages/app/tests/electrobun-latency-regression.test.mjs
+++ b/packages/app/tests/electrobun-latency-regression.test.mjs
@@ -21,16 +21,38 @@ function readPackageJson() {
 
 test('Electrobun desktop start refreshes staged workspace packages before launching', () => {
   const { scripts } = readPackageJson()
+  const rootPackage = JSON.parse(readRepoFile('package.json'))
+
+  assert.equal(
+    rootPackage.scripts.desktop,
+    'npm run desktop:dev --prefix packages/app',
+    'root npm run desktop should run the full app desktop dev pipeline',
+  )
+  assert.match(
+    scripts['desktop:dev'],
+    /npm run schema && npm run desktop:export && npm run desktop:merge && npm run desktop:start/,
+    'desktop:dev should refresh schema and web assets before launching',
+  )
 
   assert.match(
     scripts['desktop:start'],
-    /npm run desktop:ecopy && build\/dev-macos-arm64\/PearTube-dev\.app\/Contents\/MacOS\/launcher/,
-    'desktop:start must not launch a stale packaged backend directly',
+    /npm run desktop:worker && npm run desktop:bundle && npm run desktop:ebuild && build\/dev-macos-arm64\/PearTube-dev\.app\/Contents\/MacOS\/launcher/,
+    'desktop:start must rebuild the worker bundle and staged app before launching',
+  )
+  assert.match(
+    scripts['desktop:ebuild'],
+    /electrobun build && npm run desktop:ecopy/,
+    'desktop:ebuild should refresh copied app resources after rebuilding the launcher',
   )
   assert.match(
     scripts['desktop:ecopy'],
-    /rsync -a --delete \.\.\/\.\.\/packages\/backend\/ build\/dev-macos-arm64\/PearTube-dev\.app\/Contents\/Resources\/app\/node_modules\/@peartube\/backend\//,
-    'desktop:ecopy should delete stale backend files from the staged app before copying',
+    /rm -rf [^&]*\/workers [^&]*\/node_modules/,
+    'desktop:ecopy should delete stale staged workers and legacy node_modules before copying',
+  )
+  assert.match(
+    scripts['desktop:ecopy'],
+    /rsync -a --exclude=index\.mjs desktop-build\/build\/workers\/core\/ /,
+    'desktop:ecopy should copy the packed worker bundle and offloaded native addons into the staged app',
   )
 })
 

--- a/packages/app/workers/desktop/index.ts
+++ b/packages/app/workers/desktop/index.ts
@@ -20,6 +20,8 @@ import * as castTranscoder from '@peartube/backend/transcode/cast-transcoder'
 import { generateAndStoreThumbnail } from '@peartube/backend/thumbnail'
 // @ts-ignore
 import { createBackend } from '@peartube/backend/src/backend-entry.js'
+// @ts-ignore
+import { createBackendContext } from '@peartube/backend/orchestrator'
 // Bare runtime globals (available when spawned via pear.run())
 declare const Bare: { argv: string[]; IPC: any } | undefined
 // Cast proxy infrastructure
@@ -427,6 +429,7 @@ const { rpc: _rpc, backend, destroy } = await createBackend({
   stream: ipcPipe,
   storagePath: storage,
   platform: 'desktop',
+  createBackendContext,
   autoAttachSharedAppHandlers: true,
   onReady: (data: any) => { console.log('[Worker] Backend ready, blob port:', data?.blobServerPort) },
   onError: (err: any) => { console.error('[Worker] Backend error:', err?.message || err) },
@@ -441,6 +444,19 @@ const { rpc: _rpc, backend, destroy } = await createBackend({
 })
 rpc = _rpc
 const { ctx, api, identityManager, uploadManager, videoStats, initializeIdentityFromMnemonic } = backend as any
+const missingDesktopServices = [
+  ctx ? null : 'ctx',
+  api ? null : 'api',
+  identityManager ? null : 'identityManager',
+  identityManager && typeof identityManager.getIdentities !== 'function' ? 'identityManager.getIdentities' : null,
+  uploadManager ? null : 'uploadManager',
+].filter(Boolean)
+if (missingDesktopServices.length > 0) {
+  throw new Error(
+    `[Worker] Backend context did not initialize required desktop services: ${missingDesktopServices.join(', ')}. ` +
+    'Ensure createBackendContext is passed to createBackend.',
+  )
+}
 const getBlobPort = () => (ctx.blobServer as any)?.port || ctx.blobServerPort || 0
 
 console.log('[Worker] Backend initialized, attaching desktop handler methods...')


### PR DESCRIPTION
## Summary
- Boot the Electrobun desktop worker with the real backend context factory so identity/upload services exist before HRPC handlers are exposed.
- Add a fail-fast desktop worker guard for missing backend services instead of allowing late `getIdentities` crashes.
- Make the desktop bundle builder detect missing offloaded native addon files on both rebuild and up-to-date paths.
- Update Electrobun regression coverage for the current bundled worker copy strategy.

## Validation
- `git diff --check -- packages/app/package.json packages/app/scripts/build-desktop-bundle.mjs packages/app/tests/desktop-bundle-script-regression.test.mjs packages/app/tests/electrobun-latency-regression.test.mjs packages/app/workers/desktop/index.ts`
- `node --check packages/app/scripts/build-desktop-bundle.mjs`
- `node --test packages/app/tests/electrobun-latency-regression.test.mjs packages/app/tests/desktop-bundle-script-regression.test.mjs`