### PR TITLE
perf(playback): eager moov + first-GOP prefetch on preparePlayback

### DIFF
--- a/packages/backend/src/blob-playback-service.js
+++ b/packages/backend/src/blob-playback-service.js
@@ -2,6 +2,7 @@ import b4a from 'b4a'
 
 import { normalizeBlobRefInput, parseBlobRef } from './blob-ref.js'
 import { attachBlobPlaybackProfile } from './blob-playback-profile.js'
+import { prefetchBlobPlaybackStart } from './blob-range-priority.js'
 import { retainSwarmDiscovery } from './storage.js'
 
 function getCorePeerList(core) {
@@ -63,15 +64,29 @@ export class BlobPlaybackService {
     // not prewarming; no blocks are fetched until the player requests them.
     this.warmDirectBlobRef(ref.blobsCoreKey, keyBuffer)
 
+    // Eagerly pull the opening GOPs (byte 0 forward) the moment playback is
+    // prepared, so the native player's first range request lands against
+    // already-downloading bytes instead of a cold P2P round trip. Profile-free
+    // and runs in parallel with the probe below. Detached — URL resolution
+    // must never wait on it.
+    this.prefetchPlaybackStart(ref.blobsCoreKey, keyBuffer, ref.blob, null).catch(() => {})
+
     // Make the blob's playback profile (keyframe index + moov position)
     // available to range prioritization before the player's first range
     // request: stored profile when this device probed the file, remote
-    // header probe otherwise. Best-effort and detached — URL resolution
-    // must never wait on it.
+    // header probe otherwise. Once known, eagerly pull the tail moov for
+    // back-moov MP4s — the very first thing the player blocks on — so it is
+    // local before the player asks. Best-effort and detached.
     attachBlobPlaybackProfile(ctx, {
       blobsCoreKey: ref.blobsCoreKey,
       blobId: ref.blob,
       mimeType: ref.mimeType || mimeType,
+    }).then((profile) => {
+      if (profile?.moovPosition === 'back') {
+        return this.prefetchPlaybackStart(ref.blobsCoreKey, keyBuffer, ref.blob, profile, {
+          startPrefetchBytes: 0,
+        })
+      }
     }).catch(() => {})
 
     return { url }
@@ -90,6 +105,38 @@ export class BlobPlaybackService {
   warmDirectBlobRef(blobsCoreKey, keyBuffer = b4a.from(blobsCoreKey, 'hex')) {
     const blobsCore = this.getBlobCore(blobsCoreKey, keyBuffer)
     this.retainBlobCorePeers(blobsCoreKey, blobsCore).catch(() => {})
+  }
+
+  /**
+   * Eagerly download the bytes the player needs to begin rendering (opening
+   * GOPs, and the tail moov for back-moov MP4s) before the player issues its
+   * first range request. Opens a short-lived core session, runs the bounded
+   * prefetch, then closes it; downloaded blocks persist in shared storage for
+   * the blob server to serve. Best-effort — never throws, never blocks the URL.
+   *
+   * @param {string} blobsCoreKey
+   * @param {Buffer} [keyBuffer]
+   * @param {Object} blob - blob descriptor ({ blockOffset, blockLength, byteLength, ... })
+   * @param {Object|null} [profile] - playback profile (keyframe index + moov position)
+   * @param {Object} [options] - forwarded to prefetchBlobPlaybackStart (e.g. startPrefetchBytes)
+   */
+  async prefetchPlaybackStart(blobsCoreKey, keyBuffer = b4a.from(blobsCoreKey, 'hex'), blob, profile = null, options = {}) {
+    const ctx = this.ctx
+    if (!ctx?.store || !blob) return
+    let core = null
+    try {
+      core = ctx.store.get(keyBuffer)
+      await prefetchBlobPlaybackStart(core, blob, { ...options, profile })
+    } catch {
+      // Best-effort: playback never depends on the prefetch succeeding.
+    } finally {
+      if (core) {
+        try {
+          const closing = core.close?.()
+          if (closing?.catch) closing.catch(() => {})
+        } catch { /* best effort */ }
+      }
+    }
   }
 
   async retainBlobCorePeers(blobsCoreKey, blobsCore = this.getBlobCore(blobsCoreKey)) {

--- a/packages/backend/src/blob-range-priority.js
+++ b/packages/backend/src/blob-range-priority.js
@@ -26,6 +26,10 @@ const MAX_TRACKED_PRIORITY_BLOBS = 8
 // within a bounded distance so a sparse-keyframe file can't drag the window
 // megabytes behind the playhead.
 const DEFAULT_KEYFRAME_SNAP_BACK_BYTES = 8 * 1024 * 1024
+// How far into the file to eagerly pull the opening GOPs the moment playback is
+// being prepared, so the native player's first range request lands against
+// already-downloading bytes instead of a cold P2P round trip.
+const DEFAULT_PLAYBACK_START_PREFETCH_BYTES = 8 * 1024 * 1024
 
 // One entry per blob currently being prioritized for playback:
 // registryKey -> { core, range, timer, createdAt, start, end }
@@ -281,42 +285,107 @@ function decodeBlobRangeRequest(blobServer, req) {
   return { key, blob, byteRange }
 }
 
+// Kick off a linear, time-bounded download of a precomputed block range and
+// resolve once it lands (or the timeout fires). Downloads of already-local
+// blocks resolve immediately. Never rejects — prefetch is best-effort.
+function downloadRangeWithTimeout(core, downloadRange, timeoutMs) {
+  if (!core || typeof core.download !== 'function' || !downloadRange) return Promise.resolve()
+
+  let range
+  try {
+    range = core.download({ start: downloadRange.start, end: downloadRange.end, linear: true })
+  } catch {
+    return Promise.resolve()
+  }
+
+  const ms = Math.max(
+    1000,
+    Number(timeoutMs ?? DEFAULT_BLOB_RANGE_PRIORITY_TIMEOUT_MS) || DEFAULT_BLOB_RANGE_PRIORITY_TIMEOUT_MS
+  )
+  return new Promise((resolve) => {
+    let settled = false
+    const stop = () => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      try { range?.destroy?.() } catch { /* best effort */ }
+      resolve()
+    }
+    const timer = setTimeout(stop, ms)
+    const done = typeof range?.done === 'function'
+      ? range.done()
+      : typeof range?.downloaded === 'function'
+        ? range.downloaded()
+        : Promise.resolve()
+    Promise.resolve(done).catch(() => {}).finally(stop)
+  })
+}
+
+// The tail-of-file moov block range for a back-moov MP4, or null when the
+// profile is missing/front-moov/malformed.
+function computeBackMoovRange(blob, profile) {
+  if (!profile || profile.moovPosition !== 'back') return null
+  if (!isFiniteNonNegativeInteger(profile.moovStart) || !Number.isInteger(profile.moovEnd)) return null
+  if (profile.moovEnd <= profile.moovStart) return null
+  return getPrioritizedBlobDownloadRange(
+    blob,
+    { start: profile.moovStart, end: profile.moovEnd - 1 },
+    { readAheadBytes: 0 }
+  )
+}
+
 // Back-moov MP4s cannot start rendering until the tail-of-file moov box is
 // local: the player's very next request after probing the head is the tail.
 // Pull those blocks proactively the moment playback traffic appears for the
 // blob, instead of waiting out that extra request round trip. One shot per
 // registered profile; downloads of already-local blocks resolve immediately.
 function boostBackMoovDownload(core, blob, profile, options = {}) {
-  if (!profile || profile.moovPosition !== 'back' || profile._moovBoosted) return
-  if (!isFiniteNonNegativeInteger(profile.moovStart) || !Number.isInteger(profile.moovEnd)) return
-  if (profile.moovEnd <= profile.moovStart) return
-  profile._moovBoosted = true
-
-  const moovRange = getPrioritizedBlobDownloadRange(
-    blob,
-    { start: profile.moovStart, end: profile.moovEnd - 1 },
-    { readAheadBytes: 0 }
-  )
+  if (!profile || profile._moovBoosted) return
+  const moovRange = computeBackMoovRange(blob, profile)
   if (!moovRange) return
+  profile._moovBoosted = true
+  downloadRangeWithTimeout(core, moovRange, options.timeoutMs)
+}
 
-  let range
-  try {
-    range = core.download({ start: moovRange.start, end: moovRange.end, linear: true })
-  } catch {
-    return
+// Eagerly pull the bytes the player needs to BEGIN rendering, the moment
+// playback is being prepared — before the native player has even issued its
+// first range request. Two regions:
+//   1. The opening GOPs from byte 0 (front-moov files get their index here too).
+//   2. For back-moov MP4s, the tail moov index — otherwise the very first
+//      thing the player blocks on is a cold round trip to the end of the file.
+// Without this, nothing downloads until the player's first request lands, which
+// is exactly the cold-start / "won't begin until I poke it" stall. Best-effort
+// and time-bounded; resolves when the regions land or the timeout fires.
+export async function prefetchBlobPlaybackStart(core, blob, options = {}) {
+  if (!core || typeof core.download !== 'function' || !blob) return
+  if (typeof core.ready === 'function') {
+    try { await core.ready() } catch { return }
   }
 
-  const timeoutMs = Math.max(
-    1000,
-    Number(options.timeoutMs ?? DEFAULT_BLOB_RANGE_PRIORITY_TIMEOUT_MS) || DEFAULT_BLOB_RANGE_PRIORITY_TIMEOUT_MS
+  const profile = options.profile || null
+  const timeoutMs = options.timeoutMs ?? DEFAULT_BLOB_RANGE_PRIORITY_TIMEOUT_MS
+  const jobs = []
+
+  const moovRange = computeBackMoovRange(blob, profile)
+  if (moovRange) {
+    if (profile) profile._moovBoosted = true
+    jobs.push(downloadRangeWithTimeout(core, moovRange, timeoutMs))
+  }
+
+  const startBytes = Math.max(
+    0,
+    Number(options.startPrefetchBytes ?? DEFAULT_PLAYBACK_START_PREFETCH_BYTES) || 0
   )
-  const stop = () => {
-    clearTimeout(timer)
-    try { range?.destroy?.() } catch { /* best effort */ }
+  if (startBytes > 0) {
+    const headRange = getPrioritizedBlobDownloadRange(
+      blob,
+      { start: 0, end: 0, openEnded: true },
+      { readAheadBytes: startBytes, snapOffsets: profile?.keyframeOffsets }
+    )
+    if (headRange) jobs.push(downloadRangeWithTimeout(core, headRange, timeoutMs))
   }
-  const timer = setTimeout(stop, timeoutMs)
-  const done = typeof range?.done === 'function' ? range.done() : Promise.resolve()
-  Promise.resolve(done).catch(() => {}).finally(stop)
+
+  if (jobs.length > 0) await Promise.all(jobs)
 }
 
 export async function prioritizeBlobServerRangeRequest(blobServer, req, options = {}) {


### PR DESCRIPTION
Cold-start and seek on desktop were slow because nothing downloaded until
the native <video> issued its first range request, and the back-moov boost
that pulls the tail moov index only fired once the playback profile happened
to be loaded — but that profile is attached fire-and-forget and races (and
usually loses to) the player's first requests. Back-moov MP4s (the default,
since upload only probes moov position and never remuxes to faststart) then
block on a cold P2P round trip to the end of the file before rendering a
single frame: the "won't start until I poke play/pause and seek" stall.

Add prefetchBlobPlaybackStart: the moment a playback URL is resolved, eagerly
pull the opening GOPs from byte 0 (front-moov files get their index here too)
and, once the profile resolves as back-moov, the tail moov index — before the
player blocks on either. Detached and time-bounded, so URL handoff never waits.

- blob-range-priority.js: factor downloadRangeWithTimeout + computeBackMoovRange
  out of boostBackMoovDownload (behavior-preserving) and export
  prefetchBlobPlaybackStart.
- blob-playback-service.js: kick a profile-free head prefetch immediately, and
  a tail-moov prefetch when the profile attaches, via a short-lived core session.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Jq5hQqjY5HcCDhm2SwJqS5