### PR TITLE
Fix desktop video autoplay retry

### DIFF
--- a/packages/app/components/video-player/PearInlineVideoView.tsx
+++ b/packages/app/components/video-player/PearInlineVideoView.tsx
@@ -66,11 +66,11 @@ const PLAYBACK_ERROR_RECOVERY_MAX_ATTEMPTS = 4
 const PLAYBACK_ERROR_RECOVERY_BASE_DELAY_MS = 1000
 const PLAYBACK_ERROR_RECOVERY_PROGRESS_SEC = 2
 // The playingChange/statusChange guards only run when the native player emits
-// an event. On Android, a play() issued while ExoPlayer is mid source-replace
+// an event. A play() issued while the native/html element is mid source-replace
 // can be dropped, leaving the player parked at readyToPlay + paused with no
 // further events — so videos open frozen on the first frame. Verify shortly
-// after each play request that the native player actually started, re-asserting
-// with backoff (0.4s/0.8s/1.6s/3.2s) until the first real play event arrives.
+// after each play request that the player actually started, re-asserting with
+// backoff (0.4s/0.8s/1.6s/3.2s) until the first real play event arrives.
 const AUTOPLAY_VERIFY_BASE_DELAY_MS = 400
 const AUTOPLAY_VERIFY_MAX_ATTEMPTS = 4
 
