### PR TITLE
docs: local-client content moderation — design spec + Phase 1 plan

### DIFF
--- a/docs/superpowers/plans/2026-06-26-local-moderation-phase1.md
+++ b/docs/superpowers/plans/2026-06-26-local-moderation-phase1.md
@@ -536,19 +536,31 @@ git commit -m "feat(moderation): metaDb store with version-keyed verdict invalid
 
 **Files:**
 - Create: `packages/backend/src/moderation/frames.js`
-- Reference: `packages/backend/src/thumbnail.js:215-323` (decode loop to mirror)
+- Reference: `packages/backend/src/thumbnail.js:215-323` (decode loop to mirror);
+  `api.js:2290` (`ctx.blobServer.getLink(coreKey, {...})` → local blob URL)
 
 - [ ] **Step 5.1 — Implement `extractRgbFrames(filePath, { count = 4, size = 224 })`** by
-  adapting the `thumbnail.js` pipeline: open `InputFormatContext`, best video stream, decoder;
-  compute `count` target frame indices spread across `decoder`/duration; for each, scale via
-  `ff.Scaler(inFmt, srcW, srcH, RGB24, size, size)` into a fresh `Frame`; **copy the buffer
-  before `unref`** and push `{ data: Buffer, width: size, height: size, channels: 3 }`. Return
-  `[]` on any failure (fail-open). Differences from `thumbnail.js`: `dstPixelFormat = RGB24`
-  (not the image-encoder format), multiple indices, no encoding.
+  adapting the `thumbnail.js` pipeline (via `createFileReadIOContext`): open
+  `InputFormatContext`, best video stream, decoder; compute `count` indices spread across the
+  duration; for each, scale via `ff.Scaler(inFmt, srcW, srcH, RGB24, size, size)` into a fresh
+  `Frame`; **copy the buffer before `unref`** and push `{ data: Buffer, width: size, height:
+  size, channels: 3 }`. Return `[]` on any failure (fail-open). Differences from
+  `thumbnail.js`: `dstPixelFormat = RGB24`, multiple indices, no encoding.
 
-- [ ] **Step 5.2 — Test** `moderation-frames.test.mjs`: against a tiny bundled test video
-  (add `packages/backend/test/fixtures/sample.mp4` if none exists), assert it returns N frames
-  of `size*size*3` bytes; assert `[]` for a missing file. Run with brittle. Commit.
+- [ ] **Step 5.2 — Implement `resolveClassifiableSource({ blobsCoreKey, blobId, thumbnailBlobsCoreKey, thumbnailBlobId, blobServer, kind })`**
+  → a local file path or null. P2P/playback code only has blob refs + a blob-server URL, **not**
+  a filesystem path, so materialize bytes into a bounded temp file:
+  - `kind:'thumb'` → fetch the small thumbnail blob from
+    `blobServer.getLink(thumbnailBlobsCoreKey, { blob: thumbnailBlobId })` to a temp file.
+  - `kind:'video'` → only if bytes are already local (seeded/cached); stream a **bounded
+    prefix** (covering the sampled frame range) from `blobServer.getLink(blobsCoreKey, { blob:
+    blobId })` to a temp file; if not local yet, return null (fail-open, classify later).
+  Caller deletes the temp file after `extractRgbFrames`.
+
+- [ ] **Step 5.3 — Test** `moderation-frames.test.mjs` (red → green): against a tiny bundled
+  fixture (`packages/backend/test/fixtures/sample.mp4`), assert `extractRgbFrames` returns N
+  frames of `size*size*3` bytes; assert `[]` for a missing file. Run `npx brittle
+  test/moderation-frames.test.mjs`. Commit.
 
 ### Task 6: NsfwClassifier (ONNX impl + test stub)
 
