### PR TITLE
fix(playback): restore deep read-ahead so streaming doesn't settle at bitrate

### DIFF
--- a/packages/backend/src/orchestrator.js
+++ b/packages/backend/src/orchestrator.js
@@ -14,6 +14,7 @@ import { PublicFeedManager } from './public-feed.js';
 import { VideoStatsTracker } from './video-stats.js';
 import { SeedingManager } from './seeding.js';
 import { createPlaybackWindowCache } from './playback-window-cache.js';
+import { createPlaybackForwardFill } from './playback-forward-fill.js';
 import { createApi } from './api.js';
 import { createIdentityManager } from './identity.js';
 import { createPersonalManager } from './personal/personal-manager.js';
@@ -401,6 +402,14 @@ export async function createBackendContext(config) {
   const playbackWindowCache = createPlaybackWindowCache({ store: ctx.store });
   playbackWindowCache.start();
   ctx.playbackWindowCache = playbackWindowCache;
+
+  // Symmetric counterpart to the window cache: keep a deep read-ahead window
+  // downloading *ahead* of the playhead so a fast peer builds a real buffer
+  // instead of the on-demand stream settling at playback bitrate. The window
+  // cache trims behind, so the two together bound the on-disk footprint.
+  const playbackForwardFill = createPlaybackForwardFill({ store: ctx.store });
+  playbackForwardFill.start();
+  ctx.playbackForwardFill = playbackForwardFill;
 
   const uploadManager = createUploadManager({ ctx });
 

--- a/packages/backend/src/playback-forward-fill.js
+++ b/packages/backend/src/playback-forward-fill.js
@@ -1,0 +1,198 @@
+/**
+ * PlaybackForwardFill - keep a deep read-ahead window downloading ahead of the
+ * actively-playing video's playhead.
+ *
+ * Streaming playback resolves a blob-server URL and the server fetches byte
+ * ranges from peers as the player requests them. The per-request priority
+ * window (blob-range-priority.js) only reaches ~16MB ahead and is re-armed per
+ * HTTP range request, so once the player's own buffer is full it stops asking
+ * and the download collapses to the video's consumption bitrate — even when the
+ * connected peer(s) could deliver many times faster. That leaves no cushion, so
+ * any network jitter rebuffers.
+ *
+ * This is the symmetric counterpart to PlaybackWindowCache: both follow the
+ * blob-server playhead (subscribeBlobPlayhead). The cache trims blocks *behind*
+ * the playhead; this fill downloads a large bounded window *ahead* of it,
+ * continuously re-anchoring as the playhead advances. Together they bound the
+ * on-disk footprint of a single watch (head + read-behind + this read-ahead)
+ * while keeping a deep, rebuffer-resistant buffer in front of the player.
+ *
+ * Downloads use `linear: true` so the window fills front-to-back (play order):
+ * the contiguous bytes the player is about to read land first. hypercore never
+ * re-requests blocks that are already local, so re-anchoring the window as the
+ * playhead moves only fetches the new holes ahead.
+ */
+
+import { subscribeBlobPlayhead } from './blob-range-priority.js'
+
+const MB = 1024 * 1024
+
+export const DEFAULT_FORWARD_FILL_CONFIG = {
+  // How far ahead of the playhead to keep downloading. The per-request priority
+  // window is only ~16MB; this is the deep cushion that lets a fast peer build
+  // a real buffer instead of the download settling at playback bitrate.
+  lookAheadBytes: 128 * MB,
+  // Don't re-anchor the window on every playhead tick — only once the playhead
+  // has advanced this far past the last anchor. Bounds how often we tear down
+  // and recreate download ranges.
+  minAdvanceBytes: 16 * MB,
+  // Per-core throttle: at most one re-anchor this often.
+  minIntervalMs: 1000,
+  // Bound how many blob cores we keep a fill session open for at once.
+  maxTrackedCores: 4,
+}
+
+/**
+ * Pure range math: given a playhead event and the retention config, return the
+ * absolute core block range [start, end) to keep downloading ahead of the
+ * playhead, or null if there is nothing new worth anchoring yet.
+ *
+ * @param {{ blockOffset: number, blockLength: number, byteLength: number, windowStart: number }} event
+ * @param {{ lookAheadBytes: number, minAdvanceBytes: number }} config
+ * @param {number|null} [lastAnchorBlock] - the block we last anchored the fill at, or null
+ * @returns {{ start: number, end: number, bytesPerBlock: number } | null}
+ */
+export function computeForwardFillRange(event, config, lastAnchorBlock = null) {
+  const blockOffset = Number(event?.blockOffset)
+  const blockLength = Number(event?.blockLength)
+  const byteLength = Number(event?.byteLength)
+  const windowStart = Number(event?.windowStart)
+
+  if (!Number.isInteger(blockOffset) || blockOffset < 0) return null
+  if (!Number.isInteger(blockLength) || blockLength <= 0) return null
+  if (!Number.isFinite(byteLength) || byteLength <= 0) return null
+  if (!Number.isInteger(windowStart) || windowStart < blockOffset) return null
+
+  const blobEndBlock = blockOffset + blockLength
+  if (windowStart >= blobEndBlock) return null
+
+  const bytesPerBlock = Math.max(1, byteLength / blockLength)
+  const lookAheadBlocks = Math.max(1, Math.ceil(Math.max(0, config.lookAheadBytes) / bytesPerBlock))
+  const minAdvanceBlocks = Math.max(1, Math.ceil(Math.max(0, config.minAdvanceBytes) / bytesPerBlock))
+
+  const start = windowStart
+  const end = Math.min(blobEndBlock, start + lookAheadBlocks)
+  if (end <= start) return null
+
+  // Skip churn: if the playhead has not advanced past the cadence threshold
+  // since the last anchor, the existing range still covers the cushion.
+  if (lastAnchorBlock != null && start - lastAnchorBlock < minAdvanceBlocks) {
+    // ...unless the window has already reached the end of the blob, in which
+    // case there is nothing left to extend regardless.
+    return null
+  }
+
+  return { start, end, bytesPerBlock }
+}
+
+export class PlaybackForwardFill {
+  /**
+   * @param {{ store: import('corestore'), config?: Partial<typeof DEFAULT_FORWARD_FILL_CONFIG>, log?: (...args: any[]) => void }} options
+   */
+  constructor({ store, config = {}, log = console.log } = {}) {
+    this.store = store
+    this.config = { ...DEFAULT_FORWARD_FILL_CONFIG, ...config }
+    this.log = typeof log === 'function' ? log : () => {}
+    /** @type {Map<string, { core: any, range: any, anchorBlock: number, lastFillAt: number, opening: boolean }>} */
+    this.coreState = new Map()
+    this.unsubscribe = null
+  }
+
+  start() {
+    if (this.unsubscribe) return
+    this.unsubscribe = subscribeBlobPlayhead((event) => this.onPlayhead(event))
+  }
+
+  stop() {
+    try { this.unsubscribe?.() } catch { /* best effort */ }
+    this.unsubscribe = null
+    for (const state of this.coreState.values()) this._releaseState(state)
+    this.coreState.clear()
+  }
+
+  onPlayhead(event) {
+    if (!this.store || !event?.coreKeyHex) return
+    const state = this.coreState.get(event.coreKeyHex) || null
+
+    const now = Date.now()
+    if (state?.opening) return
+    if (state && now - state.lastFillAt < this.config.minIntervalMs) return
+
+    const range = computeForwardFillRange(event, this.config, state ? state.anchorBlock : null)
+    if (!range) return
+
+    // Fire-and-forget: filling must never block or throw into the serving path.
+    this.anchorFill(event.coreKeyHex, range.start, range.end)
+      .catch((err) => this.log('[PlaybackForwardFill] fill failed:', err?.message))
+  }
+
+  async anchorFill(coreKeyHex, start, end) {
+    let state = this.coreState.get(coreKeyHex)
+    if (!state) {
+      state = { core: null, range: null, anchorBlock: -1, lastFillAt: 0, opening: true }
+      this.coreState.set(coreKeyHex, state)
+    } else {
+      state.opening = true
+    }
+    state.lastFillAt = Date.now()
+
+    try {
+      if (!state.core || state.core.closed === true) {
+        const core = this.store.get(Buffer.from(coreKeyHex, 'hex'))
+        await core.ready?.()
+        state.core = core
+      }
+      if (typeof state.core.download !== 'function') return
+
+      // Drop the previous, shallower range before anchoring the new one so peer
+      // bandwidth refocuses on the bytes ahead of the current playhead. Blocks
+      // already downloaded by it stay local (hypercore keeps them), so this only
+      // moves the *request* window forward, it does not discard data.
+      if (state.range) {
+        try { state.range.destroy?.() } catch { /* best effort */ }
+        state.range = null
+      }
+
+      state.range = state.core.download({ start, end, linear: true })
+      state.anchorBlock = start
+      try {
+        this.log('[PlaybackForwardFill] read-ahead:', coreKeyHex.slice(0, 16), `blocks ${start}-${end} (${end - start})`)
+      } catch { /* diagnostics only */ }
+
+      // Keep the open-session pool bounded (Map preserves insertion order = LRU).
+      this._enforceTrackedLimit(coreKeyHex)
+    } finally {
+      const current = this.coreState.get(coreKeyHex)
+      if (current) current.opening = false
+    }
+  }
+
+  _enforceTrackedLimit(keepKey) {
+    while (this.coreState.size > this.config.maxTrackedCores) {
+      const oldestKey = this.coreState.keys().next().value
+      if (oldestKey === keepKey || oldestKey == null) break
+      const oldest = this.coreState.get(oldestKey)
+      this.coreState.delete(oldestKey)
+      this._releaseState(oldest)
+    }
+  }
+
+  _releaseState(state) {
+    if (!state) return
+    if (state.range) {
+      try { state.range.destroy?.() } catch { /* best effort */ }
+      state.range = null
+    }
+    if (state.core) {
+      try {
+        const closing = state.core.close?.()
+        if (closing && typeof closing.catch === 'function') closing.catch(() => {})
+      } catch { /* best effort */ }
+      state.core = null
+    }
+  }
+}
+
+export function createPlaybackForwardFill(options) {
+  return new PlaybackForwardFill(options)
+}

--- a/packages/backend/src/storage.js
+++ b/packages/backend/src/storage.js
@@ -2329,6 +2329,10 @@ export async function shutdownBackend(ctx) {
       try { ctx.playbackWindowCache.stop() } catch { /* best effort */ }
     }
 
+    if (ctx.playbackForwardFill) {
+      try { ctx.playbackForwardFill.stop() } catch { /* best effort */ }
+    }
+
     if (ctx.blobServer) {
       console.log('[Backend] Shutdown: closing blobServer...')
       try {

--- a/packages/backend/test/playback-forward-fill.test.mjs
+++ b/packages/backend/test/playback-forward-fill.test.mjs
@@ -1,0 +1,165 @@
+import test from 'brittle'
+
+import {
+  computeForwardFillRange,
+  PlaybackForwardFill,
+  DEFAULT_FORWARD_FILL_CONFIG,
+} from '../src/playback-forward-fill.js'
+import { subscribeBlobPlayhead } from '../src/blob-range-priority.js'
+
+const MB = 1024 * 1024
+
+// A blob: 80,000 blocks of ~64KB = ~5GB, mapped at core block offset 1000.
+const BLOCK_BYTES = 64 * 1024
+const BLOCK_LENGTH = 80000
+const BYTE_LENGTH = BLOCK_LENGTH * BLOCK_BYTES
+const BLOCK_OFFSET = 1000
+
+const cfg = {
+  lookAheadBytes: 128 * MB,
+  minAdvanceBytes: 16 * MB,
+  minIntervalMs: 1000,
+  maxTrackedCores: 4,
+}
+
+function eventAtBlock(windowStart) {
+  return {
+    coreKeyHex: 'aa'.repeat(32),
+    blockOffset: BLOCK_OFFSET,
+    blockLength: BLOCK_LENGTH,
+    byteLength: BYTE_LENGTH,
+    windowStart,
+    windowEnd: windowStart + 256,
+  }
+}
+
+test('computeForwardFillRange anchors a deep window ahead of the playhead', (t) => {
+  const playhead = BLOCK_OFFSET + Math.floor((100 * MB) / BLOCK_BYTES)
+  const range = computeForwardFillRange(eventAtBlock(playhead), cfg, null)
+  t.ok(range, 'a fill range is produced')
+  t.is(range.start, playhead, 'starts at the playhead')
+  const lookAheadBlocks = Math.ceil((128 * MB) / BLOCK_BYTES)
+  t.is(range.end, playhead + lookAheadBlocks, 'reaches the full look-ahead ahead of the playhead')
+})
+
+test('computeForwardFillRange clamps the window to the end of the blob', (t) => {
+  // Playhead near the end: only a few MB remain before EOF.
+  const playhead = BLOCK_OFFSET + BLOCK_LENGTH - 100
+  const range = computeForwardFillRange(eventAtBlock(playhead), cfg, null)
+  t.ok(range)
+  t.is(range.end, BLOCK_OFFSET + BLOCK_LENGTH, 'never requests past the last block')
+})
+
+test('computeForwardFillRange skips re-anchoring until the playhead advances enough', (t) => {
+  const anchor = BLOCK_OFFSET + Math.floor((100 * MB) / BLOCK_BYTES)
+  // Advanced only ~4MB past the last anchor -> below the 16MB cadence threshold.
+  const small = anchor + Math.floor((4 * MB) / BLOCK_BYTES)
+  t.is(computeForwardFillRange(eventAtBlock(small), cfg, anchor), null, 'no churn for tiny advances')
+
+  // Advanced ~20MB past the last anchor -> re-anchors.
+  const big = anchor + Math.floor((20 * MB) / BLOCK_BYTES)
+  const range = computeForwardFillRange(eventAtBlock(big), cfg, anchor)
+  t.ok(range, 're-anchors once the playhead moves past the cadence threshold')
+  t.is(range.start, big)
+})
+
+test('computeForwardFillRange returns null at or past EOF', (t) => {
+  const event = eventAtBlock(BLOCK_OFFSET + BLOCK_LENGTH)
+  t.is(computeForwardFillRange(event, cfg, null), null)
+})
+
+test('PlaybackForwardFill downloads ahead and re-anchors as the playhead advances', async (t) => {
+  const cores = new Map()
+  const store = {
+    get(key) {
+      const hex = Buffer.isBuffer(key) ? key.toString('hex') : String(key)
+      if (!cores.has(hex)) {
+        cores.set(hex, {
+          hex,
+          closed: false,
+          downloadCalls: [],
+          destroyed: [],
+          closeCount: 0,
+          async ready() {},
+          download(opts) {
+            const range = { opts, destroy: () => { range._destroyed = true; this.destroyed.push(opts) } }
+            this.downloadCalls.push(opts)
+            return range
+          },
+          async close() { this.closeCount += 1; this.closed = true },
+        })
+      }
+      return cores.get(hex)
+    },
+  }
+
+  const fill = new PlaybackForwardFill({ store, config: cfg, log: () => {} })
+  const coreKeyHex = 'aa'.repeat(32)
+  const playhead = BLOCK_OFFSET + Math.floor((100 * MB) / BLOCK_BYTES)
+
+  // First playhead event -> one deep download anchored at the playhead.
+  fill.onPlayhead(eventAtBlock(playhead))
+  await new Promise((resolve) => setTimeout(resolve, 0))
+
+  const core = cores.get(coreKeyHex)
+  t.is(core.downloadCalls.length, 1, 'anchored one read-ahead window')
+  t.is(core.downloadCalls[0].start, playhead, 'window starts at the playhead')
+  t.is(core.downloadCalls[0].linear, true, 'fills front-to-back in play order')
+
+  // A second event immediately after is throttled (no new download).
+  fill.onPlayhead(eventAtBlock(playhead + 100))
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  t.is(core.downloadCalls.length, 1, 'throttled within minIntervalMs')
+
+  // After the throttle elapses, a large advance re-anchors and drops the stale range.
+  fill.config.minIntervalMs = 0
+  const advanced = playhead + Math.floor((20 * MB) / BLOCK_BYTES)
+  fill.onPlayhead(eventAtBlock(advanced))
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  t.is(core.downloadCalls.length, 2, 'anchored a fresh window after advancing')
+  t.is(core.downloadCalls[1].start, advanced, 're-anchored at the new playhead')
+  t.is(core.destroyed.length, 1, 'destroyed the stale request window')
+})
+
+test('PlaybackForwardFill bounds open core sessions to maxTrackedCores', async (t) => {
+  const closed = []
+  const store = {
+    get(key) {
+      const hex = Buffer.isBuffer(key) ? key.toString('hex') : String(key)
+      return {
+        hex,
+        closed: false,
+        async ready() {},
+        download(opts) { return { opts, destroy() {} } },
+        async close() { closed.push(hex); this.closed = true },
+      }
+    },
+  }
+
+  const fill = new PlaybackForwardFill({ store, config: { ...cfg, maxTrackedCores: 2 }, log: () => {} })
+  const playhead = BLOCK_OFFSET + Math.floor((100 * MB) / BLOCK_BYTES)
+
+  for (const prefix of ['aa', 'bb', 'cc']) {
+    fill.onPlayhead({ ...eventAtBlock(playhead), coreKeyHex: prefix.repeat(32) })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  }
+
+  t.is(fill.coreState.size, 2, 'keeps only maxTrackedCores fill sessions')
+  t.ok(closed.includes('aa'.repeat(32)), 'evicted and closed the oldest core session')
+})
+
+test('PlaybackForwardFill.start subscribes to the blob playhead', (t) => {
+  const store = { get() { return { async ready() {}, download() { return { destroy() {} } }, async close() {} } } }
+  const fill = new PlaybackForwardFill({ store, config: cfg, log: () => {} })
+  fill.start()
+  t.ok(fill.unsubscribe, 'holds an unsubscribe handle')
+  fill.stop()
+  t.absent(fill.unsubscribe, 'cleared on stop')
+})
+
+test('default look-ahead is deep but bounded', (t) => {
+  const c = DEFAULT_FORWARD_FILL_CONFIG
+  t.ok(c.lookAheadBytes >= 64 * MB, 'deep enough to outpace playback bitrate')
+  t.ok(c.lookAheadBytes <= 512 * MB, 'still bounded so on-disk footprint stays small')
+  t.is(typeof subscribeBlobPlayhead, 'function')
+})


### PR DESCRIPTION
## Problem

Buffering / "throttled" video streaming. The tell was the download curve: a **5–10 MB/s burst at startup from a single peer, then a steady drop to <1 MB/s** once playback begins, with only ~1% of the file ever cached.

That's not a bandwidth cap or peer starvation — the peer clearly can go fast. Since b756892 ("remove warmup/prefetch, stream on open") opening a video streams purely on demand, and the only forward look-ahead is the ~16MB per-request priority window. Once the player's buffer fills it stops requesting, so the download collapses to the video's consumption bitrate. With no cushion, any network jitter rebuffers.

## Fix

Add `PlaybackForwardFill`, the symmetric counterpart to the existing `PlaybackWindowCache`. Both follow the blob-server playhead (`subscribeBlobPlayhead`):

- the cache trims blocks **behind** the playhead (existing — bounds disk),
- this fill keeps a deep, bounded window (~128MB) downloading **ahead** of it, re-anchoring as the playhead advances (`linear`, so the contiguous bytes the player needs land first; hypercore never re-requests local blocks).

Together they bound a single watch's on-disk footprint to ≈ head (16MB) + read-behind (32MB) + read-ahead (128MB) ≈ **~176MB** — well under the 5GB quota — while using the bandwidth headroom to keep a rebuffer-resistant buffer in front of the player.

## Changes

- `playback-forward-fill.js`: pure range math (`computeForwardFillRange`) + a throttled, session-pooled `PlaybackForwardFill` that fills ahead of the playhead.
- `orchestrator.js`: start it with the store alongside the window cache.
- `storage.js`: stop it on shutdown.
- Unit + behavior tests (8/8 pass; existing window-cache suite still green).

## Testing notes

Validated the new test suite locally (8/8). Dependencies don't install in the dev sandbox (sharp fails to build behind the proxy), so I linked the few small deps the test needs rather than running the full `npm test`. Worth a full suite run + a real playback check that steady-state download now climbs above bitrate before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018wDWQKC4JpFYchHtnqeHZq)_