### PR TITLE
Serve mobile thumbnails as inline data URLs

### DIFF
--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -1728,7 +1728,7 @@ export function createApi({
      *   these refs mobile thumbnails never resolved at all.
      * @returns {Promise<{url?: string, exists: boolean}>}
      */
-    async getVideoThumbnail(driveKey, videoId, refs = {}) {
+    async getVideoThumbnail(driveKey, videoId, refs = {}, opts = {}) {
       try {
         const normalizeVideoId = (value) => {
           if (!value || typeof value !== 'string') return value
@@ -1872,7 +1872,32 @@ export function createApi({
           host: ctx.blobServerHost || '127.0.0.1',
           port: ctx.blobServer?.port || ctx.blobServerPort
           });
-          return { url, exists: true };
+
+          // Inline the thumbnail bytes as a base64 data URL when requested.
+          // On mobile, the React Native <Image> loader must otherwise fetch the
+          // blob-server URL over the worklet's loopback HTTP listener — a step
+          // that races backend readiness/port assignment and is the one thing
+          // that keeps feed cards on placeholders even after the URL resolves.
+          // Thumbnails are tiny (≤640x360 JPEG), so serving the bytes directly
+          // over the existing RPC channel sidesteps that transport entirely.
+          // Best-effort: any read failure falls back to the blob-server URL.
+          let dataUrl = null;
+          if (opts?.includeDataUrl) {
+            try {
+              const Hyperblobs = (await import('hyperblobs')).default;
+              const blobs = new Hyperblobs(blobsCore);
+              await blobs.ready();
+              const buf = await Promise.race([
+                blobs.get(blob),
+                new Promise((_, reject) => setTimeout(() => reject(new Error('thumbnail blob read timeout')), 2000))
+              ]);
+              if (buf && buf.length) {
+                dataUrl = `data:${thumbnailMimeType};base64,${b4a.toString(buf, 'base64')}`;
+              }
+            } catch { /* best effort: fall back to the blob-server URL */ }
+          }
+
+          return { url, dataUrl, exists: true };
         }
 
         return { exists: false };

--- a/packages/backend/src/mobile-handlers.js
+++ b/packages/backend/src/mobile-handlers.js
@@ -181,7 +181,7 @@ export function attachMobileHandlers(B, deps) {
   B.prepareLivePlayback = async (r) => api.prepareLivePlayback(r.liveCoreKey)
   B.getVideoData = async (r) => ({ video: (await api.getVideoData(r.channelKey, r.videoId, r.publicBeeKey, r.blobId, r.blobsCoreKey, r.mimeType)) || { id: r.videoId, title: 'Unknown' } })
   B.getVideoMetadata = async (r) => ({ video: (await api.getVideoData(r.channelKey, r.videoId)) || { id: r.videoId, title: 'Unknown' } })
-  B.getVideoThumbnail = async (r) => { const res = await api.getVideoThumbnail(r.channelKey, r.videoId, { thumbnailBlobId: r.thumbnailBlobId || null, thumbnailBlobsCoreKey: r.thumbnailBlobsCoreKey || null, thumbnailMimeType: r.thumbnailMimeType || null }); return { url: res.url || null, exists: res.exists || false, dataUrl: null } }
+  B.getVideoThumbnail = async (r) => { const res = await api.getVideoThumbnail(r.channelKey, r.videoId, { thumbnailBlobId: r.thumbnailBlobId || null, thumbnailBlobsCoreKey: r.thumbnailBlobsCoreKey || null, thumbnailMimeType: r.thumbnailMimeType || null }, { includeDataUrl: true }); return { url: res.url || null, exists: res.exists || false, dataUrl: res.dataUrl || null } }
   B.setVideoThumbnail = async () => ({ success: false, error: 'setVideoThumbnail is disabled. Use setVideoThumbnailFromFile.' })
   B.deleteVideo = async (r) => {
     let ch; try { ch = await identityManager.getActiveChannel?.() } catch (e) { return { success: false, error: e?.message } }

--- a/packages/backend/test/mobile-handlers.test.mjs
+++ b/packages/backend/test/mobile-handlers.test.mjs
@@ -240,8 +240,8 @@ test('getVideoThumbnail forwards feed preview blob refs to the API', async () =>
   const calls = []
   const deps = createDeps({
     api: {
-      async getVideoThumbnail(channelKey, videoId, refs) {
-        calls.push([channelKey, videoId, refs])
+      async getVideoThumbnail(channelKey, videoId, refs, opts) {
+        calls.push([channelKey, videoId, refs, opts])
         return { url: 'http://127.0.0.1:1/thumb', exists: true }
       },
     },
@@ -261,11 +261,38 @@ test('getVideoThumbnail forwards feed preview blob refs to the API', async () =>
   // dropping these refs (as the handler used to) meant mobile thumbnails for
   // feed previews could never resolve at all. The MIME type is forwarded too so
   // the blob server serves the correct Content-Type (Android/Fresco rejects a
-  // JPEG mislabeled as webp).
+  // JPEG mislabeled as webp). includeDataUrl asks the API to inline the bytes as
+  // a base64 data URL so the RN <Image> loader never has to reach the worklet's
+  // loopback blob-server HTTP listener (the step that kept cards on placeholders).
   assert.deepEqual(calls, [[
     'channel-key',
     'video-1',
     { thumbnailBlobId: '0:4:0:1024', thumbnailBlobsCoreKey: 'a'.repeat(64), thumbnailMimeType: 'image/jpeg' },
+    { includeDataUrl: true },
   ]])
   assert.deepEqual(result, { url: 'http://127.0.0.1:1/thumb', exists: true, dataUrl: null })
+})
+
+test('getVideoThumbnail returns the inlined base64 data URL from the API', async () => {
+  const backend = {}
+  const deps = createDeps({
+    api: {
+      async getVideoThumbnail() {
+        // The API inlines the thumbnail bytes when includeDataUrl is set; the
+        // handler must surface that data URL so mobile renders it directly
+        // instead of fetching the blob-server URL over loopback HTTP.
+        return { url: 'http://127.0.0.1:1/thumb', exists: true, dataUrl: 'data:image/jpeg;base64,AAAA' }
+      },
+    },
+  })
+
+  attachMobileHandlers(backend, deps)
+
+  const result = await backend.getVideoThumbnail({ channelKey: 'channel-key', videoId: 'video-1' })
+
+  assert.deepEqual(result, {
+    url: 'http://127.0.0.1:1/thumb',
+    exists: true,
+    dataUrl: 'data:image/jpeg;base64,AAAA',
+  })
 })


### PR DESCRIPTION
Mobile feed cards stayed on placeholders even though the thumbnail RPC
resolved a valid blob-server URL. The remaining failure was the transport
itself: the RN <Image> loader has to fetch http://127.0.0.1:<port>/... from
the BareKit worklet's loopback HTTP listener, which races backend
readiness / port assignment. Thumbnails are the only image RN loads that
way (avatars fall back to channel initials, video plays via the native VLC
layer), so the problem only ever showed up here.

The response schema and lib/thumbnail.ts already prefer a 'dataUrl' over
'url', but the mobile handler hardcoded dataUrl: null — the intended path
was never finished. Complete it:

- api.getVideoThumbnail accepts an opts.includeDataUrl flag and, when set,
  reads the resolved thumbnail blob via Hyperblobs (bounded 2s) and returns
  the bytes as a base64 data URL alongside the URL. Best-effort: any read
  failure falls back to the blob-server URL.
- The mobile handler requests includeDataUrl and surfaces res.dataUrl.

Thumbnails are tiny (<=640x360 JPEG), so inlining over the existing RPC
channel is cheap and sidesteps the loopback transport entirely. Desktop is
unchanged: its worker still calls the API with no opts, so it keeps serving
the blob-server URL.