@@ -573,7 +585,7 @@ export class StubClassifier {
   (Task 7) and re-run.
 
 - [ ] **Step 6.3 — Implement `OnnxClassifier`** (only if Chunk 0 PASSED for the platform):
-  mirror `semantic-finder.js:60-110` lazy-load with the string-concatenated import,
+  mirror `packages/backend/src/search/semantic-finder.js:60-110` lazy-load with its string-concatenated import,
   `env.allowRemoteModels=false`, `env.localModelPath`, `env.backends.onnx.wasm.wasmPaths`, a
   load timeout, and **fail-open** (`classifyFrames` returns `none` scores + sets an
   `available=false` diagnostic flag if load failed — never throws to the caller). Build
@@ -601,17 +613,22 @@ git commit -m "feat(moderation): raw-RGB frame sampler + NsfwClassifier (ONNX + 
 - Test: `packages/backend/test/moderation-orchestrator.test.mjs`
 
 - [ ] **Step 7.1 — Implement `Moderation`** holding `{ store, classifier }` with:
-  - `async classifyVideo({ blobsCoreKey, filePath })` → if `store.getSelfVerdict` hit, return
-    it; else `extractRgbFrames` → `classifier.classifyFrames` → reduce to `maxCategory` +
-    max score → `store.putSelfVerdict` → return. Fail-open: on any throw, return
-    `{ category:'none', score:0 }` and do not cache a poisoned verdict.
-  - `async getEffectiveVerdict({ blobsCoreKey })` → read policy + self-verdict + override →
-    call `resolveModerationAction({ override, localVideo: selfVerdict })` (Phase 1 has no
-    labels/thumb-pass split unless implemented; pass `localVideo` for the authoritative pass
-    and optionally `localThumb` for the thumbnail pass) → return the resolver result.
-  - `async applyModeration(videos)` → map each video to `{ ...video, moderation }`, dropping
-    those whose `action === 'hide'`. **Pure local-cache reads only** (spec §3.3 hot-path rule)
-    — no classify, no network here.
+  - `async classifyOne({ blobKey, sourceRefs, kind, blobServer })` → if
+    `store.getSelfVerdict(blobKey)` hits, return it; else `resolveClassifiableSource(...)` →
+    `extractRgbFrames(path)` → `classifier.classifyFrames` → reduce to `maxCategory` + max
+    score → `store.putSelfVerdict(blobKey, verdict)` → delete temp → return. Fail-open: on any
+    throw or null source, return `{ category:'none', score:0 }` and do **not** cache it.
+    `kind:'thumb'` keys on `thumbnailBlobsCoreKey`; `kind:'video'` on `blobsCoreKey` (spec §3.1).
+  - `async getEffectiveVerdict({ blobsCoreKey, thumbnailBlobsCoreKey })` → read policy +
+    override + `store.getSelfVerdict(blobsCoreKey)` (authoritative `localVideo`) +
+    `store.getSelfVerdict(thumbnailBlobsCoreKey)` (weak `localThumb`) →
+    `resolveModerationAction({ override, localVideo, localThumb }, policy)` → return the result
+    (with its nested `badge`).
+  - `async applyModeration(videos)` → for each, `getEffectiveVerdict(...)`, attach a
+    **flattened wire** `moderation` `{ action, category, source, score, badgeLocal,
+    badgeTrusted, badgeSelfReported, badgeAdvisory }` (map the resolver's nested `badge.*`), and
+    drop `action === 'hide'`. **Pure local-cache reads only** (spec §3.3) — no classify, no
+    network here.
 - [ ] **Step 7.2 — Tests:** classifyVideo caches + reuses; getEffectiveVerdict honors override;
   applyModeration drops `hide` and keeps `blur`/`show` with the field. Run, commit.
 
@@ -630,11 +647,11 @@ git commit -m "feat(moderation): raw-RGB frame sampler + NsfwClassifier (ONNX + 
   policy change doesn't serve stale filtered results — spec §3.3), or invalidate
   `listVideosCache` on `setPolicy`/`setOverride`. Choose invalidation: simplest correct option
   is to apply `applyModeration` *after* reading from `listVideosCache`.
-- [ ] **Step 8.3 — Background classify trigger:** on first playback / thumbnail resolution
-  (e.g. in `getVideoThumbnail`/playback URL path), fire-and-forget
-  `context.moderation.classifyVideo({ blobsCoreKey, filePath })` in the `bare-worker` so the
-  next `listVideos` has a verdict. Never block playback. Only when `policy.mode !== 'off'`
-  (dormant when off, spec §6).
+- [ ] **Step 8.3 — Background classify trigger:** when a thumbnail resolves
+  (`getVideoThumbnail`, `api.js:2290`) fire-and-forget `moderation.classifyOne({ blobKey:
+  thumbnailBlobsCoreKey, kind:'thumb', sourceRefs, blobServer: ctx.blobServer })`; on playback,
+  when video bytes are local, schedule the `kind:'video'` pass. Run in the `bare-worker`; never
+  block playback/thumbnail. Skip entirely when `policy.mode === 'off'` (dormant, spec §6).
 - [ ] **Step 8.4 — Add RPC handlers** (methods object in `api.js`): `getModerationPolicy`,
   `setModerationPolicy` (validates), `setContentOverride`, `classifyVideo`. Follow the existing
   method-registration pattern in the `api.js` returned object.
@@ -681,20 +698,30 @@ ns.register({
   category map to `explicitAction`/`suggestiveAction` for the wire; the backend re-inflates to
   `categories`.)
 
-- [ ] **Step 9.2 — Register RPC methods** on `rpcNs`: `getModerationPolicy` (empty →
-  moderation-policy), `setModerationPolicy` (moderation-policy → moderation-policy),
-  `setContentOverride` ({blobsCoreKey, action} → empty), `classifyVideo` ({blobsCoreKey,
-  videoId, channelKey} → moderation-verdict). Match the request/response pattern of existing
-  methods in the file.
+- [ ] **Step 9.2 — Register named request types** in `schema.cjs` (HRPC needs named types,
+  not inline shapes): `set-content-override-request { blobsCoreKey: string, action: string }`
+  and `classify-video-request { blobsCoreKey, videoId, channelKey, thumbnailBlobsCoreKey }`.
 
-- [ ] **Step 9.3 — Regenerate:** `npm run schema:full` (regenerates JS + copies Swift). Verify
-  no errors.
+- [ ] **Step 9.3 — Register RPC methods** on `rpcNs` (~`schema.cjs:2682`):
+  `getModerationPolicy` (empty → moderation-policy), `setModerationPolicy` (moderation-policy →
+  moderation-policy), `setContentOverride` (set-content-override-request → empty),
+  `classifyVideo` (classify-video-request → moderation-verdict). Match the existing method
+  pattern.
 
-- [ ] **Step 9.4 — Expose** the new methods through `create-client.js` (a `moderation`
-  namespace) and `rpc.shared.ts` (app-facing facade), following how `video`/`feed` namespaces
-  are wired.
+- [ ] **Step 9.4 — Register the app-facing namespace (REQUIRED).** Add a `moderation` entry
+  listing these commands to `APP_RPC_NAMESPACES` in
+  `packages/spec/lib/app-rpc-adapter-codegen.cjs` (line 7). An HRPC command absent from this
+  map makes `schema:full` fail as an *unclassified command* and leaves
+  `NAMESPACE_METHODS.moderation` undefined.
 
-- [ ] **Step 9.5 — Commit** (schema, generated output, protocol, platform).
+- [ ] **Step 9.5 — Regenerate:** `npm run schema:full` (JS + Swift). Expected: clean, no
+  "unclassified command" error; generated `app-rpc-adapter.mjs` lists `moderation`.
+
+- [ ] **Step 9.6 — Expose** the `moderation` namespace through `create-client.js` and
+  `rpc.shared.ts`, following the `video`/`feed` wiring. The api handler (Task 8.4) returns the
+  **flattened** `moderation-verdict` (`badge.local → badgeLocal`, etc.).
+
+- [ ] **Step 9.7 — Commit** (schema, generated output, adapter codegen, protocol, platform).
 
 **→ Plan review checkpoint.**
 
@@ -710,8 +737,9 @@ screen, and the video card component.
   switch (off→blur), and when on, an "explicit content" choice (blur/hide) and a
   "blur suggestive" toggle. Wire to `getModerationPolicy`/`setModerationPolicy` via the
   platform facade. Default reflects OFF.
-- [ ] **Step 10.2 — NSFW badge.** On each video card, if `video.moderation?.badge*` is set,
-  render a small "NSFW"/"may be explicit" badge (always visible, even in show mode — spec G4).
+- [ ] **Step 10.2 — NSFW badge.** On each video card, if any of
+  `video.moderation?.badgeLocal | badgeTrusted | badgeSelfReported | badgeAdvisory` is set,
+  render a small "NSFW / may be explicit" badge (always visible, even in show mode — spec G4).
 - [ ] **Step 10.3 — Blur overlay.** If `video.moderation?.action === 'blur'`, render the
   thumbnail behind a blur + tap-to-reveal overlay. (`hide` videos are already absent from the
   list — filtered server-side.)

--- a/docs/superpowers/plans/2026-06-26-local-moderation-phase1.md
+++ b/docs/superpowers/plans/2026-06-26-local-moderation-phase1.md
@@ -1,0 +1,752 @@
+# Local-Client Moderation — Phase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use subagent-driven-development (if subagents available) or executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the *local-only* content-moderation slice of PearTube: an on-device NSFW
+classifier whose verdicts (plus a local policy and per-video user override) drive a
+fail-open view filter that blurs/hides/badges videos — entirely client-side, no network
+labels.
+
+**Architecture:** Five backend modules under `packages/backend/src/moderation/` (pure
+`verdict` resolver, `policy`, metaDb `store`, raw-RGB `frames` sampler, `classifier`) plus an
+`index` orchestrator wired into `api.js` `listVideos`; HRPC schema additions for policy /
+override / verdict; an opt-in settings toggle + NSFW badge + tap-to-reveal blur in the app.
+Moderation ships **OFF by default** (per spec §13 D4) and uses **no network trust set** (D3a)
+— the local model is the sole enforcer once enabled.
+
+**Tech Stack:** Node/Bare (backend), `bare-ffmpeg` (frame decode), `@xenova/transformers`
+ONNX (classifier PoC), Hyperbee `metaDb` (storage), Hyperschema/HRPC (`packages/spec`),
+Expo/React Native + Expo-web (app), `brittle` (backend tests).
+
+**Spec:** `docs/superpowers/specs/2026-06-26-local-client-moderation-design.md` (rev 5,
+review-approved). This plan implements **Phase 1 + Phase 1a only**; signed labels, trusted-set
+crowd, and seeding control are Phase 2 (separate plan).
+
+---
+
+## File structure (Phase 1)
+
+| File | Responsibility |
+|------|----------------|
+| `packages/backend/src/moderation/verdict.js` *(new)* | Pure severity-lattice resolver + category constants. No I/O. |
+| `packages/backend/src/moderation/policy.js` *(new)* | `defaultPolicy()`, `validatePolicy()`, `normalizePolicy()`. Pure. |
+| `packages/backend/src/moderation/store.js` *(new)* | metaDb read/write: policy, self-verdict (version-keyed), override. |
+| `packages/backend/src/moderation/frames.js` *(new)* | Raw-RGB24 multi-frame sampler (reuses the `thumbnail.js` decode pipeline). |
+| `packages/backend/src/moderation/classifier.js` *(new)* | `NsfwClassifier` interface, ONNX impl (spike-gated), deterministic test stub. |
+| `packages/backend/src/moderation/index.js` *(new)* | Orchestrator: `classifyVideo`, `getEffectiveVerdict`, `applyModeration`. |
+| `packages/backend/src/api.js` *(modify)* | View filter in `listVideos`; RPC method handlers; background classify trigger. |
+| `packages/spec/schema.cjs` *(modify)* | `moderation-policy`, `moderation-verdict` types; `video.moderation`; RPC methods. |
+| `packages/protocol/src/create-client.js` *(modify)* | Expose `moderation` namespace methods. |
+| `packages/platform/src/rpc.shared.ts` *(modify)* | App-facing facade for moderation RPC. |
+| `packages/app/...` *(modify)* | Settings toggle, NSFW badge, blur overlay, override action. |
+| `packages/backend/test/moderation-*.test.mjs` *(new)* | brittle tests for verdict/policy/store/classifier. |
+
+---
+
+## Chunk 0: Phase 1a feasibility spike (go/no-go gate)
+
+**Purpose:** Prove the bundled-ONNX-on-raw-RGB classifier actually runs in the BareKit
+(mobile) and Electrobun (desktop) worker runtimes before building on it (spec §5.1). This is
+exploratory; its output is a decision + the chosen classifier backend, not shipped product
+code. **Do not start Chunk 3 until this passes or routes to native.**
+
+- [ ] **Step 0.1 — Pick + fetch a small int8 model.** Choose a MobileNetV2-class NSFW
+  image-classification model exported to ONNX int8 (2–5 MB). Place it under
+  `packages/backend/assets/moderation/nsfw-mnv2-int8/` (model + `config.json` +
+  `preprocessor_config.json` as transformers.js expects for a local model). Record the
+  chosen `classifierVersion` string (e.g. `nsfw-mnv2-int8@1`).
+
+- [ ] **Step 0.2 — Write a standalone spike script** `scripts/moderation-spike.mjs` that, in a
+  `bare-worker` (mirror the worker-spawn pattern in `packages/backend/src/mirror/seeder.js`):
+  - sets `env.allowRemoteModels = false`, `env.localModelPath = <assets dir>`, and
+    `env.backends.onnx.wasm.wasmPaths = <bundled ort-wasm dir>`;
+  - decodes one RGB24 224×224 frame from a sample video via `bare-ffmpeg` (reuse
+    `thumbnail.js` decode; force `dstPixelFormat = RGB24`);
+  - builds a transformers.js `RawImage(buffer, 224, 224, 3)` and runs
+    `pipeline('image-classification', localModelId)`;
+  - logs: cold-load ms, per-frame ms, peak RSS, and the label output.
+
+- [ ] **Step 0.3 — Run on desktop (Electrobun/Node-Bare).** `node scripts/moderation-spike.mjs`.
+  Expected: a label + scores printed, load < ~3 s, per-frame < ~50 ms. Capture numbers.
+
+- [ ] **Step 0.4 — Run inside the mobile BareKit worklet** (iOS + Android dev client). Expected:
+  same — model loads, classification returns. Capture numbers + any module-load failures
+  (transformers.js imports `sharp`/`onnxruntime-node` at module scope; note whether the Bare
+  bundler tolerates the dynamic, string-concatenated import used in `semantic-finder.js:65`).
+
+- [ ] **Step 0.5 — Decide & record.** Append a "Phase 1a results" note to the spec's §5.1 with
+  the measured numbers and the decision: **PASS** (use ONNX `classifier.js` everywhere that
+  passed) or **PER-PLATFORM FALLBACK** (that platform skips to native Core ML/TFLite behind the
+  same `NsfwClassifier` interface — file a Phase-3 task; for Phase 1 that platform reports the
+  verdict as `unknown` = fail-open). Commit the assets + spike script + results note.
+
+```bash
+git add packages/backend/assets/moderation scripts/moderation-spike.mjs docs/superpowers/specs/2026-06-26-local-client-moderation-design.md
+git commit -m "spike(moderation): validate bundled ONNX raw-RGB classifier on Bare/Electrobun"
+```
+
+---
+
+## Chunk 1: Pure core — verdict resolver + policy
+
+The heart of the design (spec §3.3). Pure functions, zero I/O, fully unit-testable. Build
+this first; everything else depends on it.
+
+### Task 1: Category constants + severity helpers
+
+**Files:**
+- Create: `packages/backend/src/moderation/verdict.js`
+- Test: `packages/backend/test/moderation-verdict.test.mjs`
+
+- [ ] **Step 1.1 — Write the failing test** (`moderation-verdict.test.mjs`):
+
+```js
+import test from 'brittle'
+import { CATEGORY, severity, maxCategory } from '../src/moderation/verdict.js'
+
+test('severity orders categories explicit > suggestive > none', (t) => {
+  t.ok(severity(CATEGORY.EXPLICIT) > severity(CATEGORY.SUGGESTIVE))
+  t.ok(severity(CATEGORY.SUGGESTIVE) > severity(CATEGORY.NONE))
+  t.is(severity('garbage'), 0) // unknown treated as none
+})
+
+test('maxCategory picks the strongest', (t) => {
+  t.is(maxCategory([CATEGORY.NONE, CATEGORY.SUGGESTIVE, CATEGORY.EXPLICIT]), CATEGORY.EXPLICIT)
+  t.is(maxCategory([CATEGORY.NONE]), CATEGORY.NONE)
+  t.is(maxCategory([]), CATEGORY.NONE)
+})
+```
+
+- [ ] **Step 1.2 — Run, verify it fails:** `cd packages/backend && npx brittle test/moderation-verdict.test.mjs` → FAIL (module not found).
+
+- [ ] **Step 1.3 — Implement** (`verdict.js`, part 1):
+
+```js
+// Pure moderation verdict resolver — no I/O. Implements spec §3.3 severity lattice.
+export const CATEGORY = Object.freeze({
+  NONE: 'none',
+  SUGGESTIVE: 'nsfw-suggestive',
+  EXPLICIT: 'nsfw-explicit'
+})
+
+const SEVERITY = Object.freeze({
+  [CATEGORY.NONE]: 0,
+  [CATEGORY.SUGGESTIVE]: 1,
+  [CATEGORY.EXPLICIT]: 2
+})
+
+export function severity (category) {
+  return SEVERITY[category] || 0
+}
+
+export function maxCategory (categories) {
+  let best = CATEGORY.NONE
+  for (const c of categories) if (severity(c) > severity(best)) best = c
+  return best
+}
+```
+
+- [ ] **Step 1.4 — Run, verify pass.** Then commit:
+
+```bash
+git add packages/backend/src/moderation/verdict.js packages/backend/test/moderation-verdict.test.mjs
+git commit -m "feat(moderation): category constants + severity helpers"
+```
+
+### Task 2: The resolver (`resolveModerationAction`)
+
+**Files:**
+- Modify: `packages/backend/src/moderation/verdict.js`
+- Test: `packages/backend/test/moderation-verdict.test.mjs`
+
+- [ ] **Step 2.1 — Write the failing table-driven test.** Cover every spec §3.3 case:
+
+```js
+import { resolveModerationAction } from '../src/moderation/verdict.js'
+
+const POLICY = {
+  mode: 'blur',
+  categories: { 'nsfw-explicit': 'blur', 'nsfw-suggestive': 'show' },
+  trustLocalModel: true,
+  blurThreshold: 1,
+  hideThreshold: 3
+}
+const off = (p) => ({ ...POLICY, ...p })
+
+test('override show beats everything', (t) => {
+  const r = resolveModerationAction({ override: 'show', localVideo: { category: 'nsfw-explicit', score: 1 } }, POLICY)
+  t.is(r.action, 'show'); t.is(r.source, 'override')
+})
+
+test('override hide beats everything', (t) => {
+  const r = resolveModerationAction({ override: 'hide' }, POLICY)
+  t.is(r.action, 'hide'); t.is(r.source, 'override')
+})
+
+test('mode off shows everything', (t) => {
+  const r = resolveModerationAction({ localVideo: { category: 'nsfw-explicit', score: 1 } }, off({ mode: 'off' }))
+  t.is(r.action, 'show'); t.is(r.source, 'policy-off')
+})
+
+test('no signal -> show', (t) => {
+  const r = resolveModerationAction({}, POLICY)
+  t.is(r.action, 'show'); t.is(r.category, 'none')
+})
+
+test('thumbnail-only explicit caps at blur (never hide) even with categories=hide', (t) => {
+  const r = resolveModerationAction(
+    { localThumb: { category: 'nsfw-explicit', score: 1 } },
+    off({ mode: 'hide', categories: { 'nsfw-explicit': 'hide', 'nsfw-suggestive': 'show' } })
+  )
+  t.is(r.action, 'blur') // weakOnly downgrades hide->blur
+})
+
+test('authoritative local explicit under default blur policy -> blur', (t) => {
+  const r = resolveModerationAction({ localVideo: { category: 'nsfw-explicit', score: 0.9 } }, POLICY)
+  t.is(r.action, 'blur'); t.is(r.source, 'local')
+})
+
+test('authoritative local explicit + user categories=hide + mode hide -> hide', (t) => {
+  const r = resolveModerationAction(
+    { localVideo: { category: 'nsfw-explicit', score: 0.9 } },
+    off({ mode: 'hide', categories: { 'nsfw-explicit': 'hide', 'nsfw-suggestive': 'show' } })
+  )
+  t.is(r.action, 'hide')
+})
+
+test('single trusted label -> blur, never hide', (t) => {
+  const r = resolveModerationAction({ trustedCount: { 'nsfw-explicit': 1, 'nsfw-suggestive': 1 } }, POLICY)
+  t.is(r.action, 'blur')
+})
+
+test('hideThreshold distinct trusted labelers -> hide when mode allows', (t) => {
+  const r = resolveModerationAction(
+    { trustedCount: { 'nsfw-explicit': 3, 'nsfw-suggestive': 3 } },
+    off({ mode: 'hide' })
+  )
+  t.is(r.action, 'hide')
+})
+
+test('hideThreshold trusted labelers but mode blur clamps to blur', (t) => {
+  const r = resolveModerationAction({ trustedCount: { 'nsfw-explicit': 3, 'nsfw-suggestive': 3 } }, POLICY)
+  t.is(r.action, 'blur')
+})
+
+test('advisory count never changes action, only badge', (t) => {
+  const r = resolveModerationAction({ advisoryCount: 999 }, POLICY)
+  t.is(r.action, 'show'); t.ok(r.badge)
+})
+
+test('sparse local negative does not lower a trusted positive', (t) => {
+  // localVideo says none/safe, trusted says explicit -> must still raise
+  const r = resolveModerationAction(
+    { localVideo: { category: 'none', score: 0.1 }, trustedCount: { 'nsfw-explicit': 3, 'nsfw-suggestive': 3 } },
+    off({ mode: 'hide' })
+  )
+  t.is(r.action, 'hide')
+})
+```
+
+- [ ] **Step 2.2 — Run, verify it fails** (resolver not defined).
+
+- [ ] **Step 2.3 — Implement `resolveModerationAction`** (append to `verdict.js`):
+
+```js
+const DEFAULT_CATEGORY_POLICY = { 'nsfw-explicit': 'blur', 'nsfw-suggestive': 'show' }
+
+/**
+ * Pure resolver. `inputs` may include: override ('show'|'hide'|null),
+ * localVideo {category,score}|null (authoritative), localThumb {category,score}|null (weak),
+ * selfLabelUp {category}|null, trustedCount { <category>: distinctLabelerKeys }, advisoryCount uint.
+ * Returns { action:'show'|'blur'|'hide', category, source, score, badge }.
+ */
+export function resolveModerationAction (inputs = {}, policy = {}) {
+  const {
+    override = null, localVideo = null, localThumb = null,
+    selfLabelUp = null, trustedCount = {}, advisoryCount = 0
+  } = inputs
+  const mode = policy.mode || 'off'
+  const cats = policy.categories || DEFAULT_CATEGORY_POLICY
+  const trustLocalModel = policy.trustLocalModel !== false
+  const blurThreshold = Math.max(1, policy.blurThreshold || 1)
+  const hideThreshold = Math.max(blurThreshold, policy.hideThreshold || 3)
+  const badge = makeBadge({ localVideo, localThumb, selfLabelUp, trustedCount, advisoryCount, trustLocalModel })
+
+  if (override === 'show') return { action: 'show', category: CATEGORY.NONE, source: 'override', score: 0, badge }
+  if (override === 'hide') return { action: 'hide', category: CATEGORY.NONE, source: 'override', score: 0, badge }
+  if (mode === 'off') return { action: 'show', category: CATEGORY.NONE, source: 'policy-off', score: 0, badge }
+
+  // Collect contributors as { category, strong, source, score }.
+  const contributors = []
+  if (trustLocalModel && localVideo && severity(localVideo.category) > 0) {
+    contributors.push({ category: localVideo.category, strong: true, source: 'local', score: localVideo.score || 0 })
+  }
+  if (trustLocalModel && localThumb && severity(localThumb.category) > 0) {
+    contributors.push({ category: localThumb.category, strong: false, source: 'local', score: localThumb.score || 0 })
+  }
+  if (selfLabelUp && severity(selfLabelUp.category) > 0) {
+    contributors.push({ category: selfLabelUp.category, strong: true, source: 'label', score: 1 })
+  }
+  for (const c of [CATEGORY.EXPLICIT, CATEGORY.SUGGESTIVE]) {
+    const n = trustedCount[c] || 0
+    if (n >= blurThreshold) contributors.push({ category: c, strong: n >= hideThreshold, source: 'label', score: 1 })
+  }
+
+  const C = maxCategory(contributors.map((c) => c.category))
+  if (C === CATEGORY.NONE) return { action: 'show', category: CATEGORY.NONE, source: 'none', score: 0, badge }
+
+  const atC = contributors.filter((c) => c.category === C)
+  const weakOnly = !atC.some((c) => c.strong)
+  const winner = atC.find((c) => c.strong) || atC[0]
+
+  // base action
+  let action
+  if ((trustedCount[C] || 0) >= hideThreshold) action = 'hide'
+  else action = cats[C] || DEFAULT_CATEGORY_POLICY[C] || 'show'
+  if (weakOnly && action === 'hide') action = 'blur'           // weak signals never hide
+  if (mode === 'blur' && action === 'hide') action = 'blur'     // mode clamp
+
+  return { action, category: C, source: winner.source, score: winner.score, badge }
+}
+
+function makeBadge ({ localVideo, localThumb, selfLabelUp, trustedCount, advisoryCount, trustLocalModel }) {
+  const anyLocal = trustLocalModel && ((localVideo && severity(localVideo.category) > 0) || (localThumb && severity(localThumb.category) > 0))
+  const anyTrusted = (trustedCount[CATEGORY.EXPLICIT] || 0) > 0 || (trustedCount[CATEGORY.SUGGESTIVE] || 0) > 0
+  const anyAdvisory = (advisoryCount || 0) > 0
+  if (!anyLocal && !anyTrusted && !selfLabelUp && !anyAdvisory) return null
+  return { local: !!anyLocal, trusted: !!anyTrusted, selfReported: !!selfLabelUp, advisory: !!anyAdvisory }
+}
+```
+
+- [ ] **Step 2.4 — Run, verify all cases pass.** Commit:
+
+```bash
+git add packages/backend/src/moderation/verdict.js packages/backend/test/moderation-verdict.test.mjs
+git commit -m "feat(moderation): severity-lattice resolver with full case coverage"
+```
+
+### Task 3: Policy defaults + validation
+
+**Files:**
+- Create: `packages/backend/src/moderation/policy.js`
+- Test: `packages/backend/test/moderation-policy.test.mjs`
+
+- [ ] **Step 3.1 — Failing test:**
+
+```js
+import test from 'brittle'
+import { defaultPolicy, validatePolicy, normalizePolicy } from '../src/moderation/policy.js'
+
+test('default policy is OFF and B-only', (t) => {
+  const p = defaultPolicy()
+  t.is(p.mode, 'off')
+  t.alike(p.trustedLabelers, [])
+  t.is(p.categories['nsfw-explicit'], 'blur')
+  t.is(p.blurThreshold, 1); t.is(p.hideThreshold, 3)
+})
+
+test('validatePolicy rejects bad thresholds and enums', (t) => {
+  t.ok(validatePolicy(defaultPolicy()).ok)
+  t.absent(validatePolicy({ ...defaultPolicy(), blurThreshold: 0 }).ok)
+  t.absent(validatePolicy({ ...defaultPolicy(), hideThreshold: 0 }).ok) // < blurThreshold
+  t.absent(validatePolicy({ ...defaultPolicy(), mode: 'wat' }).ok)
+  t.absent(validatePolicy({ ...defaultPolicy(), categories: { 'nsfw-explicit': 'nuke' } }).ok)
+})
+
+test('normalizePolicy fills missing fields from defaults', (t) => {
+  const p = normalizePolicy({ mode: 'blur' })
+  t.is(p.mode, 'blur'); t.is(p.hideThreshold, 3)
+})
+```
+
+- [ ] **Step 3.2 — Run, verify fail.**
+
+- [ ] **Step 3.3 — Implement `policy.js`:**
+
+```js
+import { CATEGORY } from './verdict.js'
+
+const MODES = new Set(['off', 'blur', 'hide'])
+const ACTIONS = new Set(['show', 'blur', 'hide'])
+
+export function defaultPolicy () {
+  return {
+    mode: 'off',                                  // spec §13 D4: ships OFF
+    categories: { [CATEGORY.EXPLICIT]: 'blur', [CATEGORY.SUGGESTIVE]: 'show' },
+    trustLocalModel: true,
+    trustedLabelers: [],                          // spec §13 D3a: no defaults
+    blurThreshold: 1,
+    hideThreshold: 3,
+    showAdvisoryBadge: true,
+    seedFlagged: false,                            // seeder-only (Phase 2)
+    seedUnknown: false
+  }
+}
+
+export function validatePolicy (p) {
+  const errors = []
+  if (!MODES.has(p.mode)) errors.push('mode must be off|blur|hide')
+  if (!(p.blurThreshold >= 1)) errors.push('blurThreshold must be >= 1')
+  if (!(p.hideThreshold >= p.blurThreshold)) errors.push('hideThreshold must be >= blurThreshold')
+  for (const [k, v] of Object.entries(p.categories || {})) {
+    if (!ACTIONS.has(v)) errors.push(`category ${k} action must be show|blur|hide`)
+  }
+  return { ok: errors.length === 0, errors }
+}
+
+export function normalizePolicy (partial = {}) {
+  const merged = { ...defaultPolicy(), ...partial }
+  merged.categories = { ...defaultPolicy().categories, ...(partial.categories || {}) }
+  return merged
+}
+```
+
+- [ ] **Step 3.4 — Run, verify pass.** Commit:
+
+```bash
+git add packages/backend/src/moderation/policy.js packages/backend/test/moderation-policy.test.mjs
+git commit -m "feat(moderation): policy defaults (off, B-only) + validation"
+```
+
+**→ Plan review checkpoint: dispatch the reviewer on Chunk 1 before continuing.**
+
+---
+
+## Chunk 2: metaDb store
+
+Persistence for policy, version-keyed self-verdicts, and overrides (spec §8). Hyperbee
+`metaDb` `.get` returns `{ value }`; `.put(key, value)` stores it.
+
+### Task 4: Store read/write + version invalidation
+
+**Files:**
+- Create: `packages/backend/src/moderation/store.js`
+- Test: `packages/backend/test/moderation-store.test.mjs`
+
+- [ ] **Step 4.1 — Failing test** (reuse the metaDb mock shape from
+  `test/api-comments-hyperdb.test.mjs`):
+
+```js
+import test from 'brittle'
+import { ModerationStore } from '../src/moderation/store.js'
+
+function fakeMetaDb () {
+  const m = new Map()
+  return {
+    async get (k) { return m.has(k) ? { value: m.get(k) } : null },
+    async put (k, v) { m.set(k, v) },
+    async del (k) { m.delete(k) }
+  }
+}
+
+test('policy round-trips and defaults when absent', async (t) => {
+  const s = new ModerationStore({ metaDb: fakeMetaDb() })
+  t.is((await s.getPolicy()).mode, 'off')             // default
+  await s.setPolicy({ mode: 'blur' })
+  t.is((await s.getPolicy()).mode, 'blur')
+})
+
+test('self-verdict invalidates on classifierVersion change', async (t) => {
+  const s = new ModerationStore({ metaDb: fakeMetaDb(), classifierVersion: 'v1' })
+  await s.putSelfVerdict('blob1', { category: 'nsfw-explicit', score: 0.9 })
+  t.is((await s.getSelfVerdict('blob1')).category, 'nsfw-explicit')
+  const s2 = new ModerationStore({ metaDb: s.metaDb, classifierVersion: 'v2' })
+  t.is(await s2.getSelfVerdict('blob1'), null)        // stale -> null
+})
+
+test('override round-trips', async (t) => {
+  const s = new ModerationStore({ metaDb: fakeMetaDb() })
+  await s.setOverride('blob1', 'show')
+  t.is(await s.getOverride('blob1'), 'show')
+  await s.setOverride('blob1', null)
+  t.is(await s.getOverride('blob1'), null)
+})
+```
+
+- [ ] **Step 4.2 — Run, verify fail.**
+
+- [ ] **Step 4.3 — Implement `store.js`:**
+
+```js
+import { normalizePolicy, validatePolicy } from './policy.js'
+
+const K_POLICY = 'moderation:policy'
+const kSelf = (blob) => `moderation:self:${blob}`
+const kOverride = (blob) => `moderation:override:${blob}`
+
+export class ModerationStore {
+  constructor ({ metaDb, classifierVersion = 'unknown' } = {}) {
+    this.metaDb = metaDb
+    this.classifierVersion = classifierVersion
+  }
+
+  async getPolicy () {
+    const row = await this.metaDb?.get(K_POLICY)
+    return normalizePolicy(row?.value || {})
+  }
+
+  async setPolicy (partial) {
+    const next = normalizePolicy(partial)
+    const v = validatePolicy(next)
+    if (!v.ok) throw new Error(`invalid moderation policy: ${v.errors.join('; ')}`)
+    await this.metaDb?.put(K_POLICY, next)
+    return next
+  }
+
+  async getSelfVerdict (blobsCoreKey) {
+    const row = await this.metaDb?.get(kSelf(blobsCoreKey))
+    const val = row?.value
+    if (!val) return null
+    if (val.classifierVersion !== this.classifierVersion) return null // stale -> recompute
+    return val
+  }
+
+  async putSelfVerdict (blobsCoreKey, verdict) {
+    await this.metaDb?.put(kSelf(blobsCoreKey), {
+      ...verdict, classifierVersion: this.classifierVersion, ts: Date.now()
+    })
+  }
+
+  async getOverride (blobsCoreKey) {
+    const row = await this.metaDb?.get(kOverride(blobsCoreKey))
+    return row?.value?.action || null
+  }
+
+  async setOverride (blobsCoreKey, action) {
+    if (action == null) { await this.metaDb?.del(kOverride(blobsCoreKey)); return }
+    await this.metaDb?.put(kOverride(blobsCoreKey), { action })
+  }
+}
+```
+
+- [ ] **Step 4.4 — Run, verify pass.** Commit:
+
+```bash
+git add packages/backend/src/moderation/store.js packages/backend/test/moderation-store.test.mjs
+git commit -m "feat(moderation): metaDb store with version-keyed verdict invalidation"
+```
+
+**→ Plan review checkpoint.**
+
+---
+
+## Chunk 3: Frames + classifier (spike-gated)
+
+### Task 5: Raw-RGB24 multi-frame sampler
+
+**Files:**
+- Create: `packages/backend/src/moderation/frames.js`
+- Reference: `packages/backend/src/thumbnail.js:215-323` (decode loop to mirror)
+
+- [ ] **Step 5.1 — Implement `extractRgbFrames(filePath, { count = 4, size = 224 })`** by
+  adapting the `thumbnail.js` pipeline: open `InputFormatContext`, best video stream, decoder;
+  compute `count` target frame indices spread across `decoder`/duration; for each, scale via
+  `ff.Scaler(inFmt, srcW, srcH, RGB24, size, size)` into a fresh `Frame`; **copy the buffer
+  before `unref`** and push `{ data: Buffer, width: size, height: size, channels: 3 }`. Return
+  `[]` on any failure (fail-open). Differences from `thumbnail.js`: `dstPixelFormat = RGB24`
+  (not the image-encoder format), multiple indices, no encoding.
+
+- [ ] **Step 5.2 — Test** `moderation-frames.test.mjs`: against a tiny bundled test video
+  (add `packages/backend/test/fixtures/sample.mp4` if none exists), assert it returns N frames
+  of `size*size*3` bytes; assert `[]` for a missing file. Run with brittle. Commit.
+
+### Task 6: NsfwClassifier (ONNX impl + test stub)
+
+**Files:**
+- Create: `packages/backend/src/moderation/classifier.js`
+- Test: `packages/backend/test/moderation-classifier.test.mjs`
+
+- [ ] **Step 6.1 — Define the interface + a deterministic stub** for tests (no model):
+
+```js
+export class StubClassifier {
+  constructor (map = {}) { this.version = 'stub@1'; this.map = map } // map: frameTag -> {category,score}
+  async classifyFrames (frames) {
+    return frames.map((f, i) => this.map[i] || { category: 'none', score: 0 })
+  }
+}
+```
+
+- [ ] **Step 6.2 — Test fail-open + max-over-frames** using the stub + the orchestrator's
+  reduce (see Task 7): a classifier that throws → verdict `unknown`(=none); frames with one
+  explicit → video verdict explicit (max). Run, fail, then implement reduce in `index.js`
+  (Task 7) and re-run.
+
+- [ ] **Step 6.3 — Implement `OnnxClassifier`** (only if Chunk 0 PASSED for the platform):
+  mirror `semantic-finder.js:60-110` lazy-load with the string-concatenated import,
+  `env.allowRemoteModels=false`, `env.localModelPath`, `env.backends.onnx.wasm.wasmPaths`, a
+  load timeout, and **fail-open** (`classifyFrames` returns `none` scores + sets an
+  `available=false` diagnostic flag if load failed — never throws to the caller). Build
+  `RawImage(frame.data, frame.width, frame.height, 3)` and run `image-classification`; map the
+  model's labels to `CATEGORY` + threshold (explicit ≥ 0.85, suggestive ≥ 0.60). `version` =
+  the `classifierVersion` from Chunk 0.
+
+- [ ] **Step 6.4 — Run tests, commit.**
+
+```bash
+git add packages/backend/src/moderation/frames.js packages/backend/src/moderation/classifier.js packages/backend/test/moderation-frames.test.mjs packages/backend/test/moderation-classifier.test.mjs
+git commit -m "feat(moderation): raw-RGB frame sampler + NsfwClassifier (ONNX + stub, fail-open)"
+```
+
+**→ Plan review checkpoint.**
+
+---
+
+## Chunk 4: Orchestrator + api.js + schema/RPC
+
+### Task 7: Orchestrator (`index.js`)
+
+**Files:**
+- Create: `packages/backend/src/moderation/index.js`
+- Test: `packages/backend/test/moderation-orchestrator.test.mjs`
+
+- [ ] **Step 7.1 — Implement `Moderation`** holding `{ store, classifier }` with:
+  - `async classifyVideo({ blobsCoreKey, filePath })` → if `store.getSelfVerdict` hit, return
+    it; else `extractRgbFrames` → `classifier.classifyFrames` → reduce to `maxCategory` +
+    max score → `store.putSelfVerdict` → return. Fail-open: on any throw, return
+    `{ category:'none', score:0 }` and do not cache a poisoned verdict.
+  - `async getEffectiveVerdict({ blobsCoreKey })` → read policy + self-verdict + override →
+    call `resolveModerationAction({ override, localVideo: selfVerdict })` (Phase 1 has no
+    labels/thumb-pass split unless implemented; pass `localVideo` for the authoritative pass
+    and optionally `localThumb` for the thumbnail pass) → return the resolver result.
+  - `async applyModeration(videos)` → map each video to `{ ...video, moderation }`, dropping
+    those whose `action === 'hide'`. **Pure local-cache reads only** (spec §3.3 hot-path rule)
+    — no classify, no network here.
+- [ ] **Step 7.2 — Tests:** classifyVideo caches + reuses; getEffectiveVerdict honors override;
+  applyModeration drops `hide` and keeps `blur`/`show` with the field. Run, commit.
+
+### Task 8: Wire into api.js + background classify
+
+**Files:**
+- Modify: `packages/backend/src/api.js` (construct `Moderation` near
+  `context.semanticFinder = new SemanticFinder(...)` at `api.js:292`; apply filter inside
+  `listVideos` at `api.js:1428` after `withAvailability` is built and before returning/caching)
+- Test: extend an api test or add `moderation-api.test.mjs`
+
+- [ ] **Step 8.1 — Construct** `context.moderation = new Moderation({ store: new ModerationStore({ metaDb: context.metaDb, classifierVersion }), classifier })`.
+- [ ] **Step 8.2 — Apply the filter** in `listVideos`: replace the returned/cached
+  `withAvailability` value with `await context.moderation.applyModeration(withAvailability)`.
+  Keep the existing cache, but cache the **unfiltered** list and apply moderation on read (so a
+  policy change doesn't serve stale filtered results — spec §3.3), or invalidate
+  `listVideosCache` on `setPolicy`/`setOverride`. Choose invalidation: simplest correct option
+  is to apply `applyModeration` *after* reading from `listVideosCache`.
+- [ ] **Step 8.3 — Background classify trigger:** on first playback / thumbnail resolution
+  (e.g. in `getVideoThumbnail`/playback URL path), fire-and-forget
+  `context.moderation.classifyVideo({ blobsCoreKey, filePath })` in the `bare-worker` so the
+  next `listVideos` has a verdict. Never block playback. Only when `policy.mode !== 'off'`
+  (dormant when off, spec §6).
+- [ ] **Step 8.4 — Add RPC handlers** (methods object in `api.js`): `getModerationPolicy`,
+  `setModerationPolicy` (validates), `setContentOverride`, `classifyVideo`. Follow the existing
+  method-registration pattern in the `api.js` returned object.
+- [ ] **Step 8.5 — Tests + commit.**
+
+### Task 9: Schema + protocol + platform plumbing
+
+**Files:**
+- Modify: `packages/spec/schema.cjs` (types near other `ns.register` blocks; RPC near
+  `rpcNs` at `schema.cjs:2682`)
+- Modify: `packages/protocol/src/create-client.js`, `packages/platform/src/rpc.shared.ts`
+
+- [ ] **Step 9.1 — Register types** in `schema.cjs`:
+
+```js
+ns.register({
+  name: 'moderation-verdict',
+  fields: [
+    { name: 'action', type: 'string', required: true },     // show|blur|hide
+    { name: 'category', type: 'string', required: false },
+    { name: 'source', type: 'string', required: false },
+    { name: 'score', type: 'float', required: false },
+    { name: 'badgeLocal', type: 'bool', required: false },
+    { name: 'badgeTrusted', type: 'bool', required: false },
+    { name: 'badgeSelfReported', type: 'bool', required: false },
+    { name: 'badgeAdvisory', type: 'bool', required: false }
+  ]
+})
+ns.register({
+  name: 'moderation-policy',
+  fields: [
+    { name: 'mode', type: 'string', required: true },
+    { name: 'explicitAction', type: 'string', required: false },
+    { name: 'suggestiveAction', type: 'string', required: false },
+    { name: 'trustLocalModel', type: 'bool', required: false },
+    { name: 'blurThreshold', type: 'uint', required: false },
+    { name: 'hideThreshold', type: 'uint', required: false },
+    { name: 'showAdvisoryBadge', type: 'bool', required: false }
+  ]
+})
+```
+
+  Add optional `moderation` (`moderation-verdict`) to the existing `video` type. (Flatten the
+  category map to `explicitAction`/`suggestiveAction` for the wire; the backend re-inflates to
+  `categories`.)
+
+- [ ] **Step 9.2 — Register RPC methods** on `rpcNs`: `getModerationPolicy` (empty →
+  moderation-policy), `setModerationPolicy` (moderation-policy → moderation-policy),
+  `setContentOverride` ({blobsCoreKey, action} → empty), `classifyVideo` ({blobsCoreKey,
+  videoId, channelKey} → moderation-verdict). Match the request/response pattern of existing
+  methods in the file.
+
+- [ ] **Step 9.3 — Regenerate:** `npm run schema:full` (regenerates JS + copies Swift). Verify
+  no errors.
+
+- [ ] **Step 9.4 — Expose** the new methods through `create-client.js` (a `moderation`
+  namespace) and `rpc.shared.ts` (app-facing facade), following how `video`/`feed` namespaces
+  are wired.
+
+- [ ] **Step 9.5 — Commit** (schema, generated output, protocol, platform).
+
+**→ Plan review checkpoint.**
+
+---
+
+## Chunk 5: App UI (opt-in)
+
+**Files (read first to match patterns):** the feed/list component that renders thumbnails
+(grep `getVideoThumbnail`/`thumbnailBlobsCoreKey` usage in `packages/app/`), the settings
+screen, and the video card component.
+
+- [ ] **Step 10.1 — Settings: moderation toggle.** Add a "Content moderation" section: a master
+  switch (off→blur), and when on, an "explicit content" choice (blur/hide) and a
+  "blur suggestive" toggle. Wire to `getModerationPolicy`/`setModerationPolicy` via the
+  platform facade. Default reflects OFF.
+- [ ] **Step 10.2 — NSFW badge.** On each video card, if `video.moderation?.badge*` is set,
+  render a small "NSFW"/"may be explicit" badge (always visible, even in show mode — spec G4).
+- [ ] **Step 10.3 — Blur overlay.** If `video.moderation?.action === 'blur'`, render the
+  thumbnail behind a blur + tap-to-reveal overlay. (`hide` videos are already absent from the
+  list — filtered server-side.)
+- [ ] **Step 10.4 — Override.** Add a long-press / menu action "Always show" / "Always hide"
+  calling `setContentOverride`; refresh the affected card.
+- [ ] **Step 10.5 — Manual QA** (see Verification) + commit.
+
+**→ Plan review checkpoint (final).**
+
+---
+
+## Verification (whole-feature, after all chunks)
+
+- [ ] `cd packages/backend && npm test` — all `moderation-*.test.mjs` green (run the full
+  suite once at the end, per harness policy).
+- [ ] `npm run typecheck` at root (covers `platform`/`app` TS).
+- [ ] `npm run schema` clean (no drift).
+- [ ] **Manual E2E (desktop, `npm run desktop`):** moderation OFF by default → feed shows
+  everything, no badges, classifier dormant. Turn ON (blur) → seed/playback a known-explicit
+  test clip → after background classify, its card blurs + shows the badge; tap reveals. Set
+  override "Always show" → stays revealed across refresh. Set explicit→hide + mode hide → the
+  card disappears from the feed. Turn moderation OFF again → everything shows.
+- [ ] **Fail-open check:** with the model asset removed/renamed, enabling moderation must NOT
+  empty or freeze the feed (verdict `unknown` → shown); a diagnostic logs the load failure.
+
+---
+
+## Notes for the implementer
+
+- **DRY/YAGNI:** Phase 1 has no labels, no trusted set, no seeding control — do **not** build
+  `label-feed.js`, label signing, or seed quarantine here (Phase 2). The resolver already
+  accepts `trustedCount`/`selfLabelUp` for forward-compat; leave them unfed in Phase 1.
+- **Fail-open is load-bearing.** Every classifier/frame path returns a benign `unknown` on
+  error; the feed must never break because moderation failed.
+- **Hot path purity (spec §3.3):** `listVideos` must only read cached verdicts via the pure
+  resolver — never classify or hit the network inside it.
+- **Dormant when off (spec §6):** when `policy.mode === 'off'`, skip classification entirely.
+- Reference skills with @ as needed: @test-driven-development, @verification-before-completion.

--- a/docs/superpowers/specs/2026-06-26-local-client-moderation-design.md
+++ b/docs/superpowers/specs/2026-06-26-local-client-moderation-design.md
@@ -1,37 +1,48 @@
 # Local-Client Content Moderation — Design
 
-**Status:** Draft / proposal — revision 2 (design dialogue resolved)
+**Status:** Draft / proposal — revision 3 (spec-review hardened)
 **Date:** 2026-06-26
 **Author:** Claude (with @ayooooo123)
 **Branch:** `claude/local-client-moderation-spec-fh5rnx`
 
 ---
 
-## 0. Revision 2 — what changed and why
+## 0. Revision history
 
-Revision 1 proposed pure composable moderation (local self-classification + opt-in
-subscribed labelers + local enforcement) and **deliberately excluded crowd/consensus
-signals** to avoid a censorship lever. The design dialogue reshaped four things:
+- **Rev 1** — pure composable moderation (local self-classification + opt-in subscribed
+  labelers + local enforcement); deliberately excluded crowd signals.
+- **Rev 2** — design dialogue: fail-open + mandatory visibility badge; crowd signal added
+  but split into sybil-resistant trusted-set enforcement vs forgeable advisory-only counts;
+  local model = ground truth, instant only for on-device content; thumbnails are a weak
+  first pass; classifier fed raw RGB to dodge transformers.js image-decode fragility.
+- **Rev 3 (this)** — hardened against a structured spec review. Material changes:
+  1. **Connected peers removed from the enforcement trust set** (a connection is not a
+     scarce identity → sybil hole). Trust set = default relays ∪ explicit subscriptions
+     only; connected peers may be *manually promoted*, never auto-counted (§2).
+  2. **Effective verdict is now a severity lattice, not "first hit wins."** Affirmative
+     signals only ever *raise* severity; weak/unknown/safe never lowers it; advisory counts
+     never enter enforcement; the final action is mapped through `mode` + per-category
+     policy + thresholds. Removes the case where a sparse local false-negative suppressed a
+     dense trusted relay label (§3.3).
+  3. **Advisory `flagSummary` can never influence enforcement** — the resolver's `action`
+     is the *only* enforcement output; advisory data is display-only (§3.3, §11).
+  4. **Concrete label transport.** Each labeler owns an append-only **label feed**
+     (Hyperbee on a Hypercore) advertised by labeler key; subscribers replicate selected
+     feeds; relays serve a bounded `get-content-labels`. Replaces the hand-wavy "pull RPC"
+     (§3.2).
+  5. **Revocation / expiry / model-version invalidation.** Labels carry id + `expiresAt` +
+     supersession; local verdict cache is keyed by `classifierVersion` and invalidated on
+     model upgrade. Nothing is "trusted forever" (§3.1, §3.2, §8).
+  6. **Seeding is fail-*closed* for relays/CLI**, opposite of the viewer's fail-open: a
+     relay downloads the whole file, so it classifies densely and **quarantines** content
+     until a verdict exists; flagged or (by default) unknown content is never durably
+     seeded; a verdict-change hook unseeds already-active blobs (§3.3, §6).
+  7. **A runtime-feasibility spike (Phase 1a) gates Phase 1.** transformers.js still imports
+     `sharp`/`onnxruntime-node`/`onnxruntime-web` at module scope; bypassing image-decode
+     does not prove ORT-WASM loads in BareKit. Phase 1 is contingent on a measured spike;
+     on failure we go straight to native bindings (§5.1, §10).
 
-1. **Fail-open, not fail-closed.** Moderation is a *silent background pass*. It never
-   blocks the feed, never shows a "classifying…" gate. Unrated content is shown. A verdict
-   only ever *removes/blurs* content once it exists.
-2. **Visibility is a first-class goal.** Whenever *any* signal suggests content may be
-   NSFW, the UI must say so clearly — a badge — even when the content is still shown.
-3. **Crowd signal is in — but split into two paths.** Users want "if N people flagged it,
-   hide it." Raw P2P counts are a brigading weapon (keypairs are free → sybils). So:
-   - **Enforcement path = trusted-set counting** (sybil-resistant): only labels the client
-     itself verified, signed by keys in a *trust set* (default relay labelers + user
-     subscriptions + connected peers), are counted toward auto-blur/auto-hide thresholds.
-   - **Advisory path = raw anonymous count** (forgeable): shown as a badge ("N peers
-     flagged"), **never** auto-enforces.
-4. **The local model is ground truth but only *instant for on-device content*.** Inference
-   is milliseconds; the cost is fetching+decoding frames. So the local model protects
-   cached / currently-playing content invisibly, and **labels cover content not yet
-   downloaded**. Thumbnails are a *weak* first-pass signal (a dumb mid-point grab can be a
-   black frame in an otherwise explicit video), never the authoritative verdict.
-
-The decision log is in §13.
+Decision log + open questions: §13.
 
 ---
 
@@ -42,10 +53,9 @@ no central authority and we never want one: anyone can publish anything, and we 
 and do not want to be able to — prevent uploads or sharing.
 
 But "no central authority" must not mean "every user is force-fed explicit content."
-We want **strong, user-controlled protection that is invisible when it works**: a user who
-opts out of sexually explicit material should not see it, the app should make it *clear*
-when content might be NSFW, and **relays/seeders should be able to decline to replicate**
-content they don't want to host.
+A user who opts out of sexually explicit material should not see it; the app must make it
+*clear* when content might be NSFW; and **relays/seeders must be able to decline to
+replicate** content they don't want to host.
 
 ### Goals
 
@@ -53,27 +63,29 @@ content they don't want to host.
   it has on disk is NSFW, with zero trust in anyone else.
 - **G2 — Invisible & efficient.** No 2 GB model. Single-digit-MB classifier, runs off
   frames we *already* decode, on a background thread, never blocking playback or the feed.
-- **G3 — Fail-open, never block.** Unrated content is shown. A verdict only ever removes or
-  blurs content *after* it exists. No "classifying…" gates.
+- **G3 — Viewer fail-open.** On *viewer* clients, unrated content is shown. A verdict only
+  ever removes/blurs content *after* it exists. No "classifying…" gates. (Seeders are the
+  opposite — see G7.)
 - **G4 — Always make NSFW-likelihood visible.** When any signal (local model, trusted
   label, advisory crowd count) suggests NSFW, surface a clear badge — even in show mode.
 - **G5 — Shareable hints (labels).** A client (especially a relay that downloaded the whole
   file) can publish a signed label so other clients pre-hide content *before downloading
   frames*.
 - **G6 — Trust is opt-in and composable; crowd signal is sybil-resistant.** Auto-enforcing
-  thresholds count only verified labels from a *trust set*. Raw anonymous counts are
-  advisory-only and never auto-enforce.
-- **G7 — Seeding control.** A relay/seeder/CLI can flip one switch to refuse to replicate
-  flagged content.
-- **G8 — User override always wins.** Local "show this anyway" / "hide this" beats any
-  classifier or label, in both directions.
+  thresholds count only verified labels from a *trust set* (default relays ∪ explicit
+  subscriptions). Raw anonymous counts are advisory-only and never auto-enforce.
+- **G7 — Seeder fail-closed.** A relay/seeder/CLI flips one switch (`seedFlagged=false`,
+  default) and never durably replicates flagged content; by default it also declines
+  *unknown* content until it classifies it. It quarantines while classifying and unseeds on
+  an adverse later verdict.
+- **G8 — User override always wins**, in both directions (reveal hidden, hide shown).
 
 ### Non-goals
 
 - Preventing uploads or takedowns of content from the network (impossible and undesired in
   a P2P system).
 - A global reputation/consensus system, or treating raw anonymous crowd counts as
-  authoritative. The label format leaves room for reputation later (§13, Q-open).
+  authoritative. The label format leaves room for reputation later (§13 Q3).
 - Perfect classification. We target high-recall NSFW-explicit detection with a conservative
   bias, not legal-grade accuracy.
 
@@ -82,34 +94,35 @@ content they don't want to host.
 ## 2. The hard part: trust, not detection
 
 NSFW *detection* is a solved, small problem (§5). The architectural risk is the **trust
-model**. In a decentralized network a "flag" is just a claim by some peer. Get it wrong and
-you build either a **censorship lever** (one actor's flag hides content for everyone) or
-**noise** (flags nobody trusts).
+model**. A "flag" in a decentralized network is just a claim by some peer. Get it wrong and
+you build either a **censorship lever** (one actor hides content for everyone) or **noise**
+(flags nobody trusts).
 
-We adopt the **AT Protocol / Bluesky "composable moderation"** model — content carries no
-authoritative rating; independent labelers emit signed labels; each client enforces
-locally and can always override — and **extend it with a sybil-resistant crowd signal**:
+We adopt **AT Protocol / Bluesky "composable moderation"** — content carries no
+authoritative rating; independent labelers emit signed labels; each client enforces locally
+and can always override — extended with a **sybil-resistant** crowd signal.
 
-> **Enforcement signals, in precedence order, are all things the client can verify or
-> compute itself:** (1) the user's explicit override, (2) the client's own local model
-> verdict, (3) the count of *verified signed labels from the client's trust set*. A raw
-> count of anonymous flags is shown to the user but never auto-enforces.
+> **Enforcement uses only signals the client can verify or compute itself**, combined by a
+> severity lattice (§3.3): the user's override, the client's own local-model verdict, a
+> verified uploader self-label that flags *up*, and the count of *verified signed labels
+> from the trust set*. Raw anonymous flag counts are shown but **never** auto-enforce.
 
-This maps onto primitives PearTube already has: gossip feed, per-client `metaDb`, selective
-seeding, signed channel/relay writers.
+### The trust set (enforcement)
 
-### Why a trust set instead of raw counts
+"Hide if N people flagged it" is trivially defeated: one attacker mints N keypairs at zero
+cost and buries any target. So auto-enforcing thresholds count flags **only** from keys
+that cost something to be:
 
-"Hide if 10 people flagged it" is trivially defeated: a single attacker generates 10 (or
-10,000) keypairs at zero cost and buries any target. The fix is to **only count flags from
-keys that cost something to be**:
+- **Default relay labelers** — relays run real infrastructure and seed content → expensive
+  to sybil at scale. A small set of relay labeler keys ships with the app
+  (editable/removable). *(Default-set choice flagged for review — §13 D3a.)*
+- **Explicit subscriptions** — labelers the user added by key.
 
-- **Relays** run real infrastructure and seed content → expensive to sybil at scale. A
-  small **default set of relay labeler keys** ships with the app (editable/removable).
-- **Subscribed labelers** the user explicitly added.
-- **Connected peers** the client has actually exchanged data with (weaker, optional).
+**Connected peers are NOT in the enforcement trust set** — a peer connection is not a
+scarce identity (an attacker opens many connections cheaply). A connected peer's flags are
+advisory-only unless the user *manually promotes* that peer's key into `trustedLabelers`.
 
-Counts *within this set* are meaningful; flags from outside it are advisory-only.
+Flags from outside the trust set are advisory-only (§3.2).
 
 ---
 
@@ -118,166 +131,207 @@ Counts *within this set* are meaningful; flags from outside it are advisory-only
 ```
             ┌──────────────────────────────────────────────────────────┐
             │  Layer 1 — LOCAL SELF-CLASSIFICATION  (zero trust)        │
-            │  bare-ffmpeg RGB frames → tiny NSFW model (bare-worker)   │
-            │  multi-frame; thumbnail = cheap first pass, not verdict   │
-            │  → verdict cached in metaDb[moderation:self:<blobsKey>]   │
+            │  bare-ffmpeg RGB24 frames → tiny NSFW model (bare-worker) │
+            │  multi-frame; thumbnail = weak first pass, not verdict    │
+            │  → verdict cached in metaDb, keyed by classifierVersion   │
             └──────────────────────────────────────────────────────────┘
                                    │ produces
                                    ▼
             ┌──────────────────────────────────────────────────────────┐
             │  Layer 2 — SIGNED LABELS  (trust set + advisory crowd)    │
-            │  content-label{ targetBlobsCoreKey, category, score,      │
-            │                 labelerKeyHex, signature }                │
-            │  self-label rides feed-entry; 3rd-party via pull RPC;     │
-            │  advisory count summary rides HAVE_FEED (forgeable)       │
+            │  labeler-owned append-only label FEED (Hyperbee/Hypercore)│
+            │  self-label rides feed-entry (verified writer);           │
+            │  advisory boolean rides HAVE_FEED (forgeable, display-only)│
             └──────────────────────────────────────────────────────────┘
                                    │ informs
                                    ▼
             ┌──────────────────────────────────────────────────────────┐
-            │  Layer 3 — LOCAL ENFORCEMENT  (fail-open + visible badge) │
-            │  effective verdict = override ?? localModel ??            │
-            │      trustedLabelThreshold ?? unknown(show + maybe badge) │
-            │  • view filter: show+badge | blur | hide                  │
-            │  • seed filter: refuse to seed flagged (relays/CLI)       │
+            │  Layer 3 — LOCAL ENFORCEMENT (severity lattice + override)│
+            │  action = resolve(override, local, selfLabelUp, trusted)  │
+            │  • view filter (viewer): show+badge | blur | hide         │
+            │  • seed filter (relay/CLI): quarantine → seed | evict     │
             └──────────────────────────────────────────────────────────┘
 ```
 
-### Layer 1 — Local self-classification (zero trust)
+### 3.1 Layer 1 — Local self-classification (zero trust)
 
 A tiny vision classifier runs **on-device** against frames we already decode. This is
 **ground truth for that user** — the uploader cannot game it because *the user ran it
 themselves*.
 
-- **Input — multi-frame, not thumbnail-only.** The thumbnail (a single mid-point grab) is
-  too dumb to trust: an explicit video can have a black frame at `frameIndex 300`. So:
-  - **Cheap first pass:** classify the thumbnail blob (already decoded for display) for an
-    *immediate* feed signal. Cheap because the thumbnail is a separate, content-addressed
-    Hyperblobs blob (`thumbnailBlobsCoreKey`) fetched in a few KB independently of the
-    video.
-  - **Authoritative pass:** sample N frames across the duration from whatever video bytes
-    are local (default 3–5 viewer-side), extending `generateThumbnail`
-    (`packages/backend/src/thumbnail.js:215`) to loop the same `ff.InputFormatContext` /
-    `ff.Scaler` / `ff.Frame` pipeline over several frame indices.
-  - **Relays sample densely.** A relay/seeder downloads the *whole* file, so it can sample
-    many frames → high-confidence verdict → becomes the natural high-signal labeler (§2).
-- **Output:** per-frame `{ category → score }`; the video verdict is the **max over
-  frames** (conservative: any explicit frame ⇒ explicit).
-- **Cache:** verdict written to `metaDb`, keyed `moderation:self:<blobsCoreKey>` (the
-  authoritative video pass) and `moderation:self:<thumbnailBlobsCoreKey>` (the cheap pass).
-  `blobsCoreKey` is content-addressed, so a verdict can never be redirected to other
-  content. Computed **once per blob**, reused forever.
-- **Thread:** runs in the existing `bare-worker` pool so it never blocks playback or the
-  RPC loop. **Fail-open:** failures (or model-unavailable) leave the verdict `unknown` and
-  the content is shown; model-load failure is surfaced in diagnostics, not to the feed.
+- **Frame source — a NEW raw-RGB helper, not the thumbnail encoder.** `generateThumbnail`
+  (`packages/backend/src/thumbnail.js:215`) selects an image-encoder pixel format and
+  encodes a still (JPEG/WebP). The classifier needs *raw* pixels, so add a sibling helper
+  that reuses the `ff.InputFormatContext` / `ff.Scaler` / `ff.Frame` decode but:
+  - scales to the model input (e.g. 224×224, **RGB24**, no encoder),
+  - samples by **timestamp/keyframe across the duration** (not a fixed frame index),
+  - **copies frame bytes before `unref`**, and transfers the `ArrayBuffer`s to the worker
+    (zero-copy handoff, no extra allocation).
+- **Two passes:**
+  - **Weak first pass:** classify the thumbnail blob (already decoded for display) for an
+    *immediate* feed signal. Cheap — the thumbnail is a separate content-addressed
+    Hyperblobs blob (`thumbnailBlobsCoreKey`), a few KB, fetched independently. **The
+    thumbnail pass may only raise severity to `blur`, never `hide`** (it's a single dumb
+    frame).
+  - **Authoritative pass:** sample N frames (default 3–5 viewer-side) from whatever video
+    bytes are local; verdict = **max over frames**. May reach full policy (incl. hide).
+  - **Relays sample densely** across the whole file (§6) → high-confidence labeler.
+- **Cache & invalidation:** verdict stored in `metaDb` under
+  `moderation:self:<blobsCoreKey>` with the producing `classifierVersion` and a timestamp.
+  On model upgrade (`currentClassifierVersion !== cached.classifierVersion`) the cached
+  verdict is treated as stale and recomputed in the background; it is **not** "trusted
+  forever." `blobsCoreKey` is content-addressed so a verdict can never be redirected.
+- **Thread & failure mode:** runs in the `bare-worker` pool; never blocks the RPC/feed loop.
+  **Viewer fail-open:** model failure / not-yet-run ⇒ verdict `unknown` ⇒ content shown.
+  Model-load failure is surfaced via diagnostics (coverage dropped), not to the feed.
 
-### Layer 2 — Signed labels (trust set + advisory crowd)
+### 3.2 Layer 2 — Signed labels (trust set + advisory crowd)
 
-Any peer may publish a signed `content-label`. A label is a verifiable, standalone claim —
-**not** stored on the uploader's channel — so an uploader can neither forge nor suppress
-it.
+A `content-label` is a verifiable, standalone claim — **not** stored on the uploader's
+channel — so an uploader can neither forge nor suppress third-party labels.
 
 ```
 content-label {
-  targetBlobsCoreKey : string   // content-addressed identity of the video blob
+  id                 : string   // labelerKeyHex + seq (stable identity for supersession)
+  seq                : uint      // labeler's monotonic sequence (latest wins per target/category)
+  targetBlobsCoreKey : string    // content-addressed identity of the video blob
   videoId            : string
   channelKey         : string
-  category           : string   // see taxonomy §6
-  score              : float     // classifier confidence 0..1
-  classifierVersion  : string   // e.g. "nsfw-mnv2-int8@1"  (or "self-report" / "manual")
-  labelerKeyHex      : string   // public key of the labeler
+  category           : string    // taxonomy §6
+  score              : float      // classifier confidence 0..1
+  classifierVersion  : string     // "nsfw-mnv2-int8@1" | "self-report" | "manual"
+  labelerKeyHex      : string     // public key of the labeler
   createdAt          : uint
-  signature          : string   // sign(labelerKeyHex_secret, canonical(label))
+  expiresAt          : uint        // 0 = no expiry; clients ignore expired labels
+  revoked            : bool         // tombstone supersedes an earlier label with same id
+  signature          : string      // sign(labelerKeyHex_secret, canonical(label-minus-signature))
 }
 ```
 
-- **Binding:** the signature covers all fields including `targetBlobsCoreKey`, so a label
-  cannot be lifted onto different content.
-- **Propagation (kept cheap — HAVE_FEED is already a memory concern, see
-  `public-feed.js:1906`):**
-  - **Self-label** rides in the channel's `feed-entry` (at most one tiny label per video,
-    by the uploader).
-  - **Third-party labels** (relays, opt-in users) are fetched **on demand** via a pull RPC
-    `get-content-labels { channelKey | blobsCoreKey }` and cached in `metaDb`. They do
-    **not** bloat `HAVE_FEED`.
-  - **Advisory crowd summary** — a few bytes per entry in `HAVE_FEED`
-    (`{ nsfwExplicitFlags, nsfwSuggestiveFlags }`) as a *forgeable hint only*. It feeds the
-    "N peers flagged" badge; it **never** drives enforcement.
-- **Import / counting policy:**
-  - **Self-label asymmetry:** honor a self-label only when it flags content *up* (more
-    restrictive: explicit/suggestive). A self-label claiming "safe" is ignored (an uploader
-    can't vouch their own content down). Honest creators self-tagging adult content is the
-    happy path.
-  - **Enforcement counting:** count a label toward auto-blur/auto-hide thresholds **only
-    if** the client verified its signature **and** `labelerKeyHex` is in the trust set
-    (default relays ∪ subscriptions ∪ connected peers).
-  - **Advisory counting:** flags from outside the trust set increment the advisory badge
-    count only.
+- **Binding:** the signature covers all fields incl. `targetBlobsCoreKey`, so a label can't
+  be lifted onto other content. Canonical signing bytes = compact-encoding of all fields
+  except `signature`, identical in JS and Swift (golden vector committed, §7).
+- **Transport — labeler-owned feeds (concrete):**
+  - Each labeler maintains an **append-only label feed**: a Hyperbee over a Hypercore,
+    discoverable by `labelerKeyHex`. The labeler writes/ revokes labels there; it is the
+    durable home for that labeler's claims, independent of any uploader.
+  - **Subscribing** to a labeler = replicating its label feed (selectively, keyed by the
+    blobs/channels the client cares about) and adding its key to `trustedLabelers`.
+  - **Relays** (the high-signal default labelers) expose a bounded `get-content-labels`
+    `{ channelKey | blobsCoreKey }` over the existing RPC for on-demand pull, backed by
+    their own label feed.
+  - **Self-label** rides in the channel's `feed-entry` (≤1 tiny label by the uploader).
+  - **Advisory hint** in `HAVE_FEED`: a *boolean-ish capped* `flagHint`
+    (`{ nsfwExplicit: bool, nsfwSuggestive: bool }`, optionally a coarse bucket) — forgeable,
+    **display-only**, feeds the badge, never enforcement. (We deliberately do *not* gossip
+    exact counts; see §13 Q4.)
+- **Import / verification (done at import time, off the hot path):**
+  - **Verify signature**, drop on failure.
+  - **Self-label authorization:** honor a self-label only if `labelerKeyHex` is an
+    authorized writer for `channelKey` (per `multi-writer-channel.js` `VALID_WRITER_ROLES`)
+    **and** it flags *up* (toward more restrictive). A self-label claiming "safe", or from a
+    non-writer, is ignored.
+  - **Supersession/expiry:** keep only the latest non-revoked, non-expired label per
+    `(labelerKeyHex, targetBlobsCoreKey, category)`; tombstones (`revoked`) remove prior.
+  - **Quotas (§8):** one effective label per labeler/category/version; cap untrusted labels
+    per blob; bounded canonical payload size; verify-before-persist.
+  - **Counting:** a label counts toward enforcement thresholds **only if** verified **and**
+    `labelerKeyHex ∈ trustedLabelers`. All other verified labels are advisory-only.
 
-### Layer 3 — Local enforcement + override
+### 3.3 Layer 3 — Local enforcement, severity lattice, override
 
 Each client holds a **moderation policy** (local, in `metaDb`):
 
 ```
 moderation-policy {
-  mode               : "off" | "blur" | "hide"   // master switch; default "blur"
-  categories         : { <category>: "show"|"blur"|"hide" }
-  trustLocalModel    : bool                        // default true
-  trustedLabelers    : string[]                    // labelerKeyHex; seeded w/ default relays
-  blurThreshold      : uint                         // trusted flags → blur; default 1
-  hideThreshold      : uint                         // trusted flags → hide; default 10
-  countConnectedPeers: bool                         // include connected peers in trust set; default false
-  showAdvisoryCount  : bool                         // show "N peers flagged" badge; default true
-  seedFlagged        : bool                         // relays/CLI: replicate flagged? default false
+  mode             : "off" | "blur" | "hide"   // master switch; default "blur"
+  categories       : { <category>: "show"|"blur"|"hide" }
+  trustLocalModel  : bool                        // default true
+  trustedLabelers  : string[]                    // labelerKeyHex; seeded w/ default relays
+  blurThreshold    : uint                         // trusted labels (per category) → at least blur; default 1
+  hideThreshold    : uint                         // trusted labels (per category) → hide; default 3
+  showAdvisoryBadge: bool                          // show "unverified peers flagged" badge; default true
+  // seeder-only (relays/CLI):
+  seedFlagged      : bool                          // replicate flagged content? default false
+  seedUnknown      : bool                          // replicate not-yet-classified content? default false
 }
 ```
 
-**Effective verdict** for a video (first hit wins; everything below is fail-open):
+**Effective verdict — a severity lattice (replaces "first hit wins").** Severity order:
+`hide-explicit` > `blur-explicit` > `blur-suggestive` > `none`. The resolver is a **pure,
+local-cache-only function** (no model exec, no network, no signature verification — all done
+earlier at import time):
 
-1. **User override** (`moderation:override:<blobsCoreKey>` = `show` | `hide`) — always wins.
-2. **Local model verdict** (`moderation:self:*`) — if present and `trustLocalModel`.
-3. **Trusted-label threshold** — count verified trusted-set labels per category; if
-   `count ≥ hideThreshold` → hide, else if `≥ blurThreshold` → blur. (Also: the *max score*
-   of a trusted relay label can hide directly, since a relay's dense multi-frame pass is
-   higher-confidence than any single threshold.)
-4. **Unknown** → **show**, but attach an advisory badge if `showAdvisoryCount` and the raw
-   crowd count > 0, or if a self-label flagged it.
+1. **Override** short-circuits: `show` ⇒ `{action: show}`; `hide` ⇒ `{action: hide}`.
+2. If `mode == "off"` ⇒ `{action: show, badge: advisory}`.
+3. Otherwise compute `sev = none`, then **raise** it (never lower) from each affirmative,
+   verifiable signal:
+   - authoritative local **video** positive (if `trustLocalModel`) → its category, full
+     strength;
+   - local **thumbnail** positive (if `trustLocalModel`) → its category, **capped at blur**;
+   - verified **self-label-up** (authorized writer) → its category;
+   - for each category, `trustedCount = #verified trusted labels ≥ that category`;
+     `trustedCount ≥ blurThreshold` raises to at least `blur` of that category.
+   *Unknown, "safe", expired, advisory-only, and thumbnail-negative signals never lower
+   `sev`.*
+4. If `sev == none` ⇒ `{action: show, badge: advisory}`.
+5. Map `sev` → action via per-category policy and thresholds:
+   - `action = policy.categories[sevCategory]` (default: explicit→blur, suggestive→show);
+   - escalate: if `trustedCount(sevCategory) ≥ hideThreshold` ⇒ `hide`; else if
+     `≥ blurThreshold` and action would be `show` ⇒ `blur`;
+   - clamp by `mode` (`mode==blur` caps action at `blur`; `mode==hide` allows `hide`).
+   A *single* trusted label can therefore **blur** but, by default, not **hide** (hide needs
+   `hideThreshold` trusted labels, or the user's own authoritative local verdict, or an
+   explicit `categories[...]="hide"`). See §13 D3a/NB2.
 
-Enforcement points:
+**Advisory counts never affect `action`.** They populate only `moderation.badge`.
 
-1. **View filter** — in `api.js` `listVideos()` / feed assembly (`api.js:1428`). Each video
-   gets a `moderation` field: `{ action: "show"|"blur"|"hide", category, source, score,
-   advisoryCount }`. `hide` drops it; `blur` returns it flagged for a tap-to-reveal blur;
-   `show` passes through (UI still renders the badge when `advisoryCount`/self-label
-   present).
-2. **Seed filter** — in `SeedingManager.addSeed()` (`seeding.js:214`). Before admitting a
-   blob to the cache/quota, consult the effective verdict; if flagged and
-   `seedFlagged === false`, decline to seed. Satisfies "flip a switch and never seed
-   explicit" for relays and CLI.
+**Enforcement points:**
+
+1. **View filter (viewer)** — `api.js` `listVideos()` / feed assembly (`api.js:1428`). This
+   path is hot and cached, so it calls only the pure resolver against pre-computed local
+   caches — **no model run, no network pull, no bulk verification here.** Each video gets a
+   `moderation` field `{ action, category, source, score, badge }`. `hide` drops it; `blur`
+   returns it flagged for tap-to-reveal; `show` passes through (badge still rendered).
+   Policy/label/verdict changes **invalidate** cached lists (or post-filter) rather than
+   caching already-filtered results.
+2. **Seed filter (relay/CLI) — fail-closed + quarantine.** In `SeedingManager.addSeed()`
+   (`seeding.js:214`): admit the blob but mark it **quarantined** (not advertised/served,
+   not counted as durable seed) until a verdict exists; run the dense classifier on the
+   downloaded file. Then:
+   - flagged & `seedFlagged=false` ⇒ **evict** (remove from cache, never advertise);
+   - unknown & `seedUnknown=false` ⇒ evict (relay seeds only what it verified acceptable);
+   - otherwise ⇒ promote to a durable seed.
+   A **verdict-change hook** evicts an already-active seed if a later trusted/local verdict
+   marks it flagged. (Viewer caches stay fail-open; this strict policy is seeder-only.)
 3. **Override** — `set-content-override { blobsCoreKey, action }` in `metaDb`. Always wins.
 
-This generalizes the existing local `hideChannel` mechanism (`api.js:2818`,
+Generalizes the existing local `hideChannel` (`api.js:2818`,
 `PUBLIC_FEED_HIDDEN_CHANNELS_KEY`) from whole-channel to per-video, category-aware hiding.
 
 ---
 
 ## 4. Why this can't be weaponized
 
-- **Raw flag brigading is defused** — anonymous counts are advisory-only (a badge); they
-  never hide anything. Auto-hide counts only verified labels from the trust set, where
-  identities cost real infra (relays) or explicit user choice (subscriptions).
-- A **malicious trusted labeler** only affects clients that *chose* to trust it (or shipped
-  it as a default relay they can remove). No global hide.
-- The **uploader cannot poison** the local model — the user runs it themselves.
-- The **uploader cannot suppress** labels — they live independently of the channel, signed
-  by the labeler.
-- The **uploader cannot mislabel themselves "safe"** — self-labels are honored only when
-  they flag *up*.
-- **User autonomy is preserved** — override always wins, both directions.
+- **Raw brigading is defused** — anonymous flags are advisory-only (a badge), never hide
+  anything. The advisory hint is even degraded to boolean/coarse so a number can't imply
+  precision (§13 Q4).
+- **Connected-peer sybil is closed** — connections aren't counted; only default relays and
+  explicit subscriptions are, and connected peers must be *manually* promoted.
+- **Sparse-local suppression is closed** — the severity lattice only raises; a weak local
+  pass can't cancel a dense trusted relay label.
+- **A malicious trusted labeler** only affects clients that *chose* it (or shipped it as a
+  removable default). A single default relay can `blur` but not unilaterally `hide` (§3.3).
+- **The uploader can't poison** the local model (the user runs it), **can't suppress**
+  third-party labels (labeler-owned feeds), and **can't self-label "safe"** (flags only
+  honored *up*, and only from authorized channel writers).
+- **Stale enforcement is bounded** — labels expire / can be revoked; local verdicts
+  invalidate on model upgrade.
+- **User autonomy** — override always wins, both directions.
 
-Threat summary: the worst a bad actor can do is (a) mislabel content *for their own
-subscribers*, who opted in and can leave, or (b) inflate the advisory badge count, which
-never auto-hides anything. The worst a bad uploader can do is publish content — which the
-network always allowed — that each client independently classifies and filters.
+Worst case: a bad actor mislabels content *for their own subscribers* (who opted in and can
+leave) or inflates an advisory badge that hides nothing; a bad uploader publishes content
+the network always allowed, which each client independently classifies and filters.
 
 ---
 
@@ -286,27 +340,30 @@ network always allowed — that each client independently classifies and filters
 For images the right tool is a small **vision** classifier — far smaller and more mature
 than any LLM.
 
-### 5.1 PoC runtime — transformers.js / ONNX, fed raw RGB (ship first)
+### 5.1 Phase 1a — runtime-feasibility spike (GATES Phase 1)
 
-Reuse `@xenova/transformers` (already a `packages/backend` dependency, used by
-`search/semantic-finder.js`). One codepath across iOS (BareKit), Android (BareKit), and
-desktop (Electrobun), in the `bare-worker` pool.
+`@xenova/transformers ^2.17.2` is already a backend dep, but `search/semantic-finder.js`
+loads it lazily, hides the import from `bare-pack`, sets only `allowLocalModels`, races a
+10 s load, and **silently falls back to a hash stub** — proving the module is *not reliably*
+loadable in these runtimes. transformers.js also imports `sharp`, `onnxruntime-node`, and
+`onnxruntime-web` at module scope; feeding raw RGB skips image *decode* but does **not**
+prove ORT-WASM initializes under BareKit.
 
-**Critical robustness change vs. the search path.** `semantic-finder.js` loads the model
-lazily and **silently falls back to a hash stub** when load fails — fine for search, fatal
-for a moderation guarantee (it would quietly become "show everything"). Two mitigations:
+**Before committing to the ONNX PoC, run a spike** that, on desktop (Electrobun) **and** iOS
+**and** Android BareKit workers:
 
-1. **Bundle the model as a versioned app asset** (`classifierVersion`), no network fetch at
-   inference time — removes the download-failure path the search code hits.
-2. **Feed pre-resized raw RGB straight into the pipeline**, bypassing transformers.js's
-   image *decode* (sharp/jimp/canvas), which is the fragile part under Bare. We already
-   produce decoded RGB via `ff.Scaler`; scale to the model's input (e.g. 224×224, RGB),
-   wrap the buffer in a transformers.js `RawImage(data, width, height, channels)`, and run
-   `image-classification`. Only the WASM ONNX runtime + normalize/tensor steps remain —
-   pure compute, no I/O.
+- bundles a small int8 NSFW model + the ORT-WASM assets as app assets;
+- sets `env.allowRemoteModels = false`, `env.localModelPath`, and
+  `env.backends.onnx.wasm.wasmPaths` to the bundled paths;
+- constructs a `RawImage(data, width, height, channels)` from a bare-ffmpeg RGB24 frame and
+  runs the `image-classification` pipeline in a `bare-worker`;
+- measures cold-load time, per-frame latency, peak memory, and ArrayBuffer transfer cost.
 
-If the model still cannot load, the verdict stays `unknown` (fail-open) and the failure is
-reported via diagnostics so we know coverage dropped.
+**Gate:** if the spike passes on all targets, proceed with the ONNX PoC (§5.2). If it fails
+on a target, that target skips straight to native bindings (§5.3) behind the same
+`NsfwClassifier` interface — the rest of the design is unchanged.
+
+### 5.2 PoC runtime — transformers.js / ONNX, fed raw RGB
 
 Candidate models (quantized int8):
 
@@ -315,20 +372,14 @@ Candidate models (quantized int8):
 | MobileNetV2 NSFW classifier | **2–5 MB** | fastest, lowest footprint; recommended default |
 | `Falconsai/nsfw_image_detection` (ViT) | ~22 MB | higher accuracy, heavier |
 
-Per-frame inference is single-digit ms on desktop, tens of ms on mobile; we classify a
-handful of frames once per blob, in the background.
+Bundled (not downloaded) so it works offline and on first run; `classifierVersion` records
+the asset. Per-frame inference is single-digit ms desktop / tens of ms mobile; we classify a
+handful of frames once per blob in the background.
 
-### 5.2 Target runtime — native Neural Engine / GPU
+### 5.3 Target runtime — native Neural Engine / GPU
 
-Once the PoC validates the pipeline, swap the inference backend per platform behind a stable
-interface. Frame extraction, caching, labels, and enforcement are **runtime-agnostic**.
-
-- **iOS / macOS — Core ML** (`.mlmodelc`, Apple Neural Engine). Swift module on the native
-  desktop shell (`packages/desktop-native/Sources/Services/`); native bridge from the
-  BareKit worklet on mobile.
-- **Android — TFLite / NNAPI** (or GPU delegate).
-- **Desktop (Electrobun) — ONNX Runtime EPs** (CoreML on macOS, DirectML on Windows,
-  CUDA/ROCm where available; WASM/CPU fallback).
+Frame extraction, caching, labels, and enforcement are **runtime-agnostic**; only the
+backend swaps behind:
 
 ```
 interface NsfwClassifier {
@@ -337,35 +388,42 @@ interface NsfwClassifier {
 }
 ```
 
-Native classifiers must produce the **same taxonomy and comparable score calibration** so
+- **iOS / macOS — Core ML** (`.mlmodelc`, Apple Neural Engine): Swift module on the native
+  desktop shell (`packages/desktop-native/Sources/Services/`); native bridge from the
+  BareKit worklet on mobile.
+- **Android — TFLite / NNAPI** (or GPU delegate).
+- **Desktop (Electrobun) — ONNX Runtime EPs** (CoreML/DirectML/CUDA; WASM/CPU fallback).
+
+Native backends must produce the **same taxonomy and comparable score calibration** so
 labels stay interoperable; `classifierVersion` records which backend/threshold produced a
-label so consumers can weight or re-evaluate.
+label so consumers can weight or re-evaluate (§13 Q2).
 
 ---
 
-## 6. Category taxonomy (v1)
+## 6. Category taxonomy & defaults (v1)
 
-Start small and conservative; the field is a string so we can extend without a wire break.
-
-| category | meaning | default policy |
-|----------|---------|----------------|
-| `nsfw-explicit` | sexually explicit / pornographic | `blur` (tap-to-reveal; strict users: `hide`) |
+| category | meaning | default per-category policy |
+|----------|---------|------------------------------|
+| `nsfw-explicit` | sexually explicit / pornographic | `blur` (tap-to-reveal; strict: `hide`) |
 | `nsfw-suggestive` | suggestive but not explicit | `show` + badge (opt-in `blur`) |
-| `unknown` | not yet classified / model failure | `show` (fail-open) |
+| `unknown` | not yet classified / model failure | `show` (viewer fail-open) |
 
-`violence`, `gore`, etc. are reserved for later and intentionally **not** auto-detected in
-v1 to keep the model tiny and false-positives low.
+`violence`, `gore`, etc. are reserved and intentionally **not** auto-detected in v1 (keeps
+the model tiny, false positives low).
 
-Threshold defaults (tunable): `nsfw-explicit` if max-frame score ≥ 0.85; `nsfw-suggestive`
-if ≥ 0.60. Conservative = bias toward protecting opted-out users.
+Score thresholds (tunable): explicit if max-frame score ≥ 0.85; suggestive if ≥ 0.60.
 
-### Default policy out of the box
+**Default policy out of the box (flagged — §13 D4):** `mode: "blur"`, `nsfw-explicit → blur`
+ON by default — protective but non-destructive (one tap reveals) and always badge-visible.
+Copy must say *"blurred after a signal is detected,"* **not** "guaranteed you'll never see
+it" (fail-open means brand-new unrated content can appear before any signal exists).
 
-Ship `mode: "blur"` with `nsfw-explicit → blur` **on by default**: protective, but
-non-destructive (one tap reveals) and always accompanied by the visible badge (G4). Relays
-and CLI default to `seedFlagged: false`. This is the conservative middle between "force
-strict hide" and "show everything"; users flip to `off` or `hide` per taste. *(Flagged for
-review — see §13 D4.)*
+**Seeder defaults:** `seedFlagged=false`, `seedUnknown=false` — relays/CLI durably seed only
+content they verified acceptable (§3.3, G7).
+
+**Default relay labelers (flagged — §13 D3a):** a single default relay may `blur` alone;
+`hide` requires `hideThreshold` (default 3) trusted labelers or explicit user opt-in, so one
+compromised default relay can't bury content.
 
 ---
 
@@ -373,32 +431,33 @@ review — see §13 D4.)*
 
 New message types (names indicative):
 
-- `content-label` — the signed label record (§3).
-- `moderation-policy` — local policy (also persisted to `metaDb`, typed for RPC so the UI
-  can read/write it).
+- `content-label` — the signed label record (§3.2), incl. `id`, `seq`, `expiresAt`,
+  `revoked`.
+- `moderation-policy` — local policy (persisted to `metaDb`, typed for RPC).
 - `moderation-verdict` — `{ action, category, score, source: "override"|"local"|"label",
-  advisoryCount, classifierVersion }`, attached to `video` results when present.
+  badge }` attached to `video` results when present.
 
 Extend existing types:
 
-- `video` — add optional `moderation: moderation-verdict` (populated by the view filter).
-- `feed-entry` — add optional `selfLabel: content-label` (≤1, tiny) and a compact
-  `flagSummary: { nsfwExplicit: uint, nsfwSuggestive: uint }` advisory count.
+- `video` — optional `moderation: moderation-verdict` (populated by the view filter).
+- `feed-entry` — optional `selfLabel: content-label` (≤1) and a forgeable, display-only
+  `flagHint: { nsfwExplicit: bool, nsfwSuggestive: bool }`.
 
 New RPC endpoints:
 
 - `classify-video { blobsCoreKey, videoId, channelKey }` → trigger/return a local verdict.
-- `get-content-labels { channelKey | blobsCoreKey }` → `content-label[]` (pull path).
-- `publish-content-label { ... }` → sign + gossip a label (relays / opt-in users).
+- `get-content-labels { channelKey | blobsCoreKey }` → `content-label[]` (bounded pull).
+- `publish-content-label { ... }` → sign + append to the labeler's own label feed
+  (relays / opt-in users); **rate-limited** per labeler/target.
 - `get-moderation-policy` / `set-moderation-policy`.
 - `set-content-override { blobsCoreKey, action }`.
 - `subscribe-labeler { labelerKeyHex }` / `unsubscribe-labeler`.
+- `promote-peer-labeler { peerKeyHex }` (manual; moves an advisory peer into the trust set).
 
 Regenerate JS **and** Swift codegen after editing (`cd packages/spec && node schema.cjs`,
-then copy generated Swift into `desktop-native` per `AGENTS.md`/`CLAUDE.md`). Because labels
-are signed, the canonical signing encoding must be deterministic and identical in JS and
-Swift — reuse the compact-encoding wire bytes of `content-label` (minus `signature`) as the
-signing payload.
+then copy generated Swift into `desktop-native` per `AGENTS.md`). The canonical signing
+bytes (`content-label` minus `signature`) must be deterministic and identical in JS and
+Swift — commit a golden vector and cross-check it in tests (§11).
 
 ---
 
@@ -407,59 +466,72 @@ signing payload.
 | key | value |
 |-----|-------|
 | `moderation:policy` | `moderation-policy` |
-| `moderation:self:<blobsCoreKey>` | local verdict + `classifierVersion` + timestamp |
+| `moderation:self:<blobsCoreKey>` | local verdict + `classifierVersion` + timestamp (recomputed on version bump) |
 | `moderation:override:<blobsCoreKey>` | `"show"` \| `"hide"` |
-| `moderation:labels:<blobsCoreKey>` | verified signed labels (trusted + advisory, tagged) |
-| `moderation:labelers` | trust set (default relays ∪ subscriptions) |
+| `moderation:labels:<blobsCoreKey>` | verified labels (trusted + advisory, tagged), deduped per labeler/category/version |
+| `moderation:labelers` | trust set (default relays ∪ subscriptions ∪ manually-promoted peers) |
+| `moderation:resolved:<blobsCoreKey>` | cached pure-resolver output for the hot list path; invalidated on policy/label/verdict change |
 
-All per-client and local. Nothing here is authoritative for anyone else.
+**Quotas:** one effective label per `(labeler, category, version)`; max untrusted labels per
+blob (e.g. 64); bounded canonical label size; signature verified before persistence. All
+keys are per-client and local; nothing here is authoritative for anyone else.
 
 ---
 
 ## 9. Identity for labelers
 
 Reuse the existing channel/device keypair model (`VALID_WRITER_ROLES` etc. in
-`packages/backend/src/channel/multi-writer-channel.js`). A labeler key is just a Hypercore
-keypair; a relay signs with its relay identity, a user who opts in to publishing signs with
-their channel key. Subscribing = adding a public key to `moderation:labelers`. The default
-relay labeler keys ship with the app and are editable/removable. No new PKI.
+`packages/backend/src/channel/multi-writer-channel.js`). A labeler key is a Hypercore
+keypair; a relay signs with its relay identity, an opt-in user with their channel key.
+Subscribing replicates a labeler's label feed and adds its key to `trustedLabelers`. Default
+relay labeler keys ship with the app (editable/removable). Self-label authorization is
+verified against channel writer roles (§3.2). No new PKI.
 
 ---
 
 ## 10. Phasing
 
 - **Phase 0 (this doc).** Design sign-off.
-- **Phase 1 — Local classifier + visible badge (PoC).** Multi-frame extraction in
-  `thumbnail.js`; bundled ONNX MobileNet NSFW model fed raw RGB, run in `bare-worker`;
-  `metaDb` verdict cache; `moderation-policy` + fail-open view filter (show+badge / blur /
-  hide) in `listVideos`; user override; UI badge + tap-to-reveal blur. No network labels.
-  **Smallest end-to-end slice that protects a user and shows the signal.**
+- **Phase 1a — runtime spike (gate).** §5.1; outcome chooses ONNX vs native per platform.
+- **Phase 1 — Local classifier + visible badge (PoC).** Raw-RGB multi-frame helper;
+  bundled model run in `bare-worker`; version-keyed `metaDb` verdict cache;
+  `moderation-policy` + pure-resolver view filter (show+badge / blur / hide) in
+  `listVideos`; override; UI badge + tap-to-reveal blur. No network labels. **Smallest
+  end-to-end slice that protects a viewer and shows the signal.**
 - **Phase 2 — Signed labels + trusted-set crowd + seeding control.** `content-label` schema
-  + signing; self-label on feed-entry; `get-content-labels` pull; advisory `flagSummary` in
-  HAVE_FEED; trust set + thresholds; seed filter in `SeedingManager.addSeed()`; relay
-  discovery-mode dense auto-labeling.
-- **Phase 3 — Native acceleration.** Core ML (iOS/macOS), TFLite/NNAPI (Android), ONNX
-  Runtime EPs (desktop) behind `NsfwClassifier`. No changes above the interface.
-- **Phase 4 (optional, later).** Labeler reputation/weighting, more categories
-  (violence/gore), richer labeler-subscription UI.
+  + signing + golden vector; labeler-owned label feeds; self-label on feed-entry; bounded
+  `get-content-labels`; advisory `flagHint` in HAVE_FEED; trust set + thresholds; seed
+  quarantine/evict + verdict-change hook in `SeedingManager`; relay dense auto-labeling.
+- **Phase 3 — Native acceleration.** Core ML / TFLite-NNAPI / ONNX-EP behind
+  `NsfwClassifier`. No changes above the interface.
+- **Phase 4 (optional).** Labeler reputation/weighting, more categories (violence/gore),
+  richer subscription UI.
 
 ---
 
 ## 11. Testing strategy
 
-- **Classifier unit tests** (backend, `bare`-runnable): feed known-RGB fixtures (a few
-  bundled benign + synthetic explicit-proxy frames) through `NsfwClassifier`; assert
-  category/score and the max-over-frames verdict. Assert **fail-open** when the model is
-  forced unavailable (verdict `unknown`, content shown).
-- **Effective-verdict logic** (pure function, no model): table-driven over
-  {override, local, trusted-count, advisory-count, policy} → expected `{action, source,
-  badge}`. This is where the trust precedence + thresholds live; test it hard.
-- **Label signing/verify** round-trip in JS; cross-check the canonical signing bytes match
-  Swift codegen output (golden vector committed).
-- **Seed filter**: `addSeed` declines a flagged blob when `seedFlagged=false`, admits when
-  `true` or `unknown`.
-- **No network mocks for classification** — use real bundled frame fixtures and the real
-  model in PoC tests.
+- **Effective-verdict resolver** (pure function, no model/network) — table-driven over
+  {override, local-video, local-thumb, self-label-up, trusted-count, advisory, mode,
+  category-policy, thresholds} → expected `{action, source, badge}`. The trust logic lives
+  here; test it hardest.
+- **Adversarial cases** (explicit tests): connected-peer sybil cannot reach a threshold;
+  a single malicious default relay can blur but not hide; forged `flagHint` returns `show`
+  and never changes seeding; self-label "safe" ignored; self-label-up from a non-writer
+  ignored; self-label-up from a writer enforced; **sparse local false-negative + dense
+  trusted relay positive ⇒ hidden** (lattice doesn't suppress); expired/revoked label
+  ignored; model-version bump invalidates a cached verdict; late adverse verdict unseeds an
+  active blob.
+- **Classifier unit tests** (bare-runnable): known RGB24 fixtures (bundled benign +
+  synthetic explicit-proxy) → category/score and max-over-frames; **fail-open** when the
+  model is forced unavailable (verdict `unknown`, viewer shows content).
+- **Label signing/verify** round-trip in JS; cross-check canonical bytes against committed
+  Swift golden vector.
+- **Seed filter:** `addSeed` quarantines unknown, evicts flagged when `seedFlagged=false`,
+  evicts unknown when `seedUnknown=false`, promotes acceptable; verdict-change hook evicts.
+- **Hot-path guard:** assert the `listVideos` resolver performs no model run, no network
+  pull, and no signature verification (those happen at import time).
+- No network mocks for classification — use real bundled frame fixtures + the real model.
 
 ---
 
@@ -467,62 +539,69 @@ relay labeler keys ship with the app and are editable/removable. No new PKI.
 
 | Area | File | Change |
 |------|------|--------|
-| Frame extraction | `packages/backend/src/thumbnail.js` | multi-frame sampling helper |
-| Classifier | `packages/backend/src/moderation/classifier.js` *(new)* | `NsfwClassifier` (ONNX, raw RGB) |
-| Verdict logic | `packages/backend/src/moderation/verdict.js` *(new)* | pure effective-verdict resolver |
-| Verdict cache / policy | `packages/backend/src/moderation/store.js` *(new)* | `metaDb` read/write |
-| Labels | `packages/backend/src/moderation/labels.js` *(new)* | sign / verify / trust-set count |
-| Worker offload | existing `bare-worker` usage | run inference off main thread |
-| View filter | `packages/backend/src/api.js` (`listVideos`, feed) | apply effective verdict |
-| Seed filter | `packages/backend/src/seeding.js` (`addSeed`) | decline flagged blobs |
-| Labels gossip | `packages/backend/src/public-feed.js` | self-label + advisory summary; pull RPC |
+| Raw-RGB frames | `packages/backend/src/moderation/frames.js` *(new)* | RGB24 multi-frame sampler (decode reuse from `thumbnail.js`) |
+| Classifier | `packages/backend/src/moderation/classifier.js` *(new)* | `NsfwClassifier` (ONNX raw-RGB; native later) |
+| Verdict logic | `packages/backend/src/moderation/verdict.js` *(new)* | pure severity-lattice resolver |
+| Verdict cache / policy | `packages/backend/src/moderation/store.js` *(new)* | version-keyed `metaDb` read/write + quotas |
+| Labels | `packages/backend/src/moderation/labels.js` *(new)* | sign/verify, self-label authz, supersession, trust-set count |
+| Label feed | `packages/backend/src/moderation/label-feed.js` *(new)* | labeler-owned Hyperbee feed; replicate/pull |
+| Worker offload | existing `bare-worker` usage | inference off main thread |
+| View filter | `packages/backend/src/api.js` (`listVideos`, feed) | pure resolver + cache invalidation |
+| Seed filter | `packages/backend/src/seeding.js` (`addSeed` + hook) | quarantine/evict + verdict-change hook |
+| Labels gossip | `packages/backend/src/public-feed.js` | self-label + advisory `flagHint` |
 | Schema | `packages/spec/schema.cjs` | new types + RPC; regen JS + Swift |
 | Native (Phase 3) | `packages/desktop-native/Sources/Services/` | Core ML classifier |
-| UI | `packages/app/` | NSFW badge, blur overlay, policy settings, override toggle |
+| UI | `packages/app/` | NSFW badge, blur overlay, policy settings, override, labeler subs |
 
 ---
 
 ## 13. Decision log & open questions
 
-**Decisions adopted this session (D#):**
+**Adopted this session (D#):**
 
-- **D1 — Fail-open.** Unrated content is always shown; verdicts only ever remove/blur.
-- **D2 — Visible badge is mandatory** whenever any NSFW signal exists, even in show mode.
-- **D3 — Crowd signal split:** trusted-set verified-label counting drives auto-blur/hide
-  (sybil-resistant); raw anonymous counts are advisory-only (badge), never auto-enforce.
-- **D5 — Local model = ground truth, instant only for on-device content;** labels cover
-  not-yet-downloaded content; relays are the dense, high-confidence labelers.
-- **D6 — Thumbnail is a weak first pass, not the verdict;** authoritative verdict is
-  multi-frame; relays sample the whole file.
-- **D7 — Classifier robustness:** bundle the model, feed raw RGB into ONNX (bypass
-  transformers.js image decode), fail-open with diagnostics on load failure.
-- **D8 — Self-label asymmetry:** honor self-labels only when they flag *up*.
+- **D1** Viewer fail-open; **seeder fail-closed/quarantine** (D11).
+- **D2** Visible badge mandatory whenever any NSFW signal exists.
+- **D3** Crowd split: trusted-set verified counting enforces; raw anonymous = advisory-only.
+- **D3b** Connected peers are **not** auto-counted; manual promotion only.
+- **D5** Local model = ground truth, instant only for on-device content; relays = dense
+  labelers; labels cover not-yet-downloaded content.
+- **D6** Thumbnail = weak first pass (blur-cap), not the verdict; authoritative = multi-frame.
+- **D7** Classifier robustness: bundle model, feed raw RGB into ONNX, fail-open + diagnostics
+  on load failure — **gated by the Phase 1a spike** (D12).
+- **D8** Self-labels honored only when they flag *up* **and** come from an authorized
+  channel writer.
+- **D9** Effective verdict is a **severity lattice** (only raises); advisory never enforces.
+- **D10** Labels carry id/seq/expiry/revocation; local verdict cache invalidates on model
+  version bump; nothing trusted forever.
+- **D11** Labeler-owned append-only label feeds (Hyperbee/Hypercore) are the durable label
+  transport; relays expose bounded `get-content-labels`.
+- **D12** Phase 1 is gated by a measured BareKit/Electrobun ONNX-WASM spike (§5.1).
+- **D13** `listVideos` stays hot: the view filter is a pure local-cache resolver only.
 
 **Flagged for your review:**
 
-- **D4 — Default policy.** Proposed: `nsfw-explicit → blur` ON by default (protective,
-  reversible, badge-visible); relays/CLI `seedFlagged=false`. Alternative: ship `off` by
-  default (pure opt-in switch). *Pick one before implementation.*
-- **D3a — Default trust set.** Proposed: ship a small set of default relay labeler keys
-  (the one mild centralization point; editable/removable). Alternative: no defaults
-  (B-only), accepting that auto-hide-on-crowd can't function until the user subscribes to a
-  labeler. *Pick one.*
+- **D4 — Default policy.** Proposed `nsfw-explicit → blur` ON by default (copy = "blur after
+  a signal," not "guaranteed never see"). Alternative: ship `off` (pure opt-in). *Pick one.*
+- **D3a — Default trust set.** Proposed: ship a small removable set of default relay labeler
+  keys; a single default relay can blur but not hide. Alternative: no defaults (auto-hide
+  -on-crowd won't function until the user subscribes). *Pick one.*
 
 **Open questions (revisit with PoC numbers):**
 
-- **Q1 — Frame budget.** How many keyframes per video balances recall vs. mobile cost?
-  (Proposed 3–5 viewer-side; relays dense.)
-- **Q2 — Calibration across backends.** Keeping Core ML / TFLite / ONNX scores comparable
-  enough that `score ≥ threshold` means the same thing everywhere.
-- **Q3 — Reputation (Phase 4).** Whether/how to weight labelers beyond binary trust-set
-  membership.
-- **Q4 — Advisory count provenance.** The HAVE_FEED `flagSummary` is forgeable; do we cap
-  the displayed number, or only show the badge boolean to avoid implying precision?
+- **Q1** Frame budget (proposed 3–5 viewer-side; relays dense).
+- **Q2** Cross-backend score calibration (Core ML / TFLite / ONNX comparable).
+- **Q3** Labeler reputation/weighting beyond binary trust-set membership (Phase 4).
+- **Q4** Advisory provenance — ship the badge as a boolean "some unverified peers flagged"
+  (proposed) vs a capped bucket; avoid exact counts (precision/brigading theater).
+- **Q5** Label-publishing privacy — publishing a label leaks what you watched/seed. Proposed:
+  user publishing is opt-in; durable publishing defaults to relays/seeders; batch/pad
+  `get-content-labels` queries to limit per-video lookup leakage.
 
 ---
 
 *Adapts AT Protocol composable moderation (self-labels + subscribable labelers + local
 override) to the Hypercore stack, extended with a sybil-resistant trusted-set crowd signal
-and a forgeable advisory count. The detection is the easy, tiny part; the opt-in trust
-model — and refusing to let raw counts auto-hide anything — is what keeps "local
-moderation" from quietly becoming "decentralized censorship."*
+and a forgeable, display-only advisory hint. The detection is the easy, tiny part; the
+opt-in trust model — a severity lattice that only ever raises, refusing to let raw counts or
+weak signals auto-hide anything — is what keeps "local moderation" from quietly becoming
+"decentralized censorship."*

--- a/docs/superpowers/specs/2026-06-26-local-client-moderation-design.md
+++ b/docs/superpowers/specs/2026-06-26-local-client-moderation-design.md
@@ -41,7 +41,7 @@
      `sharp`/`onnxruntime-node`/`onnxruntime-web` at module scope; bypassing image-decode
      does not prove ORT-WASM loads in BareKit. Phase 1 is contingent on a measured spike;
      on failure we go straight to native bindings (§5.1, §10).
-- **Rev 4 (this)** — second review pass refinements: the resolver is now a **total**
+- **Rev 4** — second review pass refinements: the resolver is now a **total**
   function with an exact category→action table (weak/thumb-only never `hide`; D9); labels
   drop the redundant `id`, supersede by the `(labeler,target,category)` triple ordered by
   `seq` (D10); a labeler's identity **is** its label-feed core key, self-labels separated
@@ -50,6 +50,12 @@
   `addSeed` (which commits immediately) with the Corestore global-replicate caveat, and
   Phase 1 scoped **strictly local** (§3.3, D15); resolved-cache gains wall-clock `validUntil`
   (§8).
+- **Rev 5 (this)** — author set the two flagged product defaults to the **fully
+  decentralized** options: moderation is **off by default** (pure opt-in; `mode:"off"`) and
+  **no default relay labeler set ships** (`trustedLabelers` empty; B-only). Consequence:
+  Phase 1's local on-device model is the entire default-enabled protection story; signed
+  labels / crowd signal (Phase 2) are opt-in only and inert until the user subscribes to a
+  labeler by key. §13 D4/D3a resolved.
 
 Decision log + open questions: §13.
 
@@ -81,8 +87,8 @@ replicate** content they don't want to host.
   file) can publish a signed label so other clients pre-hide content *before downloading
   frames*.
 - **G6 — Trust is opt-in and composable; crowd signal is sybil-resistant.** Auto-enforcing
-  thresholds count only verified labels from a *trust set* (default relays ∪ explicit
-  subscriptions). Raw anonymous counts are advisory-only and never auto-enforce.
+  thresholds count only verified labels from a *trust set* of **explicit subscriptions** (no
+  default labelers ship — §13 D3a). Raw anonymous counts are advisory-only, never auto-enforce.
 - **G7 — Seeder fail-closed.** A relay/seeder/CLI flips one switch (`seedFlagged=false`,
   default) and never durably replicates flagged content; by default it also declines
   *unknown* content until it classifies it. It quarantines while classifying and unseeds on
@@ -122,10 +128,11 @@ and can always override — extended with a **sybil-resistant** crowd signal.
 cost and buries any target. So auto-enforcing thresholds count flags **only** from keys
 that cost something to be:
 
-- **Default relay labelers** — relays run real infrastructure and seed content → expensive
-  to sybil at scale. A small set of relay labeler keys ships with the app
-  (editable/removable). *(Default-set choice flagged for review — §13 D3a.)*
-- **Explicit subscriptions** — labelers the user added by key.
+- **Explicit subscriptions only** — labelers the user added by key. **No default labeler set
+  ships** (§13 D3a): out of the box nothing is trusted and only the local model can enforce.
+  A would-be default labeler (e.g. a relay running a classifier) earns trust the same way —
+  the user subscribes to its key. Relays remain the natural high-signal labelers (they
+  classify everything they replicate, §3.1); they are simply not trusted automatically.
 
 **Connected peers are NOT in the enforcement trust set** — a peer connection is not a
 scarce identity (an attacker opens many connections cheaply). A connected peer's flags are
@@ -261,10 +268,10 @@ Each client holds a **moderation policy** (local, in `metaDb`):
 
 ```
 moderation-policy {
-  mode             : "off" | "blur" | "hide"   // master switch; default "blur"
+  mode             : "off" | "blur" | "hide"   // master switch; default "off" (opt-in)
   categories       : { <category>: "show"|"blur"|"hide" }
   trustLocalModel  : bool                        // default true
-  trustedLabelers  : string[]                    // labelerKeyHex; seeded w/ default relays
+  trustedLabelers  : string[]                    // labelerKeyHex; EMPTY by default (no defaults shipped)
   blurThreshold    : uint                         // trusted labels (per category) → at least blur; default 1
   hideThreshold    : uint                         // trusted labels (per category) → hide; default 3
   showAdvisoryBadge: bool                          // show "unverified peers flagged" badge; default true
@@ -300,12 +307,14 @@ label of category ≥ `c`.
    then, in order: if `weakOnly` and the action is `hide`, **downgrade to `blur`** (weak
    signals never hide); finally **clamp by `mode`** — `mode=="blur"` caps the result at
    `blur`, so `hideThreshold` and a per-category `"hide"` only produce an actual `hide` when
-   `mode=="hide"`. (Default `mode:"blur"` therefore never hides, only blurs.)
+   `mode=="hide"`. (With the default `mode:"off"` nothing is blurred or hidden at all; when
+   set to `blur`, any `hide` is clamped to `blur`.)
 
    Consequences: a single trusted label ⇒ `blur`, never `hide`; `hide` needs `hideThreshold`
    distinct trusted labelers **or** the user setting `categories[C]="hide"` (their own choice,
    applied to their own authoritative/self signals — not `weakOnly`, so not downgraded). The
-   local model never auto-hides under the default `blur` policy. See §13 D3a/NB2.
+   local model never auto-hides — and under the default `mode:"off"` it does not enforce at
+   all until the user enables moderation. See §13 D3a.
 
 **Advisory counts never affect `action`.** They populate only `moderation.badge`.
 
@@ -343,12 +352,12 @@ Generalizes the existing local `hideChannel` (`api.js:2818`,
 - **Raw brigading is defused** — anonymous flags are advisory-only (a badge), never hide
   anything. The advisory hint is even degraded to boolean/coarse so a number can't imply
   precision (§13 Q4).
-- **Connected-peer sybil is closed** — connections aren't counted; only default relays and
-  explicit subscriptions are, and connected peers must be *manually* promoted.
+- **Connected-peer sybil is closed** — connections aren't counted; only explicit
+  subscriptions are, and connected peers must be *manually* promoted.
 - **Sparse-local suppression is closed** — the severity lattice only raises; a weak local
   pass can't cancel a dense trusted relay label.
-- **A malicious trusted labeler** only affects clients that *chose* it (or shipped it as a
-  removable default). A single default relay can `blur` but not unilaterally `hide` (§3.3).
+- **A subscribed labeler** only affects clients that *chose* it; nothing is trusted by
+  default. A single labeler can `blur` but never unilaterally `hide` (needs `hideThreshold`).
 - **The uploader can't poison** the local model (the user runs it), **can't suppress**
   third-party labels (labeler-owned feeds), and **can't self-label "safe"** (flags only
   honored *up*, and only from authorized channel writers).
@@ -440,17 +449,20 @@ the model tiny, false positives low).
 
 Score thresholds (tunable): explicit if max-frame score ≥ 0.85; suggestive if ≥ 0.60.
 
-**Default policy out of the box (flagged — §13 D4):** `mode: "blur"`, `nsfw-explicit → blur`
-ON by default — protective but non-destructive (one tap reveals) and always badge-visible.
-Copy must say *"blurred after a signal is detected,"* **not** "guaranteed you'll never see
-it" (fail-open means brand-new unrated content can appear before any signal exists).
+**Default policy out of the box (D4 — off):** `mode: "off"` — PearTube ships showing
+everything; the user opts in. When enabled (`blur`/`hide`), `nsfw-explicit` defaults to
+`blur` (non-destructive tap-to-reveal, badge-visible); the toggle copy must say *"blurred
+after a signal is detected,"* **not** "guaranteed you'll never see it." While moderation is
+off the feature is **dormant** — no classification, no badges, no enforcement — so the
+default carries zero battery/UX cost; enabling it starts the background classifier.
 
 **Seeder defaults:** `seedFlagged=false`, `seedUnknown=false` — relays/CLI durably seed only
 content they verified acceptable (§3.3, G7).
 
-**Default relay labelers (flagged — §13 D3a):** a single default relay may `blur` alone;
-`hide` requires `hideThreshold` (default 3) trusted labelers or explicit user opt-in, so one
-compromised default relay can't bury content.
+**No default labelers (D3a — B-only):** `trustedLabelers` ships **empty**. Auto-blur/hide
+from labels/crowd is inert until the user subscribes to a labeler by key; until then the
+local model is the sole enforcer. This is the fully-decentralized choice — no shipped trust
+anchors — at the cost of no out-of-the-box pre-download protection (G5 needs a subscription).
 
 ---
 
@@ -498,7 +510,7 @@ Swift — commit a golden vector and cross-check it in tests (§11).
 | `moderation:self:<blobsCoreKey>` | local verdict + `classifierVersion` + timestamp (recomputed on version bump) |
 | `moderation:override:<blobsCoreKey>` | `"show"` \| `"hide"` |
 | `moderation:labels:<blobsCoreKey>` | verified labels (trusted + advisory, tagged), one effective record per `(labeler, category)` latest `seq` |
-| `moderation:labelers` | trust set (default relays ∪ subscriptions ∪ manually-promoted peers) |
+| `moderation:labelers` | trust set — explicit subscriptions ∪ manually-promoted peers (empty by default) |
 | `moderation:resolved:<blobsCoreKey>` | cached resolver output for the hot list path + `validUntil` (next label `expiresAt`); invalidated on policy/label/verdict change **or** when `validUntil` passes |
 
 **Quotas:** one effective label per `(labeler, category)` (latest `seq`); max untrusted labels per
@@ -556,7 +568,7 @@ Subscribing to a third-party labeler replicates its label feed and adds its key 
   category-policy, thresholds} → expected `{action, source, badge}`. The trust logic lives
   here; test it hardest.
 - **Adversarial cases** (explicit tests): connected-peer sybil cannot reach a threshold;
-  a single malicious default relay can blur but not hide; forged `flagHint` returns `show`
+  a single subscribed (manually-trusted) labeler can blur but not hide; forged `flagHint` returns `show`
   and never changes seeding; self-label "safe" ignored; self-label-up from a non-writer
   ignored; self-label-up from a writer enforced; **sparse local false-negative + dense
   trusted relay positive ⇒ hidden** (lattice doesn't suppress); expired/revoked label
@@ -627,13 +639,14 @@ Subscribing to a third-party labeler replicates its label feed and adds its key 
   Phase 1 is strictly local (no labels, no seeding control). True upload-suppression under
   Corestore's global replicate is a Phase-2 caveat (§3.3).
 
-**Flagged for your review:**
+**Resolved (author decision):**
 
-- **D4 — Default policy.** Proposed `nsfw-explicit → blur` ON by default (copy = "blur after
-  a signal," not "guaranteed never see"). Alternative: ship `off` (pure opt-in). *Pick one.*
-- **D3a — Default trust set.** Proposed: ship a small removable set of default relay labeler
-  keys; a single default relay can blur but not hide. Alternative: no defaults (auto-hide
-  -on-crowd won't function until the user subscribes). *Pick one.*
+- **D4 — Default policy: OFF (pure opt-in).** Ships `mode:"off"`; the feature is dormant
+  until enabled. When enabled, `nsfw-explicit → blur`. (Chose the libertarian default over
+  blur-on-by-default.)
+- **D3a — Default trust set: NONE (B-only).** No relay labeler keys ship; `trustedLabelers`
+  empty. The local model is the sole default enforcer; labels/crowd are opt-in via
+  subscription.
 
 **Open questions (revisit with PoC numbers):**
 

--- a/docs/superpowers/specs/2026-06-26-local-client-moderation-design.md
+++ b/docs/superpowers/specs/2026-06-26-local-client-moderation-design.md
@@ -1,0 +1,383 @@
+# Local-Client Content Moderation — Design
+
+**Status:** Draft / proposal
+**Date:** 2026-06-26
+**Author:** Claude (with @ayooooo123)
+**Branch:** `claude/local-client-moderation-spec-fh5rnx`
+
+---
+
+## 1. Problem & goals
+
+PearTube discovers *all* public content via gossip on `peartube-public-feed-v1`. There is
+no central authority and we never want one: anyone can publish anything, and we cannot —
+and do not want to be able to — prevent uploads or sharing.
+
+But "no central authority" must not mean "every user is force-fed explicit content."
+We want **strict, user-controlled protection**: a normal user who opts out of sexually
+explicit material should never see it, and ideally never even download the frames. We also
+want **relays and seeders** to be able to decline to replicate content they don't want to
+host.
+
+### Goals
+
+- **G1 — Local-first.** Every client can decide, on its own, whether a given video is
+  NSFW, with zero trust in anyone else.
+- **G2 — Unobtrusive & efficient.** No 2 GB model. Single-digit-MB classifier, runs off
+  frames we *already* extract, on a background thread, never blocking playback.
+- **G3 — Shareable hints.** A client (especially a relay) that has classified content can
+  publish a signed label so other clients can pre-hide it *before downloading frames*.
+- **G4 — Trust is opt-in and composable.** A label only affects a client that chose to
+  trust its author. No label can globally hide anything for anyone.
+- **G5 — Seeding control.** A relay/seeder can refuse to replicate flagged content.
+- **G6 — User override always wins.** Local "show this anyway" / "hide this" beats any
+  classifier or label.
+
+### Non-goals
+
+- Preventing uploads or takedowns of content from the network (impossible and undesired
+  in a P2P system).
+- A global reputation/consensus system. Out of scope for v1; the label format leaves room
+  for it later.
+- Perfect classification. We target high-recall NSFW-explicit detection with a
+  conservative default, not legal-grade accuracy.
+
+---
+
+## 2. The hard part: trust, not detection
+
+NSFW *detection* is a solved, small problem (Section 5). The architectural risk is the
+**trust model**. In a decentralized network a "flag" is just a claim by some peer. If we
+get this wrong we build either:
+
+- a **censorship lever** — one actor's flag hides content for everyone, or
+- **noise** — flags nobody trusts, so nobody uses them.
+
+We avoid both by adopting the **AT Protocol / Bluesky "composable moderation"** model,
+adapted to Hypercore:
+
+> Content carries no authoritative rating. Instead, **independent labelers** emit signed
+> labels, and **each client subscribes** to the labelers it trusts. Enforcement is local.
+> The user can always override.
+
+This maps cleanly onto primitives PearTube already has (gossip feed, per-client `metaDb`,
+selective seeding, signed channel writers).
+
+---
+
+## 3. Architecture: three layers
+
+```
+            ┌──────────────────────────────────────────────────────────┐
+            │  Layer 1 — LOCAL SELF-CLASSIFICATION  (zero trust)        │
+            │  keyframes (bare-ffmpeg) → tiny NSFW model (bare-worker)  │
+            │  → verdict cached in metaDb[blobsCoreKey]                 │
+            └──────────────────────────────────────────────────────────┘
+                                   │ produces
+                                   ▼
+            ┌──────────────────────────────────────────────────────────┐
+            │  Layer 2 — SIGNED LABELS  (opt-in trust)                 │
+            │  content-label{ targetBlobsCoreKey, category, score,     │
+            │                 labelerKeyHex, signature }               │
+            │  gossiped over peartube-public-feed-v1; imported only    │
+            │  from subscribed labelers                                │
+            └──────────────────────────────────────────────────────────┘
+                                   │ informs
+                                   ▼
+            ┌──────────────────────────────────────────────────────────┐
+            │  Layer 3 — LOCAL ENFORCEMENT  (+ user override)          │
+            │  • view filter (listVideos / feed): hide | blur | show   │
+            │  • seed filter (SeedingManager.addSeed): refuse to seed  │
+            └──────────────────────────────────────────────────────────┘
+```
+
+### Layer 1 — Local self-classification (zero trust)
+
+A tiny vision classifier runs **on-device** against the keyframes we already decode for
+thumbnails. This is **ground truth for that user** — the uploader cannot game it because
+*the user ran it themselves*.
+
+- **Input:** N keyframes (default: extend the existing single-thumbnail extraction at
+  `frameIndex 300` to a small set, e.g. 3–5 frames sampled across the duration). See
+  `packages/backend/src/thumbnail.js:215` (`generateThumbnail`) — same `ff.InputFormatContext`
+  / `ff.Scaler` / `ff.Frame` pipeline, looped over several frame indices.
+- **Output:** per-frame `{ category → score }`; the video verdict is the max over frames
+  (conservative: any explicit frame ⇒ explicit).
+- **Cache:** verdict written to `metaDb` keyed by `moderation:self:<blobsCoreKey>`.
+  `blobsCoreKey` is content-addressed, so a verdict can never be redirected to other
+  content. Computed **once per blob**, reused forever.
+- **Thread:** runs in the existing `bare-worker` pool so it never blocks playback or the
+  RPC loop. Best-effort; failures leave the verdict `unknown`.
+
+**Limitation that motivates Layer 2:** self-classification only protects a user *after*
+they've fetched and decoded a frame. A user who opted out of explicit content shouldn't
+fetch the blob at all. Hence subscribed labels.
+
+### Layer 2 — Signed labels (opt-in trust)
+
+Any peer may publish a signed `content-label`. **Relays are the natural high-signal
+labelers** because, in discovery mode, they classify everything they replicate. A label is
+a verifiable, standalone claim — it is **not** stored on the uploader's channel, so an
+uploader can neither forge nor suppress it.
+
+```
+content-label {
+  targetBlobsCoreKey : string   // content-addressed identity of the video blob
+  videoId            : string
+  channelKey         : string
+  category           : string   // see taxonomy §6
+  score              : float     // classifier confidence 0..1
+  classifierVersion  : string   // e.g. "nsfw-mnv2-int8@1"
+  labelerKeyHex      : string   // public key of the labeler
+  createdAt          : uint
+  signature          : string   // sign(labelerKeyHex_secret, canonical(label))
+}
+```
+
+- **Binding:** the signature covers all fields including `targetBlobsCoreKey`, so a label
+  cannot be lifted onto different content.
+- **Propagation:** piggyback on the existing feed gossip (`public-feed.js` `HAVE_FEED` /
+  `SUBMIT_CHANNEL`, see `packages/backend/src/public-feed.js:1781`, `:1894`). Labels for a
+  channel ride alongside its `feed-entry`, plus a pull RPC (`get-content-labels`) for
+  on-demand fetch. Labels are small; we cap and tail them like feed entries already do.
+- **Import policy:** a client imports a label **only if `labelerKeyHex` is in its
+  subscribed-labelers set.** Unsubscribed labels are ignored (but may be counted purely
+  for an optional, off-by-default "N peers flagged this" hint — never auto-enforced).
+
+### Layer 3 — Local enforcement + override
+
+Each client holds a **moderation policy** (local, in `metaDb`):
+
+```
+moderation-policy {
+  mode            : "off" | "blur" | "hide"      // default: "blur" for nsfw-explicit
+  categories      : { <category>: "show"|"blur"|"hide" }
+  trustLocalModel : bool                          // default true
+  subscribedLabelers : string[]                   // labelerKeyHex list; default []
+  seedFlagged     : bool                          // relays: replicate flagged? default false
+}
+```
+
+Enforcement points:
+
+1. **View filter** — in `api.js` `listVideos()` / feed assembly. For each video, resolve an
+   **effective verdict** = userOverride ?? localSelfVerdict ?? max(subscribedLabelVerdicts).
+   Apply policy: `hide` removes it from results; `blur` returns it with a `moderation`
+   field the UI uses to blur the thumbnail behind a tap-to-reveal; `show` passes through.
+2. **Seed filter** — in `SeedingManager.addSeed()` (`packages/backend/src/seeding.js:214`).
+   Before admitting a blob to the cache/quota, consult the effective verdict; if flagged
+   and `seedFlagged === false`, decline to seed (return without registering). This satisfies
+   the "ignore it for seeding purposes" requirement for both normal users and relays.
+3. **Override** — `set-content-override { blobsCoreKey, action: "show"|"hide" }` stored in
+   `metaDb` under `moderation:override:<blobsCoreKey>`. Always wins.
+
+This generalizes the existing local `hideChannel` mechanism
+(`packages/backend/src/api.js:2818`, `PUBLIC_FEED_HIDDEN_CHANNELS_KEY`) from
+whole-channel to per-video, category-aware hiding.
+
+---
+
+## 4. Why this can't be weaponized
+
+- A **malicious labeler** only affects clients that *chose* to subscribe to it. There is no
+  global hide.
+- The **uploader cannot poison** self-classification — the user runs the model locally.
+- The **uploader cannot suppress** labels — they live independently of the channel and are
+  signed by the labeler, not the uploader.
+- **No consensus = no majority attack.** v1 deliberately does not auto-trust crowd counts;
+  the optional "N peers flagged" hint is advisory only and off by default.
+- **User autonomy is preserved** — override always wins, in both directions (reveal hidden,
+  or hide shown).
+
+Threat summary: the worst a bad actor can do is mislabel content *for their own
+subscribers*, who opted in and can unsubscribe. The worst a bad uploader can do is publish
+content — which the network was always going to allow — that each client independently
+classifies and filters.
+
+---
+
+## 5. The model (PoC: ONNX; target: native)
+
+"Tiny language model to view frames" — for images the right tool is a small **vision**
+classifier, which is far smaller and more mature than any LLM.
+
+### 5.1 PoC runtime — transformers.js / ONNX (ship first)
+
+Reuse `@xenova/transformers`, already a `packages/backend` dependency (used by the semantic
+search finder). One codepath across iOS (BareKit), Android (BareKit), and desktop
+(Electrobun). Runs in the `bare-worker` thread pool already in the stack.
+
+Candidate models (quantized int8):
+
+| Model | Approx size | Notes |
+|-------|-------------|-------|
+| MobileNetV2 NSFW classifier | **2–5 MB** | fastest, lowest footprint; recommended default |
+| `Falconsai/nsfw_image_detection` (ViT) | ~22 MB | higher accuracy, heavier |
+
+A few MB, not 2 GB. Per-frame inference is single-digit milliseconds on desktop, tens of ms
+on mobile — and we only classify a handful of keyframes, once per blob, in the background.
+
+The model file ships with the app (bundled asset), versioned via `classifierVersion`. No
+network fetch at inference time (unlike the current search-embeddings download path), so it
+works offline and on first run.
+
+### 5.2 Target runtime — native Neural Engine / GPU
+
+Once the PoC validates the pipeline, swap the inference backend per platform behind a stable
+interface (`classifyFrames(frames) → verdict`). The frame extraction, caching, labels, and
+enforcement layers are **runtime-agnostic** and do not change.
+
+- **iOS / macOS — Core ML.** Compile the classifier to a `.mlmodelc`, run via the Apple
+  Neural Engine. On the native desktop shell this is a Swift module
+  (`packages/desktop-native/Sources/Services/`); on mobile, a small native bridge from the
+  BareKit worklet. Sub-millisecond per frame, near-zero battery.
+- **Android — TFLite / NNAPI (or GPU delegate).** Ship a `.tflite` model, run through the
+  NNAPI or GPU delegate.
+- **Desktop (Electrobun) — ONNX Runtime with execution providers.** Use CoreML EP on macOS,
+  DirectML on Windows, CUDA/ROCm where available; fall back to WASM/CPU.
+
+The interface contract (so PoC ↔ native are drop-in):
+
+```
+interface NsfwClassifier {
+  version: string                              // -> classifierVersion in labels
+  classifyFrames(frames: RGBImage[]): Promise<{ category: string, score: number }[]>
+}
+```
+
+Native classifiers must produce the **same category taxonomy and comparable score
+calibration** so labels remain interoperable across clients regardless of which backend
+generated them. `classifierVersion` records which backend/threshold produced a label so
+consumers can weight or re-evaluate.
+
+---
+
+## 6. Category taxonomy (v1)
+
+Start small and conservative; the field is a string so we can extend without a wire break.
+
+| category | meaning | default policy |
+|----------|---------|----------------|
+| `nsfw-explicit` | sexually explicit / pornographic | `blur` (strict users: `hide`) |
+| `nsfw-suggestive` | suggestive but not explicit | `show` (opt-in `blur`) |
+| `unknown` | not yet classified / model failure | `show` |
+
+`violence`, `gore`, etc. are reserved for later and intentionally **not** auto-detected in
+v1 to keep the model tiny and the false-positive surface small.
+
+Threshold defaults (tunable): `nsfw-explicit` if max-frame score ≥ 0.85; `nsfw-suggestive`
+if ≥ 0.60. Conservative = bias toward protecting opted-out users.
+
+---
+
+## 7. Schema additions (`packages/spec/schema.cjs`)
+
+New message types (names indicative):
+
+- `content-label` — as in §3, the signed label record.
+- `moderation-policy` — local policy (also persisted to `metaDb`, but typed for RPC so UI
+  can read/write it).
+- `moderation-verdict` — `{ category, score, source: "local"|"label"|"override", classifierVersion }`,
+  attached to `video` results when present.
+
+Extend existing types:
+
+- `video` — add optional `moderation: moderation-verdict` (populated by the view filter).
+- `feed-entry` — add optional `labels: content-label[]` (small, tailed) so labels gossip
+  with the feed.
+
+New RPC endpoints:
+
+- `classify-video { blobsCoreKey, videoId, channelKey }` → triggers/returns a local verdict.
+- `get-content-labels { channelKey | blobsCoreKey }` → `content-label[]` (pull path).
+- `publish-content-label { ... }` → sign + gossip a label (relays / opt-in users).
+- `get-moderation-policy` / `set-moderation-policy`.
+- `set-content-override { blobsCoreKey, action }`.
+- `subscribe-labeler { labelerKeyHex }` / `unsubscribe-labeler`.
+
+Regenerate JS **and** Swift codegen after editing (`cd packages/spec && node schema.cjs`,
+then copy generated Swift into `desktop-native` per `CLAUDE.md`). Because labels are signed,
+the canonical encoding used for signing must be deterministic and identical in JS and Swift
+— reuse the compact-encoding wire bytes of `content-label` (minus the `signature` field) as
+the signing payload.
+
+---
+
+## 8. Storage & keys (`metaDb`, per client)
+
+| key | value |
+|-----|-------|
+| `moderation:policy` | `moderation-policy` |
+| `moderation:self:<blobsCoreKey>` | local verdict + `classifierVersion` + timestamp |
+| `moderation:override:<blobsCoreKey>` | `"show"` \| `"hide"` |
+| `moderation:labels:<blobsCoreKey>` | imported signed labels from subscribed labelers |
+| `moderation:labelers` | subscribed labeler key set |
+
+All per-client and local. Nothing here is authoritative for anyone else.
+
+---
+
+## 9. Identity for labelers
+
+Reuse the existing channel/device keypair model (`VALID_WRITER_ROLES` etc. in
+`packages/backend/src/channel/multi-writer-channel.js`). A labeler key is just a Hypercore
+keypair; a relay signs with its relay identity, a user who opts in to publishing signs with
+their channel key. Subscribing to a labeler = adding its public key to
+`moderation:labelers`. No new PKI.
+
+---
+
+## 10. Phasing
+
+- **Phase 0 (this doc).** Design sign-off.
+- **Phase 1 — Local classifier (PoC).** Multi-frame extraction in `thumbnail.js`; ONNX
+  MobileNet NSFW model bundled + run in `bare-worker`; `metaDb` verdict cache;
+  `moderation-policy` + view filter (blur/hide) in `listVideos`; user override. No network
+  labels. **Smallest end-to-end slice that protects a user.**
+- **Phase 2 — Signed labels + seeding control.** `content-label` schema + signing; gossip
+  on the feed + `get-content-labels`; subscribe-to-labeler trust; seed filter in
+  `SeedingManager.addSeed()`; relay discovery-mode auto-labeling.
+- **Phase 3 — Native acceleration.** Core ML (iOS/macOS), TFLite/NNAPI (Android), ONNX
+  Runtime EPs (desktop) behind the `NsfwClassifier` interface. No changes above the
+  interface.
+- **Phase 4 (optional, later).** Crowd-signal heuristics, labeler reputation, additional
+  categories (violence/gore), UI for managing labeler subscriptions.
+
+---
+
+## 11. Open questions
+
+1. **Frame budget.** How many keyframes per video balances recall vs. cost on mobile?
+   (Proposed: 3–5, sampled across duration; revisit with PoC numbers.)
+2. **When does Layer-1 classification run?** On thumbnail generation (publish side) and/or
+   on first playback (viewer side)? Proposed: viewer-side on first access *plus* publisher
+   classifies its own uploads and can self-label.
+3. **Default policy out of the box.** Ship `nsfw-explicit → blur` by default, or `show`
+   with an onboarding prompt? Strict-by-default is safer but more opinionated.
+4. **Label volume control.** How aggressively to cap/tail labels in the feed gossip to avoid
+   ballooning `HAVE_FEED` (already a concern — see `public-feed.js:1906`).
+5. **Calibration across backends.** Ensuring Core ML / TFLite / ONNX scores stay comparable
+   enough that `score ≥ threshold` means the same thing everywhere.
+
+---
+
+## 12. Files this will touch (forward reference)
+
+| Area | File | Change |
+|------|------|--------|
+| Frame extraction | `packages/backend/src/thumbnail.js` | multi-frame sampling helper |
+| Classifier | `packages/backend/src/moderation/classifier.js` *(new)* | `NsfwClassifier` impl (ONNX) |
+| Worker offload | existing `bare-worker` usage | run inference off main thread |
+| Verdict cache / policy | `packages/backend/src/moderation/store.js` *(new)* | `metaDb` read/write |
+| View filter | `packages/backend/src/api.js` (`listVideos`, feed) | apply effective verdict |
+| Seed filter | `packages/backend/src/seeding.js` (`addSeed`) | decline flagged blobs |
+| Labels gossip | `packages/backend/src/public-feed.js` | carry/pull `content-label`s |
+| Schema | `packages/spec/schema.cjs` | new types + RPC; regen JS + Swift |
+| Native (Phase 3) | `packages/desktop-native/Sources/Services/` | Core ML classifier |
+| UI | `packages/app/` | blur overlay, policy settings, override toggle |
+
+---
+
+*Adapts AT Protocol composable moderation (self-labels + subscribable labelers + local
+override) to the Hypercore stack. The detection is the easy, tiny part; the opt-in trust
+model is what keeps "local moderation" from quietly becoming "decentralized censorship."*

--- a/docs/superpowers/specs/2026-06-26-local-client-moderation-design.md
+++ b/docs/superpowers/specs/2026-06-26-local-client-moderation-design.md
@@ -1,9 +1,37 @@
 # Local-Client Content Moderation — Design
 
-**Status:** Draft / proposal
+**Status:** Draft / proposal — revision 2 (design dialogue resolved)
 **Date:** 2026-06-26
 **Author:** Claude (with @ayooooo123)
 **Branch:** `claude/local-client-moderation-spec-fh5rnx`
+
+---
+
+## 0. Revision 2 — what changed and why
+
+Revision 1 proposed pure composable moderation (local self-classification + opt-in
+subscribed labelers + local enforcement) and **deliberately excluded crowd/consensus
+signals** to avoid a censorship lever. The design dialogue reshaped four things:
+
+1. **Fail-open, not fail-closed.** Moderation is a *silent background pass*. It never
+   blocks the feed, never shows a "classifying…" gate. Unrated content is shown. A verdict
+   only ever *removes/blurs* content once it exists.
+2. **Visibility is a first-class goal.** Whenever *any* signal suggests content may be
+   NSFW, the UI must say so clearly — a badge — even when the content is still shown.
+3. **Crowd signal is in — but split into two paths.** Users want "if N people flagged it,
+   hide it." Raw P2P counts are a brigading weapon (keypairs are free → sybils). So:
+   - **Enforcement path = trusted-set counting** (sybil-resistant): only labels the client
+     itself verified, signed by keys in a *trust set* (default relay labelers + user
+     subscriptions + connected peers), are counted toward auto-blur/auto-hide thresholds.
+   - **Advisory path = raw anonymous count** (forgeable): shown as a badge ("N peers
+     flagged"), **never** auto-enforces.
+4. **The local model is ground truth but only *instant for on-device content*.** Inference
+   is milliseconds; the cost is fetching+decoding frames. So the local model protects
+   cached / currently-playing content invisibly, and **labels cover content not yet
+   downloaded**. Thumbnails are a *weak* first-pass signal (a dumb mid-point grab can be a
+   black frame in an otherwise explicit video), never the authoritative verdict.
+
+The decision log is in §13.
 
 ---
 
@@ -14,54 +42,74 @@ no central authority and we never want one: anyone can publish anything, and we 
 and do not want to be able to — prevent uploads or sharing.
 
 But "no central authority" must not mean "every user is force-fed explicit content."
-We want **strict, user-controlled protection**: a normal user who opts out of sexually
-explicit material should never see it, and ideally never even download the frames. We also
-want **relays and seeders** to be able to decline to replicate content they don't want to
-host.
+We want **strong, user-controlled protection that is invisible when it works**: a user who
+opts out of sexually explicit material should not see it, the app should make it *clear*
+when content might be NSFW, and **relays/seeders should be able to decline to replicate**
+content they don't want to host.
 
 ### Goals
 
-- **G1 — Local-first.** Every client can decide, on its own, whether a given video is
-  NSFW, with zero trust in anyone else.
-- **G2 — Unobtrusive & efficient.** No 2 GB model. Single-digit-MB classifier, runs off
-  frames we *already* extract, on a background thread, never blocking playback.
-- **G3 — Shareable hints.** A client (especially a relay) that has classified content can
-  publish a signed label so other clients can pre-hide it *before downloading frames*.
-- **G4 — Trust is opt-in and composable.** A label only affects a client that chose to
-  trust its author. No label can globally hide anything for anyone.
-- **G5 — Seeding control.** A relay/seeder can refuse to replicate flagged content.
-- **G6 — User override always wins.** Local "show this anyway" / "hide this" beats any
-  classifier or label.
+- **G1 — Local-first ground truth.** Every client can decide, on its own, whether content
+  it has on disk is NSFW, with zero trust in anyone else.
+- **G2 — Invisible & efficient.** No 2 GB model. Single-digit-MB classifier, runs off
+  frames we *already* decode, on a background thread, never blocking playback or the feed.
+- **G3 — Fail-open, never block.** Unrated content is shown. A verdict only ever removes or
+  blurs content *after* it exists. No "classifying…" gates.
+- **G4 — Always make NSFW-likelihood visible.** When any signal (local model, trusted
+  label, advisory crowd count) suggests NSFW, surface a clear badge — even in show mode.
+- **G5 — Shareable hints (labels).** A client (especially a relay that downloaded the whole
+  file) can publish a signed label so other clients pre-hide content *before downloading
+  frames*.
+- **G6 — Trust is opt-in and composable; crowd signal is sybil-resistant.** Auto-enforcing
+  thresholds count only verified labels from a *trust set*. Raw anonymous counts are
+  advisory-only and never auto-enforce.
+- **G7 — Seeding control.** A relay/seeder/CLI can flip one switch to refuse to replicate
+  flagged content.
+- **G8 — User override always wins.** Local "show this anyway" / "hide this" beats any
+  classifier or label, in both directions.
 
 ### Non-goals
 
-- Preventing uploads or takedowns of content from the network (impossible and undesired
-  in a P2P system).
-- A global reputation/consensus system. Out of scope for v1; the label format leaves room
-  for it later.
-- Perfect classification. We target high-recall NSFW-explicit detection with a
-  conservative default, not legal-grade accuracy.
+- Preventing uploads or takedowns of content from the network (impossible and undesired in
+  a P2P system).
+- A global reputation/consensus system, or treating raw anonymous crowd counts as
+  authoritative. The label format leaves room for reputation later (§13, Q-open).
+- Perfect classification. We target high-recall NSFW-explicit detection with a conservative
+  bias, not legal-grade accuracy.
 
 ---
 
 ## 2. The hard part: trust, not detection
 
-NSFW *detection* is a solved, small problem (Section 5). The architectural risk is the
-**trust model**. In a decentralized network a "flag" is just a claim by some peer. If we
-get this wrong we build either:
+NSFW *detection* is a solved, small problem (§5). The architectural risk is the **trust
+model**. In a decentralized network a "flag" is just a claim by some peer. Get it wrong and
+you build either a **censorship lever** (one actor's flag hides content for everyone) or
+**noise** (flags nobody trusts).
 
-- a **censorship lever** — one actor's flag hides content for everyone, or
-- **noise** — flags nobody trusts, so nobody uses them.
+We adopt the **AT Protocol / Bluesky "composable moderation"** model — content carries no
+authoritative rating; independent labelers emit signed labels; each client enforces
+locally and can always override — and **extend it with a sybil-resistant crowd signal**:
 
-We avoid both by adopting the **AT Protocol / Bluesky "composable moderation"** model,
-adapted to Hypercore:
+> **Enforcement signals, in precedence order, are all things the client can verify or
+> compute itself:** (1) the user's explicit override, (2) the client's own local model
+> verdict, (3) the count of *verified signed labels from the client's trust set*. A raw
+> count of anonymous flags is shown to the user but never auto-enforces.
 
-> Content carries no authoritative rating. Instead, **independent labelers** emit signed
-> labels, and **each client subscribes** to the labelers it trusts. Enforcement is local.
-> The user can always override.
+This maps onto primitives PearTube already has: gossip feed, per-client `metaDb`, selective
+seeding, signed channel/relay writers.
 
-This maps cleanly onto primitives PearTube already has (gossip feed, per-client `metaDb`,
-selective seeding, signed channel writers).
+### Why a trust set instead of raw counts
+
+"Hide if 10 people flagged it" is trivially defeated: a single attacker generates 10 (or
+10,000) keypairs at zero cost and buries any target. The fix is to **only count flags from
+keys that cost something to be**:
+
+- **Relays** run real infrastructure and seed content → expensive to sybil at scale. A
+  small **default set of relay labeler keys** ships with the app (editable/removable).
+- **Subscribed labelers** the user explicitly added.
+- **Connected peers** the client has actually exchanged data with (weaker, optional).
+
+Counts *within this set* are meaningful; flags from outside it are advisory-only.
 
 ---
 
@@ -70,55 +118,63 @@ selective seeding, signed channel writers).
 ```
             ┌──────────────────────────────────────────────────────────┐
             │  Layer 1 — LOCAL SELF-CLASSIFICATION  (zero trust)        │
-            │  keyframes (bare-ffmpeg) → tiny NSFW model (bare-worker)  │
-            │  → verdict cached in metaDb[blobsCoreKey]                 │
+            │  bare-ffmpeg RGB frames → tiny NSFW model (bare-worker)   │
+            │  multi-frame; thumbnail = cheap first pass, not verdict   │
+            │  → verdict cached in metaDb[moderation:self:<blobsKey>]   │
             └──────────────────────────────────────────────────────────┘
                                    │ produces
                                    ▼
             ┌──────────────────────────────────────────────────────────┐
-            │  Layer 2 — SIGNED LABELS  (opt-in trust)                 │
-            │  content-label{ targetBlobsCoreKey, category, score,     │
-            │                 labelerKeyHex, signature }               │
-            │  gossiped over peartube-public-feed-v1; imported only    │
-            │  from subscribed labelers                                │
+            │  Layer 2 — SIGNED LABELS  (trust set + advisory crowd)    │
+            │  content-label{ targetBlobsCoreKey, category, score,      │
+            │                 labelerKeyHex, signature }                │
+            │  self-label rides feed-entry; 3rd-party via pull RPC;     │
+            │  advisory count summary rides HAVE_FEED (forgeable)       │
             └──────────────────────────────────────────────────────────┘
                                    │ informs
                                    ▼
             ┌──────────────────────────────────────────────────────────┐
-            │  Layer 3 — LOCAL ENFORCEMENT  (+ user override)          │
-            │  • view filter (listVideos / feed): hide | blur | show   │
-            │  • seed filter (SeedingManager.addSeed): refuse to seed  │
+            │  Layer 3 — LOCAL ENFORCEMENT  (fail-open + visible badge) │
+            │  effective verdict = override ?? localModel ??            │
+            │      trustedLabelThreshold ?? unknown(show + maybe badge) │
+            │  • view filter: show+badge | blur | hide                  │
+            │  • seed filter: refuse to seed flagged (relays/CLI)       │
             └──────────────────────────────────────────────────────────┘
 ```
 
 ### Layer 1 — Local self-classification (zero trust)
 
-A tiny vision classifier runs **on-device** against the keyframes we already decode for
-thumbnails. This is **ground truth for that user** — the uploader cannot game it because
-*the user ran it themselves*.
+A tiny vision classifier runs **on-device** against frames we already decode. This is
+**ground truth for that user** — the uploader cannot game it because *the user ran it
+themselves*.
 
-- **Input:** N keyframes (default: extend the existing single-thumbnail extraction at
-  `frameIndex 300` to a small set, e.g. 3–5 frames sampled across the duration). See
-  `packages/backend/src/thumbnail.js:215` (`generateThumbnail`) — same `ff.InputFormatContext`
-  / `ff.Scaler` / `ff.Frame` pipeline, looped over several frame indices.
-- **Output:** per-frame `{ category → score }`; the video verdict is the max over frames
-  (conservative: any explicit frame ⇒ explicit).
-- **Cache:** verdict written to `metaDb` keyed by `moderation:self:<blobsCoreKey>`.
+- **Input — multi-frame, not thumbnail-only.** The thumbnail (a single mid-point grab) is
+  too dumb to trust: an explicit video can have a black frame at `frameIndex 300`. So:
+  - **Cheap first pass:** classify the thumbnail blob (already decoded for display) for an
+    *immediate* feed signal. Cheap because the thumbnail is a separate, content-addressed
+    Hyperblobs blob (`thumbnailBlobsCoreKey`) fetched in a few KB independently of the
+    video.
+  - **Authoritative pass:** sample N frames across the duration from whatever video bytes
+    are local (default 3–5 viewer-side), extending `generateThumbnail`
+    (`packages/backend/src/thumbnail.js:215`) to loop the same `ff.InputFormatContext` /
+    `ff.Scaler` / `ff.Frame` pipeline over several frame indices.
+  - **Relays sample densely.** A relay/seeder downloads the *whole* file, so it can sample
+    many frames → high-confidence verdict → becomes the natural high-signal labeler (§2).
+- **Output:** per-frame `{ category → score }`; the video verdict is the **max over
+  frames** (conservative: any explicit frame ⇒ explicit).
+- **Cache:** verdict written to `metaDb`, keyed `moderation:self:<blobsCoreKey>` (the
+  authoritative video pass) and `moderation:self:<thumbnailBlobsCoreKey>` (the cheap pass).
   `blobsCoreKey` is content-addressed, so a verdict can never be redirected to other
   content. Computed **once per blob**, reused forever.
 - **Thread:** runs in the existing `bare-worker` pool so it never blocks playback or the
-  RPC loop. Best-effort; failures leave the verdict `unknown`.
+  RPC loop. **Fail-open:** failures (or model-unavailable) leave the verdict `unknown` and
+  the content is shown; model-load failure is surfaced in diagnostics, not to the feed.
 
-**Limitation that motivates Layer 2:** self-classification only protects a user *after*
-they've fetched and decoded a frame. A user who opted out of explicit content shouldn't
-fetch the blob at all. Hence subscribed labels.
+### Layer 2 — Signed labels (trust set + advisory crowd)
 
-### Layer 2 — Signed labels (opt-in trust)
-
-Any peer may publish a signed `content-label`. **Relays are the natural high-signal
-labelers** because, in discovery mode, they classify everything they replicate. A label is
-a verifiable, standalone claim — it is **not** stored on the uploader's channel, so an
-uploader can neither forge nor suppress it.
+Any peer may publish a signed `content-label`. A label is a verifiable, standalone claim —
+**not** stored on the uploader's channel — so an uploader can neither forge nor suppress
+it.
 
 ```
 content-label {
@@ -127,7 +183,7 @@ content-label {
   channelKey         : string
   category           : string   // see taxonomy §6
   score              : float     // classifier confidence 0..1
-  classifierVersion  : string   // e.g. "nsfw-mnv2-int8@1"
+  classifierVersion  : string   // e.g. "nsfw-mnv2-int8@1"  (or "self-report" / "manual")
   labelerKeyHex      : string   // public key of the labeler
   createdAt          : uint
   signature          : string   // sign(labelerKeyHex_secret, canonical(label))
@@ -136,13 +192,26 @@ content-label {
 
 - **Binding:** the signature covers all fields including `targetBlobsCoreKey`, so a label
   cannot be lifted onto different content.
-- **Propagation:** piggyback on the existing feed gossip (`public-feed.js` `HAVE_FEED` /
-  `SUBMIT_CHANNEL`, see `packages/backend/src/public-feed.js:1781`, `:1894`). Labels for a
-  channel ride alongside its `feed-entry`, plus a pull RPC (`get-content-labels`) for
-  on-demand fetch. Labels are small; we cap and tail them like feed entries already do.
-- **Import policy:** a client imports a label **only if `labelerKeyHex` is in its
-  subscribed-labelers set.** Unsubscribed labels are ignored (but may be counted purely
-  for an optional, off-by-default "N peers flagged this" hint — never auto-enforced).
+- **Propagation (kept cheap — HAVE_FEED is already a memory concern, see
+  `public-feed.js:1906`):**
+  - **Self-label** rides in the channel's `feed-entry` (at most one tiny label per video,
+    by the uploader).
+  - **Third-party labels** (relays, opt-in users) are fetched **on demand** via a pull RPC
+    `get-content-labels { channelKey | blobsCoreKey }` and cached in `metaDb`. They do
+    **not** bloat `HAVE_FEED`.
+  - **Advisory crowd summary** — a few bytes per entry in `HAVE_FEED`
+    (`{ nsfwExplicitFlags, nsfwSuggestiveFlags }`) as a *forgeable hint only*. It feeds the
+    "N peers flagged" badge; it **never** drives enforcement.
+- **Import / counting policy:**
+  - **Self-label asymmetry:** honor a self-label only when it flags content *up* (more
+    restrictive: explicit/suggestive). A self-label claiming "safe" is ignored (an uploader
+    can't vouch their own content down). Honest creators self-tagging adult content is the
+    happy path.
+  - **Enforcement counting:** count a label toward auto-blur/auto-hide thresholds **only
+    if** the client verified its signature **and** `labelerKeyHex` is in the trust set
+    (default relays ∪ subscriptions ∪ connected peers).
+  - **Advisory counting:** flags from outside the trust set increment the advisory badge
+    count only.
 
 ### Layer 3 — Local enforcement + override
 
@@ -150,62 +219,94 @@ Each client holds a **moderation policy** (local, in `metaDb`):
 
 ```
 moderation-policy {
-  mode            : "off" | "blur" | "hide"      // default: "blur" for nsfw-explicit
-  categories      : { <category>: "show"|"blur"|"hide" }
-  trustLocalModel : bool                          // default true
-  subscribedLabelers : string[]                   // labelerKeyHex list; default []
-  seedFlagged     : bool                          // relays: replicate flagged? default false
+  mode               : "off" | "blur" | "hide"   // master switch; default "blur"
+  categories         : { <category>: "show"|"blur"|"hide" }
+  trustLocalModel    : bool                        // default true
+  trustedLabelers    : string[]                    // labelerKeyHex; seeded w/ default relays
+  blurThreshold      : uint                         // trusted flags → blur; default 1
+  hideThreshold      : uint                         // trusted flags → hide; default 10
+  countConnectedPeers: bool                         // include connected peers in trust set; default false
+  showAdvisoryCount  : bool                         // show "N peers flagged" badge; default true
+  seedFlagged        : bool                         // relays/CLI: replicate flagged? default false
 }
 ```
 
+**Effective verdict** for a video (first hit wins; everything below is fail-open):
+
+1. **User override** (`moderation:override:<blobsCoreKey>` = `show` | `hide`) — always wins.
+2. **Local model verdict** (`moderation:self:*`) — if present and `trustLocalModel`.
+3. **Trusted-label threshold** — count verified trusted-set labels per category; if
+   `count ≥ hideThreshold` → hide, else if `≥ blurThreshold` → blur. (Also: the *max score*
+   of a trusted relay label can hide directly, since a relay's dense multi-frame pass is
+   higher-confidence than any single threshold.)
+4. **Unknown** → **show**, but attach an advisory badge if `showAdvisoryCount` and the raw
+   crowd count > 0, or if a self-label flagged it.
+
 Enforcement points:
 
-1. **View filter** — in `api.js` `listVideos()` / feed assembly. For each video, resolve an
-   **effective verdict** = userOverride ?? localSelfVerdict ?? max(subscribedLabelVerdicts).
-   Apply policy: `hide` removes it from results; `blur` returns it with a `moderation`
-   field the UI uses to blur the thumbnail behind a tap-to-reveal; `show` passes through.
-2. **Seed filter** — in `SeedingManager.addSeed()` (`packages/backend/src/seeding.js:214`).
-   Before admitting a blob to the cache/quota, consult the effective verdict; if flagged
-   and `seedFlagged === false`, decline to seed (return without registering). This satisfies
-   the "ignore it for seeding purposes" requirement for both normal users and relays.
-3. **Override** — `set-content-override { blobsCoreKey, action: "show"|"hide" }` stored in
-   `metaDb` under `moderation:override:<blobsCoreKey>`. Always wins.
+1. **View filter** — in `api.js` `listVideos()` / feed assembly (`api.js:1428`). Each video
+   gets a `moderation` field: `{ action: "show"|"blur"|"hide", category, source, score,
+   advisoryCount }`. `hide` drops it; `blur` returns it flagged for a tap-to-reveal blur;
+   `show` passes through (UI still renders the badge when `advisoryCount`/self-label
+   present).
+2. **Seed filter** — in `SeedingManager.addSeed()` (`seeding.js:214`). Before admitting a
+   blob to the cache/quota, consult the effective verdict; if flagged and
+   `seedFlagged === false`, decline to seed. Satisfies "flip a switch and never seed
+   explicit" for relays and CLI.
+3. **Override** — `set-content-override { blobsCoreKey, action }` in `metaDb`. Always wins.
 
-This generalizes the existing local `hideChannel` mechanism
-(`packages/backend/src/api.js:2818`, `PUBLIC_FEED_HIDDEN_CHANNELS_KEY`) from
-whole-channel to per-video, category-aware hiding.
+This generalizes the existing local `hideChannel` mechanism (`api.js:2818`,
+`PUBLIC_FEED_HIDDEN_CHANNELS_KEY`) from whole-channel to per-video, category-aware hiding.
 
 ---
 
 ## 4. Why this can't be weaponized
 
-- A **malicious labeler** only affects clients that *chose* to subscribe to it. There is no
-  global hide.
-- The **uploader cannot poison** self-classification — the user runs the model locally.
-- The **uploader cannot suppress** labels — they live independently of the channel and are
-  signed by the labeler, not the uploader.
-- **No consensus = no majority attack.** v1 deliberately does not auto-trust crowd counts;
-  the optional "N peers flagged" hint is advisory only and off by default.
-- **User autonomy is preserved** — override always wins, in both directions (reveal hidden,
-  or hide shown).
+- **Raw flag brigading is defused** — anonymous counts are advisory-only (a badge); they
+  never hide anything. Auto-hide counts only verified labels from the trust set, where
+  identities cost real infra (relays) or explicit user choice (subscriptions).
+- A **malicious trusted labeler** only affects clients that *chose* to trust it (or shipped
+  it as a default relay they can remove). No global hide.
+- The **uploader cannot poison** the local model — the user runs it themselves.
+- The **uploader cannot suppress** labels — they live independently of the channel, signed
+  by the labeler.
+- The **uploader cannot mislabel themselves "safe"** — self-labels are honored only when
+  they flag *up*.
+- **User autonomy is preserved** — override always wins, both directions.
 
-Threat summary: the worst a bad actor can do is mislabel content *for their own
-subscribers*, who opted in and can unsubscribe. The worst a bad uploader can do is publish
-content — which the network was always going to allow — that each client independently
-classifies and filters.
+Threat summary: the worst a bad actor can do is (a) mislabel content *for their own
+subscribers*, who opted in and can leave, or (b) inflate the advisory badge count, which
+never auto-hides anything. The worst a bad uploader can do is publish content — which the
+network always allowed — that each client independently classifies and filters.
 
 ---
 
-## 5. The model (PoC: ONNX; target: native)
+## 5. The model (PoC: ONNX from raw RGB; target: native)
 
-"Tiny language model to view frames" — for images the right tool is a small **vision**
-classifier, which is far smaller and more mature than any LLM.
+For images the right tool is a small **vision** classifier — far smaller and more mature
+than any LLM.
 
-### 5.1 PoC runtime — transformers.js / ONNX (ship first)
+### 5.1 PoC runtime — transformers.js / ONNX, fed raw RGB (ship first)
 
-Reuse `@xenova/transformers`, already a `packages/backend` dependency (used by the semantic
-search finder). One codepath across iOS (BareKit), Android (BareKit), and desktop
-(Electrobun). Runs in the `bare-worker` thread pool already in the stack.
+Reuse `@xenova/transformers` (already a `packages/backend` dependency, used by
+`search/semantic-finder.js`). One codepath across iOS (BareKit), Android (BareKit), and
+desktop (Electrobun), in the `bare-worker` pool.
+
+**Critical robustness change vs. the search path.** `semantic-finder.js` loads the model
+lazily and **silently falls back to a hash stub** when load fails — fine for search, fatal
+for a moderation guarantee (it would quietly become "show everything"). Two mitigations:
+
+1. **Bundle the model as a versioned app asset** (`classifierVersion`), no network fetch at
+   inference time — removes the download-failure path the search code hits.
+2. **Feed pre-resized raw RGB straight into the pipeline**, bypassing transformers.js's
+   image *decode* (sharp/jimp/canvas), which is the fragile part under Bare. We already
+   produce decoded RGB via `ff.Scaler`; scale to the model's input (e.g. 224×224, RGB),
+   wrap the buffer in a transformers.js `RawImage(data, width, height, channels)`, and run
+   `image-classification`. Only the WASM ONNX runtime + normalize/tensor steps remain —
+   pure compute, no I/O.
+
+If the model still cannot load, the verdict stays `unknown` (fail-open) and the failure is
+reported via diagnostics so we know coverage dropped.
 
 Candidate models (quantized int8):
 
@@ -214,29 +315,20 @@ Candidate models (quantized int8):
 | MobileNetV2 NSFW classifier | **2–5 MB** | fastest, lowest footprint; recommended default |
 | `Falconsai/nsfw_image_detection` (ViT) | ~22 MB | higher accuracy, heavier |
 
-A few MB, not 2 GB. Per-frame inference is single-digit milliseconds on desktop, tens of ms
-on mobile — and we only classify a handful of keyframes, once per blob, in the background.
-
-The model file ships with the app (bundled asset), versioned via `classifierVersion`. No
-network fetch at inference time (unlike the current search-embeddings download path), so it
-works offline and on first run.
+Per-frame inference is single-digit ms on desktop, tens of ms on mobile; we classify a
+handful of frames once per blob, in the background.
 
 ### 5.2 Target runtime — native Neural Engine / GPU
 
 Once the PoC validates the pipeline, swap the inference backend per platform behind a stable
-interface (`classifyFrames(frames) → verdict`). The frame extraction, caching, labels, and
-enforcement layers are **runtime-agnostic** and do not change.
+interface. Frame extraction, caching, labels, and enforcement are **runtime-agnostic**.
 
-- **iOS / macOS — Core ML.** Compile the classifier to a `.mlmodelc`, run via the Apple
-  Neural Engine. On the native desktop shell this is a Swift module
-  (`packages/desktop-native/Sources/Services/`); on mobile, a small native bridge from the
-  BareKit worklet. Sub-millisecond per frame, near-zero battery.
-- **Android — TFLite / NNAPI (or GPU delegate).** Ship a `.tflite` model, run through the
-  NNAPI or GPU delegate.
-- **Desktop (Electrobun) — ONNX Runtime with execution providers.** Use CoreML EP on macOS,
-  DirectML on Windows, CUDA/ROCm where available; fall back to WASM/CPU.
-
-The interface contract (so PoC ↔ native are drop-in):
+- **iOS / macOS — Core ML** (`.mlmodelc`, Apple Neural Engine). Swift module on the native
+  desktop shell (`packages/desktop-native/Sources/Services/`); native bridge from the
+  BareKit worklet on mobile.
+- **Android — TFLite / NNAPI** (or GPU delegate).
+- **Desktop (Electrobun) — ONNX Runtime EPs** (CoreML on macOS, DirectML on Windows,
+  CUDA/ROCm where available; WASM/CPU fallback).
 
 ```
 interface NsfwClassifier {
@@ -245,10 +337,9 @@ interface NsfwClassifier {
 }
 ```
 
-Native classifiers must produce the **same category taxonomy and comparable score
-calibration** so labels remain interoperable across clients regardless of which backend
-generated them. `classifierVersion` records which backend/threshold produced a label so
-consumers can weight or re-evaluate.
+Native classifiers must produce the **same taxonomy and comparable score calibration** so
+labels stay interoperable; `classifierVersion` records which backend/threshold produced a
+label so consumers can weight or re-evaluate.
 
 ---
 
@@ -258,15 +349,23 @@ Start small and conservative; the field is a string so we can extend without a w
 
 | category | meaning | default policy |
 |----------|---------|----------------|
-| `nsfw-explicit` | sexually explicit / pornographic | `blur` (strict users: `hide`) |
-| `nsfw-suggestive` | suggestive but not explicit | `show` (opt-in `blur`) |
-| `unknown` | not yet classified / model failure | `show` |
+| `nsfw-explicit` | sexually explicit / pornographic | `blur` (tap-to-reveal; strict users: `hide`) |
+| `nsfw-suggestive` | suggestive but not explicit | `show` + badge (opt-in `blur`) |
+| `unknown` | not yet classified / model failure | `show` (fail-open) |
 
 `violence`, `gore`, etc. are reserved for later and intentionally **not** auto-detected in
-v1 to keep the model tiny and the false-positive surface small.
+v1 to keep the model tiny and false-positives low.
 
 Threshold defaults (tunable): `nsfw-explicit` if max-frame score ≥ 0.85; `nsfw-suggestive`
 if ≥ 0.60. Conservative = bias toward protecting opted-out users.
+
+### Default policy out of the box
+
+Ship `mode: "blur"` with `nsfw-explicit → blur` **on by default**: protective, but
+non-destructive (one tap reveals) and always accompanied by the visible badge (G4). Relays
+and CLI default to `seedFlagged: false`. This is the conservative middle between "force
+strict hide" and "show everything"; users flip to `off` or `hide` per taste. *(Flagged for
+review — see §13 D4.)*
 
 ---
 
@@ -274,21 +373,21 @@ if ≥ 0.60. Conservative = bias toward protecting opted-out users.
 
 New message types (names indicative):
 
-- `content-label` — as in §3, the signed label record.
-- `moderation-policy` — local policy (also persisted to `metaDb`, but typed for RPC so UI
+- `content-label` — the signed label record (§3).
+- `moderation-policy` — local policy (also persisted to `metaDb`, typed for RPC so the UI
   can read/write it).
-- `moderation-verdict` — `{ category, score, source: "local"|"label"|"override", classifierVersion }`,
-  attached to `video` results when present.
+- `moderation-verdict` — `{ action, category, score, source: "override"|"local"|"label",
+  advisoryCount, classifierVersion }`, attached to `video` results when present.
 
 Extend existing types:
 
 - `video` — add optional `moderation: moderation-verdict` (populated by the view filter).
-- `feed-entry` — add optional `labels: content-label[]` (small, tailed) so labels gossip
-  with the feed.
+- `feed-entry` — add optional `selfLabel: content-label` (≤1, tiny) and a compact
+  `flagSummary: { nsfwExplicit: uint, nsfwSuggestive: uint }` advisory count.
 
 New RPC endpoints:
 
-- `classify-video { blobsCoreKey, videoId, channelKey }` → triggers/returns a local verdict.
+- `classify-video { blobsCoreKey, videoId, channelKey }` → trigger/return a local verdict.
 - `get-content-labels { channelKey | blobsCoreKey }` → `content-label[]` (pull path).
 - `publish-content-label { ... }` → sign + gossip a label (relays / opt-in users).
 - `get-moderation-policy` / `set-moderation-policy`.
@@ -296,10 +395,10 @@ New RPC endpoints:
 - `subscribe-labeler { labelerKeyHex }` / `unsubscribe-labeler`.
 
 Regenerate JS **and** Swift codegen after editing (`cd packages/spec && node schema.cjs`,
-then copy generated Swift into `desktop-native` per `CLAUDE.md`). Because labels are signed,
-the canonical encoding used for signing must be deterministic and identical in JS and Swift
-— reuse the compact-encoding wire bytes of `content-label` (minus the `signature` field) as
-the signing payload.
+then copy generated Swift into `desktop-native` per `AGENTS.md`/`CLAUDE.md`). Because labels
+are signed, the canonical signing encoding must be deterministic and identical in JS and
+Swift — reuse the compact-encoding wire bytes of `content-label` (minus `signature`) as the
+signing payload.
 
 ---
 
@@ -310,8 +409,8 @@ the signing payload.
 | `moderation:policy` | `moderation-policy` |
 | `moderation:self:<blobsCoreKey>` | local verdict + `classifierVersion` + timestamp |
 | `moderation:override:<blobsCoreKey>` | `"show"` \| `"hide"` |
-| `moderation:labels:<blobsCoreKey>` | imported signed labels from subscribed labelers |
-| `moderation:labelers` | subscribed labeler key set |
+| `moderation:labels:<blobsCoreKey>` | verified signed labels (trusted + advisory, tagged) |
+| `moderation:labelers` | trust set (default relays ∪ subscriptions) |
 
 All per-client and local. Nothing here is authoritative for anyone else.
 
@@ -322,42 +421,45 @@ All per-client and local. Nothing here is authoritative for anyone else.
 Reuse the existing channel/device keypair model (`VALID_WRITER_ROLES` etc. in
 `packages/backend/src/channel/multi-writer-channel.js`). A labeler key is just a Hypercore
 keypair; a relay signs with its relay identity, a user who opts in to publishing signs with
-their channel key. Subscribing to a labeler = adding its public key to
-`moderation:labelers`. No new PKI.
+their channel key. Subscribing = adding a public key to `moderation:labelers`. The default
+relay labeler keys ship with the app and are editable/removable. No new PKI.
 
 ---
 
 ## 10. Phasing
 
 - **Phase 0 (this doc).** Design sign-off.
-- **Phase 1 — Local classifier (PoC).** Multi-frame extraction in `thumbnail.js`; ONNX
-  MobileNet NSFW model bundled + run in `bare-worker`; `metaDb` verdict cache;
-  `moderation-policy` + view filter (blur/hide) in `listVideos`; user override. No network
-  labels. **Smallest end-to-end slice that protects a user.**
-- **Phase 2 — Signed labels + seeding control.** `content-label` schema + signing; gossip
-  on the feed + `get-content-labels`; subscribe-to-labeler trust; seed filter in
-  `SeedingManager.addSeed()`; relay discovery-mode auto-labeling.
+- **Phase 1 — Local classifier + visible badge (PoC).** Multi-frame extraction in
+  `thumbnail.js`; bundled ONNX MobileNet NSFW model fed raw RGB, run in `bare-worker`;
+  `metaDb` verdict cache; `moderation-policy` + fail-open view filter (show+badge / blur /
+  hide) in `listVideos`; user override; UI badge + tap-to-reveal blur. No network labels.
+  **Smallest end-to-end slice that protects a user and shows the signal.**
+- **Phase 2 — Signed labels + trusted-set crowd + seeding control.** `content-label` schema
+  + signing; self-label on feed-entry; `get-content-labels` pull; advisory `flagSummary` in
+  HAVE_FEED; trust set + thresholds; seed filter in `SeedingManager.addSeed()`; relay
+  discovery-mode dense auto-labeling.
 - **Phase 3 — Native acceleration.** Core ML (iOS/macOS), TFLite/NNAPI (Android), ONNX
-  Runtime EPs (desktop) behind the `NsfwClassifier` interface. No changes above the
-  interface.
-- **Phase 4 (optional, later).** Crowd-signal heuristics, labeler reputation, additional
-  categories (violence/gore), UI for managing labeler subscriptions.
+  Runtime EPs (desktop) behind `NsfwClassifier`. No changes above the interface.
+- **Phase 4 (optional, later).** Labeler reputation/weighting, more categories
+  (violence/gore), richer labeler-subscription UI.
 
 ---
 
-## 11. Open questions
+## 11. Testing strategy
 
-1. **Frame budget.** How many keyframes per video balances recall vs. cost on mobile?
-   (Proposed: 3–5, sampled across duration; revisit with PoC numbers.)
-2. **When does Layer-1 classification run?** On thumbnail generation (publish side) and/or
-   on first playback (viewer side)? Proposed: viewer-side on first access *plus* publisher
-   classifies its own uploads and can self-label.
-3. **Default policy out of the box.** Ship `nsfw-explicit → blur` by default, or `show`
-   with an onboarding prompt? Strict-by-default is safer but more opinionated.
-4. **Label volume control.** How aggressively to cap/tail labels in the feed gossip to avoid
-   ballooning `HAVE_FEED` (already a concern — see `public-feed.js:1906`).
-5. **Calibration across backends.** Ensuring Core ML / TFLite / ONNX scores stay comparable
-   enough that `score ≥ threshold` means the same thing everywhere.
+- **Classifier unit tests** (backend, `bare`-runnable): feed known-RGB fixtures (a few
+  bundled benign + synthetic explicit-proxy frames) through `NsfwClassifier`; assert
+  category/score and the max-over-frames verdict. Assert **fail-open** when the model is
+  forced unavailable (verdict `unknown`, content shown).
+- **Effective-verdict logic** (pure function, no model): table-driven over
+  {override, local, trusted-count, advisory-count, policy} → expected `{action, source,
+  badge}`. This is where the trust precedence + thresholds live; test it hard.
+- **Label signing/verify** round-trip in JS; cross-check the canonical signing bytes match
+  Swift codegen output (golden vector committed).
+- **Seed filter**: `addSeed` declines a flagged blob when `seedFlagged=false`, admits when
+  `true` or `unknown`.
+- **No network mocks for classification** — use real bundled frame fixtures and the real
+  model in PoC tests.
 
 ---
 
@@ -366,18 +468,61 @@ their channel key. Subscribing to a labeler = adding its public key to
 | Area | File | Change |
 |------|------|--------|
 | Frame extraction | `packages/backend/src/thumbnail.js` | multi-frame sampling helper |
-| Classifier | `packages/backend/src/moderation/classifier.js` *(new)* | `NsfwClassifier` impl (ONNX) |
-| Worker offload | existing `bare-worker` usage | run inference off main thread |
+| Classifier | `packages/backend/src/moderation/classifier.js` *(new)* | `NsfwClassifier` (ONNX, raw RGB) |
+| Verdict logic | `packages/backend/src/moderation/verdict.js` *(new)* | pure effective-verdict resolver |
 | Verdict cache / policy | `packages/backend/src/moderation/store.js` *(new)* | `metaDb` read/write |
+| Labels | `packages/backend/src/moderation/labels.js` *(new)* | sign / verify / trust-set count |
+| Worker offload | existing `bare-worker` usage | run inference off main thread |
 | View filter | `packages/backend/src/api.js` (`listVideos`, feed) | apply effective verdict |
 | Seed filter | `packages/backend/src/seeding.js` (`addSeed`) | decline flagged blobs |
-| Labels gossip | `packages/backend/src/public-feed.js` | carry/pull `content-label`s |
+| Labels gossip | `packages/backend/src/public-feed.js` | self-label + advisory summary; pull RPC |
 | Schema | `packages/spec/schema.cjs` | new types + RPC; regen JS + Swift |
 | Native (Phase 3) | `packages/desktop-native/Sources/Services/` | Core ML classifier |
-| UI | `packages/app/` | blur overlay, policy settings, override toggle |
+| UI | `packages/app/` | NSFW badge, blur overlay, policy settings, override toggle |
+
+---
+
+## 13. Decision log & open questions
+
+**Decisions adopted this session (D#):**
+
+- **D1 — Fail-open.** Unrated content is always shown; verdicts only ever remove/blur.
+- **D2 — Visible badge is mandatory** whenever any NSFW signal exists, even in show mode.
+- **D3 — Crowd signal split:** trusted-set verified-label counting drives auto-blur/hide
+  (sybil-resistant); raw anonymous counts are advisory-only (badge), never auto-enforce.
+- **D5 — Local model = ground truth, instant only for on-device content;** labels cover
+  not-yet-downloaded content; relays are the dense, high-confidence labelers.
+- **D6 — Thumbnail is a weak first pass, not the verdict;** authoritative verdict is
+  multi-frame; relays sample the whole file.
+- **D7 — Classifier robustness:** bundle the model, feed raw RGB into ONNX (bypass
+  transformers.js image decode), fail-open with diagnostics on load failure.
+- **D8 — Self-label asymmetry:** honor self-labels only when they flag *up*.
+
+**Flagged for your review:**
+
+- **D4 — Default policy.** Proposed: `nsfw-explicit → blur` ON by default (protective,
+  reversible, badge-visible); relays/CLI `seedFlagged=false`. Alternative: ship `off` by
+  default (pure opt-in switch). *Pick one before implementation.*
+- **D3a — Default trust set.** Proposed: ship a small set of default relay labeler keys
+  (the one mild centralization point; editable/removable). Alternative: no defaults
+  (B-only), accepting that auto-hide-on-crowd can't function until the user subscribes to a
+  labeler. *Pick one.*
+
+**Open questions (revisit with PoC numbers):**
+
+- **Q1 — Frame budget.** How many keyframes per video balances recall vs. mobile cost?
+  (Proposed 3–5 viewer-side; relays dense.)
+- **Q2 — Calibration across backends.** Keeping Core ML / TFLite / ONNX scores comparable
+  enough that `score ≥ threshold` means the same thing everywhere.
+- **Q3 — Reputation (Phase 4).** Whether/how to weight labelers beyond binary trust-set
+  membership.
+- **Q4 — Advisory count provenance.** The HAVE_FEED `flagSummary` is forgeable; do we cap
+  the displayed number, or only show the badge boolean to avoid implying precision?
 
 ---
 
 *Adapts AT Protocol composable moderation (self-labels + subscribable labelers + local
-override) to the Hypercore stack. The detection is the easy, tiny part; the opt-in trust
-model is what keeps "local moderation" from quietly becoming "decentralized censorship."*
+override) to the Hypercore stack, extended with a sybil-resistant trusted-set crowd signal
+and a forgeable advisory count. The detection is the easy, tiny part; the opt-in trust
+model — and refusing to let raw counts auto-hide anything — is what keeps "local
+moderation" from quietly becoming "decentralized censorship."*

--- a/docs/superpowers/specs/2026-06-26-local-client-moderation-design.md
+++ b/docs/superpowers/specs/2026-06-26-local-client-moderation-design.md
@@ -298,7 +298,9 @@ label of category ≥ `c`.
    | otherwise | `policy.categories[C]` (default: explicit→`blur`, suggestive→`show`) |
 
    then, in order: if `weakOnly` and the action is `hide`, **downgrade to `blur`** (weak
-   signals never hide); finally **clamp by `mode`** (`mode=="blur"` caps at `blur`).
+   signals never hide); finally **clamp by `mode`** — `mode=="blur"` caps the result at
+   `blur`, so `hideThreshold` and a per-category `"hide"` only produce an actual `hide` when
+   `mode=="hide"`. (Default `mode:"blur"` therefore never hides, only blurs.)
 
    Consequences: a single trusted label ⇒ `blur`, never `hide`; `hide` needs `hideThreshold`
    distinct trusted labelers **or** the user setting `categories[C]="hide"` (their own choice,
@@ -474,7 +476,9 @@ New RPC endpoints:
 - `get-content-labels { channelKey | blobsCoreKey }` → `content-label[]` (bounded pull).
 - `publish-content-label { ... }` → sign + append to the labeler's own label feed
   (relays / opt-in users); **rate-limited** per labeler/target.
-- `get-moderation-policy` / `set-moderation-policy`.
+- `get-moderation-policy` / `set-moderation-policy` — `set` **validates** writes
+  (`blurThreshold ≥ 1`, `hideThreshold ≥ blurThreshold`, known category/action enums) so a
+  malformed policy can't undermine the lattice semantics.
 - `set-content-override { blobsCoreKey, action }`.
 - `subscribe-labeler { labelerKeyHex }` / `unsubscribe-labeler`.
 - `promote-peer-labeler { peerKeyHex }` (manual; moves an advisory peer into the trust set).
@@ -535,6 +539,9 @@ Subscribing to a third-party labeler replicates its label feed and adds its key 
   + signing + golden vector; labeler-owned label feeds; self-label on feed-entry; bounded
   `get-content-labels`; advisory `flagHint` in HAVE_FEED; trust set + thresholds; seed
   quarantine/evict + verdict-change hook in `SeedingManager`; relay dense auto-labeling.
+  **Acceptance gate:** a quarantined blob must be provably non-uploadable — assert via a
+  per-core upload gate, or by keeping the quarantined core unopened/undiscoverable until
+  promotion (resolves the Corestore global-replicate caveat, §3.3).
 - **Phase 3 — Native acceleration.** Core ML / TFLite-NNAPI / ONNX-EP behind
   `NsfwClassifier`. No changes above the interface.
 - **Phase 4 (optional).** Labeler reputation/weighting, more categories (violence/gore),

--- a/docs/superpowers/specs/2026-06-26-local-client-moderation-design.md
+++ b/docs/superpowers/specs/2026-06-26-local-client-moderation-design.md
@@ -1,6 +1,6 @@
 # Local-Client Content Moderation — Design
 
-**Status:** Draft / proposal — revision 3 (spec-review hardened)
+**Status:** Draft / proposal — revision 4 (second review pass)
 **Date:** 2026-06-26
 **Author:** Claude (with @ayooooo123)
 **Branch:** `claude/local-client-moderation-spec-fh5rnx`
@@ -15,7 +15,7 @@
   but split into sybil-resistant trusted-set enforcement vs forgeable advisory-only counts;
   local model = ground truth, instant only for on-device content; thumbnails are a weak
   first pass; classifier fed raw RGB to dodge transformers.js image-decode fragility.
-- **Rev 3 (this)** — hardened against a structured spec review. Material changes:
+- **Rev 3** — hardened against a structured spec review. Material changes:
   1. **Connected peers removed from the enforcement trust set** (a connection is not a
      scarce identity → sybil hole). Trust set = default relays ∪ explicit subscriptions
      only; connected peers may be *manually promoted*, never auto-counted (§2).
@@ -41,6 +41,15 @@
      `sharp`/`onnxruntime-node`/`onnxruntime-web` at module scope; bypassing image-decode
      does not prove ORT-WASM loads in BareKit. Phase 1 is contingent on a measured spike;
      on failure we go straight to native bindings (§5.1, §10).
+- **Rev 4 (this)** — second review pass refinements: the resolver is now a **total**
+  function with an exact category→action table (weak/thumb-only never `hide`; D9); labels
+  drop the redundant `id`, supersede by the `(labeler,target,category)` triple ordered by
+  `seq` (D10); a labeler's identity **is** its label-feed core key, self-labels separated
+  onto the channel-writer path (§9, D11); thresholds count **distinct trusted labeler keys**
+  (D14); seeder quarantine respecified as a **pre-admission state** against the real
+  `addSeed` (which commits immediately) with the Corestore global-replicate caveat, and
+  Phase 1 scoped **strictly local** (§3.3, D15); resolved-cache gains wall-clock `validUntil`
+  (§8).
 
 Decision log + open questions: §13.
 
@@ -192,19 +201,21 @@ channel — so an uploader can neither forge nor suppress third-party labels.
 
 ```
 content-label {
-  id                 : string   // labelerKeyHex + seq (stable identity for supersession)
-  seq                : uint      // labeler's monotonic sequence (latest wins per target/category)
-  targetBlobsCoreKey : string    // content-addressed identity of the video blob
+  // Identity: a third-party labeler IS its label-feed Hypercore key; a self-label uses the
+  // channel-writer key. labelerKeyHex == that public key; the signature verifies against it.
+  labelerKeyHex      : string    // labeler identity = label-feed core key | channel-writer key
+  source             : string     // "relay" | "user" | "self"
+  seq                : uint        // labeler's monotonic sequence; latest wins per (labeler,target,category)
+  targetBlobsCoreKey : string      // content-addressed identity of the video blob
   videoId            : string
   channelKey         : string
-  category           : string    // taxonomy §6
-  score              : float      // classifier confidence 0..1
-  classifierVersion  : string     // "nsfw-mnv2-int8@1" | "self-report" | "manual"
-  labelerKeyHex      : string     // public key of the labeler
+  category           : string      // taxonomy §6
+  score              : float        // classifier confidence 0..1
+  classifierVersion  : string       // "nsfw-mnv2-int8@1" | "self-report" | "manual"
   createdAt          : uint
-  expiresAt          : uint        // 0 = no expiry; clients ignore expired labels
-  revoked            : bool         // tombstone supersedes an earlier label with same id
-  signature          : string      // sign(labelerKeyHex_secret, canonical(label-minus-signature))
+  expiresAt          : uint          // 0 = no expiry; clients ignore expired labels
+  revoked            : bool           // higher-seq revoked record tombstones the (labeler,target,category) triple
+  signature          : string         // sign(labeler secret, canonical(label-minus-signature))
 }
 ```
 
@@ -212,15 +223,18 @@ content-label {
   be lifted onto other content. Canonical signing bytes = compact-encoding of all fields
   except `signature`, identical in JS and Swift (golden vector committed, §7).
 - **Transport — labeler-owned feeds (concrete):**
-  - Each labeler maintains an **append-only label feed**: a Hyperbee over a Hypercore,
-    discoverable by `labelerKeyHex`. The labeler writes/ revokes labels there; it is the
-    durable home for that labeler's claims, independent of any uploader.
-  - **Subscribing** to a labeler = replicating its label feed (selectively, keyed by the
-    blobs/channels the client cares about) and adding its key to `trustedLabelers`.
+  - **A third-party labeler's identity *is* its label-feed core.** Each labeler maintains an
+    append-only label feed (a Hyperbee over a Hypercore); the feed's public key *is*
+    `labelerKeyHex` and the key labels are signed with. Discovery, replication, and
+    signature verification all key off this one identity — no separate signing/feed keys, no
+    new PKI.
+  - **Subscribing** = replicating that feed (selectively, by the blobs/channels the client
+    cares about) and adding its key to `trustedLabelers`.
   - **Relays** (the high-signal default labelers) expose a bounded `get-content-labels`
-    `{ channelKey | blobsCoreKey }` over the existing RPC for on-demand pull, backed by
-    their own label feed.
-  - **Self-label** rides in the channel's `feed-entry` (≤1 tiny label by the uploader).
+    `{ channelKey | blobsCoreKey }` over the existing RPC, backed by their own label feed.
+  - **Self-labels take a *separate* path** — they ride the channel's `feed-entry` (≤1 tiny
+    label by the uploader), are *not* third-party feed labels, and carry `source:"self"`
+    with `labelerKeyHex` = the authorizing channel-writer key (authz below).
   - **Advisory hint** in `HAVE_FEED`: a *boolean-ish capped* `flagHint`
     (`{ nsfwExplicit: bool, nsfwSuggestive: bool }`, optionally a coarse bucket) — forgeable,
     **display-only**, feeds the badge, never enforcement. (We deliberately do *not* gossip
@@ -231,12 +245,15 @@ content-label {
     authorized writer for `channelKey` (per `multi-writer-channel.js` `VALID_WRITER_ROLES`)
     **and** it flags *up* (toward more restrictive). A self-label claiming "safe", or from a
     non-writer, is ignored.
-  - **Supersession/expiry:** keep only the latest non-revoked, non-expired label per
-    `(labelerKeyHex, targetBlobsCoreKey, category)`; tombstones (`revoked`) remove prior.
-  - **Quotas (§8):** one effective label per labeler/category/version; cap untrusted labels
-    per blob; bounded canonical payload size; verify-before-persist.
-  - **Counting:** a label counts toward enforcement thresholds **only if** verified **and**
-    `labelerKeyHex ∈ trustedLabelers`. All other verified labels are advisory-only.
+  - **Supersession/expiry:** per `(labelerKeyHex, targetBlobsCoreKey, category)` keep only
+    the **highest-`seq`** record; a higher-`seq` `revoked` record tombstones it; expired
+    (`expiresAt` past) records are ignored. There is no separate `id` — the triple is the
+    stable identity and `seq` the order.
+  - **Quotas (§8):** store one effective record per `(labeler, category)` (latest seq);
+    cap untrusted labelers per blob; bounded canonical payload; verify-before-persist.
+  - **Counting:** thresholds count **distinct trusted labeler keys** (not labels) holding an
+    effective ≥-category record — so one labeler can't inflate a count. A labeler counts only
+    if its key ∈ `trustedLabelers`; every other verified label is advisory-only.
 
 ### 3.3 Layer 3 — Local enforcement, severity lattice, override
 
@@ -257,32 +274,36 @@ moderation-policy {
 }
 ```
 
-**Effective verdict — a severity lattice (replaces "first hit wins").** Severity order:
-`hide-explicit` > `blur-explicit` > `blur-suggestive` > `none`. The resolver is a **pure,
-local-cache-only function** (no model exec, no network, no signature verification — all done
-earlier at import time):
+**Effective verdict — a total resolver over a severity lattice (replaces "first hit
+wins").** Pure and **local-cache-only** (no model exec, no network, no signature
+verification — those happen at import time). Inputs per video: `override`, `localVideo`
+(authoritative pass verdict | none), `localThumb` (weak pass | none), `selfLabelUp`
+(verified | none), and `trustedCount[c]` = distinct trusted labeler keys with an effective
+label of category ≥ `c`.
 
-1. **Override** short-circuits: `show` ⇒ `{action: show}`; `hide` ⇒ `{action: hide}`.
-2. If `mode == "off"` ⇒ `{action: show, badge: advisory}`.
-3. Otherwise compute `sev = none`, then **raise** it (never lower) from each affirmative,
-   verifiable signal:
-   - authoritative local **video** positive (if `trustLocalModel`) → its category, full
-     strength;
-   - local **thumbnail** positive (if `trustLocalModel`) → its category, **capped at blur**;
-   - verified **self-label-up** (authorized writer) → its category;
-   - for each category, `trustedCount = #verified trusted labels ≥ that category`;
-     `trustedCount ≥ blurThreshold` raises to at least `blur` of that category.
-   *Unknown, "safe", expired, advisory-only, and thumbnail-negative signals never lower
-   `sev`.*
-4. If `sev == none` ⇒ `{action: show, badge: advisory}`.
-5. Map `sev` → action via per-category policy and thresholds:
-   - `action = policy.categories[sevCategory]` (default: explicit→blur, suggestive→show);
-   - escalate: if `trustedCount(sevCategory) ≥ hideThreshold` ⇒ `hide`; else if
-     `≥ blurThreshold` and action would be `show` ⇒ `blur`;
-   - clamp by `mode` (`mode==blur` caps action at `blur`; `mode==hide` allows `hide`).
-   A *single* trusted label can therefore **blur** but, by default, not **hide** (hide needs
-   `hideThreshold` trusted labels, or the user's own authoritative local verdict, or an
-   explicit `categories[...]="hide"`). See §13 D3a/NB2.
+1. **Override short-circuits:** `show` ⇒ `{action:"show"}`; `hide` ⇒ `{action:"hide"}`.
+2. If `mode=="off"` ⇒ `{action:"show", badge}`.
+3. **Pick the strongest category** `C ∈ {explicit, suggestive, none}` by *raising* over the
+   affirmative signals — `localVideo` and `localThumb` (if `trustLocalModel`), `selfLabelUp`,
+   and any `c` with `trustedCount[c] ≥ blurThreshold`. Unknown / "safe" / expired / advisory /
+   negative signals contribute nothing (the lattice only raises). Set `weakOnly = true` iff
+   every signal contributing to `C` is weak — i.e. only `localThumb` and/or
+   `trustedCount[C] < hideThreshold`, with no authoritative `localVideo` and no `selfLabelUp`.
+4. If `C == none` ⇒ `{action:"show", badge}`.
+5. **Map `C` to an action via this exact table, then clamp:**
+
+   | condition (for category `C`) | base action |
+   |------------------------------|-------------|
+   | `trustedCount[C] ≥ hideThreshold` | `hide` |
+   | otherwise | `policy.categories[C]` (default: explicit→`blur`, suggestive→`show`) |
+
+   then, in order: if `weakOnly` and the action is `hide`, **downgrade to `blur`** (weak
+   signals never hide); finally **clamp by `mode`** (`mode=="blur"` caps at `blur`).
+
+   Consequences: a single trusted label ⇒ `blur`, never `hide`; `hide` needs `hideThreshold`
+   distinct trusted labelers **or** the user setting `categories[C]="hide"` (their own choice,
+   applied to their own authoritative/self signals — not `weakOnly`, so not downgraded). The
+   local model never auto-hides under the default `blur` policy. See §13 D3a/NB2.
 
 **Advisory counts never affect `action`.** They populate only `moderation.badge`.
 
@@ -295,15 +316,19 @@ earlier at import time):
    returns it flagged for tap-to-reveal; `show` passes through (badge still rendered).
    Policy/label/verdict changes **invalidate** cached lists (or post-filter) rather than
    caching already-filtered results.
-2. **Seed filter (relay/CLI) — fail-closed + quarantine.** In `SeedingManager.addSeed()`
-   (`seeding.js:214`): admit the blob but mark it **quarantined** (not advertised/served,
-   not counted as durable seed) until a verdict exists; run the dense classifier on the
-   downloaded file. Then:
-   - flagged & `seedFlagged=false` ⇒ **evict** (remove from cache, never advertise);
-   - unknown & `seedUnknown=false` ⇒ evict (relay seeds only what it verified acceptable);
-   - otherwise ⇒ promote to a durable seed.
-   A **verdict-change hook** evicts an already-active seed if a later trusted/local verdict
-   marks it flagged. (Viewer caches stay fail-open; this strict policy is seeder-only.)
+2. **Seed filter (relay/CLI) — fail-closed, Phase 2.** `addSeed` (`seeding.js:214`)
+   *immediately* commits to `activeSeeds` + `persistSeeds()`, and Corestore replicates all
+   cores globally — so "quarantine" is a **new pre-admission state**, not a flag on an active
+   seed: download the blob into a *quarantine* set that is **never** added to `activeSeeds`,
+   never announced on the swarm/feed, and excluded from the relay catalog, availability hints,
+   warmup, and durable-quota accounting. Classify densely (the whole file is present). Then:
+   flagged & `seedFlagged=false`, or unknown & `seedUnknown=false` ⇒ delete blocks + drop;
+   acceptable ⇒ promote via the normal `addSeed` path. A **verdict-change hook** evicts an
+   already-active seed when a later trusted/local verdict turns adverse.
+   *(Open caveat — Corestore's global `store.replicate` means true upload-suppression for a
+   quarantined core needs a per-core upload gate or simply not joining its discovery topic;
+   validated in Phase 2. Viewer caches stay fail-open; this strict policy is seeder-only and
+   out of scope for Phase 1.)*
 3. **Override** — `set-content-override { blobsCoreKey, action }` in `metaDb`. Always wins.
 
 Generalizes the existing local `hideChannel` (`api.js:2818`,
@@ -431,8 +456,8 @@ compromised default relay can't bury content.
 
 New message types (names indicative):
 
-- `content-label` — the signed label record (§3.2), incl. `id`, `seq`, `expiresAt`,
-  `revoked`.
+- `content-label` — the signed label record (§3.2): `labelerKeyHex`, `source`, `seq`,
+  `expiresAt`, `revoked` (no separate `id` — identity is the `(labeler,target,category)` triple).
 - `moderation-policy` — local policy (persisted to `metaDb`, typed for RPC).
 - `moderation-verdict` — `{ action, category, score, source: "override"|"local"|"label",
   badge }` attached to `video` results when present.
@@ -468,11 +493,11 @@ Swift — commit a golden vector and cross-check it in tests (§11).
 | `moderation:policy` | `moderation-policy` |
 | `moderation:self:<blobsCoreKey>` | local verdict + `classifierVersion` + timestamp (recomputed on version bump) |
 | `moderation:override:<blobsCoreKey>` | `"show"` \| `"hide"` |
-| `moderation:labels:<blobsCoreKey>` | verified labels (trusted + advisory, tagged), deduped per labeler/category/version |
+| `moderation:labels:<blobsCoreKey>` | verified labels (trusted + advisory, tagged), one effective record per `(labeler, category)` latest `seq` |
 | `moderation:labelers` | trust set (default relays ∪ subscriptions ∪ manually-promoted peers) |
-| `moderation:resolved:<blobsCoreKey>` | cached pure-resolver output for the hot list path; invalidated on policy/label/verdict change |
+| `moderation:resolved:<blobsCoreKey>` | cached resolver output for the hot list path + `validUntil` (next label `expiresAt`); invalidated on policy/label/verdict change **or** when `validUntil` passes |
 
-**Quotas:** one effective label per `(labeler, category, version)`; max untrusted labels per
+**Quotas:** one effective label per `(labeler, category)` (latest `seq`); max untrusted labels per
 blob (e.g. 64); bounded canonical label size; signature verified before persistence. All
 keys are per-client and local; nothing here is authoritative for anyone else.
 
@@ -480,12 +505,20 @@ keys are per-client and local; nothing here is authoritative for anyone else.
 
 ## 9. Identity for labelers
 
-Reuse the existing channel/device keypair model (`VALID_WRITER_ROLES` etc. in
-`packages/backend/src/channel/multi-writer-channel.js`). A labeler key is a Hypercore
-keypair; a relay signs with its relay identity, an opt-in user with their channel key.
-Subscribing replicates a labeler's label feed and adds its key to `trustedLabelers`. Default
-relay labeler keys ship with the app (editable/removable). Self-label authorization is
-verified against channel writer roles (§3.2). No new PKI.
+There are two distinct label sources with two distinct identities:
+
+- **Third-party labelers** (relays, opt-in users): the labeler identity **is** its
+  append-only **label-feed Hypercore key** (§3.2). It signs with that core's keypair;
+  `labelerKeyHex` = that public key; discovery, replication, signature verification, and
+  trust-set membership all key off it. Default relay labeler keys ship with the app
+  (editable/removable). No separate signing/feed keys, no new PKI.
+- **Self-labels** (an uploader tagging its own video): authorized via the existing channel
+  writer model (`VALID_WRITER_ROLES` in `multi-writer-channel.js`); `labelerKeyHex` = the
+  channel-writer key, `source:"self"`. These ride the channel `feed-entry`, never a label
+  feed, and are honored only when they flag *up* (§3.2).
+
+Subscribing to a third-party labeler replicates its label feed and adds its key to
+`trustedLabelers`.
 
 ---
 
@@ -570,13 +603,22 @@ verified against channel writer roles (§3.2). No new PKI.
   on load failure — **gated by the Phase 1a spike** (D12).
 - **D8** Self-labels honored only when they flag *up* **and** come from an authorized
   channel writer.
-- **D9** Effective verdict is a **severity lattice** (only raises); advisory never enforces.
-- **D10** Labels carry id/seq/expiry/revocation; local verdict cache invalidates on model
-  version bump; nothing trusted forever.
-- **D11** Labeler-owned append-only label feeds (Hyperbee/Hypercore) are the durable label
-  transport; relays expose bounded `get-content-labels`.
+- **D9** Effective verdict is a **total resolver** over a severity lattice (only ever
+  *raises* severity; weak/thumb-only signals never `hide`; advisory never enforces; the
+  C→action mapping is an exact table clamped by `mode`).
+- **D10** Labels carry `seq`/`expiresAt`/`revoked` (no separate `id`); supersession is by the
+  `(labeler, target, category)` triple ordered by `seq`; the local verdict cache invalidates
+  on model-version bump and the resolved cache on `validUntil`. Nothing is trusted forever.
+- **D11** A third-party labeler's identity **is** its append-only label-feed Hypercore key
+  (Hyperbee over Hypercore); self-labels use the channel-writer key on a separate path.
+  Relays expose a bounded `get-content-labels`.
 - **D12** Phase 1 is gated by a measured BareKit/Electrobun ONNX-WASM spike (§5.1).
 - **D13** `listVideos` stays hot: the view filter is a pure local-cache resolver only.
+- **D14** Thresholds count **distinct trusted labeler keys** (not labels); one labeler can't
+  inflate a count.
+- **D15** Seeder quarantine is a **pre-admission state** (not a flag on an `activeSeed`);
+  Phase 1 is strictly local (no labels, no seeding control). True upload-suppression under
+  Corestore's global replicate is a Phase-2 caveat (§3.3).
 
 **Flagged for your review:**
 


### PR DESCRIPTION
## Local-client content moderation — design spec + Phase 1 plan

Adds the **design** and a **Phase 1 implementation plan** for fully-P2P, on-device content
moderation. No code changes yet — docs only.

### What & why
PearTube gossips *all* public content with no central authority. This brings a way for each
client to **locally** decide whether content is NSFW and filter it — using a tiny on-device
vision model — without any entity gaining takedown power. Three layers (AT-Protocol
"composable moderation" adapted to Hypercore):

1. **Local self-classification** (zero trust) — bundled int8 ONNX model fed raw RGB straight
   from `bare-ffmpeg`, in a `bare-worker`. Ground truth for that user; the uploader can't game
   it.
2. **Signed labels** (opt-in trust) — labeler-owned append-only feeds; relays that replicate
   whole files are the natural high-signal labelers. *(Phase 2.)*
3. **Local enforcement + override** — a total severity-lattice resolver (only ever raises
   severity; weak/thumbnail signals never hide; advisory crowd counts never auto-enforce);
   viewer fail-open, seeder fail-closed quarantine.

### Product decisions (fully decentralized)
- **Moderation OFF by default** — pure opt-in; dormant (no classify/badge/enforce) until the
  user flips the switch.
- **No shipped trust set** (B-only) — the local model is the sole default enforcer; signed
  labels / crowd signal are inert until the user subscribes to a labeler by key.

Consequence: **Phase 1 (local model only) is the entire default-enabled feature**; labels +
trusted-set crowd + relay seeding-control are Phase 2; native Core ML / TFLite / ONNX-EP
acceleration is Phase 3.

### Review status
- **Spec:** 3 review iterations → **0 blocking issues** (severity lattice, sybil-resistant
  trust, labeler-feed transport, revocation/expiry + model-version cache invalidation,
  fail-closed seeder quarantine grounded in the real `addSeed`, ONNX-on-Bare feasibility-spike
  gate).
- **Phase 1 plan:** reviewed; fixed blob→frame source resolution, HRPC codegen-adapter
  registration (`APP_RPC_NAMESPACES`), and badge field flattening across the wire.

### Files
- `docs/superpowers/specs/2026-06-26-local-client-moderation-design.md` (rev 5)
- `docs/superpowers/plans/2026-06-26-local-moderation-phase1.md`

### Not in scope
No implementation code. Phase 1 begins with a feasibility spike (does bundled-ONNX-on-raw-RGB
run in BareKit/Electrobun?) before any product code is written.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
