### PR TITLE
Fix phantom "synced device" on freshly created channels

### DIFF
--- a/packages/backend/src/channel/multi-writer-channel.js
+++ b/packages/backend/src/channel/multi-writer-channel.js
@@ -164,10 +164,40 @@ export class MultiWriterChannel extends ReadyResource {
     }
 
     if (this.localWriterKeyHex) {
-      const writer = await this.db.get('@peartubeChannel/writers', { keyHex: this.localWriterKeyHex })
-      if (!writer) {
+      // A writable channel core has exactly one physical owner device. Two code
+      // paths historically derived that device's *writer-table key* from
+      // different names — the identity-scoped `peartube-channel-writer:<id>`
+      // (whose public key equals the channel key) on load, vs. the internal
+      // fallback `peartube-channel-writer-<channelKey>` when the channel was
+      // created/opened without a writer key. Opening the same owned channel via
+      // each path inserted a *second* "owner" record, surfacing in the UI as a
+      // phantom "synced device" that was never paired.
+      //
+      // Reconcile to a single owner: prefer the record this device actually
+      // claimed (it has a device name or a blob drive), adopt that identity so
+      // blob drives and authorship stay consistent across every open path, and
+      // prune leftover un-claimed owner records.
+      const owners = (await this.db.find('@peartubeChannel/writers', {}).toArray())
+        .filter((w) => w?.role === 'owner')
+      const claimed = owners.find((w) => w.keyHex && (w.deviceName || w.blobDriveKey))
+      const ownerKeyHex = claimed?.keyHex || this.localWriterKeyHex
+
+      if (ownerKeyHex !== this.localWriterKeyHex) {
+        this._localWriterKeyHex = ownerKeyHex
+        this._localWriterKey = b4a.from(ownerKeyHex, 'hex')
+      }
+
+      // Only ever delete un-claimed owner records (no device name, no blob
+      // drive) so this can never drop a device that holds uploaded content.
+      for (const w of owners) {
+        if (w.keyHex && w.keyHex !== ownerKeyHex && !w.deviceName && !w.blobDriveKey) {
+          await this.db.delete('@peartubeChannel/writers', { keyHex: w.keyHex })
+        }
+      }
+
+      if (!owners.some((w) => w.keyHex === ownerKeyHex)) {
         await this.db.insert('@peartubeChannel/writers', {
-          keyHex: this.localWriterKeyHex,
+          keyHex: ownerKeyHex,
           role: 'owner',
           deviceName: '',
           addedAt: now,

--- a/packages/backend/src/storage.js
+++ b/packages/backend/src/storage.js
@@ -1961,10 +1961,20 @@ export async function createChannel(ctx, options = {}) {
       encrypt: Boolean(options.encrypt)
     })
 
+  // Derive the same writer keypair the load paths use (loadChannel passes
+  // `writerKeyName`). Without this, creation falls back to a different internal
+  // writer-key derivation than every subsequent load, so the owner ends up with
+  // two writer-table records — one of which shows up as a phantom "synced
+  // device". Passing it here keeps the owner's writer key stable from creation.
+  const writerKeyPair = typeof ctx.store.createKeyPair === 'function'
+    ? await ctx.store.createKeyPair(writerKeyName)
+    : null
+
   const ch = new MultiWriterChannel(ctx.store, {
     key: derivedChannelKeyHex ? b4a.from(derivedChannelKeyHex, 'hex') : null,
     encryptionKey: derivedEncryptionKeyHex ? b4a.from(derivedEncryptionKeyHex, 'hex') : null,
     encrypt: Boolean(options.encrypt),
+    keyPair: writerKeyPair || undefined,
     swarm: ctx.swarm // Pass swarm for early replication setup
   })
   await ch.ready()

--- a/packages/backend/test/channel-owner-writer-dedupe.test.mjs
+++ b/packages/backend/test/channel-owner-writer-dedupe.test.mjs
@@ -1,0 +1,80 @@
+import test from 'brittle'
+import os from 'node:os'
+import path from 'node:path'
+import fs from 'node:fs'
+
+import Corestore from 'corestore'
+
+import { createChannel, loadChannel } from '../src/storage.js'
+
+function mkCtx () {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'peartube-owner-writer-'))
+  const store = new Corestore(dir)
+  return {
+    dir,
+    store,
+    channels: new Map(),
+    metaDb: { async put () {} },
+    swarm: null
+  }
+}
+
+async function cleanup (ctx) {
+  try { await ctx.store.close() } catch {}
+  try { fs.rmSync(ctx.dir, { recursive: true, force: true }) } catch {}
+}
+
+// A fresh channel must list exactly one device (the creator) and never a
+// phantom "synced device". Regression for the owner writer-key divergence:
+// createChannel used to open without the writer keypair the load paths use, so
+// the owner ended up with two writer-table records across sessions.
+test('fresh channel has a single owner writer using the load-path writer key', async (t) => {
+  const ctx = mkCtx()
+  await ctx.store.ready()
+  t.teardown(() => cleanup(ctx))
+
+  const writerKeyName = `peartube-channel-writer:${'ab'.repeat(32)}`
+  const { channel } = await createChannel(ctx, { encrypt: false, writerKeyName })
+
+  // Mirror the identity-creation flow which names the local device.
+  await channel.ensureLocalBlobDrive({ deviceName: 'My Phone' })
+
+  // The owner writer key must be the one derived from the writer key name —
+  // the SAME key every later loadChannel(writerKeyName) open uses — so creation
+  // and load agree on a single owner record.
+  const expectedWriterKeyHex = Buffer.from((await ctx.store.createKeyPair(writerKeyName)).publicKey).toString('hex')
+
+  const writers = await channel.listWriters()
+  t.is(writers.length, 1, 'exactly one writer after creation')
+  t.is(writers[0].deviceName, 'My Phone', 'the single writer is the named local device')
+  t.is(writers[0].keyHex, expectedWriterKeyHex, 'owner writer key matches the writer-key-name derivation used on load')
+})
+
+// Reloading the owner's channel — with OR without the writer key name — must not
+// mint a second owner record.
+test('reloading the owner channel does not add a phantom synced device', async (t) => {
+  const ctx = mkCtx()
+  await ctx.store.ready()
+  t.teardown(() => cleanup(ctx))
+
+  const writerKeyName = `peartube-channel-writer:${'cd'.repeat(32)}`
+  const { channel, channelKeyHex } = await createChannel(ctx, { encrypt: false, writerKeyName })
+  await channel.ensureLocalBlobDrive({ deviceName: 'Laptop' })
+  await channel.close()
+  ctx.channels.delete(channelKeyHex)
+
+  // Reload the way startup does (with the writer key name).
+  const reloaded = await loadChannel(ctx, channelKeyHex, { writerKeyName, preferWritable: true })
+  let writers = await reloaded.listWriters()
+  t.is(writers.length, 1, 'no phantom owner after a writer-keyed reload')
+  t.is(writers[0].deviceName, 'Laptop')
+  await reloaded.close()
+  ctx.channels.delete(channelKeyHex)
+
+  // Reload the way a racing read path does (no writer key name) — the fallback
+  // writer-key derivation must adopt the existing owner instead of duplicating.
+  const reloadedPlain = await loadChannel(ctx, channelKeyHex, { preferWritable: true })
+  writers = await reloadedPlain.listWriters()
+  t.is(writers.length, 1, 'no phantom owner after a fallback-keyed reload')
+  t.is(writers[0].deviceName, 'Laptop')
+})


### PR DESCRIPTION
## Problem

A brand-new channel showed an extra unnamed device under **Your devices** even though no device was ever paired (reported with a screenshot showing an unnamed "Device 1" alongside the real, user-named device).

## Root cause

The channel owner's writer-table key was derived **inconsistently** between creation and load:

- **At creation** (`createChannel`), the `MultiWriterChannel` was opened *without* passing the writer keypair, so `_open` fell back to deriving `peartube-channel-writer-<channelKey>` and bootstrapped the owner record under that key (later named by `ensureLocalBlobDrive`).
- **On every subsequent load**, the code passes `writerKeyName` and derives a *different* key, `peartube-channel-writer:<identityKey>`.

Because the owner's core is always writable, `_ensureBootstrapRecords` then inserted a **second, unnamed "owner" record** under the second key — surfacing in the UI as a phantom synced device. It also split the device's blob drive across two writer keys between sessions.

## Fixes

- **`createChannel`** now derives and passes the same writer keypair the load paths use, so creation and load agree on a single owner writer key.
- **`_ensureBootstrapRecords`** reconciles to one owner: it prefers the owner record this device already claimed (has a device name or blob drive), adopts that identity, and prunes only un-claimed (empty) stray owner records. This both **prevents** new duplicates and **heals** channels already affected, without ever dropping a record that holds content (paired devices / uploads are safe).

## Tests

- Adds `test/channel-owner-writer-dedupe.test.mjs` covering single-owner creation and no-phantom reloads via both the writer-keyed and fallback open paths.
- Full backend suite passes (the one unrelated failure, `holepunch-major-migration`, is a pre-existing `bare-pack` version check and not touched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019aC1Easgx6y6ATMpqC3Jjq

---
_Generated by [Claude Code](https://claude.ai/code/session_019aC1Easgx6y6ATMpqC3Jjq)_