### PR TITLE
perf(playback): fast failover for half-open peer connections

### DIFF
--- a/packages/backend/src/api.js
+++ b/packages/backend/src/api.js
@@ -40,6 +40,25 @@ function isSeedingAuthorizationError(err) {
 }
 
 const PLAYBACK_STARTUP_PREFETCH_TIMEOUT_MS = 10000
+// If a blob has synced peers but not one block has arrived in this window, the
+// connection is almost certainly half-open (handshaked + synced, but unable to
+// move data — observed: ~42s of zero data before hyperswarm's own ~56s timeout
+// redials and blocks then flow at full speed). Drop the non-delivering
+// connection so the swarm redials a fresh one in seconds. One shot per playback.
+const PLAYBACK_STALL_RECONNECT_MS = 7000
+
+// Best-effort extraction of a hypercore replication peer's 64-hex public key,
+// to match it against a swarm connection's remotePublicKey.
+function extractPeerKeyHex(peer) {
+  try {
+    const key = peer?.remotePublicKey || peer?.stream?.remotePublicKey || peer?.publicKey
+    if (!key) return null
+    const hex = typeof key === 'string' ? key : b4a.toString(key, 'hex')
+    return /^[a-f0-9]{64}$/i.test(hex) ? hex.toLowerCase() : null
+  } catch {
+    return null
+  }
+}
 const PLAYBACK_STATS_HANDOFF_TIMEOUT_MS = 250
 const BLOB_PREFETCH_DISCOVERY_FLUSH_TIMEOUT_MS = 1500
 const BLOB_PREFETCH_CORE_UPDATE_TIMEOUT_MS = 2500
