### PR TITLE
Fix Android feed thumbnails losing blob refs

### DIFF
--- a/packages/app/app/(tabs)/index.tsx
+++ b/packages/app/app/(tabs)/index.tsx
@@ -25,6 +25,7 @@ import { chunkHomeFeedRows, getVirtualizedHomeFeedRows } from '@/lib/home-feed-v
 import {
   getFeedPreviewVideos,
   getFeedVideoHydrationMode,
+  getFeedVideoIdentity,
   getFeedVideoLoadEntries,
   getMissingChannelMetaRequests,
   getVisibleSeededFeedEntries,
@@ -596,6 +597,15 @@ export default function HomeScreen() {
 
     const mergeVideos = (incoming: VideoData[], refreshedChannelKeys: string[] = []) => {
       if (feedLoadRunIdRef.current !== runId) return
+      const incomingKeys = new Set(incoming.map((video: any) => `${video?.channelKey || video?.driveKey || ''}:${getFeedVideoIdentity(video)}`))
+      const nextForThumbnailFetch = mergeHydratedFeedVideos({
+        previousVideos: feedVideos,
+        incomingVideos: incoming,
+        refreshedChannelKeys,
+        feedEntries,
+        identityDriveKey: identity?.driveKey || undefined,
+        limit: 50,
+      }).filter((video: any) => incomingKeys.has(`${video?.channelKey || video?.driveKey || ''}:${getFeedVideoIdentity(video)}`))
       setFeedVideos((prev) => mergeHydratedFeedVideos({
         previousVideos: prev,
         incomingVideos: incoming,
@@ -604,8 +614,9 @@ export default function HomeScreen() {
         identityDriveKey: identity?.driveKey || undefined,
         limit: 50,
       }))
-      if (incoming.length > 0) {
-        fetchThumbnailsForVideos(incoming)
+      const thumbnailsToFetch = nextForThumbnailFetch.length > 0 ? nextForThumbnailFetch : incoming
+      if (thumbnailsToFetch.length > 0) {
+        fetchThumbnailsForVideos(thumbnailsToFetch)
       }
     }
 

--- a/packages/app/app/(tabs)/index.tsx
+++ b/packages/app/app/(tabs)/index.tsx
@@ -17,7 +17,7 @@ import { fonts } from '@/lib/typography'
 import * as watchHistoryStore from '@/lib/watch-history'
 import { resumeWatchEntry } from '@/lib/playback-resume'
 import { usePlatform } from '@/lib/PlatformProvider'
-import { fetchThumbnailUrlWithRetry, getRenderableThumbnailUrl, hasThumbnailBlobRef } from '@/lib/thumbnail'
+import { fetchThumbnailUrlWithRetry, getRenderableThumbnailUrl } from '@/lib/thumbnail'
 import { formatTimeAgo } from '@/lib/formatters'
 import { getCachedVideoUrl, makeVideoUrlCacheKey, setCachedVideoUrl } from '@/lib/video-url-cache'
 import { getDesktopVideoGridColumns } from '@/lib/video-layout'
@@ -448,9 +448,8 @@ export default function HomeScreen() {
     if (!ready || isPear) return
     const missing = feedVideos.filter((v) => {
       const cacheKey = v.channelKey && v.id ? `${v.channelKey}:${v.id}` : ''
-      return v.channelKey && v.id && !thumbnailCache[cacheKey] && (
-        hasThumbnailBlobRef(v) || (!v.thumbnailUrl && !(v as any).thumbnail)
-      )
+      if (!v.channelKey || !v.id || thumbnailCache[cacheKey]) return false
+      return !getRenderableThumbnailUrl(v)
     })
     if (missing.length === 0) {
       thumbnailResweepAttemptsRef.current = 0

--- a/packages/app/app/channel/[key].tsx
+++ b/packages/app/app/channel/[key].tsx
@@ -16,7 +16,7 @@ import { Feather } from '@expo/vector-icons'
 import { useLocalSearchParams, useRouter } from 'expo-router'
 import * as ImagePicker from 'expo-image-picker'
 import Animated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated'
-import { fetchThumbnailUrlWithRetry } from '@/lib/thumbnail'
+import { fetchThumbnailUrlWithRetry, getRenderableThumbnailUrl } from '@/lib/thumbnail'
 import { NativeButton, NativeTextInput } from '@/components/native-ui'
 import { rpc } from '@peartube/platform/rpc'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -548,7 +548,11 @@ export default function ChannelScreen() {
               </View>
             ) : (
               channelVideos.map((channelVideo) => {
-                const thumbnailUrl = thumbnailCache[`${channelKey}:${channelVideo.id}`] || channelVideo.thumbnailUrl || channelVideo.thumbnail || null
+                const thumbnailUrl = getRenderableThumbnailUrl(
+                  channelVideo,
+                  thumbnailCache[`${channelKey}:${channelVideo.id}`],
+                  { native: true }
+                )
                 return (
                   <ChannelVideoCard
                     key={channelVideo.id}

--- a/packages/app/app/search.tsx
+++ b/packages/app/app/search.tsx
@@ -12,7 +12,7 @@ import type { VideoData as CoreVideoData } from '@peartube/core'
 import { CastHeaderButton } from '@/components/cast'
 import { useVideoPlayerActions } from '@/lib/VideoPlayerContext'
 import { usePlatform } from '@/lib/PlatformProvider'
-import { fetchThumbnailUrlWithRetry } from '@/lib/thumbnail'
+import { fetchThumbnailUrlWithRetry, getRenderableThumbnailUrl } from '@/lib/thumbnail'
 import { getDesktopVideoGridColumns } from '@/lib/video-layout'
 
 // Detect Pear desktop vs mobile (must match index.web.tsx detection)
@@ -466,7 +466,11 @@ export default function SearchScreen() {
             } : {}}>
               {results.map((video, index) => {
                 const ck = video.channelKey || video.driveKey
-                const thumbUrl = (ck ? thumbnailCache[`${ck}:${video.id}`] : null) || video.thumbnailUrl || video.thumbnail || undefined
+                const thumbUrl = getRenderableThumbnailUrl(
+                  video,
+                  ck ? thumbnailCache[`${ck}:${video.id}`] : null,
+                  { native: !isPear }
+                ) || undefined
                 const videoWithThumb = thumbUrl ? { ...video, thumbnailUrl: thumbUrl } : video
                 return (
                 <View

--- a/packages/app/lib/feed-hydration.js
+++ b/packages/app/lib/feed-hydration.js
@@ -93,11 +93,33 @@ function mergeVideoPlaybackIdentity(previous, incoming) {
     blobId: incoming.blobId || previous.blobId,
     blobsCoreKey: incoming.blobsCoreKey || previous.blobsCoreKey,
     mimeType: incoming.mimeType || previous.mimeType,
+    thumbnailBlobId: incoming.thumbnailBlobId || previous.thumbnailBlobId,
+    thumbnailBlobsCoreKey: incoming.thumbnailBlobsCoreKey || previous.thumbnailBlobsCoreKey,
+    thumbnailMimeType: incoming.thumbnailMimeType || previous.thumbnailMimeType,
+    thumbnailUrl: incoming.thumbnailUrl || previous.thumbnailUrl,
+    thumbnail: incoming.thumbnail || previous.thumbnail,
     byteAvailability: incoming.byteAvailability || previous.byteAvailability,
     hasHeadBlock: incoming.hasHeadBlock ?? previous.hasHeadBlock,
     contiguousBlocks: incoming.contiguousBlocks ?? previous.contiguousBlocks,
     readyForPlayback: incoming.readyForPlayback ?? previous.readyForPlayback,
   }
+}
+
+function mergePreviewThumbnailIdentity(loadedVideos, previewFallback) {
+  const previews = Array.isArray(previewFallback) ? previewFallback : []
+  if (previews.length === 0) return loadedVideos
+
+  const previewById = new Map()
+  for (const preview of previews) {
+    const identifier = preview?.id || preview?.path || ''
+    if (identifier && !previewById.has(identifier)) previewById.set(identifier, preview)
+  }
+
+  return loadedVideos.map((video) => {
+    const identifier = video?.id || video?.path || ''
+    const preview = identifier ? previewById.get(identifier) : null
+    return mergeVideoPlaybackIdentity(preview, video)
+  })
 }
 
 function canUseFeedPreviewVideos(entry, identityDriveKey) {
@@ -181,7 +203,7 @@ export function shouldAutoLoadFeedVideos({ feedEntries, swarmStatus }) {
 
 export function selectFeedEntryVideosWithPreviewFallback(loadedVideos, previewFallback) {
   const loaded = Array.isArray(loadedVideos) ? loadedVideos : []
-  if (loaded.length > 0) return loaded
+  if (loaded.length > 0) return mergePreviewThumbnailIdentity(loaded, previewFallback)
   return Array.isArray(previewFallback) && previewFallback.length > 0 ? previewFallback : loaded
 }
 

--- a/packages/app/lib/feed-hydration.js
+++ b/packages/app/lib/feed-hydration.js
@@ -6,6 +6,16 @@ function getFeedEntryPriority(entry) {
   return 4
 }
 
+export function getFeedVideoIdentity(video) {
+  const raw = video?.id || video?.videoId || video?.path || ''
+  if (typeof raw !== 'string' || raw.length === 0) return ''
+
+  const match = raw.match(/\/videos\/([^/?#]+?)(?:\.[^./?#]+)?(?:[?#].*)?$/)
+  if (match?.[1]) return match[1]
+
+  return raw.replace(/^\/videos\//, '').replace(/\.[^./?#]+(?:[?#].*)?$/, '')
+}
+
 export function hasDirectBlobRef(video) {
   return typeof video?.blobId === 'string' && video.blobId.length > 0 &&
     typeof video?.blobsCoreKey === 'string' && /^[a-f0-9]{64}$/i.test(video.blobsCoreKey)
@@ -111,12 +121,12 @@ function mergePreviewThumbnailIdentity(loadedVideos, previewFallback) {
 
   const previewById = new Map()
   for (const preview of previews) {
-    const identifier = preview?.id || preview?.path || ''
+    const identifier = getFeedVideoIdentity(preview)
     if (identifier && !previewById.has(identifier)) previewById.set(identifier, preview)
   }
 
   return loadedVideos.map((video) => {
-    const identifier = video?.id || video?.path || ''
+    const identifier = getFeedVideoIdentity(video)
     const preview = identifier ? previewById.get(identifier) : null
     return mergeVideoPlaybackIdentity(preview, video)
   })
@@ -146,8 +156,9 @@ export function getFeedPreviewVideos(feedEntries, channelMeta, identityDriveKey,
       (identityDriveKey && channelKey === identityDriveKey ? 'Your channel' : 'Unknown')
 
     for (const preview of entry?.previewVideos || []) {
-      const videoKey = `${channelKey}:${preview?.id || preview?.path || ''}`
-      if (!preview?.id || seen.has(videoKey)) continue
+      const identifier = getFeedVideoIdentity(preview)
+      const videoKey = `${channelKey}:${identifier}`
+      if (!identifier || seen.has(videoKey)) continue
       if (!shouldRenderFeedVideo({
         video: { ...preview, channelKey },
         identityDriveKey,
@@ -234,11 +245,11 @@ function isPreviewBackedByFeedEntry(video, feedEntryByChannel) {
   if (!channelKey) return false
   const entry = feedEntryByChannel?.get(channelKey)
   const previewVideos = Array.isArray(entry?.previewVideos) ? entry.previewVideos : []
-  const identifier = video?.id || video?.path || ''
+  const identifier = getFeedVideoIdentity(video)
   if (!identifier || previewVideos.length === 0) return false
 
   return previewVideos.some((preview) => {
-    const previewIdentifier = preview?.id || preview?.path || ''
+    const previewIdentifier = getFeedVideoIdentity(preview)
     return previewIdentifier === identifier
   })
 }
@@ -263,7 +274,7 @@ export function mergeHydratedFeedVideos({
     if (!video) continue
     const channelKey = video?.channelKey || video?.driveKey || null
     if (channelKey && refreshed.has(channelKey) && !isPreviewBackedByFeedEntry(video, feedEntryByChannel)) continue
-    const identifier = video?.id || video?.path || ''
+    const identifier = getFeedVideoIdentity(video)
     if (!identifier) continue
     const key = `${channelKey || ''}:${identifier}`
     byKey.set(key, video)
@@ -273,7 +284,7 @@ export function mergeHydratedFeedVideos({
     if (!video) continue
     if (!shouldRenderFeedVideo({ video, identityDriveKey })) continue
     const channelKey = video?.channelKey || video?.driveKey || null
-    const identifier = video?.id || video?.path || ''
+    const identifier = getFeedVideoIdentity(video)
     if (!identifier) continue
     const key = `${channelKey || ''}:${identifier}`
     byKey.set(key, {
@@ -306,7 +317,7 @@ export function mergePreviewFeedVideos({
   for (const video of previousVideos || []) {
     if (!video || video?.__feedSource === 'preview') continue
     const channelKey = video?.channelKey || video?.driveKey || null
-    const identifier = video?.id || video?.path || ''
+    const identifier = getFeedVideoIdentity(video)
     if (!identifier) continue
     const key = `${channelKey || ''}:${identifier}`
     byKey.set(key, video)
@@ -315,7 +326,7 @@ export function mergePreviewFeedVideos({
   for (const video of previewVideos || []) {
     if (!video) continue
     const channelKey = video?.channelKey || video?.driveKey || null
-    const identifier = video?.id || video?.path || ''
+    const identifier = getFeedVideoIdentity(video)
     if (!identifier) continue
     const key = `${channelKey || ''}:${identifier}`
     if (byKey.has(key)) continue

--- a/packages/app/tests/feed-hydration.test.mjs
+++ b/packages/app/tests/feed-hydration.test.mjs
@@ -142,6 +142,9 @@ test('selectFeedEntryVideosWithPreviewFallback uses direct feed previews when hy
     availability: 'playable',
     blobId: '0:8:0:1024',
     blobsCoreKey: 'aa'.repeat(32),
+    thumbnailBlobId: '0:1:0:231042',
+    thumbnailBlobsCoreKey: 'bb'.repeat(32),
+    thumbnailMimeType: 'image/jpeg',
     hasHeadBlock: true,
     contiguousBlocks: 1,
     readyForPlayback: true,
@@ -150,6 +153,45 @@ test('selectFeedEntryVideosWithPreviewFallback uses direct feed previews when hy
   assert.equal(selectFeedEntryVideosWithPreviewFallback([], previews), previews)
   assert.deepEqual(selectFeedEntryVideosWithPreviewFallback([{ id: 'hydrated' }], previews), [{ id: 'hydrated' }])
   assert.deepEqual(selectFeedEntryVideosWithPreviewFallback([], []), [])
+})
+
+test('selectFeedEntryVideosWithPreviewFallback preserves preview thumbnail blob refs on hydrated matches', () => {
+  const previews = [{
+    id: 'same-video',
+    title: 'Preview title',
+    uploadedAt: 40,
+    availability: 'playable',
+    blobId: '0:8:0:1024',
+    blobsCoreKey: 'aa'.repeat(32),
+    thumbnailBlobId: '0:1:0:231042',
+    thumbnailBlobsCoreKey: 'bb'.repeat(32),
+    thumbnailMimeType: 'image/jpeg',
+    thumbnailUrl: 'http://127.0.0.1:12345/stale-thumbnail',
+  }]
+  const loaded = [{
+    id: 'same-video',
+    title: 'Hydrated title',
+    uploadedAt: 50,
+    availability: 'playable',
+    byteAvailability: 'playable',
+    blobId: '0:9:0:2048',
+    blobsCoreKey: 'cc'.repeat(32),
+  }]
+
+  assert.deepEqual(selectFeedEntryVideosWithPreviewFallback(loaded, previews), [{
+    ...loaded[0],
+    path: undefined,
+    publicBeeKey: undefined,
+    mimeType: undefined,
+    thumbnailBlobId: previews[0].thumbnailBlobId,
+    thumbnailBlobsCoreKey: previews[0].thumbnailBlobsCoreKey,
+    thumbnailMimeType: previews[0].thumbnailMimeType,
+    thumbnailUrl: previews[0].thumbnailUrl,
+    thumbnail: undefined,
+    hasHeadBlock: undefined,
+    contiguousBlocks: undefined,
+    readyForPlayback: undefined,
+  }])
 })
 
 test('getFeedPreviewVideos only uses local or live-peer manifest previews', () => {

--- a/packages/app/tests/feed-hydration.test.mjs
+++ b/packages/app/tests/feed-hydration.test.mjs
@@ -9,6 +9,7 @@ import {
   getMissingChannelMetaRequests,
   getVisibleSeededFeedEntries,
   isConfirmedFeedHydrationResult,
+  getFeedVideoIdentity,
   mergeHydratedFeedVideos,
   mergePreviewFeedVideos,
   selectFeedEntryVideosWithPreviewFallback,
@@ -16,6 +17,12 @@ import {
   isFeedVideoPlaybackReady,
   shouldRenderFeedVideo,
 } from '../lib/feed-hydration.js'
+
+test('getFeedVideoIdentity normalizes video ids and /videos paths to one key', () => {
+  assert.equal(getFeedVideoIdentity({ id: 'abc123' }), 'abc123')
+  assert.equal(getFeedVideoIdentity({ path: '/videos/abc123.mp4' }), 'abc123')
+  assert.equal(getFeedVideoIdentity({ videoId: '/videos/abc123.mov?x=1' }), 'abc123')
+})
 
 test('getMissingChannelMetaRequests dedupes channels and respects the visible-first limit', () => {
   const requests = getMissingChannelMetaRequests([
@@ -192,6 +199,55 @@ test('selectFeedEntryVideosWithPreviewFallback preserves preview thumbnail blob 
     contiguousBlocks: undefined,
     readyForPlayback: undefined,
   }])
+})
+
+test('selectFeedEntryVideosWithPreviewFallback preserves thumbnail refs when preview id matches hydrated path', () => {
+  const previews = [{
+    id: 'same-video',
+    thumbnailBlobId: '0:1:0:231042',
+    thumbnailBlobsCoreKey: 'bb'.repeat(32),
+    thumbnailMimeType: 'image/jpeg',
+  }]
+  const loaded = [{
+    path: '/videos/same-video.mp4',
+    title: 'Hydrated title',
+    availability: 'playable',
+  }]
+
+  const [merged] = selectFeedEntryVideosWithPreviewFallback(loaded, previews)
+  assert.equal(merged.thumbnailBlobId, previews[0].thumbnailBlobId)
+  assert.equal(merged.thumbnailBlobsCoreKey, previews[0].thumbnailBlobsCoreKey)
+  assert.equal(merged.thumbnailMimeType, previews[0].thumbnailMimeType)
+})
+
+test('mergeHydratedFeedVideos preserves preview thumbnail refs when hydrated id/path forms differ', () => {
+  const previousVideos = [{
+    id: 'same-video',
+    channelKey: 'channel-a',
+    title: 'Preview title',
+    availability: 'playable',
+    thumbnailBlobId: '0:1:0:231042',
+    thumbnailBlobsCoreKey: 'bb'.repeat(32),
+    thumbnailMimeType: 'image/jpeg',
+    __feedSource: 'preview',
+  }]
+  const incomingVideos = [{
+    path: '/videos/same-video.mp4',
+    channelKey: 'channel-a',
+    title: 'Hydrated title',
+    availability: 'playable',
+  }]
+
+  const merged = mergeHydratedFeedVideos({
+    previousVideos,
+    incomingVideos,
+    feedEntries: [{ driveKey: 'channel-a', previewVideos: previousVideos }],
+  })
+
+  assert.equal(merged.length, 1)
+  assert.equal(merged[0].title, 'Hydrated title')
+  assert.equal(merged[0].thumbnailBlobId, previousVideos[0].thumbnailBlobId)
+  assert.equal(merged[0].thumbnailBlobsCoreKey, previousVideos[0].thumbnailBlobsCoreKey)
 })
 
 test('getFeedPreviewVideos only uses local or live-peer manifest previews', () => {

--- a/packages/app/tests/thumbnail-fetch-resilience-regression.test.mjs
+++ b/packages/app/tests/thumbnail-fetch-resilience-regression.test.mjs
@@ -25,6 +25,8 @@ test('home feed re-sweeps thumbnails that missed their initial fetch window', as
   const sweep = src.slice(sweepStart, sweepStart + 1600)
 
   assert.match(sweep, /fetchThumbnailsForVideos\(missing\)/, 're-sweep must refetch only the videos still missing thumbnails')
+  assert.match(sweep, /getRenderableThumbnailUrl\(v\)/, 're-sweep must retry cards whose current thumbnail field exists but is not renderable on native, such as stale loopback blob-server URLs from a previous session')
+  assert.doesNotMatch(sweep, /!v\.thumbnailUrl && !\(v as any\)\.thumbnail/, 're-sweep must not treat any non-empty thumbnail field as renderable; stale loopback URLs can be present but intentionally suppressed')
   assert.match(sweep, /setThumbnailResweepNonce/, 're-sweep must reschedule itself even when every fetch misses (no state change would otherwise re-run the effect)')
   assert.match(sweep, /clearTimeout\(timer\)/, 're-sweep timer must be cleaned up')
 })


### PR DESCRIPTION
## Summary
- normalize Discover feed video identity (`id`, `videoId`, `/videos/<id>.<ext>` path) before merging preview and hydrated records
- preserve preview thumbnail blob refs when hydration returns the same video under a path-shaped identifier
- fetch thumbnails from the merged records so Android keeps using the current blob-server HTTP thumbnail URL path instead of losing refs and rendering placeholders

## Verification
- `node --test packages/app/tests/feed-hydration.test.mjs packages/app/tests/thumbnail-fetch-resilience-regression.test.mjs` → 24/24 passing
- `npm run bundle:backend --prefix packages/app` → success
- `npm run android --prefix packages/app` → Gradle debug build/install success on `emulator-5554`
- agent-device screenshot before fix/input report: attached user screenshot showed `http/ERR 210`/blank placeholders on Android
- agent-device rebuilt run after fix:
  - `/tmp/peartube-after-fix.png`: visible Discover cards showed real thumbnails, no blank placeholders
  - `/tmp/peartube-after-fix-scroll1.png`: 3 visible cards, all real thumbnails, 0 blank placeholders
  - `/tmp/peartube-after-fix-scroll2.png`: 3 visible cards, all real thumbnails, 0 blank placeholders

## Notes
- This does not add data URLs or filesystem thumbnail caching. It preserves the existing blob-server HTTP path (`pt_thumbnail=1` / `__peartube_thumbnail__.jpg`) and fixes the app-side ref-loss case that left some cards without a renderable current URL.
- During repeated emulator rebuilds, persisted emulator app state hit a separate `Out of bounds` backend-worklet init error. Clearing emulator app data removed it; backend then reached `BACKEND READY` with `Blob server listening on port: 33305`. That was not part of this patch.