### PR TITLE
Make desktop video startup more resilient

### DIFF
--- a/packages/app/components/video-player/PearInlineVideoView.tsx
+++ b/packages/app/components/video-player/PearInlineVideoView.tsx
@@ -70,9 +70,10 @@ const PLAYBACK_ERROR_RECOVERY_PROGRESS_SEC = 2
 // can be dropped, leaving the player parked at readyToPlay + paused with no
 // further events — so videos open frozen on the first frame. Verify shortly
 // after each play request that the player actually started, re-asserting with
-// backoff (0.4s/0.8s/1.6s/3.2s) until the first real play event arrives.
-const AUTOPLAY_VERIFY_BASE_DELAY_MS = 400
+// backoff (0.1s/0.2s/0.4s/0.8s) until the first real play event arrives.
+const AUTOPLAY_VERIFY_BASE_DELAY_MS = 100
 const AUTOPLAY_VERIFY_MAX_ATTEMPTS = 4
+const WEB_MEDIA_START_EVENTS = ['loadedmetadata', 'loadeddata', 'canplay'] as const
 
 function getExpoEventDurationMs(data: any, player?: VideoPlayer | null) {
   const rawDurationSeconds = Number(data?.duration ?? player?.duration ?? 0)
@@ -146,6 +147,7 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
   const wasInPipRef = useRef(isInPipMode)
   const playerRefForCallbacks = useRef<VideoPlayer | null>(null)
   const nativeVideoViewRef = useRef<any>(null)
+  const webVideoEventTargetRef = useRef<HTMLVideoElement | null>(null)
   const previousStatusRef = useRef<string | null>(null)
   const seekPlaybackRecoveryUntilRef = useRef(0)
   const isPlayingRef = useRef(isPlaying)
@@ -158,6 +160,7 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
   const errorRecoveryResumePositionRef = useRef(0)
   const errorRecoveryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const autoplayVerifyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const webVideoStartListenersCleanupRef = useRef<(() => void) | null>(null)
   const useMseBackend = Platform.OS === 'web' && webPlaybackBackend === 'mse'
 
   const videoSource = useMemo<VideoSource>(() => ({
@@ -206,8 +209,12 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
       clearTimeout(autoplayVerifyTimerRef.current)
       autoplayVerifyTimerRef.current = null
     }
+    if (Platform.OS === 'web') {
+      webVideoStartListenersCleanupRef.current?.()
+      webVideoStartListenersCleanupRef.current = null
+    }
     playerRefForCallbacks.current = player
-  }, [player, videoUrl, playbackSession, currentVideoKey])
+  }, [player, videoUrl, playbackSession, currentVideoKey, webPlaybackBackend])
 
   useEffect(() => () => {
     if (errorRecoveryTimerRef.current) {
@@ -218,6 +225,8 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
       clearTimeout(autoplayVerifyTimerRef.current)
       autoplayVerifyTimerRef.current = null
     }
+    webVideoStartListenersCleanupRef.current?.()
+    webVideoStartListenersCleanupRef.current = null
   }, [])
 
   useEffect(() => {
@@ -248,7 +257,52 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
     return nativeVideoViewRef.current?.nativeRef?.current ?? null
   }
 
+  function attachWebVideoStartListeners() {
+    if (Platform.OS !== 'web' || useMseBackend) return
+    const webVideo = getWebNativeVideoElement()
+    if (!webVideo || webVideoEventTargetRef.current === webVideo) return
+
+    webVideoStartListenersCleanupRef.current?.()
+
+    const handleStartupEvent = () => {
+      if (!isPlayingRef.current || hasReceivedPlayEventRef.current) return
+      requestNativePlayback()
+      scheduleAutoplayVerify()
+    }
+    const handlePlaying = () => {
+      hasReceivedPlayEventRef.current = true
+      if (playbackStartedAtRef.current === null) {
+        playbackStartedAtRef.current = Date.now()
+      }
+      clearAutoplayVerify()
+      onPlaying?.()
+    }
+    const handlePause = () => {
+      if (hasReceivedPlayEventRef.current || !isPlayingRef.current) return
+      requestNativePlayback()
+      scheduleAutoplayVerify()
+    }
+
+    for (const eventName of WEB_MEDIA_START_EVENTS) {
+      webVideo.addEventListener(eventName, handleStartupEvent)
+    }
+    webVideo.addEventListener('playing', handlePlaying)
+    webVideo.addEventListener('pause', handlePause)
+    webVideoEventTargetRef.current = webVideo
+    webVideoStartListenersCleanupRef.current = () => {
+      for (const eventName of WEB_MEDIA_START_EVENTS) {
+        webVideo.removeEventListener(eventName, handleStartupEvent)
+      }
+      webVideo.removeEventListener('playing', handlePlaying)
+      webVideo.removeEventListener('pause', handlePause)
+      if (webVideoEventTargetRef.current === webVideo) {
+        webVideoEventTargetRef.current = null
+      }
+    }
+  }
+
   const requestNativePlayback = useCallback(() => {
+    attachWebVideoStartListeners()
     const webVideo = getWebNativeVideoElement()
     if (webVideo) {
       try {
@@ -271,6 +325,7 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
       const currentPlayer = playerRefForCallbacks.current
       if (!currentPlayer) return
       try {
+        attachWebVideoStartListeners()
         const webVideo = getWebNativeVideoElement()
         if (webVideo) {
           if (webVideo.paused && !webVideo.ended) {
@@ -416,7 +471,7 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
     () => createPlayerPort(
       {
         play: async () => {
-          player.play()
+          requestNativePlayback()
         },
         pause: async () => {
           player.pause()
@@ -442,7 +497,7 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
         },
         resume: async (playing: boolean) => {
           if (playing) {
-            player.play()
+            requestNativePlayback()
           } else {
             player.pause()
           }
@@ -463,7 +518,7 @@ export const PearInlineVideoView = memo(function PearInlineVideoView({
         },
       },
     ),
-    [player, showNotificationControls],
+    [player, requestNativePlayback, showNotificationControls],
   )
 
   useEffect(() => {

--- a/packages/app/tests/android-video-opens-playing-regression.test.mjs
+++ b/packages/app/tests/android-video-opens-playing-regression.test.mjs
@@ -61,6 +61,26 @@ test('desktop web autoplay verification uses the real HTML video element state',
   assert.match(src, /ref=\{nativeVideoViewRef\}/, 'VideoView should receive the ref used for real web video state')
 })
 
+test('desktop web reasserts playback from real media readiness events', async () => {
+  const src = await source(inlineViewPath)
+
+  assert.match(src, /const WEB_MEDIA_START_EVENTS = \[/, 'desktop web should declare the media readiness events that can unblock startup')
+  assert.match(src, /'loadedmetadata'[\s\S]*'loadeddata'[\s\S]*'canplay'/, 'metadata/data/canplay should trigger immediate startup checks')
+  assert.match(src, /const webVideoEventTargetRef = useRef<HTMLVideoElement \| null>\(null\)/, 'the attached DOM video element should be tracked for listener cleanup')
+  assert.match(src, /function attachWebVideoStartListeners\(\)/, 'desktop web should attach listeners to the real HTML video element')
+  assert.match(src, /webVideo\.addEventListener\(eventName, handleStartupEvent\)/, 'startup events should reassert playback immediately')
+  assert.match(src, /webVideo\.addEventListener\('playing', handlePlaying\)/, 'real DOM playing should clear optimistic Expo retry state')
+  assert.match(src, /webVideo\.addEventListener\('pause', handlePause\)/, 'early real DOM pauses should be resisted while playback is desired')
+  assert.match(src, /webVideoEventTargetRef\.current = null/, 'detached DOM video listeners must clear their target ref')
+})
+
+test('desktop web autoplay verifier starts with a short retry delay', async () => {
+  const src = await source(inlineViewPath)
+
+  assert.match(src, /const AUTOPLAY_VERIFY_BASE_DELAY_MS = 100/, 'desktop startup should not wait 400ms before the first fallback retry')
+  assert.match(src, /AUTOPLAY_VERIFY_BASE_DELAY_MS \* 2 \*\* attempt/, 'retry delay should remain bounded exponential backoff')
+})
+
 test('Android reasserts desired play when source first becomes ready before native playing event', async () => {
   const src = await source(inlineViewPath)
   const handlerStart = src.indexOf("useEventListener(player, 'statusChange'")

--- a/packages/app/tests/pear-inline-player-view.test.mjs
+++ b/packages/app/tests/pear-inline-player-view.test.mjs
@@ -72,16 +72,17 @@ test('PearInlineVideoView disables native Expo source and ref effects while web 
   )
 })
 
-test('PearInlineVideoView adapter controls the shared Expo Video player directly', () => {
+test('PearInlineVideoView adapter controls the shared Expo Video player through the resilient native path', () => {
   const source = readAppFile('components/video-player/PearInlineVideoView.tsx')
 
-  assert.match(source, /play:\s*async \(\)\s*=> \{\s*player\.play\(\)\s*}/)
+  assert.match(source, /play:\s*async \(\)\s*=> \{\s*requestNativePlayback\(\)\s*}/)
   assert.match(source, /pause:\s*async \(\)\s*=> \{\s*player\.pause\(\)\s*}/)
   assert.match(
     source,
     /stop:\s*async \(\)\s*=> \{[\s\S]*player\.pause\(\)[\s\S]*player\.currentTime = 0/,
   )
   assert.match(source, /seek:\s*async \(timeSeconds: number\) => \{[\s\S]*player\.currentTime = Math\.max\(0, timeSeconds\)/)
+  assert.match(source, /resume:\s*async \(playing: boolean\) => \{[\s\S]*requestNativePlayback\(\)/)
   assert.doesNotMatch(source, /controller\./)
 })
 


### PR DESCRIPTION
## Summary
- Reassert desktop web playback from real HTML media readiness events (`loadedmetadata`, `loadeddata`, `canplay`) instead of waiting only on Expo player events.
- Shorten bounded autoplay verification from 400ms base delay to 100ms base delay.
- Route PlayerPort play/resume through the same resilient native playback path while keeping MSE fallback scoped to unsupported codecs.

## Verification
- `node --test packages/app/tests/android-video-opens-playing-regression.test.mjs`
- `node --test packages/app/tests/android-video-opens-playing-regression.test.mjs packages/app/tests/mse-player-seek-regression.test.mjs packages/app/tests/pear-inline-player-view.test.mjs packages/app/tests/player-port-contract-regression.test.mjs packages/app/tests/watch-page-mse-player-mode.test.mjs packages/app/tests/mse-seek-remux-smoke.test.mjs`
- `npx eslint --quiet packages/app/components/video-player/PearInlineVideoView.tsx packages/app/tests/android-video-opens-playing-regression.test.mjs packages/app/tests/pear-inline-player-view.test.mjs`
- `npx tsc --noEmit -p packages/app/tsconfig.json --pretty false` still reports existing unrelated app-wide errors; no errors reference touched files when filtered to this patch.
- `npm run desktop:build --prefix packages/app`