### PR TITLE
Surface real on-disk storage in the profile cache card

### DIFF
--- a/packages/app/app/profile.tsx
+++ b/packages/app/app/profile.tsx
@@ -33,6 +33,13 @@ interface StorageStats {
   maxGB: number
   seedCount: number
   pinnedCount: number
+  // Real on-disk usage measured for the whole P2P store (uploads + cache +
+  // metadata), surfaced alongside the tracked-cache quota so the storage card
+  // reflects what is actually consuming space — not just the seeded subset.
+  totalStorageBytes?: number
+  totalStorageGB?: string
+  untrackedStorageBytes?: number
+  untrackedStorageGB?: string
 }
 
 interface TranscodeSettings {
@@ -287,7 +294,7 @@ export default function ProfileScreen() {
           const result = await rpc.clearCache()
           if (result.success) {
             const clearedMB = ((result.clearedBytes || 0) / (1024 * 1024)).toFixed(1)
-            notify('Cache cleared', `Freed ${clearedMB} MB`)
+            notify('Cache cleared', `Freed ${clearedMB} MB of tracked peer cache. Your own videos are kept.`)
             await loadStorageStats()
           }
         } catch (err) {
@@ -647,6 +654,25 @@ export default function ProfileScreen() {
         <Text style={styles.trackLabel}>
           {storageStats ? `${storageStats.usedGB} GB of ${storageStats.maxGB} GB budget` : ' '}
         </Text>
+
+        {storageStats?.totalStorageGB ? (
+          <View style={styles.storageBreakdown}>
+            <View style={styles.breakdownRow}>
+              <Text style={styles.breakdownLabel}>On this device</Text>
+              <Text style={styles.breakdownValue}>{storageStats.totalStorageGB} GB total</Text>
+            </View>
+            <View style={styles.breakdownRow}>
+              <Text style={styles.breakdownLabel}>Tracked peer cache</Text>
+              <Text style={styles.breakdownValue}>{storageStats.usedGB} GB cached</Text>
+            </View>
+            {storageStats.untrackedStorageGB && Number(storageStats.untrackedStorageBytes) > 0 ? (
+              <View style={styles.breakdownRow}>
+                <Text style={styles.breakdownLabel}>Your videos & app/P2P data outside tracked peer cache</Text>
+                <Text style={styles.breakdownValue}>{storageStats.untrackedStorageGB} GB</Text>
+              </View>
+            ) : null}
+          </View>
+        ) : null}
 
         <View style={styles.presetRow}>
           {SUPPORT_PRESETS.map((preset) => {
@@ -1174,6 +1200,32 @@ const styles = StyleSheet.create({
     fontSize: 11,
     marginTop: 6,
     marginBottom: 14,
+  },
+  storageBreakdown: {
+    backgroundColor: colors.glass,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: colors.glassBorder,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    marginBottom: 14,
+    gap: 6,
+  },
+  breakdownRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+  },
+  breakdownLabel: {
+    flex: 1,
+    color: colors.textMuted,
+    fontSize: 12,
+  },
+  breakdownValue: {
+    color: colors.textSecondary,
+    fontSize: 12,
+    fontWeight: '700',
   },
   presetRow: {
     flexDirection: 'row',

--- a/packages/app/tests/settings-storage-cache-ui.test.mjs
+++ b/packages/app/tests/settings-storage-cache-ui.test.mjs
@@ -4,33 +4,33 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 const __dirname = path.dirname(new URL(import.meta.url).pathname)
-const settingsSource = fs.readFileSync(path.join(__dirname, '..', 'app', '(tabs)', 'settings.tsx'), 'utf8')
+// The settings tab is now a redirect to the Profile screen, which owns the
+// storage card (renderStorageCard). Assert the storage UI lives there.
+const profileSource = fs.readFileSync(path.join(__dirname, '..', 'app', 'profile.tsx'), 'utf8')
 
-test('settings renders storage controls before account onboarding', () => {
-  const noIdentityStart = settingsSource.indexOf('if (!identity) {')
-  const signedInStart = settingsSource.indexOf('  return (', noIdentityStart + 20)
-  const noIdentityBlock = noIdentityStart >= 0 && signedInStart >= 0
-    ? settingsSource.slice(noIdentityStart, signedInStart)
-    : ''
-  const storageStart = settingsSource.indexOf('const renderStorageSection = () => (')
-  const storageEnd = settingsSource.indexOf('// Onboarding', storageStart + 1)
+test('profile storage card surfaces real disk usage, not only the tracked cache quota', () => {
+  const storageStart = profileSource.indexOf('function renderStorageCard()')
+  // The card body ends where the main component render begins.
+  const storageEnd = profileSource.indexOf('<View style={styles.screen}>', storageStart + 1)
   const storageSection = storageStart >= 0 && storageEnd >= 0
-    ? settingsSource.slice(storageStart, storageEnd)
+    ? profileSource.slice(storageStart, storageEnd)
     : ''
 
-  assert.match(noIdentityBlock, /renderStorageSection\(\)/)
-  assert.match(storageSection, /Storage/)
-  assert.match(storageSection, /PearTube Storage/)
+  assert.ok(storageSection.length > 0, 'expected renderStorageCard in profile.tsx')
+  // Real on-disk total + tracked cache + the untracked remainder must all be shown
+  // so the user can see what is actually consuming space (the reported bug: the
+  // card only ever showed the tracked-seed subset).
   assert.match(storageSection, /GB total/)
   assert.match(storageSection, /GB cached/)
   assert.match(storageSection, /app\/P2P data outside tracked peer cache/)
+  assert.match(storageSection, /totalStorageGB/)
+  assert.match(storageSection, /untrackedStorageGB/)
   assert.match(storageSection, /handleStorageLimitChange/)
   assert.match(storageSection, /handleClearCache/)
 })
 
-test('settings exposes a custom cache limit input rather than only preset buttons', () => {
-  assert.match(settingsSource, /customStorageLimit/)
-  assert.match(settingsSource, /parseStorageLimitGB/)
-  assert.match(settingsSource, /Apply Limit/)
-  assert.match(settingsSource, /keyboardType="numeric"/)
+test('profile exposes a custom cache limit input rather than only preset buttons', () => {
+  assert.match(profileSource, /customStorageLimit/)
+  assert.match(profileSource, /handleCustomStorageLimitApply/)
+  assert.match(profileSource, /keyboardType="numeric"/)
 })

--- a/packages/platform/src/rpc.native.ts
+++ b/packages/platform/src/rpc.native.ts
@@ -1189,7 +1189,7 @@ export const rpc = {
   },
 
   // Storage management
-  async getStorageStats(): Promise<{ usedBytes: number; maxBytes: number; usedGB: string; maxGB: number; seedCount: number; pinnedCount: number }> {
+  async getStorageStats(): Promise<{ usedBytes: number; maxBytes: number; usedGB: string; maxGB: number; seedCount: number; pinnedCount: number; totalStorageBytes?: number; totalStorageGB?: string; untrackedStorageBytes?: number; untrackedStorageGB?: string }> {
     return ensureRPC().getStorageStats({});
   },
 

--- a/packages/platform/src/rpc.web.ts
+++ b/packages/platform/src/rpc.web.ts
@@ -530,7 +530,7 @@ export const rpc = {
   },
 
   // Storage management
-  async getStorageStats(): Promise<{ usedBytes: number; maxBytes: number; usedGB: string; maxGB: number; seedCount: number; pinnedCount: number }> {
+  async getStorageStats(): Promise<{ usedBytes: number; maxBytes: number; usedGB: string; maxGB: number; seedCount: number; pinnedCount: number; totalStorageBytes?: number; totalStorageGB?: string; untrackedStorageBytes?: number; untrackedStorageGB?: string }> {
     return ensureRPC().getStorageStats({});
   },
 


### PR DESCRIPTION
## Problem

Network cache storage looked untracked in the app, and "Clear cache" appeared to free nothing.

Root cause: the backend already measures **real on-disk P2P usage** (`totalStorageBytes` / `untrackedStorageBytes`) and sends it through the `get-storage-stats` HRPC response, but the profile storage card **only ever displayed the tracked-seed quota** (`usedGB`) and discarded the rest. So:

1. **"Not reflecting in app settings"** — the card showed only the seeded-cache subset (bounded by the cache quota), never the actual disk footprint.
2. **"Clear cache doesn't erase any data"** — `clearCache` by design only clears the tracked, non-pinned peer cache (never your own uploads or other corestore data). When most of the disk is uploads/other P2P data, it legitimately frees little — and with no breakdown shown, that looked like a no-op.

A stale test (`settings-storage-cache-ui.test.mjs`) confirmed the regression: it still expected a "GB total / GB cached / data outside tracked peer cache" breakdown that used to live in `settings.tsx`, which is now just a redirect to `profile.tsx`.

## Changes

- **`profile.tsx`** — storage card now renders a breakdown: total on disk, tracked peer cache, and the untracked remainder (your videos + app/P2P data). `StorageStats` gained the disk fields.
- **`rpc.web.ts` / `rpc.native.ts`** — widened the `getStorageStats` return types to include the disk fields the schema already carries.
- **Clear-cache toast** now states it freed *tracked peer cache* and that your own videos are kept.
- **Test** repointed at `profile.tsx` and asserts the total/cached/untracked breakdown renders.

## Notes

- No backend logic changed — only TS type annotations and UI.
- After Clear cache, "GB cached" drops immediately; "GB total" may lag briefly because RocksDB compaction runs in the background (intentional, to avoid stalling the RPC).

https://claude.ai/code/session_01UNkb4ChQoURKZuJ2ZfAwzA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UNkb4ChQoURKZuJ2ZfAwzA)_