### PR TITLE
fix(android): actually open app on media notification tap

### DIFF
--- a/packages/app/plugins/withExpoVideoNotificationTap.js
+++ b/packages/app/plugins/withExpoVideoNotificationTap.js
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
 const fs = require('node:fs')
 const path = require('node:path')
 

--- a/packages/app/plugins/withExpoVideoNotificationTap.js
+++ b/packages/app/plugins/withExpoVideoNotificationTap.js
@@ -1,22 +1,26 @@
 const fs = require('node:fs')
 const path = require('node:path')
-const { withDangerousMod } = require('@expo/config-plugins')
 
-// expo-video's ExpoVideoPlaybackService builds its media3 MediaSession without a
-// session activity. media3 derives the playback notification's content intent
-// from the session activity, so without one, tapping the notification on Android
-// does nothing — it never brings the app back to the foreground.
+// expo-video's ExpoVideoPlaybackService builds the playback notification itself
+// with a plain NotificationCompat.Builder (it does NOT use media3's default
+// notification provider). That builder sets a small icon, title and MediaStyle
+// but never calls setContentIntent(...), so the notification has no tap target —
+// tapping it on Android does nothing and never brings the app back.
+// (Setting MediaSession.setSessionActivity does NOT help here: that only feeds
+// media3's default provider, which expo-video bypasses.)
 //
-// We inject a session activity that launches the app's main launcher activity.
-// MainActivity is launchMode="singleTask", so this brings the existing task to
-// the foreground (preserving JS + the playing video) instead of recreating it.
-// Once foregrounded, VideoPlayerContext's APP_FOREGROUND handler surfaces the
-// player page (resumedWithBackgroundPlayback).
+// We inject setContentIntent(...) into that NotificationCompat.Builder, pointing
+// at the app's main launcher activity. MainActivity is launchMode="singleTask",
+// so the launch intent brings the existing task to the foreground (preserving JS
+// + the playing video) instead of recreating it. Once foregrounded,
+// VideoPlayerContext's APP_FOREGROUND handler surfaces the player page
+// (resumedWithBackgroundPlayback).
 //
 // expo autolinking compiles expo-video from its node_modules source, so patching
 // that source during prebuild takes effect at gradle build time. `npm run android`
 // runs `expo prebuild` on every build, so this re-applies automatically; the patch
