### PR TITLE
perf(playback): defer tail/mid index prefetch until front head is local

### DIFF
--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -3375,6 +3375,59 @@ export function createApi({
               startFillPass(nextAnchor)
             })
 
+            // Speculative index pre-warm for the END and MIDDLE of the file
+            // (back-moov MP4 / MKV cues). Deferred until the front head range is
+            // local: on a bandwidth-starved single peer these ~hundreds of
+            // far-away blocks otherwise steal delivery slots from the front-moov
+            // index the player is actually blocked on, adding many seconds to
+            // first frame. Front-moov files (the common case) never need them
+            // during startup; back-moov files still get their tail/index via the
+            // player's own reactive range request + forward-fill, so deferring is
+            // safe — it only stops the pre-warm from competing before the player
+            // can start.
+            let tailMidStarted = false
+            const startTailMidPrefetch = () => {
+              if (tailMidStarted || fillCancelled) return
+              tailMidStarted = true
+
+              if (tailBlocks > 0 && tailBlocks < totalBlocks) {
+                const tailStart = Math.max(startBlock, endBlock - tailBlocks)
+                // Avoid duplicating the head range on tiny files.
+                if (tailStart > startBlock + Math.max(1, headBlocks)) {
+                  console.log('[API] Prefetch tail range (blobs):', (endBlock - tailStart), 'blocks')
+                  const tailRange = core.download({ start: tailStart, end: endBlock })
+                  activeRangeRequests.get(prefetchKey)?.ranges.push(tailRange)
+                  tailRange.done().then((completed) => {
+                    if (completed === false) return
+                    console.log('[API] Tail prefetch complete (blobs)')
+                  }).catch(err => {
+                    console.log('[API] Tail prefetch error (blobs):', err?.message)
+                  })
+                }
+              }
+
+              if (midBlocks > 0 && midBlocks < totalBlocks && totalBlocks > (headBlocks + tailBlocks + midBlocks + 4)) {
+                const midCenter = startBlock + Math.floor(totalBlocks / 2)
+                const midStart = Math.max(startBlock, Math.min(endBlock - 1, midCenter - Math.floor(midBlocks / 2)))
+                const midEnd = Math.min(endBlock, midStart + midBlocks)
+                const headEnd = Math.min(endBlock, startBlock + headBlocks)
+                const tailStart = Math.max(startBlock, endBlock - tailBlocks)
+                const overlapsHead = midStart < headEnd && midEnd > startBlock
+                const overlapsTail = midStart < endBlock && midEnd > tailStart
+                if (!overlapsHead && !overlapsTail && midEnd > midStart) {
+                  console.log('[API] Prefetch mid range (blobs):', (midEnd - midStart), 'blocks')
+                  const midRange = core.download({ start: midStart, end: midEnd })
+                  activeRangeRequests.get(prefetchKey)?.ranges.push(midRange)
+                  midRange.done().then((completed) => {
+                    if (completed === false) return
+                    console.log('[API] Mid prefetch complete (blobs)')
+                  }).catch(err => {
+                    console.log('[API] Mid prefetch error (blobs):', err?.message)
+                  })
+                }
+              }
+            }
+
             const startInitPrefetch = () => {
               // Head prefetch: prioritize container headers and early samples.
               if (headBlocks > 0 && headBlocks < totalBlocks) {
@@ -3410,53 +3463,20 @@ export function createApi({
                   markPlaybackTiming(blobCoreKeyHex, 'head-local', downloadSpeed > 0 ? `${(downloadSpeed / 1048576).toFixed(2)}MB/s` : '')
                   resolvePlaybackReady?.()
                   startFullDownload()
+                  // Front index is local and the player can start — now it is
+                  // safe to pre-warm the end/middle without stealing startup
+                  // bandwidth.
+                  startTailMidPrefetch()
                 }).catch(err => {
                   console.log('[API] Head prefetch error (blobs):', err?.message)
                   logBlobDownloadDiagnostics('startup-head-download-error', core, startBlock, headEnd)
                   if (headTimeout) clearTimeout(headTimeout)
                   startFullDownload()
+                  startTailMidPrefetch()
                 })
               } else {
                 startFullDownload()
-              }
-
-              // Tail prefetch: helps players that seek for indices (MP4 moov-at-end, MKV cues).
-              if (tailBlocks > 0 && tailBlocks < totalBlocks) {
-                const tailStart = Math.max(startBlock, endBlock - tailBlocks)
-                // Avoid duplicating the head range on tiny files.
-                if (tailStart > startBlock + Math.max(1, headBlocks)) {
-                  console.log('[API] Prefetch tail range (blobs):', (endBlock - tailStart), 'blocks')
-                  const tailRange = core.download({ start: tailStart, end: endBlock })
-                  activeRangeRequests.get(prefetchKey).ranges.push(tailRange)
-                  tailRange.done().then((completed) => {
-                    if (completed === false) return
-                    console.log('[API] Tail prefetch complete (blobs)')
-                  }).catch(err => {
-                    console.log('[API] Tail prefetch error (blobs):', err?.message)
-                  })
-                }
-              }
-
-              // Mid prefetch: some files place indexes/headers in the middle; keep it small.
-              if (midBlocks > 0 && midBlocks < totalBlocks && totalBlocks > (headBlocks + tailBlocks + midBlocks + 4)) {
-                const midCenter = startBlock + Math.floor(totalBlocks / 2)
-                const midStart = Math.max(startBlock, Math.min(endBlock - 1, midCenter - Math.floor(midBlocks / 2)))
-                const midEnd = Math.min(endBlock, midStart + midBlocks)
-                const headEnd = Math.min(endBlock, startBlock + headBlocks)
-                const tailStart = Math.max(startBlock, endBlock - tailBlocks)
-                const overlapsHead = midStart < headEnd && midEnd > startBlock
-                const overlapsTail = midStart < endBlock && midEnd > tailStart
-                if (!overlapsHead && !overlapsTail && midEnd > midStart) {
-                  console.log('[API] Prefetch mid range (blobs):', (midEnd - midStart), 'blocks')
-                  const midRange = core.download({ start: midStart, end: midEnd })
-                  activeRangeRequests.get(prefetchKey).ranges.push(midRange)
-                  midRange.done().then((completed) => {
-                    if (completed === false) return
-                    console.log('[API] Mid prefetch complete (blobs)')
-                  }).catch(err => {
-                    console.log('[API] Mid prefetch error (blobs):', err?.message)
-                  })
-                }
+                startTailMidPrefetch()
               }
             }
 


