### PR TITLE
fix(android): open app when media playback notification is tapped

### DIFF
--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -79,6 +79,7 @@
         }
       ],
       "./plugins/withAndroidPiP.js",
+      "./plugins/withExpoVideoNotificationTap.js",
       "./plugins/withPipBackgroundAudio.js",
       "./plugins/withNextLib.js",
       "./plugins/withExoplayerKeepResources.js",

--- a/packages/app/plugins/withExpoVideoNotificationTap.js
+++ b/packages/app/plugins/withExpoVideoNotificationTap.js
@@ -1,0 +1,97 @@
+const fs = require('node:fs')
+const path = require('node:path')
+const { withDangerousMod } = require('@expo/config-plugins')
+
+// expo-video's ExpoVideoPlaybackService builds its media3 MediaSession without a
+// session activity. media3 derives the playback notification's content intent
+// from the session activity, so without one, tapping the notification on Android
+// does nothing — it never brings the app back to the foreground.
+//
+// We inject a session activity that launches the app's main launcher activity.
+// MainActivity is launchMode="singleTask", so this brings the existing task to
+// the foreground (preserving JS + the playing video) instead of recreating it.
+// Once foregrounded, VideoPlayerContext's APP_FOREGROUND handler surfaces the
+// player page (resumedWithBackgroundPlayback).
+//
+// expo autolinking compiles expo-video from its node_modules source, so patching
+// that source during prebuild takes effect at gradle build time. `npm run android`
+// runs `expo prebuild` on every build, so this re-applies automatically; the patch
+// is idempotent (guarded by a marker) so repeated runs are safe.
+
+const RELATIVE_SERVICE_PATH = path.join(
+  'android', 'src', 'main', 'java', 'expo', 'modules', 'video',
+  'playbackService', 'ExpoVideoPlaybackService.kt',
+)
+
+const MARKER = 'PearTube: open the app when the media notification is tapped'
+
+// Inserted between `.setCustomLayout(...)` and `.build()` on MediaSession.Builder.
+// Fully-qualified android.app.PendingIntent avoids touching the import block.
+const INJECTION = `        .also { builder ->
+          // ${MARKER}.
+          packageManager.getLaunchIntentForPackage(packageName)?.let { launchIntent ->
+            builder.setSessionActivity(
+              android.app.PendingIntent.getActivity(
+                this@ExpoVideoPlaybackService,
+                0,
+                launchIntent,
+                android.app.PendingIntent.FLAG_IMMUTABLE or android.app.PendingIntent.FLAG_UPDATE_CURRENT
+              )
+            )
+          }
+        }
+`
+
+function resolveServiceFile() {
+  let pkgJson
+  try {
+    pkgJson = require.resolve('expo-video/package.json', { paths: [__dirname] })
+  } catch {
+    return null
+  }
+  const file = path.join(path.dirname(pkgJson), RELATIVE_SERVICE_PATH)
+  return fs.existsSync(file) ? file : null
+}
+
+// Exported for unit testing without a real expo-video checkout.
+function patchSource(source) {
+  if (source.includes(MARKER) || source.includes('.setSessionActivity(')) {
+    return { changed: false, source }
+  }
+  // Match the `.build()` that closes the MediaSession.Builder chain, anchored on
+  // the preceding `.setCustomLayout(...)` line so we never patch an unrelated build().
+  const builderRegex = /(\.setCustomLayout\(ImmutableList\.of\(seekBackwardButton, seekForwardButton\)\)\n)(\s*\.build\(\))/
+  if (!builderRegex.test(source)) {
+    return { changed: false, source, missing: true }
+  }
+  const next = source.replace(builderRegex, `$1${INJECTION}$2`)
+  return { changed: next !== source, source: next }
+}
+
+function withExpoVideoNotificationTap(config) {
+  return withDangerousMod(config, [
+    'android',
+    (config) => {
+      const file = resolveServiceFile()
+      if (!file) {
+        console.warn('[withExpoVideoNotificationTap] Could not locate ExpoVideoPlaybackService.kt; skipping notification-tap patch')
+        return config
+      }
+      const original = fs.readFileSync(file, 'utf8')
+      const { changed, source, missing } = patchSource(original)
+      if (missing) {
+        console.warn('[withExpoVideoNotificationTap] MediaSession.Builder pattern not found; expo-video may have changed. Skipping notification-tap patch.')
+        return config
+      }
+      if (changed) {
+        fs.writeFileSync(file, source)
+        console.log('[withExpoVideoNotificationTap] Patched ExpoVideoPlaybackService.kt to open app on notification tap')
+      }
+      return config
+    },
+  ])
+}
+
+module.exports = withExpoVideoNotificationTap
+module.exports._patchSource = patchSource
+module.exports._MARKER = MARKER


### PR DESCRIPTION
## Problem

Tapping the Android media playback notification did **not** return the user to the app.

That control is the system media notification (media3 `MediaSession`) created by `expo-video`. Upstream, `ExpoVideoPlaybackService` builds its `MediaSession` without calling `setSessionActivity(...)`:

```kotlin
MediaSession.Builder(this@ExpoVideoPlaybackService, player)
  .setId(...)
  .setCallback(...)
  .setCustomLayout(...)
  .build()        // ← no .setSessionActivity(...)
```

media3 derives the notification's **content intent** from the session activity. With none set, tapping the notification does nothing — the app never comes to the foreground. The JS side was already prepared for this case: `VideoPlayerContext`'s `APP_FOREGROUND` handler surfaces the player when the app returns with background playback (`resumedWithBackgroundPlayback`). It just never fired because the app wasn't being foregrounded.

## Fix

New config plugin `packages/app/plugins/withExpoVideoNotificationTap.js` (registered in `app.json`) injects a session activity into expo-video's notification:

```kotlin
.setCustomLayout(...)
.also { builder ->
  packageManager.getLaunchIntentForPackage(packageName)?.let { launchIntent ->
    builder.setSessionActivity(
      android.app.PendingIntent.getActivity(this@ExpoVideoPlaybackService, 0, launchIntent,
        PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT))
  }
}
.build()
```

It launches the launcher `MainActivity` (`launchMode="singleTask"`), so the **existing** task is brought forward — JS state and the playing video are preserved — and `APP_FOREGROUND` then surfaces the player page.

### Why a config plugin (not editing committed `android/`)

`npm run android` runs `expo prebuild --clean` on every build (wiping `android/`), and `expo-video` lives in `node_modules`, compiled from source via autolinking. The plugin patches that source during prebuild, re-applies on every build, and is idempotent (guarded by a marker, with a graceful skip-with-warning if upstream changes the builder shape).

## Notes / caveats

- **Android-only** — iOS returns to the app from the now-playing controls automatically.
- node_modules isn't installed in the dev container, so this wasn't built/run on a device. The injection logic was verified against the exact upstream `sdk-56` source with a standalone test (produces valid, correctly-indented Kotlin; idempotent on re-run). Worth a real `npm run android` to confirm tap behavior on a device.

https://claude.ai/code/session_0183QMGPVmoUwCtWtkk4bopZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0183QMGPVmoUwCtWtkk4bopZ)_