-// is idempotent (guarded by a marker) so repeated runs are safe.
+// is idempotent (guarded by setContentIntent already being present) so repeated
+// runs are safe.
 
 const RELATIVE_SERVICE_PATH = path.join(
   'android', 'src', 'main', 'java', 'expo', 'modules', 'video',
@@ -25,21 +29,21 @@ const RELATIVE_SERVICE_PATH = path.join(
 
 const MARKER = 'PearTube: open the app when the media notification is tapped'
 
-// Inserted between `.setCustomLayout(...)` and `.build()` on MediaSession.Builder.
-// Fully-qualified android.app.PendingIntent avoids touching the import block.
-const INJECTION = `        .also { builder ->
-          // ${MARKER}.
-          packageManager.getLaunchIntentForPackage(packageName)?.let { launchIntent ->
-            builder.setSessionActivity(
-              android.app.PendingIntent.getActivity(
-                this@ExpoVideoPlaybackService,
-                0,
-                launchIntent,
-                android.app.PendingIntent.FLAG_IMMUTABLE or android.app.PendingIntent.FLAG_UPDATE_CURRENT
-              )
-            )
-          }
+// Inserted between `.setStyle(MediaStyleNotificationHelper.MediaStyle(session))`
+// and `.build()` on the NotificationCompat.Builder. The 6-space indent matches the
+// surrounding builder chain. `this` is the service (a Context); fully-qualified
+// android.app.PendingIntent avoids touching the import block.
+const INJECTION = `      .setContentIntent(
+        // ${MARKER}.
+        packageManager.getLaunchIntentForPackage(packageName)?.let { launchIntent ->
+          android.app.PendingIntent.getActivity(
+            this,
+            0,
+            launchIntent,
+            android.app.PendingIntent.FLAG_IMMUTABLE or android.app.PendingIntent.FLAG_UPDATE_CURRENT
+          )
         }
+      )
 `
 
 function resolveServiceFile() {
@@ -55,12 +59,12 @@ function resolveServiceFile() {
 
 // Exported for unit testing without a real expo-video checkout.
 function patchSource(source) {
-  if (source.includes(MARKER) || source.includes('.setSessionActivity(')) {
+  if (source.includes('.setContentIntent(') || source.includes(MARKER)) {
     return { changed: false, source }
   }
-  // Match the `.build()` that closes the MediaSession.Builder chain, anchored on
-  // the preceding `.setCustomLayout(...)` line so we never patch an unrelated build().
-  const builderRegex = /(\.setCustomLayout\(ImmutableList\.of\(seekBackwardButton, seekForwardButton\)\)\n)(\s*\.build\(\))/
+  // Anchor on the MediaStyle line so we only touch the notification builder's
+  // `.build()`, never the unrelated MediaSession.Builder.build() in the same file.
+  const builderRegex = /(\.setStyle\(MediaStyleNotificationHelper\.MediaStyle\(session\)\)\n)(\s*\.build\(\))/
   if (!builderRegex.test(source)) {
     return { changed: false, source, missing: true }
   }
@@ -69,6 +73,9 @@ function patchSource(source) {
 }
 
 function withExpoVideoNotificationTap(config) {
+  // Lazy require so the patch logic above stays importable for unit tests
+  // without @expo/config-plugins installed.
+  const { withDangerousMod } = require('@expo/config-plugins')
   return withDangerousMod(config, [
     'android',
     (config) => {
@@ -80,7 +87,7 @@ function withExpoVideoNotificationTap(config) {
       const original = fs.readFileSync(file, 'utf8')
       const { changed, source, missing } = patchSource(original)
       if (missing) {
-        console.warn('[withExpoVideoNotificationTap] MediaSession.Builder pattern not found; expo-video may have changed. Skipping notification-tap patch.')
+        console.warn('[withExpoVideoNotificationTap] NotificationCompat.Builder pattern not found; expo-video may have changed. Skipping notification-tap patch.')
         return config
       }
       if (changed) {

--- a/packages/app/tests/expo-video-notification-tap-regression.test.mjs
+++ b/packages/app/tests/expo-video-notification-tap-regression.test.mjs
@@ -1,0 +1,56 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+const plugin = require('../plugins/withExpoVideoNotificationTap.js')
+const { _patchSource } = plugin
+
+// Mirrors the relevant shape of expo-video's ExpoVideoPlaybackService.kt: the
+// MediaSession.Builder ends in .build(), and createNotification builds its own
+// NotificationCompat (no content intent). The patch must target the NOTIFICATION
+// builder's .build(), not the MediaSession builder's.
+const SAMPLE = `      val mediaSession = MediaSession.Builder(this@ExpoVideoPlaybackService, player)
+        .setId("ExpoVideoPlaybackService_\${player.hashCode()}")
+        .setCallback(VideoMediaSessionCallback())
+        .setCustomLayout(ImmutableList.of(seekBackwardButton, seekForwardButton))
+        .build()
+
+    val notificationCompat = NotificationCompat.Builder(this, CHANNEL_ID)
+      .setSmallIcon(androidx.media3.session.R.drawable.media3_icon_circular_play)
+      .setContentTitle(contentTitle)
+      .setStyle(MediaStyleNotificationHelper.MediaStyle(session))
+      .build()
+`
+
+test('injects a content intent into the notification builder', () => {
+  const { changed, source, missing } = _patchSource(SAMPLE)
+  assert.equal(missing, undefined, 'should find the NotificationCompat.Builder')
+  assert.equal(changed, true, 'should modify the source')
+  assert.equal(
+    (source.match(/setContentIntent/g) || []).length,
+    1,
+    'should add exactly one content intent',
+  )
+  // The content intent must sit on the NotificationCompat builder (after setStyle),
+  // not on the MediaSession builder (which has no setStyle and must be untouched).
+  assert.match(
+    source,
+    /\.setStyle\(MediaStyleNotificationHelper\.MediaStyle\(session\)\)\n\s*\.setContentIntent\(/,
+  )
+  assert.match(source, /getLaunchIntentForPackage\(packageName\)/)
+  assert.match(source, /FLAG_IMMUTABLE/)
+})
+
+test('is idempotent — re-running does not double-patch', () => {
+  const first = _patchSource(SAMPLE)
+  const second = _patchSource(first.source)
+  assert.equal(second.changed, false)
+  assert.equal(second.source, first.source)
+})
+
+test('reports missing when the notification builder is absent', () => {
+  const { changed, missing } = _patchSource('class Foo {}\n')
+  assert.equal(changed, false)
+  assert.equal(missing, true)
+})


### PR DESCRIPTION
## Why the previous fix (#445) didn't work

#445 added `MediaSession.setSessionActivity(...)`. That only feeds **media3's default notification provider** — but `expo-video` doesn't use it. `ExpoVideoPlaybackService.createNotification()` builds its **own** notification:

```kotlin
NotificationCompat.Builder(this, CHANNEL_ID)
  .setSmallIcon(...)
  .setContentTitle(contentTitle)
  .setStyle(MediaStyleNotificationHelper.MediaStyle(session))
  .build()   // ← no setContentIntent(...)
```

There's no `setContentIntent`, and `MediaStyle` doesn't derive one from the session — so the notification has **no tap target**. Tapping it does nothing, regardless of the session activity. (Verified against the installed `expo-video@56.1.3` source pulled from npm.)

## The fix

Rework the `withExpoVideoNotificationTap` config plugin to inject `setContentIntent(...)` into that `NotificationCompat.Builder`, pointing at the app's launcher intent:

```kotlin
  .setStyle(MediaStyleNotificationHelper.MediaStyle(session))
  .setContentIntent(
    packageManager.getLaunchIntentForPackage(packageName)?.let { launchIntent ->
      android.app.PendingIntent.getActivity(this, 0, launchIntent,
        PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT)
    }
  )
  .build()
```

`MainActivity` is `launchMode="singleTask"`, so this brings the existing task to the foreground (preserving JS + the playing video), and `VideoPlayerContext`'s `APP_FOREGROUND` handler then surfaces the player.

## Notes

- The plugin still applies during `expo prebuild` (which `npm run android` runs every build) to expo-video's `node_modules` source, which autolinking compiles. The patch anchors on the `MediaStyle(session)` line so it only touches the notification builder's `.build()`, is idempotent, and skips with a warning if upstream changes.
- `@expo/config-plugins` is now lazily required so the patch logic is unit-testable without it installed.
- Adds `expo-video-notification-tap-regression.test.mjs` (apply, idempotency, missing-pattern). The patch was also dry-run against the real 56.1.3 source.

⚠️ This wasn't built/run on a device in CI (no Android device job). Please confirm with a real `npm run android` + tap-the-notification check.

This supersedes the ineffective portion of #445 (already merged); the manifest/`MainActivity` setup from that PR is still correct and reused here.

https://claude.ai/code/session_0183QMGPVmoUwCtWtkk4bopZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0183QMGPVmoUwCtWtkk4bopZ)_