### PR TITLE
Use DOM video state for desktop autoplay

### DIFF
--- a/packages/app/components/video-player/PearInlineVideoView.tsx
+++ b/packages/app/components/video-player/PearInlineVideoView.tsx
@@ -145,6 +145,7 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
   const pipExitPlayingRef = useRef(false)
   const wasInPipRef = useRef(isInPipMode)
   const playerRefForCallbacks = useRef<VideoPlayer | null>(null)
+  const nativeVideoViewRef = useRef<any>(null)
   const previousStatusRef = useRef<string | null>(null)
   const seekPlaybackRecoveryUntilRef = useRef(0)
   const isPlayingRef = useRef(isPlaying)
@@ -242,6 +243,25 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
     }
   }, [])
 
+  function getWebNativeVideoElement() {
+    if (Platform.OS !== 'web') return null
+    return nativeVideoViewRef.current?.nativeRef?.current ?? null
+  }
+
+  const requestNativePlayback = useCallback(() => {
+    const webVideo = getWebNativeVideoElement()
+    if (webVideo) {
+      try {
+        const playResult = webVideo.play()
+        playResult?.catch?.(() => {})
+      } catch {
+        // A blocked web play can be retried by the bounded verifier.
+      }
+      return
+    }
+    player.play()
+  }, [player])
+
   const scheduleAutoplayVerify = useCallback((attempt: number = 0) => {
     clearAutoplayVerify()
     if (attempt >= AUTOPLAY_VERIFY_MAX_ATTEMPTS) return
@@ -251,7 +271,15 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
       const currentPlayer = playerRefForCallbacks.current
       if (!currentPlayer) return
       try {
-        if (!currentPlayer.playing) currentPlayer.play()
+        const webVideo = getWebNativeVideoElement()
+        if (webVideo) {
+          if (webVideo.paused && !webVideo.ended) {
+            const playResult = webVideo.play()
+            playResult?.catch?.(() => {})
+          }
+        } else if (!currentPlayer.playing) {
+          currentPlayer.play()
+        }
       } catch {
         // The player can be mid source-replace or already released; the next
         // verification retries.
@@ -280,7 +308,7 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
         player.showNowPlayingNotification = notificationControlsRef.current
         player.staysActiveInBackground = notificationControlsRef.current
         if (isPlayingRef.current) {
-          player.play()
+          requestNativePlayback()
           scheduleAutoplayVerify()
         }
       } catch (error) {
@@ -302,7 +330,7 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
     return () => {
       cancelled = true
     }
-  }, [player, scheduleAutoplayVerify, useMseBackend, videoSource])
+  }, [player, requestNativePlayback, scheduleAutoplayVerify, useMseBackend, videoSource])
 
   const shouldSuppressStuckPlaybackRecovery = useCallback(() => {
     if (Platform.OS !== 'android') return false
@@ -363,7 +391,7 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
             player.currentTime = resumeAt
           }
           if (isPlayingRef.current) {
-            player.play()
+            requestNativePlayback()
           }
         } catch (recoveryError) {
           if (sourceReplaceGenerationRef.current !== generation) return
@@ -377,7 +405,7 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
       })()
     }, PLAYBACK_ERROR_RECOVERY_BASE_DELAY_MS * attempt)
     return true
