### PR TITLE
[codex] fix mobile playback stats

### DIFF
--- a/packages/app/app/video/[id].tsx
+++ b/packages/app/app/video/[id].tsx
@@ -140,6 +140,11 @@ function P2PStatsBar({ stats }: { stats: VideoStats | null }) {
   const videoPeerCount = stats?.peerCount ?? 0
   const downloadSpeedValue = Number(stats?.speedMBps ?? 0)
   const uploadSpeedValue = Number(stats?.uploadSpeedMBps ?? 0)
+  const hasPlayableProgress = Boolean(
+    Number(stats?.downloadedBytes ?? 0) > 0 ||
+    Number(stats?.downloadedBlocks ?? 0) > 0 ||
+    Number(stats?.progress ?? 0) > 0
+  )
   const downloadSpeedText = Number.isFinite(downloadSpeedValue) ? downloadSpeedValue.toFixed(2) : '0.00'
   const uploadSpeedText = Number.isFinite(uploadSpeedValue) ? uploadSpeedValue.toFixed(2) : '0.00'
 
@@ -150,6 +155,7 @@ function P2PStatsBar({ stats }: { stats: VideoStats | null }) {
     }
     if (stats.isComplete) return { color: '#4ade80', label: 'Cached' }
     if (stats.status === 'downloading') return { color: '#fbbf24', label: 'Downloading' }
+    if (hasPlayableProgress) return { color: '#60a5fa', label: 'Streaming' }
     if (stats.status === 'connecting') return { color: '#60a5fa', label: 'Connecting...' }
     if (stats.status === 'resolving') return { color: '#a78bfa', label: 'Resolving...' }
     if (stats.status === 'error') return { color: '#f87171', label: 'Error' }
@@ -167,7 +173,9 @@ function P2PStatsBar({ stats }: { stats: VideoStats | null }) {
         ? 'Playback hit a snag'
         : videoPeerCount > 0
           ? `Streaming from ${videoPeerCount} ${videoPeerCount === 1 ? 'peer' : 'peers'}`
-          : 'Reaching out to peers…'
+          : hasPlayableProgress
+            ? 'Streaming'
+            : 'Reaching out to peers…'
 
   return (
     <Pressable

--- a/packages/app/tests/mobile-video-stats-lifecycle-regression.test.mjs
+++ b/packages/app/tests/mobile-video-stats-lifecycle-regression.test.mjs
@@ -32,6 +32,44 @@ test('mobile watch page keeps live context stats ahead of stale polled stats', (
   )
 })
 
+test('mobile watch page does not keep saying reaching out once playback has byte progress', () => {
+  const source = read('app/video/[id].tsx')
+  const barStart = source.indexOf('function P2PStatsBar')
+  assert.notEqual(barStart, -1, 'expected mobile watch page P2PStatsBar')
+  const barBlock = source.slice(barStart, source.indexOf('// Action Button Component', barStart))
+
+  assert.match(
+    barBlock,
+    /const hasPlayableProgress =/,
+    'stats bar should classify playable byte or block progress separately from peers',
+  )
+  assert.match(
+    barBlock,
+    /hasPlayableProgress[\s\S]*\? 'Streaming'[\s\S]*: 'Reaching out to peers…'/,
+    'playback progress should beat the reaching-out empty state when peers are momentarily zero',
+  )
+})
+
+test('backend preparePlayback initializes stats for direct on-demand blob playback', () => {
+  const source = read('../backend/src/api.js')
+
+  assert.match(
+    source,
+    /async function startOnDemandPlaybackStats/,
+    'direct blob playback should attach lightweight stats tracking without prefetching',
+  )
+  assert.match(
+    source,
+    /core\.on\('download', onDownload\)/,
+    'direct playback stats should advance from blob core download events',
+  )
+  assert.match(
+    source,
+    /const playbackStats = await startOnDemandPlaybackStats\(driveKey, videoPath, playbackBlobRef\)/,
+    'preparePlayback should initialize stats before returning to mobile',
+  )
+})
+
 test('mobile watch page reattaches stats when returning to an already playing video', () => {
   const source = read('app/video/[id].tsx')
 

--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -300,6 +300,173 @@ export function createApi({
   /** @type {Map<string, Promise<any>>} */
   const prefetchInFlight = new Map()
   const activeRangeRequests = new Map() // key: `${driveKey}:${videoPath}`, value: { ranges: [], core, onDownload, onUpload }
+  const activeOnDemandPlaybackStats = new Map() // key: normalized stats key -> { core, cleanup }
+
+  function cleanupOnDemandPlaybackStats(statsKey) {
+    const active = activeOnDemandPlaybackStats.get(statsKey)
+    if (!active) return
+    try { active.cleanup?.() } catch { /* best effort */ }
+    activeOnDemandPlaybackStats.delete(statsKey)
+  }
+
+  async function countInitialBlobBlocks(core, startBlock, endBlock, totalBlocks) {
+    try {
+      if (await core.has(startBlock, endBlock)) return totalBlocks
+    } catch { /* best effort */ }
+
+    if (totalBlocks <= 512) {
+      let available = 0
+      for (let index = startBlock; index < endBlock; index++) {
+        try {
+          if (await core.has(index)) available++
+        } catch { /* best effort */ }
+      }
+      return available
+    }
+
+    const sampleSize = Math.min(totalBlocks, 20)
+    const step = Math.max(1, Math.floor(totalBlocks / sampleSize))
+    let sampledHits = 0
+    let sampledTotal = 0
+    for (let index = startBlock; index < endBlock; index += step) {
+      try {
+        if (await core.has(index)) sampledHits++
+      } catch { /* best effort */ }
+      sampledTotal++
+    }
+    return sampledTotal > 0 ? Math.round((sampledHits / sampledTotal) * totalBlocks) : 0
+  }
+
+  async function startOnDemandPlaybackStats(driveKey, videoPath, playbackBlobRef) {
+    if (!videoStats || !ctx?.store || !playbackBlobRef?.blobsCoreKey || !playbackBlobRef?.blobId) return null
+
+    const blobsCoreKey = normalizeBlobsCoreKey(playbackBlobRef.blobsCoreKey)
+    const blob = normalizeBlobRefInput(playbackBlobRef.blobId) || parseBlobRef(playbackBlobRef)?.blob
+    if (!blobsCoreKey || !blob) return null
+
+    const statsKey = getStatsKey(driveKey, videoPath)
+    if (activeRangeRequests.has(encodeIndexKey(driveKey || '', videoPath || ''))) {
+      return typeof videoStats.getStats === 'function' ? videoStats.getStats(driveKey, videoPath) : null
+    }
+
+    try {
+      cleanupOnDemandPlaybackStats(statsKey)
+      try { videoStats.cleanupMonitor(driveKey, videoPath) } catch { /* best effort */ }
+
+      const keyBuf = b4a.from(blobsCoreKey, 'hex')
+      const core = ctx.store.get({ key: keyBuf })
+      await core.ready()
+
+      const startBlock = blob.blockOffset
+      const totalBlocks = blob.blockLength
+      const endBlock = startBlock + totalBlocks
+      const totalBytes = blob.byteLength || playbackBlobRef.byteLength || 0
+      const initialBlocks = await countInitialBlobBlocks(core, startBlock, endBlock, totalBlocks)
+      const wasCached = totalBlocks > 0 && initialBlocks >= totalBlocks
+      const bytesPerBlock = totalBlocks > 0 ? totalBytes / totalBlocks : 0
+      const peerDetails = describeCorePeerDetails(core)
+
+      let downloadedBlocks = 0
+      let downloadedBytesTotal = 0
+      let downloadSpeed = 0
+      let lastSpeedTime = Date.now()
+      let lastSpeedBytes = 0
+      let uploadedBytesTotal = 0
+      let uploadSpeed = 0
+      let lastUploadTime = Date.now()
+      let lastUploadBytes = 0
+      const downloadedIndices = new Set()
+
+      const onDownload = (index, byteLength) => {
+        if (typeof index !== 'number') return
+        if (index < startBlock || index >= endBlock) return
+        if (!downloadedIndices.has(index)) {
+          downloadedIndices.add(index)
+          downloadedBlocks = downloadedIndices.size
+        }
+
+        const chunkBytes =
+          typeof byteLength === 'number' && Number.isFinite(byteLength) && byteLength > 0
+            ? byteLength
+            : bytesPerBlock
+        downloadedBytesTotal += chunkBytes
+        const now = Date.now()
+        const elapsed = (now - lastSpeedTime) / 1000
+        if (elapsed >= 0.5) {
+          const deltaBytes = downloadedBytesTotal - lastSpeedBytes
+          downloadSpeed = elapsed > 0 ? deltaBytes / elapsed : 0
+          lastSpeedBytes = downloadedBytesTotal
+          lastSpeedTime = now
+        }
+
+        const totalDownloaded = initialBlocks + downloadedBlocks
+        const isComplete = totalBlocks > 0 && totalDownloaded >= totalBlocks
+        videoStats.updateStats(driveKey, videoPath, {
+          status: isComplete ? 'complete' : 'downloading',
+          downloadedBlocks,
+          initialBlocks,
+          peerCount: describeCorePeerDetails(core).peerCount,
+        })
+        videoStats.emitStats(driveKey, videoPath, isComplete)
+      }
+
+      const onUpload = (index, byteLength) => {
+        if (typeof index !== 'number') return
+        if (index < startBlock || index >= endBlock) return
+        const chunkBytes =
+          typeof byteLength === 'number' && Number.isFinite(byteLength) && byteLength > 0
+            ? byteLength
+            : bytesPerBlock
+        uploadedBytesTotal += chunkBytes
+        const now = Date.now()
+        const elapsed = (now - lastUploadTime) / 1000
+        if (elapsed >= 0.5) {
+          const deltaBytes = uploadedBytesTotal - lastUploadBytes
+          uploadSpeed = elapsed > 0 ? deltaBytes / elapsed : 0
+          lastUploadBytes = uploadedBytesTotal
+          lastUploadTime = now
+        }
+
+        videoStats.updateStats(driveKey, videoPath, {
+          peerCount: describeCorePeerDetails(core).peerCount,
+        })
+        videoStats.emitStats(driveKey, videoPath)
+      }
+
+      videoStats.updateStats(driveKey, videoPath, {
+        status: wasCached ? 'complete' : 'downloading',
+        startTime: Date.now(),
+        totalBlocks,
+        totalBytes,
+        initialBlocks,
+        downloadedBlocks: 0,
+        peerCount: peerDetails.peerCount,
+      })
+
+      const monitor = {
+        downloadSpeed: () => (Date.now() - lastSpeedTime > 2000 ? 0 : downloadSpeed),
+        uploadSpeed: () => (Date.now() - lastUploadTime > 2000 ? 0 : uploadSpeed),
+      }
+      core.on('download', onDownload)
+      core.on('upload', onUpload)
+      videoStats.registerMonitor(driveKey, videoPath, monitor, () => {
+        try { core.off('download', onDownload) } catch { /* best effort */ }
+        try { core.off('upload', onUpload) } catch { /* best effort */ }
+        activeOnDemandPlaybackStats.delete(statsKey)
+      })
+      activeOnDemandPlaybackStats.set(statsKey, {
+        core,
+        cleanup: () => videoStats.cleanupMonitor(driveKey, videoPath),
+      })
+      videoStats.emitStats(driveKey, videoPath, true)
+
+      return videoStats.getStats(driveKey, videoPath)
+    } catch (err) {
+      console.log('[API] on-demand playback stats unavailable:', err?.message || err)
+      cleanupOnDemandPlaybackStats(statsKey)
+      return null
+    }
+  }
 
   function getActiveRangeSeedKeys() {
     const keys = new Set()
@@ -367,6 +534,40 @@ export function createApi({
     }
   }
 
+  function getStatsKey(driveKey, videoPath) {
+    return typeof videoStats?.getKey === 'function'
+      ? videoStats.getKey(driveKey, videoPath)
+      : encodeIndexKey(driveKey || '', normalizeVideoId(videoPath) || videoPath || '')
+  }
+
+  function describeCorePeerDetails(core) {
+    const peers = core?.peers
+    const peerList = Array.isArray(peers)
+      ? peers
+      : peers && typeof peers.values === 'function'
+        ? Array.from(peers.values())
+        : []
+    const peerCount = Array.isArray(peers)
+      ? peers.length
+      : typeof peers?.length === 'number'
+        ? peers.length
+        : typeof peers?.size === 'number'
+          ? peers.size
+          : peerList.length
+    const blobPeerIds = peerList.map((peer) => {
+      try {
+        const key = peer?.remotePublicKey || peer?.publicKey || peer?.key || peer?.id || peer?.stream?.remotePublicKey
+        if (!key) return null
+        const hex = typeof key === 'string' ? key : b4a.toString(key, 'hex')
+        return /^[a-f0-9]{64}$/i.test(hex) ? hex : null
+      } catch {
+        return null
+      }
+    }).filter(Boolean)
+    const blobCoreKey = core?.key ? b4a.toString(core.key, 'hex') : null
+    return { peerCount, blobPeerIds, blobCoreKey }
+  }
+
   function getVideoCorePeerDetails(driveKey, videoPath) {
     try {
       const channel = ctx.channels?.get?.(driveKey)
@@ -381,32 +582,11 @@ export function createApi({
       for (const candidate of candidates) {
         const core = channel?.videoCores?.get?.(candidate) || channel?.cores?.get?.(candidate)
         if (!core) continue
-        const peers = core.peers
-        const peerList = Array.isArray(peers)
-          ? peers
-          : peers && typeof peers.values === 'function'
-            ? Array.from(peers.values())
-            : []
-        const peerCount = Array.isArray(peers)
-          ? peers.length
-          : typeof peers?.length === 'number'
-            ? peers.length
-            : typeof peers?.size === 'number'
-              ? peers.size
-              : peerList.length
-        const blobPeerIds = peerList.map((peer) => {
-          try {
-            const key = peer?.remotePublicKey || peer?.publicKey || peer?.key || peer?.id || peer?.stream?.remotePublicKey
-            if (!key) return null
-            const hex = typeof key === 'string' ? key : b4a.toString(key, 'hex')
-            return /^[a-f0-9]{64}$/i.test(hex) ? hex : null
-          } catch {
-            return null
-          }
-        }).filter(Boolean)
-        const blobCoreKey = core.key ? b4a.toString(core.key, 'hex') : null
-        return { peerCount, blobPeerIds, blobCoreKey }
+        return describeCorePeerDetails(core)
       }
+
+      const directPlayback = activeOnDemandPlaybackStats.get(getStatsKey(driveKey, videoPath))
+      if (directPlayback?.core) return describeCorePeerDetails(directPlayback.core)
     } catch { /* best effort */ }
 
     return { peerCount: 0, blobPeerIds: [], blobCoreKey: null }
@@ -1200,6 +1380,7 @@ export function createApi({
     async preparePlayback(driveKey, videoPath, publicBeeKey, blobId, blobsCoreKey, mimeType) {
       console.log('[API] preparePlayback:', driveKey?.slice(0, 16), videoPath)
       const startedAt = Date.now()
+      const playbackBlobRef = resolvePlaybackBlobRef(driveKey, videoPath, publicBeeKey, blobId, blobsCoreKey, mimeType)
 
       // Resolve-and-stream: getVideoUrl returns a blob-server URL and joins the
       // blob core to swarm discovery so the server can fetch byte ranges on
@@ -1215,6 +1396,8 @@ export function createApi({
         resolveUrl: (...args) => this.getVideoUrl(...args),
         getStats: (...args) => this.getVideoStats(...args),
       })
+      const playbackStats = await startOnDemandPlaybackStats(driveKey, videoPath, playbackBlobRef)
+      if (playbackStats) prepared.stats = this.getVideoStats(driveKey, videoPath)
 
       trackPlaybackTiming({
         at: startedAt,

--- a/packages/backend/test/playback-api.test.mjs
+++ b/packages/backend/test/playback-api.test.mjs
@@ -1,4 +1,5 @@
 import test from 'brittle'
+import { EventEmitter } from 'node:events'
 
 import { createApi } from '../src/api.js'
 
@@ -150,6 +151,78 @@ test('preparePlayback resolves feed preview blob refs when playback request omit
   // so flush the microtask that follows blobsCore.ready().
   await new Promise((resolve) => setTimeout(resolve, 0))
   t.ok(calls.some((call) => call[0] === 'swarm.join'), 'joins selected blob discovery so the blob server can stream on demand')
+})
+
+test('preparePlayback initializes direct on-demand playback stats from blob range downloads', async (t) => {
+  const driveKey = 'channel-key'
+  const videoPath = 'videos/demo.mp4'
+  const blobsCoreKey = '78'.repeat(32)
+  const blobId = '5:4:0:4096'
+  const calls = []
+  const core = new EventEmitter()
+  core.key = Buffer.from(blobsCoreKey, 'hex')
+  core.discoveryKey = Buffer.from('discovery-key')
+  core.peers = [{ remotePublicKey: Buffer.from('a'.repeat(64), 'hex') }]
+  core.ready = async () => { calls.push(['core.ready']) }
+  core.update = () => Promise.resolve()
+  core.has = async (start, end) => {
+    calls.push(['core.has', start, end])
+    return false
+  }
+
+  const api = createApi({
+    ctx: {
+      blobServer: {
+        port: 60023,
+        getLink(_keyBuffer, options) {
+          calls.push(['getLink', options.blob, options.type])
+          return 'http://127.0.0.1:60023/demo.mp4'
+        },
+      },
+      store: {
+        get() {
+          calls.push(['store.get'])
+          return core
+        },
+      },
+      swarm: {
+        connections: new Set([1, 2]),
+        join(discoveryKey) {
+          calls.push(['swarm.join', discoveryKey])
+          return { flushed: () => Promise.resolve() }
+        },
+      },
+      channels: new Map(),
+    },
+    videoStats: new (await import('../src/video-stats.js')).VideoStatsTracker(),
+  })
+
+  const prepared = await api.preparePlayback(
+    driveKey,
+    videoPath,
+    null,
+    blobId,
+    blobsCoreKey,
+    'video/mp4',
+  )
+
+  t.is(prepared.url, 'http://127.0.0.1:60023/demo.mp4')
+  t.is(prepared.stats.status, 'downloading')
+  t.is(prepared.stats.totalBlocks, 4)
+  t.is(prepared.stats.totalBytes, 4096)
+  t.is(prepared.stats.peerCount, 1)
+
+  core.emit('download', 5, 1024)
+  const stats = api.getVideoStats(driveKey, videoPath)
+
+  t.is(stats.status, 'downloading')
+  t.is(stats.downloadedBlocks, 1)
+  t.is(stats.downloadedBytes, 1024)
+  t.is(stats.progress, 25)
+  t.is(stats.peerCount, 1)
+  t.alike(stats.blobPeerIds, ['a'.repeat(64)])
+  t.is(stats.blobCoreKey, blobsCoreKey)
+  t.absent(calls.find((call) => call[0] === 'prefetchVideo'), 'direct playback stats must not start full-file prefetch')
 })
 
 test('prefetchNextVideos lists channel videos with the correct signature', async (t) => {


### PR DESCRIPTION
## Summary
- Initialize lightweight video stats for direct on-demand blob playback in the universal backend.
- Keep the mobile stats bar from showing the peer-discovery empty state once byte/block/progress evidence exists.
- Add backend and mobile regression coverage for direct playback stats.

## Root Cause
Mobile playback uses `preparePlayback` to return a direct blob-server URL for on-demand streaming, but stats were still initialized by the old `prefetchVideo` path. Videos could play while `getVideoStats` returned the empty `unknown/0` fallback, leaving the mobile stats bar stuck on “Reaching out to peers”.

## Validation
- `npx brittle packages/backend/test/playback-api.test.mjs`
- `node packages/app/tests/mobile-video-stats-lifecycle-regression.test.mjs`
- `node packages/app/tests/p2p-stats-bar-data-truth-regression.test.mjs`
- `npm test --prefix packages/backend`
- `git diff --check` for touched files