### PR TITLE
Require inlined data URL for mobile thumbnails (Android render fix)

### DIFF
--- a/packages/app/components/video/ThumbnailImage.tsx
+++ b/packages/app/components/video/ThumbnailImage.tsx
@@ -55,7 +55,9 @@ function ThumbnailImageComponent({
   const imageSource = useMemo(
     () => {
       if (!thumbnailUrl) return null
-      if (retryAttempt === 0) return { uri: thumbnailUrl }
+      // Data URLs are self-contained — appending a cache-busting query string
+      // would corrupt the trailing base64, so never rewrite them.
+      if (retryAttempt === 0 || thumbnailUrl.startsWith('data:')) return { uri: thumbnailUrl }
       const separator = thumbnailUrl.includes('?') ? '&' : '?'
       return { uri: `${thumbnailUrl}${separator}attempt=${retryAttempt}` }
     },

--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -1874,30 +1874,40 @@ export function createApi({
           });
 
           // Inline the thumbnail bytes as a base64 data URL when requested.
-          // On mobile, the React Native <Image> loader must otherwise fetch the
-          // blob-server URL over the worklet's loopback HTTP listener — a step
-          // that races backend readiness/port assignment and is the one thing
-          // that keeps feed cards on placeholders even after the URL resolves.
-          // Thumbnails are tiny (≤640x360 JPEG), so serving the bytes directly
-          // over the existing RPC channel sidesteps that transport entirely.
-          // Best-effort: any read failure falls back to the blob-server URL.
-          let dataUrl = null;
+          // React Native's <Image> on Android (Fresco) cannot load images from
+          // the worklet's loopback HTTP blob server — only the native video
+          // player can — so the blob-server URL renders on desktop but never on
+          // mobile. Thumbnails are tiny (≤640x360 JPEG), so we read the bytes and
+          // hand them back inline over the existing RPC channel instead.
+          //
+          // Crucially, when the caller needs the data URL we must NOT fall back
+          // to returning the (unusable-on-Android) URL with exists:true: the
+          // client caches the first truthy result and never refetches, so a
+          // single timed-out read would pin the card to a permanent placeholder.
+          // If we can't inline the bytes yet, report exists:false so the client
+          // keeps retrying (the bounded core update above is already warming the
+          // blocks) until the data URL is available.
           if (opts?.includeDataUrl) {
+            let dataUrl = null;
             try {
               const Hyperblobs = (await import('hyperblobs')).default;
               const blobs = new Hyperblobs(blobsCore);
               await blobs.ready();
               const buf = await Promise.race([
                 blobs.get(blob),
-                new Promise((_, reject) => setTimeout(() => reject(new Error('thumbnail blob read timeout')), 2000))
+                new Promise((_, reject) => setTimeout(() => reject(new Error('thumbnail blob read timeout')), 2500))
               ]);
               if (buf && buf.length) {
                 dataUrl = `data:${thumbnailMimeType};base64,${b4a.toString(buf, 'base64')}`;
               }
-            } catch { /* best effort: fall back to the blob-server URL */ }
+            } catch { /* bytes not ready yet — fall through to a retryable miss */ }
+            if (!dataUrl) {
+              return { exists: false };
+            }
+            return { url, dataUrl, exists: true };
           }
 
-          return { url, dataUrl, exists: true };
+          return { url, exists: true };
         }
 
         return { exists: false };


### PR DESCRIPTION
Follow-up to the previous thumbnail PR — Android still showed placeholders. This pins down why and fixes it.

## Root cause

- **RN `<Image>` on Android (Fresco) cannot load images from the worklet's loopback HTTP blob server.** The backend resolution is correct (desktop uses the same `getVideoThumbnail` RPC and renders), and the loopback URL *is* reachable on Android — but only by the native video player (ExoPlayer), which is how video plays. Fresco won't render it. So the blob-server URL works on desktop and never on Android. Inlining the bytes as a base64 **data URL is the only path that works on mobile**.
- **The first pass left a cache-poisoning bug.** It returned the data URL best-effort: on a timed-out blob read it still handed back the loopback URL with `exists: true`. The client caches the first truthy result and never refetches, so one slow read pinned the card to a permanent placeholder — and on Android that URL never renders anyway.

## Changes

- `api.getVideoThumbnail` `includeDataUrl` mode (mobile only) now **requires** the data URL: if the bytes can't be inlined yet, it returns `exists: false` so the client keeps retrying (the bounded core update is already warming the blocks) until the data URL is ready. Locally generated thumbnails inline on the first try; feed thumbnails resolve within a couple of retries / the home re-sweep.
- Guard `ThumbnailImage`'s retry cache-buster so it never appends a query string to a `data:` URI (which would corrupt the trailing base64).
- Desktop is unchanged — it calls the API without `includeDataUrl` and still gets the blob-server URL.

## Testing

- `packages/backend/test/mobile-handlers.test.mjs` — 6/6 pass.
- Syntax checks clean.
- Not runtime-verified on a physical Android device; the "Fresco can't load loopback" conclusion is inferred from desktop-works / video-works / image-doesn't. The data-URL path sidesteps it regardless.

https://claude.ai/code/session_01PrXrXZm1L5pMdnvUSuA6Lz

---
_Generated by [Claude Code](https://claude.ai/code/session_01PrXrXZm1L5pMdnvUSuA6Lz)_