-  }, [onBuffering, player, videoSource])
+  }, [onBuffering, player, requestNativePlayback, videoSource])
 
   const tryRecoverFromPlaybackErrorRef = useRef(tryRecoverFromPlaybackError)
   useEffect(() => {
@@ -453,14 +481,14 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
     if (useMseBackend) return
     isPlayingRef.current = isPlaying
     if (isPlaying) {
-      player.play()
+      requestNativePlayback()
       if (!hasReceivedPlayEventRef.current) {
         scheduleAutoplayVerify()
       }
     } else {
       player.pause()
     }
-  }, [player, isPlaying, scheduleAutoplayVerify, useMseBackend])
+  }, [player, isPlaying, requestNativePlayback, scheduleAutoplayVerify, useMseBackend])
 
   useEffect(() => {
     if (useMseBackend) return
@@ -592,7 +620,7 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
 
     if (!hasReceivedPlayEventRef.current && isPlayingRef.current) {
       try {
-        player.play()
+        requestNativePlayback()
       } catch {
         // Best effort: keep JS desired playback state from being cancelled by
         // an expo-video paused event emitted before the first native play event.
@@ -617,13 +645,13 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
         onBuffering?.({ isBuffering: false })
         if (!hasReceivedPlayEventRef.current && isPlayingRef.current) {
           try {
-            player.play()
+            requestNativePlayback()
           } catch {
             // Best effort: Android can report readyToPlay while remaining
             // paused if play() was requested before the source was ready.
           }
         } else if (Date.now() <= seekPlaybackRecoveryUntilRef.current && isPlayingRef.current) {
-          player.play()
+          requestNativePlayback()
         }
       }
     }
@@ -667,6 +695,7 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
         />
       ) : (
         <VideoView
+          ref={nativeVideoViewRef}
           player={player}
           style={StyleSheet.absoluteFill}
           contentFit="contain"
@@ -677,6 +706,7 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
           onFirstFrameRender={() => {
             hasRenderedFrameRef.current = true
             onBuffering?.({ isBuffering: false })
+            if (isPlayingRef.current) requestNativePlayback()
           }}
           onPictureInPictureStart={() => {
             suppressStuckPlaybackRecoveryUntilRef.current = Date.now() + 6000

--- a/packages/app/tests/android-video-opens-playing-regression.test.mjs
+++ b/packages/app/tests/android-video-opens-playing-regression.test.mjs
@@ -15,7 +15,7 @@ test('Android keeps initial desired play state when expo-video emits a pre-play 
   const handler = src.slice(handlerStart, src.indexOf("useEventListener(player, 'statusChange'", handlerStart))
 
   assert.match(handler, /!hasReceivedPlayEventRef\.current && isPlayingRef\.current/, 'pre-play paused events while desired playback is true should be ignored')
-  assert.match(handler, /player\.play\(\)/, 'ignored pre-play paused events should reassert native play')
+  assert.match(handler, /requestNativePlayback\(\)/, 'ignored pre-play paused events should reassert native play')
   assert.doesNotMatch(handler, /Platform\.OS === 'web' && !hasReceivedPlayEventRef\.current/, 'the pre-play paused guard must not be web-only')
 })
 
@@ -35,11 +35,30 @@ test('native inline player verifies each play request against native state until
   const applySourceStart = src.indexOf('const applySource = async () => {')
   assert.notEqual(applySourceStart, -1, 'expected the applySource effect')
   const applySource = src.slice(applySourceStart, src.indexOf('void applySource()', applySourceStart))
-  assert.match(applySource, /player\.play\(\)\s*\n\s*scheduleAutoplayVerify\(\)/, 'applying a source with desired playback must schedule a verification')
+  assert.match(applySource, /requestNativePlayback\(\)\s*\n\s*scheduleAutoplayVerify\(\)/, 'applying a source with desired playback must schedule a verification')
 
   const playingChangeStart = src.indexOf("useEventListener(player, 'playingChange'")
   const playingChange = src.slice(playingChangeStart, src.indexOf("useEventListener(player, 'statusChange'", playingChangeStart))
   assert.match(playingChange, /hasReceivedPlayEventRef\.current = true[\s\S]*clearAutoplayVerify\(\)/, 'the first native play event must cancel pending verification')
+})
+
+test('desktop web autoplay verification uses the real HTML video element state', async () => {
+  const src = await source(inlineViewPath)
+
+  assert.match(src, /const nativeVideoViewRef = useRef<any>\(null\)/, 'desktop web should retain the VideoView ref that exposes the underlying HTML video element')
+  assert.match(src, /function getWebNativeVideoElement\(\)/, 'desktop web should have a helper for reading VideoView.nativeRef.current')
+  assert.match(src, /nativeVideoViewRef\.current\?\.nativeRef\?\.current/, 'the helper should read Expo VideoView nativeRef.current on web')
+  assert.match(
+    src,
+    /const webVideo = getWebNativeVideoElement\(\)[\s\S]*webVideo\.paused[\s\S]*webVideo\.play\(\)/,
+    'verification must use HTMLVideoElement.paused/play() because expo-video web sets player.playing optimistically',
+  )
+  assert.match(
+    src,
+    /onFirstFrameRender=\{\(\) => \{[\s\S]*requestNativePlayback\(\)/,
+    'loaded first-frame events should reassert desired playback on desktop web without waiting for a pause/play toggle',
+  )
+  assert.match(src, /ref=\{nativeVideoViewRef\}/, 'VideoView should receive the ref used for real web video state')
 })
 
 test('Android reasserts desired play when source first becomes ready before native playing event', async () => {
@@ -48,6 +67,6 @@ test('Android reasserts desired play when source first becomes ready before nati
   assert.notEqual(handlerStart, -1, 'expected expo-video statusChange handler')
   const handler = src.slice(handlerStart, src.indexOf("useEventListener(player, 'playToEnd'", handlerStart))
 
-  assert.match(handler, /status === 'readyToPlay'[\s\S]*!hasReceivedPlayEventRef\.current[\s\S]*isPlayingRef\.current[\s\S]*player\.play\(\)/, 'readyToPlay should reassert play when Android has desired playback but has not emitted native playing yet')
+  assert.match(handler, /status === 'readyToPlay'[\s\S]*!hasReceivedPlayEventRef\.current[\s\S]*isPlayingRef\.current[\s\S]*requestNativePlayback\(\)/, 'readyToPlay should reassert play when Android has desired playback but has not emitted native playing yet')
   assert.ok(handler.indexOf("status === 'readyToPlay'") < handler.indexOf('Date.now() <= seekPlaybackRecoveryUntilRef.current'), 'initial ready-to-play reassertion should run before seek-only recovery')
 })


### PR DESCRIPTION
## Summary
- Hold the Expo web `VideoView` ref so desktop can read the underlying `HTMLVideoElement` via `nativeRef.current`.
- Route autoplay reassertions through a platform-aware helper that uses real DOM `paused` state and `video.play()` on web instead of Expo's optimistic `player.playing` flag.
- Reassert desired playback after the first frame/loaded-data event so a black desktop player does not require pause/play to start.

## Why
`expo-video` web marks `player.playing = true` when `replace()`/`play()` is requested, even if the actual HTML video element is still paused or blocked. The previous retry logic therefore stopped retrying too early on desktop.

## Verification
- `node --test packages/app/tests/android-video-opens-playing-regression.test.mjs`
- `node --test packages/app/tests/android-video-opens-playing-regression.test.mjs packages/app/tests/mse-player-seek-regression.test.mjs packages/app/tests/pear-inline-player-view.test.mjs packages/app/tests/player-port-contract-regression.test.mjs packages/app/tests/watch-page-mse-player-mode.test.mjs packages/app/tests/mse-seek-remux-smoke.test.mjs`
- `npx eslint --quiet packages/app/components/video-player/PearInlineVideoView.tsx packages/app/tests/android-video-opens-playing-regression.test.mjs`
- `npx tsc --noEmit -p packages/app/tsconfig.json --pretty false 2>&1 | rg 'packages/app/(components/video-player/PearInlineVideoView|tests/android-video-opens-playing-regression)' || true`
- `npm run desktop:build --prefix packages/app`