### PR TITLE
fix(playback): advance read-ahead playhead during long streaming responses

### DIFF
--- a/packages/backend/src/blob-range-priority.js
+++ b/packages/backend/src/blob-range-priority.js
@@ -57,6 +57,43 @@ function emitBlobPlayhead(event) {
   }
 }
 
+/**
+ * Emit a playhead update from a long-lived streaming response.
+ *
+ * The Android video range responder serves an open-ended `bytes=N-` request by
+ * streaming the entire remainder of the file in ONE backpressured HTTP response
+ * (video-range-http.js). prioritizeBlobServerRangeRequest therefore fires only
+ * once — at the start — so without this the forward-fill anchors a single
+ * read-ahead window at the open position and never advances, and the window
+ * cache never trims. As that response streams, call this with the live read
+ * block so both followers (PlaybackForwardFill, PlaybackWindowCache) re-anchor
+ * to the real playhead for the whole video, not just the first 128MB.
+ *
+ * @param {{ keyHex: string, blob: { blockOffset: number, blockLength: number, byteLength: number }, blockIndex: number }} params
+ */
+export function publishBlobPlayheadProgress({ keyHex, blob, blockIndex } = {}) {
+  if (typeof keyHex !== 'string' || keyHex.length === 0 || !blob) return
+  const blockOffset = Number(blob.blockOffset)
+  const blockLength = Number(blob.blockLength)
+  const byteLength = Number(blob.byteLength)
+  const windowStart = Number(blockIndex)
+
+  if (!Number.isInteger(blockOffset) || blockOffset < 0) return
+  if (!Number.isInteger(blockLength) || blockLength <= 0) return
+  if (!Number.isFinite(byteLength) || byteLength <= 0) return
+  if (!Number.isInteger(windowStart) || windowStart < blockOffset) return
+  if (windowStart >= blockOffset + blockLength) return
+
+  emitBlobPlayhead({
+    coreKeyHex: keyHex,
+    blockOffset,
+    blockLength,
+    byteLength,
+    windowStart,
+    windowEnd: windowStart,
+  })
+}
+
 function getPriorityRegistryKey(key, blob) {
   return `${key.toString('hex')}:${blob.blockOffset}:${blob.blockLength}`
 }

--- a/packages/backend/src/video-range-http.js
+++ b/packages/backend/src/video-range-http.js
@@ -14,8 +14,18 @@ import {
   getPrioritizedBlobDownloadRange,
   parseHttpByteRange,
   prioritizeBlobServerRangeRequest,
+  publishBlobPlayheadProgress,
 } from './blob-range-priority.js'
 import { markPlaybackTiming } from './playback-timing.js'