@@ -3114,10 +3133,17 @@ export function createApi({
           let lastUploadBytes = 0
           const downloadedIndices = new Set()
           let assumedComplete = wasCached
+          let stallReconnectTimer = null
+          const clearStallReconnect = () => {
+            if (stallReconnectTimer) { clearTimeout(stallReconnectTimer); stallReconnectTimer = null }
+          }
 
           const onDownload = (index, byteLength) => {
             if (typeof index !== 'number') return
             if (index < startBlock || index >= endBlock) return
+            // Real data is flowing — the connection is healthy; cancel the
+            // half-open-connection failover.
+            clearStallReconnect()
             if (assumedComplete) {
               assumedComplete = false
               initialAvailable = 0
@@ -3208,9 +3234,45 @@ export function createApi({
           if (!wasCached || videoStats) {
             core.on('download', onDownload)
             core.on('upload', onUpload)
+            // Half-open-connection failover. A peer can complete the swarm
+            // handshake and report `remoteSynced` (so it looks like a healthy
+            // source) yet move zero bytes — the connection is dead in one
+            // direction. Hyperswarm only redials after its own ~56s timeout, so
+            // the player stalls for ~40s+ before data ever flows. If no block
+            // has arrived while synced peers exist, drop those non-delivering
+            // connections so the swarm redials a fresh one in seconds. One shot.
+            if (!wasCached) {
+              stallReconnectTimer = setTimeout(() => {
+                stallReconnectTimer = null
+                if (downloadedBlocks > 0) return
+                try {
+                  const syncedKeys = new Set()
+                  for (const p of (core.peers || [])) {
+                    if (p?.remoteSynced === false) continue
+                    const k = extractPeerKeyHex(p)
+                    if (k) syncedKeys.add(k)
+                  }
+                  if (syncedKeys.size === 0) return
+                  let dropped = 0
+                  for (const conn of (ctx.swarm?.connections || [])) {
+                    const ck = conn?.remotePublicKey ? b4a.toString(conn.remotePublicKey, 'hex').toLowerCase() : null
+                    if (ck && syncedKeys.has(ck)) {
+                      try { conn.destroy() } catch { /* best effort */ }
+                      dropped++
+                    }
+                  }
+                  if (dropped > 0) {
+                    console.log(`[API] Playback stall: 0 blob blocks after ${PLAYBACK_STALL_RECONNECT_MS}ms with ${syncedKeys.size} synced peer(s) — dropped ${dropped} stale connection(s) to force redial`)
+                  }
+                } catch (err) {
+                  console.log('[API] Playback stall reconnect error (non-fatal):', err?.message || err)
+                }
+              }, PLAYBACK_STALL_RECONNECT_MS)
+            }
           }
           if (videoStats) {
             videoStats.registerMonitor(driveKey, videoPath, monitor, () => {
+              clearStallReconnect()
               core.off('download', onDownload)
               core.off('upload', onUpload)
             })
@@ -3245,6 +3307,7 @@ export function createApi({
             if (rangeEntry) {
               rangeEntry.cancel = () => {
                 fillCancelled = true
+                clearStallReconnect()
                 unsubscribePlayhead()
               }
             }

--- a/packages/backend/src/storage.js
+++ b/packages/backend/src/storage.js
@@ -1530,6 +1530,12 @@ export async function initializeStorage(config) {
   swarm.on('connection', (conn, info) => {
     try {
       if (!conn || conn.destroyed) return
+      // Send liveness keepalives more frequently so a half-open connection (one
+      // that handshakes and syncs but then moves no data) is detected and torn
+      // down sooner — the default lets a dead link linger tens of seconds, which
+      // stalls playback until hyperswarm finally redials. Best-effort: not every
+      // stream implementation exposes setKeepAlive.
+      try { conn.setKeepAlive?.(4000) } catch { /* best effort */ }
       const remoteKey = info?.publicKey ? b4a.toString(info.publicKey, 'hex').slice(0, 16) : 'unknown';
       globalNetworkStartupTiming?.record('socket-connected', { key: remoteKey, connections: swarm.connections?.size || 0, connecting: swarm.connecting || 0 })
       globalSwarmDiagnostics?.recordConnection?.(conn, info)


### PR DESCRIPTION
## The real bottleneck (from `[PlaybackTiming]`)

Startup was **not** bandwidth- or moov-bound. On a real session:

```
[PlaybackTiming] … first-block +42609ms block 1
[PlaybackTiming] … first-byte  +42629ms block 0
[PlaybackTiming] … head-local  +50105ms 3.14MB/s
```

For the first **42 seconds** the replicator had `inflight: 97, data rx: 0` — requests into a void. What unblocked it:

```
[PublicFeed] Connection error: conn:1:9c9fb2f7b9cc connection timed out ageMs=56344
[Storage] Peer connected: 9c9fb2f7b9cc  (conn:2)
[API] Blob block downloaded: 1   ← instantly, then 3.14MB/s
```

The single seeder's connection was **half-open**: it completed the swarm handshake and reported `remoteSynced` (so the code treated it as a healthy source) but moved zero bytes. Hyperswarm only gives up after its own ~56s timeout, redials, and the fresh connection delivers immediately. The ~42s is **dead-connection failover latency**, acute because there's exactly one (flaky) peer — no fallback while the dead link lingers.

## Changes

- **`api.js` — stall→reconnect (deterministic fix):** during playback prefetch, if no blob block has arrived within `PLAYBACK_STALL_RECONNECT_MS` (7s) while synced peers exist, drop those non-delivering connections (matched by `remotePublicKey`) so the swarm redials a fresh one. One shot per playback; cleared the instant real data arrives or the session tears down.
- **`storage.js` — keepalive backstop:** best-effort `conn.setKeepAlive(4000)` so a dead link is detected sooner.

## Honest scope / risk

- The **stall→reconnect** is the dependable lever; the **keepalive** is a best-effort backstop whose exact effect on UDX's death timeout I can't verify in this env.
- This touches the swarm/connection layer and was **not runnable locally** (no deps/native toolchain). Needs real-world verification: on the next slow start, look for `[API] Playback stall: … dropped N stale connection(s)` followed by blocks flowing within ~1s, and `first-block` dropping from ~42s to single digits.
- Doesn't manufacture bandwidth — once connected it was already 3.14MB/s; this only removes the ~40s dead-connection wait. More/healthier seeders remain the durable answer.

Builds on the cap (#473) and tail/mid deferral (#474).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jq5hQqjY5HcCDhm2SwJqS5)_