### PR DESCRIPTION
## Problem (from real `[PlaybackTiming]` logs)

Startup on a slow single seeder is dominated by the **front-loaded MP4 `moov` index**. On an 8.5GB / 130k-block file, the player reads from byte 0 and only jumps to real media at **byte ~22.8MB**:

```
Video range HTTP: GET bytes=0-8573979135 …            ← reading from byte 0
Blob range priority: bytes 22872064-… blocks 349-862  ← first media sample at 22.8MB
```

That 22MB is the moov, and a native `<video>` **cannot render a frame until the entire moov is local**. The seeder delivers only a few hundred KB/s (`inflight: 160`, `data: rx ~9`), so first frame takes **~30s** — and `head-local` never even fired.

Meanwhile the startup prefetch was firing the head range **and** a speculative **tail (~257 blocks at EOF) + mid (~33 blocks)** index pre-warm *concurrently*. On a bandwidth-starved peer those ~290 far-away blocks steal delivery slots from the front moov the player is actually blocked on.

## Change

Defer the tail/mid pre-warm until the **head range is local** (or errors / is skipped for tiny files), so during startup 100% of the peer's throughput goes at the front index.

- Front-moov files (the common case, incl. the file in the logs): never need tail/mid during startup → faster first frame.
- Back-moov files: still get their index via the player's own **reactive range request + forward-fill**, so deferring is safe — it only stops the speculative pre-warm from competing before the player can start.

Pure scheduling change; no behavior change once playback is running.

## Honest scope

This recovers the bandwidth that was being wasted on tail/mid during startup, but the dominant cost remains **22MB of mandatory front index ÷ a slow single seeder**. The durable fixes are more/faster seeders or a non-monolithic index (fragmented MP4) — neither is a client scheduling change. Builds on the cap + `[PlaybackTiming]` instrumentation from #473.

## Testing

Not run locally (no deps/native toolchain in this env). Verify by rebuilding desktop and watching the `[PlaybackTiming]` line — `head-local` should now appear meaningfully sooner, and `[API] Prefetch tail/mid` should log only *after* the head completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jq5hQqjY5HcCDhm2SwJqS5)_