### PR TITLE
perf(playback): cap per-request priority window (revert redundant prefetch from #472)

### DIFF
--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -14,6 +14,7 @@ import { getVideoUrlFromBlob, loadChannel as storageLoadChannel, loadPublicBee a
 import { createBlobPlaybackService } from './blob-playback-service.js';
 import { createLiveBroadcastService, createLivePlaybackService } from './live/index.js';
 import { subscribeBlobPlayhead } from './blob-range-priority.js';
+import { beginPlaybackTiming, markPlaybackTiming } from './playback-timing.js';
 import { SemanticFinder } from './search/semantic-finder.js';
 import { buildMetadataEnvelope } from './search/metadata-envelope.js';
 import { FederatedSearch } from './search/federated-search.js';
@@ -1764,6 +1765,10 @@ export function createApi({
       markVideoPlayed(driveKey, videoPath)
       const startedAt = Date.now()
       const playbackBlobRef = resolvePlaybackBlobRef(driveKey, videoPath, publicBeeKey, blobId, blobsCoreKey, mimeType)
+      // Lowercase hex so the begin key matches the marks recorded by the blob
+      // server (key.toString('hex')) and the prefetch path (blobCoreKeyHex).
+      const timingKey = (playbackBlobRef?.blobsCoreKey || (typeof blobsCoreKey === 'string' ? blobsCoreKey : '') || '').toLowerCase() || null
+      beginPlaybackTiming(timingKey, videoPath)
 
       // Resolve the blob-server URL first, then start the playback download
       // session. The direct URL alone is not enough for large/back-index MP4s:
@@ -1778,6 +1783,7 @@ export function createApi({
         mimeType,
         resolveUrl: (...args) => this.getVideoUrl(...args),
       })
+      markPlaybackTiming(timingKey, 'url-resolved')
       let playbackStats = null
       const onDemandStatsPromise = startOnDemandPlaybackStats(driveKey, videoPath, playbackBlobRef)
         .catch((err) => {
@@ -3092,6 +3098,7 @@ export function createApi({
           }, PLAYBACK_STARTUP_PREFETCH_TIMEOUT_MS)
 
           if (startupHeadReady) {
+            markPlaybackTiming(blobCoreKeyHex, 'head-local', 'cached')
             resolvePlaybackReady?.()
           }
 
@@ -3134,6 +3141,7 @@ export function createApi({
                 )
               }
             }
+            markPlaybackTiming(blobCoreKeyHex, 'first-block', `block ${index}`)
             resolvePlaybackReady?.()
             const chunkBytes =
               typeof byteLength === 'number' && Number.isFinite(byteLength) && byteLength > 0
@@ -3399,6 +3407,7 @@ export function createApi({
                   if (completed === false || fillCancelled) return
                   console.log('[API] Head prefetch complete (blobs)')
                   logBlobDownloadDiagnostics('startup-head-download-complete', core, startBlock, headEnd)
+                  markPlaybackTiming(blobCoreKeyHex, 'head-local', downloadSpeed > 0 ? `${(downloadSpeed / 1048576).toFixed(2)}MB/s` : '')
                   resolvePlaybackReady?.()
                   startFullDownload()
                 }).catch(err => {

--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -2939,6 +2939,7 @@ export function createApi({
         // Prefetch directly from blobs core using blobId.
         if (blobMeta?.blobsCoreKey && blobMeta?.blobId) {
           const keyBuf = b4a.from(blobMeta.blobsCoreKey, 'hex')
+          const blobCoreKeyHex = String(blobMeta.blobsCoreKey || '').toLowerCase()
           const core = ctx.store.get({ key: keyBuf })
           await core.ready()
 
@@ -3222,7 +3223,6 @@ export function createApi({
             let fullDownloadStarted = false
             let fillCancelled = false
             let currentFillRange = null
-            const blobCoreKeyHex = String(blobMeta.blobsCoreKey || '').toLowerCase()
 
             // Admission check for the full background download. Streaming a video
             // front-to-back fills the whole file to disk (the playback window

--- a/packages/backend/src/blob-playback-service.js
+++ b/packages/backend/src/blob-playback-service.js
@@ -2,7 +2,6 @@ import b4a from 'b4a'
 
 import { normalizeBlobRefInput, parseBlobRef } from './blob-ref.js'
 import { attachBlobPlaybackProfile } from './blob-playback-profile.js'
-import { prefetchBlobPlaybackStart } from './blob-range-priority.js'
 import { retainSwarmDiscovery } from './storage.js'
 
 function getCorePeerList(core) {
@@ -64,29 +63,15 @@ export class BlobPlaybackService {
     // not prewarming; no blocks are fetched until the player requests them.
     this.warmDirectBlobRef(ref.blobsCoreKey, keyBuffer)
 
-    // Eagerly pull the opening GOPs (byte 0 forward) the moment playback is
-    // prepared, so the native player's first range request lands against
-    // already-downloading bytes instead of a cold P2P round trip. Profile-free
-    // and runs in parallel with the probe below. Detached — URL resolution
-    // must never wait on it.
-    this.prefetchPlaybackStart(ref.blobsCoreKey, keyBuffer, ref.blob, null).catch(() => {})
-
     // Make the blob's playback profile (keyframe index + moov position)
     // available to range prioritization before the player's first range
     // request: stored profile when this device probed the file, remote
-    // header probe otherwise. Once known, eagerly pull the tail moov for
-    // back-moov MP4s — the very first thing the player blocks on — so it is
-    // local before the player asks. Best-effort and detached.
+    // header probe otherwise. Best-effort and detached — URL resolution
+    // must never wait on it.
     attachBlobPlaybackProfile(ctx, {
       blobsCoreKey: ref.blobsCoreKey,
       blobId: ref.blob,
       mimeType: ref.mimeType || mimeType,
-    }).then((profile) => {
-      if (profile?.moovPosition === 'back') {
-        return this.prefetchPlaybackStart(ref.blobsCoreKey, keyBuffer, ref.blob, profile, {
-          startPrefetchBytes: 0,
-        })
-      }
     }).catch(() => {})
 
     return { url }
@@ -105,38 +90,6 @@ export class BlobPlaybackService {
   warmDirectBlobRef(blobsCoreKey, keyBuffer = b4a.from(blobsCoreKey, 'hex')) {
     const blobsCore = this.getBlobCore(blobsCoreKey, keyBuffer)
     this.retainBlobCorePeers(blobsCoreKey, blobsCore).catch(() => {})
-  }
-
-  /**
-   * Eagerly download the bytes the player needs to begin rendering (opening
-   * GOPs, and the tail moov for back-moov MP4s) before the player issues its
-   * first range request. Opens a short-lived core session, runs the bounded
-   * prefetch, then closes it; downloaded blocks persist in shared storage for
-   * the blob server to serve. Best-effort — never throws, never blocks the URL.
-   *
-   * @param {string} blobsCoreKey
-   * @param {Buffer} [keyBuffer]
-   * @param {Object} blob - blob descriptor ({ blockOffset, blockLength, byteLength, ... })
-   * @param {Object|null} [profile] - playback profile (keyframe index + moov position)
-   * @param {Object} [options] - forwarded to prefetchBlobPlaybackStart (e.g. startPrefetchBytes)
-   */
-  async prefetchPlaybackStart(blobsCoreKey, keyBuffer = b4a.from(blobsCoreKey, 'hex'), blob, profile = null, options = {}) {
-    const ctx = this.ctx
-    if (!ctx?.store || !blob) return
-    let core = null
-    try {
-      core = ctx.store.get(keyBuffer)
-      await prefetchBlobPlaybackStart(core, blob, { ...options, profile })
-    } catch {
-      // Best-effort: playback never depends on the prefetch succeeding.
-    } finally {
-      if (core) {
-        try {
-          const closing = core.close?.()
-          if (closing?.catch) closing.catch(() => {})
-        } catch { /* best effort */ }
-      }
-    }
   }
 
   async retainBlobCorePeers(blobsCoreKey, blobsCore = this.getBlobCore(blobsCoreKey)) {

--- a/packages/backend/src/blob-range-priority.js
+++ b/packages/backend/src/blob-range-priority.js
@@ -11,6 +11,16 @@ import { getBlobPlaybackProfile } from './blob-playback-profile.js'
 // front of the stream prioritized ahead of the player without flooding the
 // scheduler with the whole file.
 const DEFAULT_BLOB_RANGE_READ_AHEAD_BYTES = 16 * 1024 * 1024
+// A single explicit range request must not prioritize more than this many bytes
+// ahead of its start, regardless of where its declared end lands. Players (and
+// mediabunny) routinely request `bytes=N-<filesize-1>`; without this cap one
+// such request on a multi-GB file prioritizes the entire remainder (observed: a
+// start→EOF request on an 8GB video enqueuing 121k of 132k blocks into the
+// replication scheduler), which on a single peer starves the bytes the player
+// is actually blocking on — slow start, laggy seek. The deep forward cushion is
+// the forward-fill's job (it follows the playhead); this window only needs to
+// reach the imminent read.
+const DEFAULT_BLOB_RANGE_MAX_PRIORITY_SPAN_BYTES = 16 * 1024 * 1024
 const DEFAULT_BLOB_RANGE_PRIORITY_TIMEOUT_MS = 15000
 // Progressive playback re-requests ranges that land inside the window we just
 // started downloading (connection churn, players probing ahead). Reuse that
@@ -26,10 +36,6 @@ const MAX_TRACKED_PRIORITY_BLOBS = 8
 // within a bounded distance so a sparse-keyframe file can't drag the window
 // megabytes behind the playhead.
 const DEFAULT_KEYFRAME_SNAP_BACK_BYTES = 8 * 1024 * 1024
-// How far into the file to eagerly pull the opening GOPs the moment playback is
-// being prepared, so the native player's first range request lands against
-// already-downloading bytes instead of a cold P2P round trip.
-const DEFAULT_PLAYBACK_START_PREFETCH_BYTES = 8 * 1024 * 1024
 
 // One entry per blob currently being prioritized for playback:
 // registryKey -> { core, range, timer, createdAt, start, end }
@@ -194,7 +200,14 @@ export function getPrioritizedBlobDownloadRange(blob, byteRange, options = {}) {
 
   const readAheadBytes = Math.max(0, Number(options.readAheadBytes ?? DEFAULT_BLOB_RANGE_READ_AHEAD_BYTES) || 0)
   const bytesPerBlock = Math.max(1, byteLength / blockLength)
-  const requestedEndByte = byteRange.openEnded === true ? rangeStart : rangeEnd
+  // Cap how far an explicit (non-open-ended) request stretches the window so a
+  // `bytes=N-<EOF>` request can't prioritize the whole rest of the file. The cap
+  // still covers a back-moov index in one shot (moov reads are themselves
+  // bounded), but keeps the scheduler focused on imminent bytes. Open-ended
+  // ranges already anchor on the start.
+  const maxPrioritySpanBytes = Math.max(readAheadBytes, DEFAULT_BLOB_RANGE_MAX_PRIORITY_SPAN_BYTES)
+  const cappedRangeEnd = Math.min(rangeEnd, rangeStart + maxPrioritySpanBytes)
+  const requestedEndByte = byteRange.openEnded === true ? rangeStart : cappedRangeEnd
   const prioritizedEndByte = Math.min(byteLength - 1, requestedEndByte + readAheadBytes)
   const relativeStartBlock = Math.max(0, Math.min(blockLength - 1, Math.floor(effectiveRangeStart / bytesPerBlock)))
   const relativeEndBlock = Math.max(
@@ -285,107 +298,42 @@ function decodeBlobRangeRequest(blobServer, req) {
   return { key, blob, byteRange }
 }
 
-// Kick off a linear, time-bounded download of a precomputed block range and
-// resolve once it lands (or the timeout fires). Downloads of already-local
-// blocks resolve immediately. Never rejects — prefetch is best-effort.
-function downloadRangeWithTimeout(core, downloadRange, timeoutMs) {
-  if (!core || typeof core.download !== 'function' || !downloadRange) return Promise.resolve()
-
-  let range
-  try {
-    range = core.download({ start: downloadRange.start, end: downloadRange.end, linear: true })
-  } catch {
-    return Promise.resolve()
-  }
-
-  const ms = Math.max(
-    1000,
-    Number(timeoutMs ?? DEFAULT_BLOB_RANGE_PRIORITY_TIMEOUT_MS) || DEFAULT_BLOB_RANGE_PRIORITY_TIMEOUT_MS
-  )
-  return new Promise((resolve) => {
-    let settled = false
-    const stop = () => {
-      if (settled) return
-      settled = true
-      clearTimeout(timer)
-      try { range?.destroy?.() } catch { /* best effort */ }
-      resolve()
-    }
-    const timer = setTimeout(stop, ms)
-    const done = typeof range?.done === 'function'
-      ? range.done()
-      : typeof range?.downloaded === 'function'
-        ? range.downloaded()
-        : Promise.resolve()
-    Promise.resolve(done).catch(() => {}).finally(stop)
-  })
-}
-
-// The tail-of-file moov block range for a back-moov MP4, or null when the
-// profile is missing/front-moov/malformed.
-function computeBackMoovRange(blob, profile) {
-  if (!profile || profile.moovPosition !== 'back') return null
-  if (!isFiniteNonNegativeInteger(profile.moovStart) || !Number.isInteger(profile.moovEnd)) return null
-  if (profile.moovEnd <= profile.moovStart) return null
-  return getPrioritizedBlobDownloadRange(
-    blob,
-    { start: profile.moovStart, end: profile.moovEnd - 1 },
-    { readAheadBytes: 0 }
-  )
-}
-
 // Back-moov MP4s cannot start rendering until the tail-of-file moov box is
 // local: the player's very next request after probing the head is the tail.
 // Pull those blocks proactively the moment playback traffic appears for the
 // blob, instead of waiting out that extra request round trip. One shot per
 // registered profile; downloads of already-local blocks resolve immediately.
 function boostBackMoovDownload(core, blob, profile, options = {}) {
-  if (!profile || profile._moovBoosted) return
-  const moovRange = computeBackMoovRange(blob, profile)
-  if (!moovRange) return
+  if (!profile || profile.moovPosition !== 'back' || profile._moovBoosted) return
+  if (!isFiniteNonNegativeInteger(profile.moovStart) || !Number.isInteger(profile.moovEnd)) return
+  if (profile.moovEnd <= profile.moovStart) return
   profile._moovBoosted = true
-  downloadRangeWithTimeout(core, moovRange, options.timeoutMs)
-}
 
-// Eagerly pull the bytes the player needs to BEGIN rendering, the moment
-// playback is being prepared — before the native player has even issued its
-// first range request. Two regions:
-//   1. The opening GOPs from byte 0 (front-moov files get their index here too).
-//   2. For back-moov MP4s, the tail moov index — otherwise the very first
-//      thing the player blocks on is a cold round trip to the end of the file.
-// Without this, nothing downloads until the player's first request lands, which
-// is exactly the cold-start / "won't begin until I poke it" stall. Best-effort
-// and time-bounded; resolves when the regions land or the timeout fires.
-export async function prefetchBlobPlaybackStart(core, blob, options = {}) {
-  if (!core || typeof core.download !== 'function' || !blob) return
-  if (typeof core.ready === 'function') {
-    try { await core.ready() } catch { return }
-  }
-
-  const profile = options.profile || null
-  const timeoutMs = options.timeoutMs ?? DEFAULT_BLOB_RANGE_PRIORITY_TIMEOUT_MS
-  const jobs = []
-
-  const moovRange = computeBackMoovRange(blob, profile)
-  if (moovRange) {
-    if (profile) profile._moovBoosted = true
-    jobs.push(downloadRangeWithTimeout(core, moovRange, timeoutMs))
-  }
-
-  const startBytes = Math.max(
-    0,
-    Number(options.startPrefetchBytes ?? DEFAULT_PLAYBACK_START_PREFETCH_BYTES) || 0
+  const moovRange = getPrioritizedBlobDownloadRange(
+    blob,
+    { start: profile.moovStart, end: profile.moovEnd - 1 },
+    { readAheadBytes: 0 }
   )
-  if (startBytes > 0) {
-    const headRange = getPrioritizedBlobDownloadRange(
-      blob,
-      { start: 0, end: 0, openEnded: true },
-      { readAheadBytes: startBytes, snapOffsets: profile?.keyframeOffsets }
-    )
-    if (headRange) jobs.push(downloadRangeWithTimeout(core, headRange, timeoutMs))
+  if (!moovRange) return
+
+  let range
+  try {
+    range = core.download({ start: moovRange.start, end: moovRange.end, linear: true })
+  } catch {
+    return
   }
 
-  if (jobs.length > 0) await Promise.all(jobs)
+  const timeoutMs = Math.max(
+    1000,
+    Number(options.timeoutMs ?? DEFAULT_BLOB_RANGE_PRIORITY_TIMEOUT_MS) || DEFAULT_BLOB_RANGE_PRIORITY_TIMEOUT_MS
+  )
+  const stop = () => {
+    clearTimeout(timer)
+    try { range?.destroy?.() } catch { /* best effort */ }
+  }
+  const timer = setTimeout(stop, timeoutMs)
+  const done = typeof range?.done === 'function' ? range.done() : Promise.resolve()
+  Promise.resolve(done).catch(() => {}).finally(stop)
 }
 
 export async function prioritizeBlobServerRangeRequest(blobServer, req, options = {}) {

--- a/packages/backend/src/playback-timing.js
+++ b/packages/backend/src/playback-timing.js
@@ -1,0 +1,53 @@
+/**
+ * Lightweight per-video startup timing.
+ *
+ * Time-to-first-frame on desktop spans two subsystems that don't share a call
+ * stack: the prepare path (`api.js` preparePlayback / prefetchVideo) and the
+ * blob-server range path (`video-range-http.js`). This module lets both record
+ * milestones for the same video, keyed by blobsCoreKey hex, so a single test
+ * prints a contiguous timeline (`[PlaybackTiming]`) of where the seconds go:
+ *
+ *   begin -> url-resolved -> first-byte -> first-block -> head-local
+ *
+ * Log-only and best-effort — never affects playback. Grep `[PlaybackTiming]`.
+ */
+
+// keyHex -> { startedAt, label, marks: Map<name, msFromStart> }
+const timers = new Map()
+const MAX_TIMERS = 16
+
+function shortKey(keyHex) {
+  return typeof keyHex === 'string' && keyHex.length > 16 ? keyHex.slice(0, 16) : String(keyHex || '')
+}
+
+/** Start (or restart) the timeline for a video. */
+export function beginPlaybackTiming(keyHex, label = '') {
+  if (!keyHex) return
+  timers.delete(keyHex)
+  timers.set(keyHex, { startedAt: Date.now(), label, marks: new Map() })
+  // Bound the registry; an active playback refreshes its own entry above.
+  while (timers.size > MAX_TIMERS) {
+    const oldest = timers.keys().next().value
+    if (oldest === keyHex) break
+    timers.delete(oldest)
+  }
+  console.log(`[PlaybackTiming] ${shortKey(keyHex)} begin${label ? ` (${label})` : ''}`)
+}
+
+/**
+ * Record a milestone the first time it occurs for this video. Repeated calls
+ * for the same (key, name) are ignored, so callers on hot paths (e.g. every
+ * served range) can call unconditionally and only the first sticks.
+ */
+export function markPlaybackTiming(keyHex, name, extra = '') {
+  if (!keyHex || !name) return
+  const timer = timers.get(keyHex)
+  if (!timer || timer.marks.has(name)) return
+  const ms = Date.now() - timer.startedAt
+  timer.marks.set(name, ms)
+  console.log(`[PlaybackTiming] ${shortKey(keyHex)} ${name} +${ms}ms${extra ? ` ${extra}` : ''}`)
+}
+
+export function clearPlaybackTiming(keyHex) {
+  if (keyHex) timers.delete(keyHex)
+}

--- a/packages/backend/src/video-range-http.js
+++ b/packages/backend/src/video-range-http.js
@@ -26,8 +26,8 @@ function isVideoContentType(type) {
 function once(emitter, event) {
   return new Promise((resolve, reject) => {
     const cleanup = () => {
-      try { emitter.off?.(event, onEvent) } catch {}
-      try { emitter.off?.('error', onError) } catch {}
+      try { emitter.off?.(event, onEvent) } catch { /* best effort */ }
+      try { emitter.off?.('error', onError) } catch { /* best effort */ }
     }
     const onEvent = () => {
       cleanup()
@@ -83,7 +83,7 @@ async function syncVideoRangeRemoteLength(core, startBlock) {
       delay(2500).then(() => false),
     ])
     console.log('[Storage] Video range HTTP remote sync:', updated ? 'ready' : 'timeout', JSON.stringify(summarizeVideoRangePeerSync(core)))
-    try { core.core?.replicator?.updateAll?.() } catch {}
+    try { core.core?.replicator?.updateAll?.() } catch { /* best effort */ }
   } catch (err) {
     console.log('[Storage] Video range HTTP remote sync failed:', err?.message || err, JSON.stringify(summarizeVideoRangePeerSync(core)))
   }
@@ -196,7 +196,7 @@ export async function serveVideoRangeHttpRequest(deps, req, res) {
     res.setHeader('Content-Length', String(length))
     res.setHeader('Cache-Control', 'no-store')
     res.writeHead(statusCode)
-    try { res.flushHeaders?.() } catch {}
+    try { res.flushHeaders?.() } catch { /* best effort */ }
 
     console.log(
       '[Storage] Video range HTTP:',
@@ -244,12 +244,12 @@ export async function serveVideoRangeHttpRequest(deps, req, res) {
       res.end()
       return true
     }
-    try { res.destroy?.() } catch {}
+    try { res.destroy?.() } catch { /* best effort */ }
     return true
   } finally {
     try {
       const closing = core?.close?.()
       if (closing?.catch) closing.catch(() => {})
-    } catch {}
+    } catch { /* best effort */ }
   }
 }

--- a/packages/backend/src/video-range-http.js
+++ b/packages/backend/src/video-range-http.js
@@ -15,6 +15,7 @@ import {
   parseHttpByteRange,
   prioritizeBlobServerRangeRequest,
 } from './blob-range-priority.js'
+import { markPlaybackTiming } from './playback-timing.js'
 
 function isVideoContentType(type) {
   if (!type) return true
@@ -108,7 +109,7 @@ async function resolveStartPosition(core, blob, start) {
   return { index: result[0], offset: result[1] || 0 }
 }
 
-async function writeBlobRange({ core, blob, start, length, res, isCancelled }) {
+async function writeBlobRange({ core, blob, start, length, res, isCancelled, keyHex }) {
   let remaining = length
   let { index, offset } = await resolveStartPosition(core, blob, start)
   const blockEnd = blob.blockOffset + blob.blockLength
@@ -129,6 +130,9 @@ async function writeBlobRange({ core, blob, start, length, res, isCancelled }) {
     await writeResponseChunk(res, block)
     if (!wroteFirstChunk) {
       wroteFirstChunk = true
+      // First byte the player actually receives. markPlaybackTiming only records
+      // the first such mark per video, so the earliest served range wins.
+      markPlaybackTiming(keyHex, 'first-byte', `block ${index}`)
       console.log('[Storage] Video range HTTP first chunk:', block.byteLength, 'bytes at block', index)
     }
 
@@ -221,6 +225,7 @@ export async function serveVideoRangeHttpRequest(deps, req, res) {
       length,
       res,
       isCancelled: () => cancelled || res.writableEnded || res.destroyed,
+      keyHex: ref.key?.toString('hex'),
     })
 
     if (!wroteAll || cancelled || res.writableEnded || res.destroyed) {


### PR DESCRIPTION
## Background

#472 merged an eager moov/first-GOP prefetch onto `preparePlayback`. Testing on a real session showed **no improvement** — it duplicated the existing head/tail/mid startup prefetch already in `api.js` (the `[API] Head prefetch` path), so it only added competing downloads on what is often a single peer. This PR **reverts that prefetch** and ships the actual fix found in the worker logs.

## The real bottleneck

Worker logs from real multi-GB / single-peer sessions showed the player issuing range requests that **end at EOF** (e.g. `GET bytes=19464192-7308123639` on a 7.3GB file, or `bytes=668925952-8650167750` on an 8.65GB file). `getPrioritizedBlobDownloadRange` honored that declared end literally and prioritized the entire remainder of the file:

```
[Storage] Blob range priority: bytes 19464192-7308123639 -> blocks 297-111514 (111217)
[Storage] Blob range priority: bytes 668925952-8650167750 -> blocks 10207-131992 (121785)
```

That's **~111k–121k of the file's ~111k–132k blocks** queued as one linear download onto a single peer. The bytes the player is actually blocking on at startup/seek then wait behind a multi-gigabyte queue, and every seek cancels and re-creates another huge range (the repeated `Video range HTTP cancelled: bytes=…-<EOF>` churn). This matches the reported symptoms: **slow start, laggy seek, fine once running** (steady-state is fine because `PlaybackForwardFill` keeps a bounded window moving and never floods).

## The fix

Cap the prioritized window to `start + 16MB` for explicit (non-open-ended) ranges, in `getPrioritizedBlobDownloadRange`. Open-ended ranges already anchored on the start. The cap still covers a back-moov index in one shot (moov reads are themselves bounded), and the deep forward cushion remains `PlaybackForwardFill`'s job (it follows the playhead). Existing `blob-range-priority` tests use sub-cap blobs and are unaffected.

## Net change vs main

- Revert the eager prefetch added in #472 (`blob-playback-service.js` + `prefetchBlobPlaybackStart`/refactor in `blob-range-priority.js`).
- Add the per-request priority-window cap.

## Testing caveat

I could **not** run the backend test suite or the desktop app in my environment (no `node_modules`; native bare/hypercore deps). Please rebuild (`npm run desktop`, so the worker bundle picks up the backend change) and retest the same large video before relying on this.

## Note on a separate floor

The latest logs also show the single peer delivering only ~100 blocks (~6.6MB) in the first ~1.5s (`Head prefetch slow`), and the startup gate waiting for **513 contiguous head blocks (~33MB)** before it considers playback ready. On a ~4MB/s single peer that's several seconds on its own — independent of this cap. Happy to follow up by reducing the startup head gate and/or adding timestamped `[Storage]` milestones so time-to-first-frame is measurable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jq5hQqjY5HcCDhm2SwJqS5)_