+
+// A player that issues one open-ended `bytes=N-` request streams the whole
+// remainder through a single response (writeBlobRange below). Emit a playhead
+// progress event every time the live read advances this far so the forward-fill
+// re-anchors its read-ahead window — and the window cache trims behind — against
+// the real read position instead of freezing at the open position. Kept well
+// under the forward-fill's own 16MB re-anchor cadence so re-anchoring stays
+// smooth; the followers throttle the actual work.
+const PLAYHEAD_PROGRESS_EMIT_BYTES = 4 * 1024 * 1024
 
 function isVideoContentType(type) {
   if (!type) return true
@@ -114,6 +124,7 @@ async function writeBlobRange({ core, blob, start, length, res, isCancelled, key
   let { index, offset } = await resolveStartPosition(core, blob, start)
   const blockEnd = blob.blockOffset + blob.blockLength
   let wroteFirstChunk = false
+  let bytesSincePlayheadEmit = 0
 
   while (remaining > 0 && index < blockEnd) {
     if (isCancelled()) return false
@@ -138,6 +149,18 @@ async function writeBlobRange({ core, blob, start, length, res, isCancelled, key
 
     remaining -= block.byteLength
     index++
+
+    // Advance the playhead followers against the live read position. For a single
+    // open-ended response this is the only signal they get after the opening
+    // request, so without it the read-ahead cushion never moves past its first
+    // anchor and playback settles to the backpressured drain rate (rebuffering).
+    bytesSincePlayheadEmit += block.byteLength
+    if (bytesSincePlayheadEmit >= PLAYHEAD_PROGRESS_EMIT_BYTES) {
+      bytesSincePlayheadEmit = 0
+      try {
+        publishBlobPlayheadProgress({ keyHex, blob, blockIndex: index })
+      } catch { /* progress emit is best-effort; never break serving */ }
+    }
   }
 
   return remaining === 0

--- a/packages/backend/test/blob-range-priority.test.mjs
+++ b/packages/backend/test/blob-range-priority.test.mjs
@@ -10,7 +10,9 @@ import {
   getPrioritizedBlobDownloadRange,
   parseHttpByteRange,
   prioritizeBlobServerRangeRequest,
+  publishBlobPlayheadProgress,
   releaseAllPrioritizedBlobRanges,
+  subscribeBlobPlayhead,
 } from '../src/blob-range-priority.js'
 
 const blobIdEncoding = {
@@ -64,6 +66,40 @@ test('getPrioritizedBlobDownloadRange maps a seek byte range to the matching blo
     getPrioritizedBlobDownloadRange(blob, { start: 98 * 65536, end: (99 * 65536) - 1 }, { readAheadBytes: 4 * 65536 }),
     { start: 108, end: 110, blocks: 2 },
   )
+})
+
+test('publishBlobPlayheadProgress emits a playhead event anchored at the live read block', (t) => {
+  const blob = { blockOffset: 10, blockLength: 100, byteLength: 100 * 65536 }
+  const events = []
+  const unsubscribe = subscribeBlobPlayhead((event) => events.push(event))
+  t.teardown(unsubscribe)
+
+  publishBlobPlayheadProgress({ keyHex: 'ab'.repeat(32), blob, blockIndex: 42 })
+
+  t.is(events.length, 1)
+  t.alike(events[0], {
+    coreKeyHex: 'ab'.repeat(32),
+    blockOffset: 10,
+    blockLength: 100,
+    byteLength: 100 * 65536,
+    windowStart: 42,
+    windowEnd: 42,
+  })
+})
+
+test('publishBlobPlayheadProgress ignores out-of-range or malformed positions', (t) => {
+  const blob = { blockOffset: 10, blockLength: 100, byteLength: 100 * 65536 }
+  const events = []
+  const unsubscribe = subscribeBlobPlayhead((event) => events.push(event))
+  t.teardown(unsubscribe)
+
+  publishBlobPlayheadProgress({ keyHex: 'ab'.repeat(32), blob, blockIndex: 9 }) // before blockOffset
+  publishBlobPlayheadProgress({ keyHex: 'ab'.repeat(32), blob, blockIndex: 110 }) // at blockEnd
+  publishBlobPlayheadProgress({ keyHex: '', blob, blockIndex: 42 }) // no key
+  publishBlobPlayheadProgress({ keyHex: 'ab'.repeat(32), blob: null, blockIndex: 42 }) // no blob
+  publishBlobPlayheadProgress() // no args
+
+  t.is(events.length, 0)
 })
 
 test('getPrioritizedBlobDownloadRange keeps open-ended playback ranges bounded', (t) => {

--- a/packages/backend/test/video-range-http.test.mjs
+++ b/packages/backend/test/video-range-http.test.mjs
@@ -5,7 +5,7 @@ import HypercoreID from 'hypercore-id-encoding'
 import z32 from 'z32'
 
 import { serveVideoRangeHttpRequest } from '../src/video-range-http.js'
-import { releaseAllPrioritizedBlobRanges } from '../src/blob-range-priority.js'
+import { releaseAllPrioritizedBlobRanges, subscribeBlobPlayhead } from '../src/blob-range-priority.js'
 
 const blobIdEncoding = {
   preencode(state, blob) {
@@ -219,6 +219,60 @@ test('serveVideoRangeHttpRequest syncs remote length near the requested seek ran
     calls.find((call) => call[0] === 'has'),
     ['has', 100],
     'remote sync should check the seek target block, not the first block in the blob',
+  )
+})
+
+test('serveVideoRangeHttpRequest advances the playhead while streaming one open-ended response', async (t) => {
+  t.teardown(() => releaseAllPrioritizedBlobRanges())
+  const MB = 1024 * 1024
+  // 8 blocks of 2MB each = 16MB. One open-ended `bytes=0-` request streams the
+  // whole blob through a single response, so the only re-anchor signal the
+  // forward-fill/window-cache get after the opening request is the progress
+  // emit (every 4MB) from inside writeBlobRange.
+  const blob = {
+    blockOffset: 0,
+    blockLength: 8,
+    byteOffset: 0,
+    byteLength: 8 * 2 * MB,
+  }
+  const { key, req } = makeRangeRequest({ blob, range: 'bytes=0-' })
+
+  const events = []
+  const unsubscribe = subscribeBlobPlayhead((event) => {
+    if (event.coreKeyHex === key.toString('hex')) events.push(event)
+  })
+  t.teardown(unsubscribe)
+
+  const core = {
+    peers: [],
+    opened: true,
+    async ready() {},
+    async has() { return true },
+    async seek() { return [0, 0] },
+    async get() { return Buffer.alloc(2 * MB, 1) },
+    download() {
+      return { done: () => Promise.resolve(), destroy: () => {} }
+    },
+    close() {},
+  }
+  const blobServer = {
+    token: 'test-token',
+    async _getCore() { return core },
+  }
+  // Discard streamed bytes so the test does not retain 16MB of chunk strings.
+  const res = new MockResponse([])
+
+  const handled = await serveVideoRangeHttpRequest({ blobServer }, req, res)
+  t.is(handled, true)
+
+  // Initial emit from prioritizeBlobServerRangeRequest anchors at block 0; the
+  // streaming progress emits then advance through the blob (blocks 2, 4, 6).
+  const windowStarts = events.map((event) => event.windowStart)
+  t.ok(windowStarts.includes(0), 'opening request anchors the playhead at the start')
+  t.alike(
+    windowStarts.filter((start) => start > 0),
+    [2, 4, 6],
+    'streaming the single response advances the playhead every 4MB',
   )
 })
 


### PR DESCRIPTION
The Android buffering collapse returns after a video plays for a while: the
P2P download settles under ~1 MB/s and any jitter rebuffers, even though the
peer can deliver several times faster.

PlaybackForwardFill (the deep 128MB read-ahead) and PlaybackWindowCache both
follow the blob-server playhead, which is emitted by
prioritizeBlobServerRangeRequest — once per HTTP range request. But the Android
video responder (video-range-http.js) serves an open-ended `bytes=N-` request,
which ExoPlayer routinely issues, by streaming the entire remainder of the file
through a SINGLE backpressured response. So the playhead fires exactly once, at
the open position: the forward-fill anchors [start, start+128MB], fills it, and
never re-anchors because no further requests arrive. Once playback drains past
that first 128MB cushion (~a few minutes — "a little while"), there is no
read-ahead left and download collapses to the player's drain rate. The window
cache likewise never trims, so a long single-request stream caches the whole
file.

Emit a playhead progress event from inside writeBlobRange as the live read
advances (every 4MB), via the new publishBlobPlayheadProgress. Both followers
re-anchor against the real read position for the whole video — restoring the
deep, rebuffer-resistant cushion past the first request and bounding the
on-disk footprint of a long single-response stream. Robust to chunked players
too: the per-request emits remain, and the progress emits are throttled well
under the forward-fill's 16MB re-anchor cadence, so they are at worst redundant.

- blob-range-priority: export publishBlobPlayheadProgress (validated wrapper
  over emitBlobPlayhead).
- video-range-http: emit progress every 4MB while streaming a response.
- Adds unit + integration tests.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WuJSFHszdpLrk5hT4Jb2zG