### PR TITLE
ci(desktop): skip Electrobun app build on pull requests

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -33,6 +33,7 @@ concurrency:
 
 jobs:
   electrobun-desktop-build:
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: macos-14
     timeout-minutes: 60
     steps:

--- a/packages/app/tests/ci-workflow-split-regression.test.mjs
+++ b/packages/app/tests/ci-workflow-split-regression.test.mjs
@@ -98,6 +98,37 @@ test('tagged Android releases build arm64 and x86 APKs', () => {
   )
 })
 
+test('pull requests run desktop tests but skip app build/packaging jobs', () => {
+  const buildDesktop = readFile('.github/workflows/build-desktop.yml')
+
+  // App build/packaging jobs must be gated off on pull requests.
+  assert.match(
+    buildDesktop,
+    /electrobun-desktop-build:\s*\n\s*if:\s*\$\{\{\s*github\.event_name != 'pull_request'\s*\}\}/,
+    'electrobun-desktop-build (app build) should not run on pull requests',
+  )
+  assert.match(
+    buildDesktop,
+    /native-desktop-archive:\s*\n\s*if:\s*\$\{\{\s*github\.event_name != 'pull_request'\s*\}\}/,
+    'native-desktop-archive (app build) should not run on pull requests',
+  )
+
+  // The test job must still run on pull requests (no pull_request gate).
+  assert.match(
+    buildDesktop,
+    /native-desktop-test:\s*\n\s*runs-on:/,
+    'native-desktop-test should still run on pull requests',
+  )
+
+  // Mobile app builds already never run on pull requests (push/dispatch only).
+  const buildMobile = readFile('.github/workflows/build-mobile.yml')
+  assert.doesNotMatch(
+    buildMobile,
+    /^\s*pull_request:/m,
+    'build-mobile should not be triggered by pull requests',
+  )
+})
+
 test('routine validation workflows use path filters to avoid irrelevant runs', () => {
   const workflows = [
     ['ci-fast', readFile('.github/workflows/ci-fast.yml')],


### PR DESCRIPTION
## What

On pull requests, CI should run **tests only** — not full app build/packaging jobs.

`native-desktop-archive` was already gated off for `pull_request`. This applies the same gate to the `electrobun-desktop-build` job in `build-desktop.yml`.

## Resulting per-PR CI

- ✅ `native-desktop-test` (desktop tests) — still runs
- ✅ `ci-fast.yml` — lint, backend tests, typecheck, workflow-regressions — still run
- ⏭️ `electrobun-desktop-build` (app build + packaging) — now skipped on PRs
- ⏭️ `native-desktop-archive` (xcarchive build) — already skipped on PRs
- `build-mobile.yml` (Android/iOS app builds) — already push/dispatch-only, never ran on PRs

All build jobs still run on **push to `main`** and `workflow_dispatch`, so main/release coverage is unchanged.

## Tests

Added a regression assertion in `ci-workflow-split-regression.test.mjs` that the desktop app-build jobs are PR-gated while `native-desktop-test` still runs on PRs (and that mobile builds have no `pull_request` trigger). All 5 tests in that file pass; `build-desktop.yml` validates as YAML.

## Note

The `electrobun-desktop-build` job included a "smoke-test the worker bundle" step (native-addon `dlopen` check); since it's coupled to building the desktop app, it no longer runs on PRs but still runs on merge to `main`. Happy to split that smoke test into its own PR-eligible job if you'd prefer to keep it on PRs.

https://claude.ai/code/session_0183QMGPVmoUwCtWtkk4bopZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0183QMGPVmoUwCtWtkk4bopZ)_