### PR TITLE
Fix Android storage stats stuck at zero and "0 GB cleared"

### DIFF
--- a/packages/backend/src/orchestrator.js
+++ b/packages/backend/src/orchestrator.js
@@ -61,19 +61,36 @@ async function appendDebugLine(line) {
   }
 }
 
+// Resolve an async stat/readdir for whichever fs flavour the runtime provides.
+// bare-fs on mobile does not reliably expose `fs.promises`, so the original
+// `fs.promises?.stat` path returned undefined and the whole measurer bailed to
+// null — leaving Android storage stats stuck at zero. Fall back to the sync API
+// (always present on bare-fs and node) wrapped in a promise.
+function resolveAsyncFsOp(fs, name) {
+  const promiseFn = fs.promises?.[name]
+  if (typeof promiseFn === 'function') {
+    return (target) => promiseFn.call(fs.promises, target)
+  }
+  const syncFn = fs[`${name}Sync`]
+  if (typeof syncFn === 'function') {
+    return async (target) => syncFn.call(fs, target)
+  }
+  return null
+}
+
 function createStorageUsageMeasurer(storagePath) {
   return async function getDiskUsageBytes() {
     const fs = resolveBareOrNodeFsModuleSync()
     const path = resolveBareOrNodePathModuleSync()
     if (!fs || !path || !storagePath) return null
-    const stat = fs.promises?.stat
-    const readdir = fs.promises?.readdir
-    if (typeof stat !== 'function' || typeof readdir !== 'function') return null
+    const stat = resolveAsyncFsOp(fs, 'stat')
+    const readdir = resolveAsyncFsOp(fs, 'readdir')
+    if (!stat || !readdir) return null
 
     async function walk(targetPath) {
       let info
       try {
-        info = await stat.call(fs.promises, targetPath)
+        info = await stat(targetPath)
       } catch {
         return 0
       }
@@ -81,7 +98,7 @@ function createStorageUsageMeasurer(storagePath) {
       let total = 0
       let entries = []
       try {
-        entries = await readdir.call(fs.promises, targetPath)
+        entries = await readdir(targetPath)
       } catch {
         return 0
       }

--- a/packages/backend/src/seeding.js
+++ b/packages/backend/src/seeding.js
@@ -87,6 +87,8 @@ export class SeedingManager {
     this.protectedBlobCores = new Map();
     /** @type {Set<string>} driveKeys that are pinned (always seed) */
     this.pinnedChannels = new Set();
+    /** @type {ReturnType<typeof setTimeout> | null} pending throttled seed persist */
+    this._seedPersistTimer = null;
     /** @type {SeedingConfig} */
     this.config = {
       maxStorageGB: 5,            // Default 5GB quota for seeded peer content
@@ -375,8 +377,39 @@ export class SeedingManager {
     if (nextBytes === (seed.bytes || 0)) return false;
 
     this.activeSeeds.set(key, { ...seed, bytes: nextBytes });
-    if (options.persist === true) await this.persistSeeds();
+    // Persist cached-byte progress so the accounting survives an app relaunch.
+    // Without this, a video that was streamed/partially cached (the common
+    // mobile case — the full background download never finished) reset to its
+    // initial byte count, which is usually 0, on the next launch. That left the
+    // storage card stuck at zero even though blocks were cached on disk.
+    // Per-block download events are frequent, so coalesce writes with a timer
+    // unless the caller asks for an immediate flush.
+    if (options.persist === true) {
+      await this.flushSeedPersist();
+    } else {
+      this.scheduleSeedPersist();
+    }
     return true;
+  }
+
+  scheduleSeedPersist() {
+    if (this._seedPersistTimer) return;
+    this._seedPersistTimer = setTimeout(() => {
+      this._seedPersistTimer = null;
+      this.persistSeeds().catch((err) => {
+        console.log('[SeedingManager] Deferred seed persist failed:', err?.message);
+      });
+    }, 5000);
+    // Best-effort flush — never hold the process open just for this.
+    this._seedPersistTimer?.unref?.();
+  }
+
+  async flushSeedPersist() {
+    if (this._seedPersistTimer) {
+      clearTimeout(this._seedPersistTimer);
+      this._seedPersistTimer = null;
+    }
+    await this.persistSeeds();
   }
 
   /**
@@ -523,6 +556,11 @@ export class SeedingManager {
    * Persist seeds to database
    */
   async persistSeeds() {
+    // Any direct persist supersedes a pending throttled flush.
+    if (this._seedPersistTimer) {
+      clearTimeout(this._seedPersistTimer);
+      this._seedPersistTimer = null;
+    }
     const seedsObj = Object.fromEntries(this.activeSeeds);
     await this.metaDb.put('active-seeds', seedsObj);
   }
@@ -643,6 +681,11 @@ export class SeedingManager {
    */
   async clearCache(options = {}) {
     this.assertAuthorizedMutation(options)
+    // Snapshot real on-disk usage up front. Tracked `seed.bytes` can be stale
+    // (it is updated in-memory during playback and not always re-persisted), so
+    // summing it alone under-reports — and showed "0 GB cleared" on mobile even
+    // when blob ranges were actually freed.
+    const preTotalStorageBytes = await this.getTotalStorageBytes();
     let clearedBytes = 0;
     const toRemove = [];
     let clearedBlob = false;
@@ -684,10 +727,19 @@ export class SeedingManager {
       }).catch(() => {});
     }
 
-    console.log('[SeedingManager] Cleared cache:', clearedBytes, 'bytes from', toRemove.length, 'seeds');
-    const stats = this.buildStorageStats(await this.getTotalStorageBytes());
+    const postTotalStorageBytes = await this.getTotalStorageBytes();
+    // Prefer the measured on-disk delta when it is available and larger than the
+    // tracked sum (which can lag). Note: RocksDB compaction is deferred to the
+    // background, so the delta may under-count until compaction lands — hence we
+    // never report *less* than the tracked bytes we know we cleared.
+    const measuredFreed = Number.isFinite(preTotalStorageBytes) && Number.isFinite(postTotalStorageBytes)
+      ? Math.max(0, preTotalStorageBytes - postTotalStorageBytes)
+      : 0;
+    const reportedClearedBytes = Math.round(Math.max(clearedBytes, measuredFreed));
+    console.log('[SeedingManager] Cleared cache:', reportedClearedBytes, 'bytes from', toRemove.length, 'seeds');
+    const stats = this.buildStorageStats(postTotalStorageBytes);
     return {
-      clearedBytes: Math.round(clearedBytes),
+      clearedBytes: reportedClearedBytes,
       totalStorageBytes: stats.totalStorageBytes,
       totalStorageGB: stats.totalStorageGB,
       untrackedStorageBytes: stats.untrackedStorageBytes,


### PR DESCRIPTION
The "Supporting the network" card showed zero usage on Android and
clearing the cache reported "0 GB cleared" without appearing to free
anything. Three backend issues combined to cause this:

- The on-disk usage measurer (createStorageUsageMeasurer) relied on
  fs.promises.stat/readdir. bare-fs on mobile does not reliably expose
  fs.promises, so the measurer bailed to null and totalStorageBytes fell
  back to the tracked seed count. Resolve stat/readdir against whichever
  fs flavour exists, falling back to the always-present sync API.

- updateSeedCachedBytes only updated seed.bytes in memory and never
  re-persisted it. A streamed/partially-cached video (the common mobile
  case, where the background full download never finishes) reset to its
  initial byte count (usually 0) on the next launch, leaving the card
  stuck at zero. Persist progress with a coalesced timer.

- clearCache reported clearedBytes summed from the stale tracked bytes,
  so it read "0 GB cleared" even when blob ranges were actually freed.
  Snapshot real on-disk usage before/after and report the larger of the
  tracked sum and the measured delta.

https://claude.ai/code/session_01Fsp18kDRsXdk5Nm7kN34AE