@@ -243,7 +243,6 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
   }, [])
 
   const scheduleAutoplayVerify = useCallback((attempt: number = 0) => {
-    if (Platform.OS === 'web') return
     clearAutoplayVerify()
     if (attempt >= AUTOPLAY_VERIFY_MAX_ATTEMPTS) return
     autoplayVerifyTimerRef.current = setTimeout(() => {

--- a/packages/app/components/video-player/WebMseVideoBackend.web.tsx
+++ b/packages/app/components/video-player/WebMseVideoBackend.web.tsx
@@ -51,6 +51,8 @@ const POLL_MS = 250           // Pump idle poll interval
 const MAX_PENDING_SEGMENTS = 64 // Hard cap on segments awaiting append
 const PLAYLIST_POLL_MS = 1000   // Compat path: live playlist refresh interval
 const PLAYLIST_READY_TIMEOUT_MS = 30000 // Compat path: max wait for first segment
+const MSE_AUTOPLAY_RETRY_MAX_ATTEMPTS = 5
+const MSE_AUTOPLAY_RETRY_BASE_DELAY_MS = 150
 
 interface Segment {
   time: number       // Fragment start timestamp in seconds (absolute)
@@ -186,8 +188,9 @@ async function runCompatHlsPipeline(opts: {
   onError?: (error: any) => void
   setDispose: (fn: () => void) => void
   shouldAutoPlay?: () => boolean
+  requestAutoplay?: () => void
 }): Promise<void> {
-  const { el, hlsUrl, videoCodecString, durationHint, onLoad, onError, setDispose, shouldAutoPlay } = opts
+  const { el, hlsUrl, videoCodecString, durationHint, onLoad, onError, setDispose, shouldAutoPlay, requestAutoplay } = opts
 
   const ctl = { disposed: false, generation: 0 }
   const stale = (gen: number) => ctl.disposed || gen !== ctl.generation
@@ -309,7 +312,7 @@ async function runCompatHlsPipeline(opts: {
       if (!playbackStarted) {
         playbackStarted = true
         if (shouldAutoPlay?.() ?? true) {
-          el.play().catch(() => {})
+          requestAutoplay?.()
         }
       }
       index++
@@ -376,6 +379,8 @@ export const WebMseVideoBackend = memo(function WebMseVideoBackend({
   const disposeRef = useRef<(() => void) | null>(null)
   const mseBackendPortRef = useRef<PlayerPort | null>(null)
   const mseBackendControllerRef = useRef<WebMseBackendController | null>(null)
+  const mseAutoplayRetryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const requestDesiredPlaybackRef = useRef<(attempt?: number) => void>(() => {})
   const callbacksRef = useRef({
     onLoad,
     onProgress,
@@ -397,20 +402,55 @@ export const WebMseVideoBackend = memo(function WebMseVideoBackend({
   }
   isPlayingRef.current = isPlaying
 
+  const clearMseAutoplayRetry = useCallback(() => {
+    if (mseAutoplayRetryTimerRef.current) {
+      clearTimeout(mseAutoplayRetryTimerRef.current)
+      mseAutoplayRetryTimerRef.current = null
+    }
+  }, [])
+
+  const scheduleMseAutoplayRetry = useCallback((attempt: number = 0) => {
+    clearMseAutoplayRetry()
+    if (attempt >= MSE_AUTOPLAY_RETRY_MAX_ATTEMPTS) return
+    mseAutoplayRetryTimerRef.current = setTimeout(() => {
+      mseAutoplayRetryTimerRef.current = null
+      if (!isPlayingRef.current) return
+      requestDesiredPlaybackRef.current(attempt)
+    }, MSE_AUTOPLAY_RETRY_BASE_DELAY_MS * 2 ** attempt)
+  }, [clearMseAutoplayRetry])
+
+  const requestDesiredPlayback = useCallback((attempt: number = 0) => {
+    const controller = mseBackendControllerRef.current
+    if (!controller || !isPlayingRef.current) return
+    controller.play().catch(() => {
+      scheduleMseAutoplayRetry(attempt + 1)
+    })
+  }, [scheduleMseAutoplayRetry])
+
+  useEffect(() => {
+    requestDesiredPlaybackRef.current = requestDesiredPlayback
+  }, [requestDesiredPlayback])
+
   useEffect(() => {
     const controller = mseBackendControllerRef.current
     if (!controller) return
     if (isPlaying) {
-      controller.play().catch(() => {})
+      requestDesiredPlayback()
     } else {
+      clearMseAutoplayRetry()
       controller.pause()
     }
-  }, [isPlaying])
+  }, [clearMseAutoplayRetry, isPlaying, requestDesiredPlayback])
+
+  useEffect(() => () => {
+    clearMseAutoplayRetry()
+  }, [clearMseAutoplayRetry])
 
   const videoRefCallback = useCallback((el: HTMLVideoElement | null) => {
     if (!el) {
       disposeRef.current?.()
       disposeRef.current = null
+      clearMseAutoplayRetry()
       initStarted.current = false
       videoElRef.current = null
       mseBackendControllerRef.current = null
@@ -524,6 +564,7 @@ export const WebMseVideoBackend = memo(function WebMseVideoBackend({
               onError: (error) => callbacksRef.current.onError?.(error),
               setDispose: (fn) => { compatDisposeRef.current = fn },
               shouldAutoPlay: () => isPlayingRef.current,
+              requestAutoplay: requestDesiredPlayback,
             })
             return
           }
@@ -664,7 +705,7 @@ export const WebMseVideoBackend = memo(function WebMseVideoBackend({
               if (!playbackStarted) {
                 playbackStarted = true
                 if (isPlayingRef.current) {
-                  el.play().catch(() => {})
+                  requestDesiredPlayback()
                 }
               }
             }
@@ -781,7 +822,7 @@ export const WebMseVideoBackend = memo(function WebMseVideoBackend({
         callbacksRef.current.onError?.({ message: err?.message || 'MSE error' })
       }
     })()
-  }, [videoUrl, playerRef])
+  }, [clearMseAutoplayRetry, playerRef, requestDesiredPlayback, videoUrl])
 
   return (
     <video

--- a/packages/app/tests/android-video-opens-playing-regression.test.mjs
+++ b/packages/app/tests/android-video-opens-playing-regression.test.mjs
@@ -19,13 +19,14 @@ test('Android keeps initial desired play state when expo-video emits a pre-play 
   assert.doesNotMatch(handler, /Platform\.OS === 'web' && !hasReceivedPlayEventRef\.current/, 'the pre-play paused guard must not be web-only')
 })
 
-test('Android verifies each play request against native state until the first play event', async () => {
+test('native inline player verifies each play request against native state until the first play event', async () => {
   const src = await source(inlineViewPath)
 
   const verifyStart = src.indexOf('const scheduleAutoplayVerify')
   assert.notEqual(verifyStart, -1, 'expected a scheduleAutoplayVerify helper — event-driven guards alone miss dropped play() calls that leave ExoPlayer paused without emitting further events')
   const verify = src.slice(verifyStart, src.indexOf('}, [clearAutoplayVerify])', verifyStart))
 
+  assert.doesNotMatch(verify, /Platform\.OS === 'web'\) return/, 'desktop web playback must also retry a dropped initial play() call')
   assert.match(verify, /attempt >= AUTOPLAY_VERIFY_MAX_ATTEMPTS\) return/, 'verification must be bounded — no standing interval, just a capped retry chain')
   assert.match(verify, /scheduleAutoplayVerify\(attempt \+ 1\)/, 'a failed verification must re-arm itself, since the dropped-play state emits no event to react to')
   assert.match(verify, /hasReceivedPlayEventRef\.current \|\| !isPlayingRef\.current\) return/, 'verification stops once a real play event arrived or playback is no longer desired')

--- a/packages/app/tests/mse-player-seek-regression.test.mjs
+++ b/packages/app/tests/mse-player-seek-regression.test.mjs
@@ -56,7 +56,7 @@ test('MSE backend exposes Expo-style controller controls through PlayerPort', as
   assert.match(src, /set currentTime\(value: number\)/)
   assert.match(src, /function createWebMseBackendController\(el: HTMLVideoElement\): WebMseBackendController/)
   assert.match(src, /const controller = createWebMseBackendController\(el\)[\s\S]*createWebMsePlayerPort\(controller\)/)
-  assert.match(src, /const controller = mseBackendControllerRef\.current[\s\S]*if \(isPlaying\)[\s\S]*controller\.play\(\)\.catch\(\(\) => \{\}\)[\s\S]*else[\s\S]*controller\.pause\(\)/)
+  assert.match(src, /const controller = mseBackendControllerRef\.current[\s\S]*if \(isPlaying\)[\s\S]*requestDesiredPlayback\(\)[\s\S]*else[\s\S]*controller\.pause\(\)/)
 })
 
 test('MSE backend reports the full duration up front so the whole timeline is seekable', async () => {
@@ -109,15 +109,45 @@ test('MSE backend follows the parent playback state instead of forcing playback 
   assert.match(src, /const isPlayingRef = useRef\(isPlaying\)/, 'MSE backend should retain the latest desired playback state')
   assert.match(
     src,
-    /useEffect\(\(\) => \{[\s\S]*const controller = mseBackendControllerRef\.current[\s\S]*if \(isPlaying\)[\s\S]*controller\.play\(\)\.catch\(\(\) => \{\}\)[\s\S]*else[\s\S]*controller\.pause\(\)/,
+    /useEffect\(\(\) => \{[\s\S]*const controller = mseBackendControllerRef\.current[\s\S]*if \(isPlaying\)[\s\S]*requestDesiredPlayback\(\)[\s\S]*else[\s\S]*controller\.pause\(\)/,
     'MSE backend should react to parent play/pause state changes'
   )
   assert.match(
     src,
-    /if \(isPlayingRef\.current\) \{[\s\S]*el\.play\(\)\.catch\(\(\) => \{\}\)[\s\S]*\}/,
+    /if \(isPlayingRef\.current\) \{[\s\S]*requestDesiredPlayback\(\)[\s\S]*\}/,
     'MSE pipeline should only auto-start when the parent still wants playback'
   )
   assert.doesNotMatch(src, /\sautoPlay\s*[\r\n>]/, 'MSE backend video element should not bypass parent playback state with autoPlay')
+})
+
+test('MSE backend retries desired autoplay when the first play call is dropped', async () => {
+  const src = await source(mseBackendPath)
+
+  assert.match(
+    src,
+    /const requestDesiredPlayback = useCallback\(/,
+    'MSE backend should centralize desired playback requests so rejected early play() calls can be retried',
+  )
+  assert.match(
+    src,
+    /mseAutoplayRetryTimerRef/,
+    'MSE backend should keep a retry timer for startup play() calls that race MediaSource readiness',
+  )
+  assert.match(
+    src,
+    /catch\(\(\) => \{[\s\S]*scheduleMseAutoplayRetry/,
+    'a rejected play() promise should schedule a retry while playback is still desired',
+  )
+  assert.match(
+    src,
+    /if \(isPlayingRef\.current\) \{[\s\S]*requestDesiredPlayback\(\)[\s\S]*\}/,
+    'newly appended MSE data should reassert playback intent without requiring a pause/play toggle',
+  )
+  assert.match(
+    src,
+    /requestAutoplay: requestDesiredPlayback/,
+    'compat HLS fallback should use the same retrying autoplay request path',
+  )
 })
 
 test('format errors skip stall recovery so the desktop MSE fallback still triggers promptly', async () => {


### PR DESCRIPTION
## Summary
- Reuse the existing bounded autoplay verification on desktop web so a dropped initial Expo/html-video play() is retried without requiring a pause/play toggle.
- Keep MSE as the fallback backend for unsupported/unplayable codec paths only.
- Add the same retrying desired-play request inside the rare MSE backend path so fallback playback also starts once data is appended.

## Verification
- `node --test packages/app/tests/android-video-opens-playing-regression.test.mjs packages/app/tests/mse-player-seek-regression.test.mjs`
- `node --test packages/app/tests/android-video-opens-playing-regression.test.mjs packages/app/tests/mse-player-seek-regression.test.mjs packages/app/tests/pear-inline-player-view.test.mjs packages/app/tests/player-port-contract-regression.test.mjs packages/app/tests/watch-page-mse-player-mode.test.mjs packages/app/tests/mse-seek-remux-smoke.test.mjs`
- `npx eslint --quiet packages/app/components/video-player/PearInlineVideoView.tsx packages/app/components/video-player/WebMseVideoBackend.web.tsx packages/app/tests/android-video-opens-playing-regression.test.mjs packages/app/tests/mse-player-seek-regression.test.mjs`
- `npx tsc --noEmit -p packages/app/tsconfig.json --pretty false 2>&1 | rg 'packages/app/(components/video-player/PearInlineVideoView|components/video-player/WebMseVideoBackend|tests/android-video-opens-playing-regression|tests/mse-player-seek-regression)' || true`
- `npm run desktop:build --prefix packages/app`