### PR TITLE
[codex] Improve Electrobun desktop P2P reliability

### DIFF
--- a/packages/app/src/bun/index.ts
+++ b/packages/app/src/bun/index.ts
@@ -30,9 +30,9 @@ function killStaleLocks() {
       const pid = parseInt(pidStr, 10)
       if (!pid || pid === process.pid) continue
       console.log('[main] Killing stale worker holding Corestore lock: PID', pid)
-      try { process.kill(pid, 'SIGKILL') } catch {}
+      try { process.kill(pid, 'SIGKILL') } catch { /* best effort */ }
     }
-  } catch {}
+  } catch { /* best effort */ }
 }
 killStaleLocks()
 
@@ -120,7 +120,7 @@ function getWorker(specifier: string) {
 function destroyAllWorkers() {
   for (const [specifier, worker] of workers) {
     console.log('[main] Destroying worker:', specifier)
-    try { worker.destroy() } catch {}
+    try { worker.destroy() } catch { /* best effort */ }
   }
   workers.clear()
   // Force-kill any lingering bare processes after 2s
@@ -130,7 +130,7 @@ function destroyAllWorkers() {
       for (const pid of pidsToKill) {
         if (workerPids.has(pid)) {
           console.log('[main] Force-killing worker PID:', pid)
-          try { process.kill(pid, 'SIGKILL') } catch {}
+          try { process.kill(pid, 'SIGKILL') } catch { /* best effort */ }
           workerPids.delete(pid)
         }
       }
@@ -174,7 +174,7 @@ function startIPCWebSocket() {
           worker = getWorker(BACKEND_WORKER)
         } catch (err: any) {
           console.error('[main] IPC WebSocket worker startup failed:', err?.message || err)
-          try { ws.close(1011, 'worker startup failed') } catch {}
+          try { ws.close(1011, 'worker startup failed') } catch { /* best effort */ }
           return
         }
 
@@ -215,7 +215,7 @@ function startIPCWebSocket() {
 
 function stopIPCWebSocket() {
   if (!ipcWsServer) return
-  try { ipcWsServer.stop?.(true) } catch {}
+  try { ipcWsServer.stop?.(true) } catch { /* best effort */ }
   ipcWsServer = null
   ipcWsPort = 0
 }
@@ -317,7 +317,7 @@ async function startStaticServer() {
 
 function stopStaticServer() {
   if (!staticServer) return
-  try { staticServer.stop?.(true) } catch {}
+  try { staticServer.stop?.(true) } catch { /* best effort */ }
   staticServer = null
   staticPort = 0
 }
@@ -356,6 +356,6 @@ process.on('SIGTERM', () => { destroyAllWorkers(); process.exit(0) })
 process.on('SIGINT', () => { destroyAllWorkers(); process.exit(0) })
 process.on('exit', () => {
   for (const pid of workerPids) {
-    try { process.kill(pid, 'SIGKILL') } catch {}
+    try { process.kill(pid, 'SIGKILL') } catch { /* best effort */ }
   }
 })

--- a/packages/app/src/bun/index.ts
+++ b/packages/app/src/bun/index.ts
@@ -273,34 +273,6 @@ async function startStaticServer() {
         })
       }
 
-      // Blob proxy — same-origin proxy to the blob server.
-      // mediabunny's UrlSource uses fetch() which enforces CORS.
-      // Proxying through the static server avoids cross-origin issues.
-      if (url.pathname === '/__blob') {
-        const rawPort = url.searchParams.get('__port') || blobServerPort
-        const port = Number(rawPort)
-        if (!Number.isInteger(port) || port <= 0) {
-          return new Response('Blob server is not ready', { status: 503 })
-        }
-        url.searchParams.delete('__port')
-        const blobUrl = `http://127.0.0.1:${port}/?${url.searchParams.toString()}`
-        const headers: Record<string, string> = {}
-        const range = req.headers.get('range')
-        if (range) headers['Range'] = range
-        try {
-          const blobRes = await fetch(blobUrl, { headers, signal: req.signal })
-          const respHeaders = new Headers(blobRes.headers)
-          respHeaders.set('Access-Control-Allow-Origin', '*')
-          respHeaders.set('Access-Control-Expose-Headers', 'Content-Length, Content-Range, Accept-Ranges')
-          return new Response(blobRes.body, {
-            status: blobRes.status,
-            headers: respHeaders,
-          })
-        } catch (err: any) {
-          return new Response('Blob proxy error: ' + err?.message, { status: 502 })
-        }
-      }
-
       let filePath = join(viewsDir, decodeURIComponent(url.pathname === '/' ? '/index.html' : url.pathname))
 
       const file = Bun.file(filePath)

--- a/packages/app/tests/desktop-bundle-script-regression.test.mjs
+++ b/packages/app/tests/desktop-bundle-script-regression.test.mjs
@@ -270,6 +270,11 @@ test('desktop worker boots the universal backend with the real backend context',
   )
   assert.match(
     workerSource,
+    /createBackend\(\{[\s\S]*platform:\s*'desktop'/,
+    'Electrobun desktop worker should boot the universal backend with desktop transport tuning',
+  )
+  assert.match(
+    workerSource,
     /Backend context did not initialize required desktop services/,
     'desktop worker should fail fast before exposing identity handlers without the real context',
   )

--- a/packages/app/tests/electrobun-latency-regression.test.mjs
+++ b/packages/app/tests/electrobun-latency-regression.test.mjs
@@ -65,6 +65,15 @@ test('Electrobun IPC relay removes the per-socket worker data listener on close'
   assert.match(source, /removeWorkerDataListener\(worker, forwardWorkerData\)/)
 })
 
+test('Electrobun main process does not proxy blob media bytes', () => {
+  const source = readAppFile('src/bun/index.ts')
+
+  assert.match(source, /__peartube_ipc_port/, 'main process should still expose IPC port discovery')
+  assert.doesNotMatch(source, /__blob/, 'media should go directly to the backend blob server')
+  assert.doesNotMatch(source, /Blob proxy/i, 'main process should not contain a blob proxy path')
+  assert.doesNotMatch(source, /fetch\(blobUrl/, 'main process should not refetch backend blob bytes')
+})
+
 test('Electroview bridge reuses the IPC WebSocket instead of creating duplicate transports', () => {
   const source = readAppFile('src/view/index.ts')
 

--- a/packages/app/tests/native-backend-startup-regression.test.mjs
+++ b/packages/app/tests/native-backend-startup-regression.test.mjs
@@ -234,6 +234,9 @@ test('mobile getSwarmStatus forwards low-level network diagnostics', () => {
   assert.ok(handlerBlock, 'mobile getSwarmStatus handler should exist')
   for (const field of [
     'network',
+    'startupTiming',
+    'doctor',
+    'directPeerDial',
     'swarmOffline',
     'swarmOfflineReason',
     'swarmListenResolved',
@@ -256,6 +259,9 @@ test('desktop worker forwards feed update events and full swarm diagnostics', ()
   assert.match(swarmStatusBlock, /api\.getSwarmStatus\(\)/)
   for (const field of [
     'network',
+    'startupTiming',
+    'doctor',
+    'directPeerDial',
     'swarmOffline',
     'swarmOfflineReason',
     'swarmListenResolved',

--- a/packages/app/workers/desktop/index.ts
+++ b/packages/app/workers/desktop/index.ts
@@ -686,6 +686,7 @@ B.getStatus = async () => ({ status: { ready: true, hasIdentity: identityManager
 B.getSwarmStatus = async () => {
   const s = api.getSwarmStatus()
   return {
+    ...s,
     connected: (s.swarmConnections || 0) > 0,
     peerCount: s.swarmConnections || 0,
     swarmConnections: s.swarmConnections || 0,
@@ -694,6 +695,9 @@ B.getSwarmStatus = async () => {
     feedEntries: s.feedEntries || 0,
     channelsLoaded: s.channelsLoaded || 0,
     network: s.network || null,
+    startupTiming: s.startupTiming || null,
+    doctor: s.doctor || null,
+    directPeerDial: s.directPeerDial || s.doctor?.feed?.directPeerDial || null,
     swarmOffline: Boolean(s.swarmOffline),
     swarmOfflineReason: s.swarmOfflineReason || null,
     swarmListenResolved: Boolean(s.swarmListenResolved),

--- a/packages/backend/src/seeding.js
+++ b/packages/backend/src/seeding.js
@@ -8,6 +8,8 @@
 import { normalizeBlobsCoreKey, normalizeBlobRefInput, stringifyBlobId } from './blob-ref.js';
 import { collectCorestoreGarbage } from './corestore-gc.js';
 
+const DEFAULT_STORAGE_MAINTENANCE_DELAY_MS = 30000
+
 /**
  * @typedef {import('./types.js').SeedingConfig} SeedingConfig
  * @typedef {import('./types.js').SeedInfo} SeedInfo
@@ -34,6 +36,16 @@ function normalizeProtectedSeedKeys(keys) {
 
 function createNoopRelease() {
   return () => {}
+}
+
+function resolveStorageMaintenanceDelayMs(value) {
+  const explicit = Number(value)
+  if (Number.isFinite(explicit) && explicit >= 0) return Math.floor(explicit)
+
+  const envValue = Number(globalThis?.process?.env?.PEARTUBE_STORAGE_MAINTENANCE_DELAY_MS)
+  if (Number.isFinite(envValue) && envValue >= 0) return Math.floor(envValue)
+
+  return DEFAULT_STORAGE_MAINTENANCE_DELAY_MS
 }
 
 /**
@@ -87,7 +99,7 @@ export class SeedingManager {
   /**
    * @param {import('corestore')} store - Corestore instance
    * @param {import('hyperbee')} metaDb - Metadata database
-   * @param {{ getDiskUsageBytes?: () => number | Promise<number>, isCacheClearBlocked?: () => boolean }} [options]
+   * @param {{ getDiskUsageBytes?: () => number | Promise<number>, isCacheClearBlocked?: () => boolean, storageMaintenanceDelayMs?: number, setTimer?: typeof setTimeout, clearTimer?: typeof clearTimeout }} [options]
    */
   constructor(store, metaDb, options = {}) {
     this.store = store;
@@ -100,6 +112,9 @@ export class SeedingManager {
     this.isCacheClearBlocked = typeof options.isCacheClearBlocked === 'function'
       ? options.isCacheClearBlocked
       : null;
+    this.storageMaintenanceDelayMs = resolveStorageMaintenanceDelayMs(options.storageMaintenanceDelayMs);
+    this.setTimer = typeof options.setTimer === 'function' ? options.setTimer : setTimeout;
+    this.clearTimer = typeof options.clearTimer === 'function' ? options.clearTimer : clearTimeout;
     /** @type {Map<string, SeedInfo>} key: `${driveKey}:${videoPath}` -> seed info */
     this.activeSeeds = new Map();
     /** @type {Map<string, number>} blobsCoreKey -> active playback/prefetch retain count */
@@ -108,6 +123,10 @@ export class SeedingManager {
     this.pinnedChannels = new Set();
     /** @type {ReturnType<typeof setTimeout> | null} pending throttled seed persist */
     this._seedPersistTimer = null;
+    /** @type {ReturnType<typeof setTimeout> | null} pending storage compaction timer */
+    this._storageMaintenanceTimer = null;
+    this._storageMaintenanceCompacting = false;
+    this._storageMaintenancePendingLabel = null;
     /** @type {SeedingConfig} */
     this.config = {
       maxStorageGB: 5,            // Default 5GB quota for seeded peer content
@@ -170,6 +189,53 @@ export class SeedingManager {
 
   shouldSkipSeedClear(seed) {
     return this.isCacheClearBlockedNow() || this.isSeedBlobProtected(seed)
+  }
+
+  scheduleCorestoreCompaction(label = 'cache clear compaction') {
+    if (typeof this.store?.storage?.compact !== 'function') return false
+
+    this._storageMaintenancePendingLabel = label
+    if (this._storageMaintenanceTimer || this._storageMaintenanceCompacting) return true
+
+    let timer = null
+    timer = this.setTimer(() => {
+      if (this._storageMaintenanceTimer === timer) this._storageMaintenanceTimer = null
+      return this.runScheduledCorestoreCompaction()
+    }, this.storageMaintenanceDelayMs)
+    this._storageMaintenanceTimer = timer
+    timer?.unref?.()
+    return true
+  }
+
+  async runScheduledCorestoreCompaction() {
+    if (this.isCacheClearBlockedNow()) {
+      this.scheduleCorestoreCompaction(this._storageMaintenancePendingLabel || 'cache clear compaction')
+      return { compacted: false, blocked: true }
+    }
+    if (this._storageMaintenanceCompacting) return { compacted: false, running: true }
+
+    this._storageMaintenanceCompacting = true
+    const label = this._storageMaintenancePendingLabel || 'cache clear compaction'
+    this._storageMaintenancePendingLabel = null
+    try {
+      return await collectCorestoreGarbage(this.store, {
+        label,
+        log: console.log,
+        skipFlush: true
+      })
+    } finally {
+      this._storageMaintenanceCompacting = false
+      if (this._storageMaintenancePendingLabel) this.scheduleCorestoreCompaction(this._storageMaintenancePendingLabel)
+    }
+  }
+
+  async flushClearedBlobRanges(label) {
+    await collectCorestoreGarbage(this.store, {
+      label,
+      log: console.log,
+      skipCompact: true
+    });
+    this.scheduleCorestoreCompaction(`${label} compaction`);
   }
 
   /**
@@ -293,10 +359,7 @@ export class SeedingManager {
       }
       await this.persistSeeds();
       if (clearedBlob) {
-        await collectCorestoreGarbage(this.store, {
-          label: 'seed removal',
-          log: console.log
-        });
+        await this.flushClearedBlobRanges('seed removal');
       }
       console.log('[SeedingManager] Removed seed:', key.slice(0, 32));
       return true;
@@ -495,10 +558,7 @@ export class SeedingManager {
     await this.persistSeeds();
 
     if (clearedBlob) {
-      await collectCorestoreGarbage(this.store, {
-        label: 'quota enforcement',
-        log: console.log
-      });
+      await this.flushClearedBlobRanges('quota enforcement');
     }
   }
 
@@ -642,10 +702,7 @@ export class SeedingManager {
     if (gb < previousMaxStorageGB) {
       const partials = await this.clearDownloadIntents()
       if (partials.clearedBlob) {
-        await collectCorestoreGarbage(this.store, {
-          label: 'partial download intent clear',
-          log: console.log
-        });
+        await this.flushClearedBlobRanges('partial download intent clear');
       }
     }
     // Enforce quota with the new limit after any lower-limit partial cleanup.
@@ -748,21 +805,10 @@ export class SeedingManager {
     await this.persistSeeds();
 
     if (clearedBlob) {
-      // Flush synchronously so the cleared ranges are durable, but run the
-      // RocksDB compaction in the background: on multi-GB stores it can take
-      // minutes on mobile flash, and awaiting it here held the clearCache RPC
-      // reply (and starved every other storage op) until it finished — the
-      // app appeared to hang on "Clear cache".
-      await collectCorestoreGarbage(this.store, {
-        label: 'cache clear',
-        log: console.log,
-        skipCompact: true
-      });
-      void collectCorestoreGarbage(this.store, {
-        label: 'cache clear compaction',
-        log: console.log,
-        skipFlush: true
-      }).catch(() => {});
+      // Flush synchronously so cleared ranges are durable, then defer RocksDB
+      // compaction until playback is idle. Compacting immediately can contend
+      // with blob-server range reads and make the next stream crawl.
+      await this.flushClearedBlobRanges('cache clear');
     }
 
     const postTotalStorageBytes = await this.getTotalStorageBytes();

--- a/packages/backend/src/storage.js
+++ b/packages/backend/src/storage.js
@@ -88,6 +88,12 @@ const log = logger('Storage')
 // re-dial at startup for warm reconnect. Bounded so a firewalled client warms
 // its best recent peers without flooding the swarm with stale dials.
 const KNOWN_PEER_REDIAL_LIMIT = 16
+const DESKTOP_SWARM_DEFAULTS = Object.freeze({
+  maxParallel: 12,
+  maxPeers: 96
+})
+const DESKTOP_PEER_POOL_WARM_REFRESH_INTERVALS_MS = Object.freeze([3000, 10000, 30000])
+const DESKTOP_PEER_POOL_MIN_CONNECTIONS = 4
 
 // Network stats for debugging connection issues
 let HyperswarmStats = null
@@ -97,6 +103,125 @@ const HYPERSWARM_MODULE_TIMEOUT_MS = 5000
 
 // Global network stats instance (set after swarm is created)
 let networkStats = null;
+
+function copyDefinedOptions(source, keys) {
+  const out = {}
+  if (!source || typeof source !== 'object') return out
+  for (const key of keys) {
+    if (source[key] !== undefined) out[key] = source[key]
+  }
+  return out
+}
+
+function summarizeSwarmOptions(options = {}) {
+  if (!options || typeof options !== 'object') return null
+  const summary = { ...options }
+  if (summary.keyPair) {
+    summary.keyPair = {
+      publicKey: shortKeyHex(summary.keyPair.publicKey)
+    }
+  }
+  if (summary.dht) summary.dht = '[custom-dht]'
+  if (typeof summary.firewall === 'function') summary.firewall = '[function]'
+  if (typeof summary.relayThrough === 'function') summary.relayThrough = '[function]'
+  return summary
+}
+
+export function resolveHyperswarmOptions({
+  keyPair,
+  platform = 'desktop',
+  network = {},
+  swarmOptions = {}
+} = {}) {
+  const normalizedPlatform = platform === 'mobile' ? 'mobile' : 'desktop'
+  const networkOptions = copyDefinedOptions(network, [
+    'bootstrap',
+    'nodes',
+    'port',
+    'deferRandomPunch',
+    'randomPunchInterval'
+  ])
+  const explicitOptions = swarmOptions && typeof swarmOptions === 'object' ? { ...swarmOptions } : {}
+
+  // Storage owns the persisted Hyperswarm identity; launch-time tuning must not
+  // replace it with an ephemeral caller-provided keypair.
+  delete explicitOptions.keyPair
+
+  return {
+    ...networkOptions,
+    ...(normalizedPlatform === 'desktop' ? DESKTOP_SWARM_DEFAULTS : {}),
+    ...explicitOptions,
+    keyPair
+  }
+}
+
+export function schedulePeerPoolWarmupRefreshes({
+  platform = 'desktop',
+  swarm,
+  discovery,
+  startupTiming = null,
+  intervals = DESKTOP_PEER_POOL_WARM_REFRESH_INTERVALS_MS,
+  minConnections = DESKTOP_PEER_POOL_MIN_CONNECTIONS,
+  setTimer = setTimeout,
+  clearTimer = clearTimeout,
+} = {}) {
+  if (platform !== 'desktop') return { scheduled: 0, reason: 'non-desktop', cancel() {} }
+  if (!swarm || !discovery || typeof discovery.refresh !== 'function') {
+    return { scheduled: 0, reason: 'missing-discovery-refresh', cancel() {} }
+  }
+  const currentConnections = Number(swarm.connections?.size || 0)
+  if (currentConnections >= minConnections) {
+    return { scheduled: 0, reason: 'connection-target-met', cancel() {} }
+  }
+
+  let cancelled = false
+  const timers = []
+
+  intervals.forEach((delayMs, index) => {
+    const timer = setTimer(async () => {
+      if (cancelled) return
+      const connections = Number(swarm.connections?.size || 0)
+      const connecting = Number(swarm.connecting || 0)
+      if (connections >= minConnections) {
+        startupTiming?.record?.('peer-pool-warm-refresh-skipped', {
+          attempt: index + 1,
+          connections,
+          connecting,
+          reason: 'connection-target-met'
+        })
+        return
+      }
+
+      startupTiming?.record?.('peer-pool-warm-refresh', {
+        attempt: index + 1,
+        connections,
+        connecting
+      })
+      try {
+        await discovery.refresh({ server: true, client: true })
+      } catch (err) {
+        startupTiming?.record?.('peer-pool-warm-refresh-failed', {
+          attempt: index + 1,
+          connections,
+          connecting,
+          error: err?.message || String(err)
+        })
+      }
+    }, delayMs)
+    timers.push(timer)
+  })
+
+  return {
+    scheduled: timers.length,
+    reason: 'scheduled',
+    cancel() {
+      cancelled = true
+      for (const timer of timers) {
+        try { clearTimer(timer) } catch { /* best effort */ }
+      }
+    }
+  }
+}
 
 function createNetworkStartupTiming() {
   const startedAt = Date.now()
@@ -595,6 +720,7 @@ function createSwarmDiagnostics(swarm) {
       }
 
       return {
+        options: summarizeSwarmOptions(swarm?._peartubeSwarmOptions),
         recentPeers: recentPeers.slice(-10),
         recentUpdates: recentUpdates.slice(-10),
         recentConnections: recentConnections.slice(-10),
@@ -1093,7 +1219,10 @@ export async function initializeStorage(config) {
     blobServerBindHost: blobServerBindHostOverride,
     primaryKey = null,
     corestoreWaitForLock = false,
-    corestoreAllowBackup = false
+    corestoreAllowBackup = false,
+    platform = 'desktop',
+    network = {},
+    swarmOptions = {}
   } = config;
 
   console.log('[Storage] Initializing storage at:', storagePath);
@@ -1148,6 +1277,12 @@ export async function initializeStorage(config) {
   console.log('[Storage] Creating Hyperswarm (early, before storage warmup)...');
   await appendDebugLine('[storage] creating hyperswarm early')
   const LoadedHyperswarm = await waitForHyperswarmModule()
+  const hyperswarmOptions = resolveHyperswarmOptions({
+    keyPair,
+    platform,
+    network,
+    swarmOptions
+  })
   let swarm
   if (typeof LoadedHyperswarm !== 'function') {
     console.warn('[Storage] Hyperswarm unavailable; continuing with offline P2P networking')
@@ -1155,15 +1290,19 @@ export async function initializeStorage(config) {
     swarm = createOfflineSwarm(keyPair, 'module-unavailable')
   } else {
     try {
-      swarm = new LoadedHyperswarm({ keyPair });
+      swarm = new LoadedHyperswarm(hyperswarmOptions);
     } catch (err) {
       console.warn('[Storage] Hyperswarm creation failed; continuing with offline P2P networking:', err?.message)
       await appendDebugLine(`[storage] hyperswarm create failed; using offline swarm ${err?.message || String(err)}`)
       swarm = createOfflineSwarm(keyPair, err?.message || 'create-failed')
     }
   }
+  swarm._peartubeSwarmOptions = summarizeSwarmOptions(hyperswarmOptions)
   console.log('[Storage] Swarm created, publicKey:', b4a.toString(swarm.keyPair.publicKey, 'hex').slice(0, 16));
-  globalNetworkStartupTiming?.record('swarm-created', { offline: Boolean(swarm._peartubeOffline) })
+  globalNetworkStartupTiming?.record('swarm-created', {
+    offline: Boolean(swarm._peartubeOffline),
+    options: swarm._peartubeSwarmOptions
+  })
   const initialDhtState = describeDhtState(swarm.dht)
   if (initialDhtState) {
     console.log('[Storage] Initial DHT bind state:', JSON.stringify(initialDhtState))
@@ -1597,6 +1736,12 @@ export async function initializeStorage(config) {
       globalPeerPoolDiscovery = poolDiscovery;
       swarm.peerPoolDiscovery = poolDiscovery
       console.log('[Storage] Joined peartube-network topic for peer pool building immediately:', reason)
+      swarm._peartubePeerPoolWarmup = schedulePeerPoolWarmupRefreshes({
+        platform,
+        swarm,
+        discovery: poolDiscovery,
+        startupTiming: globalNetworkStartupTiming
+      })
       // Do not await flushed(); mobile DHT bootstrapping can lag behind the join.
       poolDiscovery.flushed().then(() => {
         console.log('[Storage] Peer pool topic discovery flushed, connections:', swarm.connections?.size || 0);
@@ -2397,6 +2542,9 @@ export async function shutdownBackend(ctx) {
       } catch (err) {
         console.log('[Backend] Shutdown: DHT routing table persist failed (non-fatal):', err?.message)
       }
+      try {
+        ctx.swarm._peartubePeerPoolWarmup?.cancel?.()
+      } catch { /* best effort */ }
       console.log('[Backend] Shutdown: destroying swarm...')
       await runShutdownStep('swarm destroy', async () => {
         await ctx.swarm.destroy()
@@ -2486,6 +2634,7 @@ export async function suspendNetworking() {
 
     if (globalSwarm) {
       await persistDhtRoutingTable(globalSwarm, globalMetaDb, { reason: 'suspend' })
+      try { globalSwarm._peartubePeerPoolWarmup?.cancel?.() } catch { /* best effort */ }
       await globalSwarm.suspend();
       console.log('[Network] Swarm suspended');
     }
@@ -2748,6 +2897,7 @@ export function getNetworkStats() {
       return {
         connections: globalSwarm.connections?.size || 0,
         peers: globalSwarm.peers?.size || 0,
+        swarmOptions: globalSwarm._peartubeSwarmOptions || null,
         offline: Boolean(globalSwarm._peartubeOffline),
         offlineReason: globalSwarm._peartubeOfflineReason || null,
         listenResolved: Boolean(globalSwarm._peartubeListenResolved),

--- a/packages/backend/test/clear-cache-stall-regression.test.mjs
+++ b/packages/backend/test/clear-cache-stall-regression.test.mjs
@@ -4,10 +4,55 @@ import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
 
 import { collectCorestoreGarbage } from '../src/corestore-gc.js'
+import { SeedingManager } from '../src/seeding.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const seedingSource = readFileSync(resolve(__dirname, '../src/seeding.js'), 'utf8')
 const apiSource = readFileSync(resolve(__dirname, '../src/api.js'), 'utf8')
+
+const GB = 1024 * 1024 * 1024
+const coreA = 'aa'.repeat(32)
+
+function createMetaDb() {
+  const state = new Map()
+  return {
+    async get(key) {
+      return state.has(key) ? { value: state.get(key) } : null
+    },
+    async put(key, value) {
+      state.set(key, value)
+    }
+  }
+}
+
+function createStore() {
+  const cores = new Map()
+  return {
+    storage: {
+      flushCalls: 0,
+      compactCalls: 0,
+      async flush() {
+        this.flushCalls += 1
+      },
+      async compact() {
+        this.compactCalls += 1
+      },
+    },
+    async getDiskUsageBytes() {
+      return 6 * GB
+    },
+    get(key) {
+      const keyHex = Buffer.isBuffer(key) ? key.toString('hex') : String(key)
+      if (!cores.has(keyHex)) {
+        cores.set(keyHex, {
+          async ready() {},
+          async clear() {}
+        })
+      }
+      return cores.get(keyHex)
+    }
+  }
+}
 
 test('collectCorestoreGarbage honors skipFlush/skipCompact', async (t) => {
   const calls = []
@@ -30,19 +75,59 @@ test('collectCorestoreGarbage honors skipFlush/skipCompact', async (t) => {
   t.is(compactOnly.compacted, true)
 })
 
-test('clearCache does not hold the RPC reply on RocksDB compaction', (t) => {
+test('clearCache defers RocksDB compaction to idle storage maintenance', (t) => {
   // Compacting a multi-GB store can take minutes on mobile flash. Awaiting it
   // inside clearCache held the RPC reply and starved every other storage op —
   // the app appeared to hang on "Clear cache". The flush is awaited (cleared
-  // ranges become durable) but compaction must run in the background.
+  // ranges become durable) but compaction must be scheduled for later so it can
+  // re-check playback state before touching RocksDB.
   const clearCacheStart = seedingSource.indexOf('async clearCache(')
   t.ok(clearCacheStart !== -1, 'expected SeedingManager.clearCache')
   const clearCache = seedingSource.slice(clearCacheStart, seedingSource.indexOf('clearCacheSync', clearCacheStart))
 
-  t.ok(/await collectCorestoreGarbage\(this\.store, \{[^}]*skipCompact: true/s.test(clearCache),
-    'the awaited GC pass must skip compaction')
-  t.ok(/void collectCorestoreGarbage\(this\.store, \{[^}]*skipFlush: true/s.test(clearCache),
-    'compaction must be kicked off without being awaited')
+  t.ok(/await this\.flushClearedBlobRanges\('cache clear'\)/.test(clearCache),
+    'clearCache should flush cleared ranges through the maintenance helper')
+  t.absent(/void collectCorestoreGarbage\(this\.store, \{[^}]*skipFlush: true/s.test(clearCache),
+    'clearCache must not kick off immediate background compaction')
+})
+
+test('clearCache schedules compaction and re-checks playback before compacting', async (t) => {
+  const timers = []
+  let playbackActive = false
+  const store = createStore()
+  const manager = new SeedingManager(store, createMetaDb(), {
+    isCacheClearBlocked: () => playbackActive,
+    storageMaintenanceDelayMs: 0,
+    setTimer(fn, delay) {
+      const timer = { fn, delay, cleared: false }
+      timers.push(timer)
+      return timer
+    },
+    clearTimer(timer) {
+      timer.cleared = true
+    }
+  })
+
+  await manager.addSeed('drive-a', 'videos/watched.mp4', 'watched', {
+    byteLength: 2 * GB,
+    blobId: '3:5:0:1234',
+    blobsCoreKey: coreA
+  })
+
+  await manager.clearCache()
+
+  t.is(store.storage.flushCalls, 1, 'cleared ranges are flushed before the RPC returns')
+  t.is(store.storage.compactCalls, 0, 'compaction does not start immediately')
+  t.is(timers.length, 1, 'compaction is scheduled for idle maintenance')
+
+  playbackActive = true
+  await timers.shift().fn()
+  t.is(store.storage.compactCalls, 0, 'scheduled compaction respects resumed playback')
+  t.is(timers.length, 1, 'blocked compaction is rescheduled')
+
+  playbackActive = false
+  await timers.shift().fn()
+  t.is(store.storage.compactCalls, 1, 'compaction runs after playback is idle')
 })
 
 test('clearCache cancels live prefetch downloads before clearing blocks', (t) => {

--- a/packages/backend/test/seeding-storage-accounting.test.mjs
+++ b/packages/backend/test/seeding-storage-accounting.test.mjs
@@ -52,6 +52,20 @@ function createStore({ diskUsageBytes = 0, compactedDiskUsageBytes = null, clear
   }
 }
 
+function createTimerOptions(timers) {
+  return {
+    storageMaintenanceDelayMs: 0,
+    setTimer(fn, delay) {
+      const timer = { fn, delay, cleared: false }
+      timers.push(timer)
+      return timer
+    },
+    clearTimer(timer) {
+      timer.cleared = true
+    }
+  }
+}
+
 const GB = 1024 * 1024 * 1024
 const coreA = 'aa'.repeat(32)
 const coreB = 'bb'.repeat(32)
@@ -99,12 +113,13 @@ test('clearCache reports app P2P disk usage after clearing tracked non-pinned ca
   t.is(cleared.untrackedStorageBytes, 3 * GB)
 })
 
-test('clearCache compacts Corestore before measuring app P2P disk usage', async (t) => {
+test('clearCache schedules Corestore compaction after returning storage stats', async (t) => {
+  const timers = []
   const store = createStore({
     diskUsageBytes: 6 * GB,
     compactedDiskUsageBytes: 4 * GB
   })
-  const manager = new SeedingManager(store, createMetaDb())
+  const manager = new SeedingManager(store, createMetaDb(), createTimerOptions(timers))
   await manager.setConfig({ maxStorageGB: 20 })
 
   await manager.addSeed('drive-a', 'videos/watched.mp4', 'watched', {
@@ -121,15 +136,23 @@ test('clearCache compacts Corestore before measuring app P2P disk usage', async 
   const cleared = await manager.clearCache()
 
   t.is(store.storage.flushCalls, 1)
-  t.is(store.storage.compactCalls, 1)
+  t.is(store.storage.compactCalls, 0)
   t.is(cleared.clearedBytes, 2 * GB)
-  t.is(cleared.totalStorageBytes, 4 * GB)
-  t.is(cleared.untrackedStorageBytes, 1 * GB)
+  t.is(cleared.totalStorageBytes, 6 * GB)
+  t.is(cleared.untrackedStorageBytes, 3 * GB)
+  t.is(timers.length, 1)
+
+  await timers.shift().fn()
+  const statsAfterMaintenance = await manager.getStorageStats()
+  t.is(store.storage.compactCalls, 1)
+  t.is(statsAfterMaintenance.totalStorageBytes, 4 * GB)
+  t.is(statsAfterMaintenance.untrackedStorageBytes, 1 * GB)
 })
 
 test('quota enforcement evicts tracked cache once the cached bytes exceed the limit', async (t) => {
+  const timers = []
   const store = createStore({ diskUsageBytes: 10 * GB, clearDiskUsageBytes: 4 * GB })
-  const manager = new SeedingManager(store, createMetaDb())
+  const manager = new SeedingManager(store, createMetaDb(), createTimerOptions(timers))
   await manager.setConfig({ maxStorageGB: 20 })
 
   await manager.addSeed('drive-a', 'videos/watched.mp4', 'watched', {
@@ -145,6 +168,10 @@ test('quota enforcement evicts tracked cache once the cached bytes exceed the li
   t.is(manager.getActiveSeeds().length, 0)
   t.alike(store.get(Buffer.from(coreA, 'hex')).clearCalls, [{ start: 3, end: 8 }])
   t.is(store.storage.flushCalls, 1)
+  t.is(store.storage.compactCalls, 0)
+  t.is(timers.length, 1)
+
+  await timers.shift().fn()
   t.is(store.storage.compactCalls, 1)
 })
 

--- a/packages/backend/test/storage-quota-api.test.mjs
+++ b/packages/backend/test/storage-quota-api.test.mjs
@@ -76,6 +76,20 @@ function createStore() {
   }
 }
 
+function createTimerOptions(timers) {
+  return {
+    storageMaintenanceDelayMs: 0,
+    setTimer(fn, delay) {
+      const timer = { fn, delay, cleared: false }
+      timers.push(timer)
+      return timer
+    },
+    clearTimer(timer) {
+      timer.cleared = true
+    }
+  }
+}
+
 class FakeCore extends EventEmitter {
   constructor(key) {
     super()
@@ -112,6 +126,7 @@ const coreA = 'aa'.repeat(32)
 const coreB = 'bb'.repeat(32)
 
 test('clearCache clears persisted partial download intents as cache bytes', async (t) => {
+  const timers = []
   const metaDb = createMetaDb({
     [`download-intent:drive-a:videos/partial.mp4`]: {
       driveKey: 'drive-a',
@@ -128,7 +143,7 @@ test('clearCache clears persisted partial download intents as cache bytes', asyn
   })
   const store = createStore()
   store.get(b4a.from(coreA, 'hex'))
-  const seedingManager = new SeedingManager(store, metaDb)
+  const seedingManager = new SeedingManager(store, metaDb, createTimerOptions(timers))
   const api = createApi({ ctx: { store, metaDb }, seedingManager })
 
   const result = await api.clearCache()
@@ -137,6 +152,10 @@ test('clearCache clears persisted partial download intents as cache bytes', asyn
   t.is(result.clearedBytes, 2 * GB)
   t.alike(store.cores.get(coreA).clearCalls, [{ start: 5, end: 9 }])
   t.is(store.storage.flushCalls, 1)
+  t.is(store.storage.compactCalls, 0)
+  t.is(timers.length, 1)
+
+  await timers.shift().fn()
   t.is(store.storage.compactCalls, 1)
   t.absent(metaDb.state.has('download-intent:drive-a:videos/partial.mp4'))
 })

--- a/packages/backend/test/storage-startup-regression.test.mjs
+++ b/packages/backend/test/storage-startup-regression.test.mjs
@@ -53,6 +53,19 @@ test('blob server startup does not await listen before storage init can finish',
   assert.match(blobServerBody, /blobServerListenPromise\s*\.then\(/)
 })
 
+test('blob server serves direct browser range requests without an Electrobun media proxy', () => {
+  const requestWrapper =
+    storageSource.match(/blobServer\._onrequest = async function \(req, res\) \{([\s\S]*?)\n      return origOnRequest\(req, res\)/)?.[1] ?? ''
+
+  assert.ok(requestWrapper, 'blob server request wrapper should exist')
+  assert.match(requestWrapper, /Access-Control-Allow-Origin', '\*'/)
+  assert.match(requestWrapper, /Access-Control-Allow-Methods', 'GET, HEAD, OPTIONS'/)
+  assert.match(requestWrapper, /Access-Control-Allow-Headers', 'Range'/)
+  assert.match(requestWrapper, /Access-Control-Expose-Headers', 'Content-Length, Content-Range, Accept-Ranges'/)
+  assert.match(requestWrapper, /if \(req\.method === 'OPTIONS'\) \{ res\.writeHead\(204\); res\.end\(\); return \}/)
+  assert.match(requestWrapper, /serveVideoRangeHttpRequest\(\{ blobServer \}, req, res\)/)
+})
+
 test('blob server video streams use no-timeout core sessions', () => {
   assert.match(
     storageSource,
@@ -111,12 +124,19 @@ test('storage persists and restores DHT routing table state around lifecycle eve
 
 
 
-test('storage does not warm-dial cached peers in the default feed discovery path', () => {
-  assert.match(storageSource, /import \{ createKnownPeerCache \} from '\.\/known-peers\.js'/)
-  assert.doesNotMatch(storageSource, /warmDialKnownPeers/)
-  assert.doesNotMatch(storageSource, /loadKnownPeers\(/)
-  assert.doesNotMatch(storageSource, /swarm\.joinPeer\(b4a\.from\(peer\.key, 'hex'\)\)/)
-  assert.doesNotMatch(storageSource, /swarm\.joinPeer\(/)
+test('storage uses bounded warm reconnect and desktop discovery refreshes', () => {
+  assert.match(storageSource, /import \{ createKnownPeerCache, loadKnownPeers \} from '\.\/known-peers\.js'/)
+  assert.match(storageSource, /const KNOWN_PEER_REDIAL_LIMIT = 16/)
+  assert.match(storageSource, /known\.slice\(0, KNOWN_PEER_REDIAL_LIMIT\)/)
+  assert.match(storageSource, /swarm\.joinPeer\(b4a\.from\(key, 'hex'\)\)/)
+  assert.match(storageSource, /function resolveHyperswarmOptions/)
+  assert.match(storageSource, /new LoadedHyperswarm\(hyperswarmOptions\)/)
+  assert.match(storageSource, /function schedulePeerPoolWarmupRefreshes/)
+  assert.match(storageSource, /schedulePeerPoolWarmupRefreshes\(\{[\s\S]*?platform,[\s\S]*?discovery: poolDiscovery/)
+  assert.match(storageSource, /peer-pool-warm-refresh/)
+  assert.match(storageSource, /swarm\._peartubeSwarmOptions = summarizeSwarmOptions\(hyperswarmOptions\)/)
+  assert.match(storageSource, /options: summarizeSwarmOptions\(swarm\?\._peartubeSwarmOptions\)/)
+  assert.match(storageSource, /swarmOptions: globalSwarm\._peartubeSwarmOptions \|\| null/)
 })
 
 test('storage creates an offline swarm fallback when Hyperswarm is unavailable', () => {

--- a/packages/backend/test/storage-startup-regression.test.mjs
+++ b/packages/backend/test/storage-startup-regression.test.mjs
@@ -44,7 +44,7 @@ test('blob server startup does not await listen before storage init can finish',
   // End anchor matches the outer try/catch (2-space indent) so the capture is
   // not cut short by the `catch (err)` inside the patched _onrequest handler.
   const blobServerBody = storageSource.match(
-    /const desiredPort = blobServerPortOverride \|\| 0;([\s\S]*?)\n  \} catch \(err\) \{/
+    /const desiredPort = blobServerPortOverride \|\| 0;([\s\S]*?)\n {2}\} catch \(err\) \{/
   )?.[1] ?? ''
 
   assert.ok(blobServerBody, 'blob server startup block should exist')
@@ -55,7 +55,7 @@ test('blob server startup does not await listen before storage init can finish',
 
 test('blob server serves direct browser range requests without an Electrobun media proxy', () => {
   const requestWrapper =
-    storageSource.match(/blobServer\._onrequest = async function \(req, res\) \{([\s\S]*?)\n      return origOnRequest\(req, res\)/)?.[1] ?? ''
+    storageSource.match(/blobServer\._onrequest = async function \(req, res\) \{([\s\S]*?)\n {6}return origOnRequest\(req, res\)/)?.[1] ?? ''
 
   assert.ok(requestWrapper, 'blob server request wrapper should exist')
   assert.match(requestWrapper, /Access-Control-Allow-Origin', '\*'/)

--- a/packages/backend/test/swarm-desktop-tuning.test.mjs
+++ b/packages/backend/test/swarm-desktop-tuning.test.mjs
@@ -1,0 +1,115 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import b4a from 'b4a'
+
+import {
+  resolveHyperswarmOptions,
+  schedulePeerPoolWarmupRefreshes,
+} from '../src/storage.js'
+
+test('desktop swarm options raise parallel dialing while preserving storage-owned keypair', () => {
+  const keyPair = { publicKey: b4a.alloc(32, 1), secretKey: b4a.alloc(64, 2) }
+  const result = resolveHyperswarmOptions({
+    keyPair,
+    platform: 'desktop',
+    swarmOptions: { keyPair: { publicKey: b4a.alloc(32, 9) } },
+  })
+
+  assert.equal(result.keyPair, keyPair)
+  assert.equal(result.maxParallel, 12)
+  assert.equal(result.maxPeers, 96)
+})
+
+test('mobile swarm options keep Hyperswarm defaults unless explicitly configured', () => {
+  const keyPair = { publicKey: b4a.alloc(32, 3), secretKey: b4a.alloc(64, 4) }
+  const result = resolveHyperswarmOptions({ keyPair, platform: 'mobile' })
+
+  assert.equal(result.keyPair, keyPair)
+  assert.equal(result.maxParallel, undefined)
+  assert.equal(result.maxPeers, undefined)
+})
+
+test('explicit swarm and network options override desktop defaults except keypair', () => {
+  const keyPair = { publicKey: b4a.alloc(32, 5), secretKey: b4a.alloc(64, 6) }
+  const bootstrap = ['127.0.0.1:49737']
+  const nodes = [{ host: '192.168.1.20', port: 49737 }]
+  const result = resolveHyperswarmOptions({
+    keyPair,
+    platform: 'desktop',
+    network: { bootstrap, nodes, port: 54321 },
+    swarmOptions: {
+      maxParallel: 5,
+      maxPeers: 32,
+      randomPunchInterval: 750,
+      keyPair: { publicKey: b4a.alloc(32, 9) },
+    },
+  })
+
+  assert.equal(result.keyPair, keyPair)
+  assert.equal(result.bootstrap, bootstrap)
+  assert.equal(result.nodes, nodes)
+  assert.equal(result.port, 54321)
+  assert.equal(result.maxParallel, 5)
+  assert.equal(result.maxPeers, 32)
+  assert.equal(result.randomPunchInterval, 750)
+})
+
+test('desktop peer pool warmup refreshes discovery while under connection target', async () => {
+  const calls = []
+  const timers = []
+  const swarm = { connections: new Set([{}]), connecting: 0 }
+  const discovery = {
+    async refresh(opts) {
+      calls.push(opts)
+    },
+  }
+  const startupEvents = []
+  const result = schedulePeerPoolWarmupRefreshes({
+    platform: 'desktop',
+    swarm,
+    discovery,
+    startupTiming: {
+      record(name, details) {
+        startupEvents.push({ name, details })
+      },
+    },
+    setTimer(fn, ms) {
+      timers.push({ fn, ms })
+      return timers.length
+    },
+    clearTimer() {},
+  })
+
+  assert.equal(result.scheduled, 3)
+  assert.deepEqual(timers.map((timer) => timer.ms), [3000, 10000, 30000])
+
+  await timers[0].fn()
+  assert.deepEqual(calls, [{ server: true, client: true }])
+  assert.equal(startupEvents[0].name, 'peer-pool-warm-refresh')
+  assert.equal(startupEvents[0].details.connections, 1)
+})
+
+test('peer pool warmup skips mobile and already well-connected desktop swarms', async () => {
+  const mobile = schedulePeerPoolWarmupRefreshes({
+    platform: 'mobile',
+    swarm: { connections: new Set() },
+    discovery: { refresh() { throw new Error('should not refresh mobile') } },
+    setTimer() { throw new Error('should not schedule mobile timers') },
+  })
+  assert.equal(mobile.scheduled, 0)
+
+  const timers = []
+  const desktop = schedulePeerPoolWarmupRefreshes({
+    platform: 'desktop',
+    swarm: { connections: new Set([{}, {}, {}, {}]), connecting: 0 },
+    discovery: { refresh() { throw new Error('should not refresh connected desktop') } },
+    setTimer(fn, ms) {
+      timers.push({ fn, ms })
+      return timers.length
+    },
+    clearTimer() {},
+  })
+
+  assert.equal(desktop.scheduled, 0)
+  assert.equal(timers.length, 0)
+})

--- a/packages/platform/src/rpc.shared.ts
+++ b/packages/platform/src/rpc.shared.ts
@@ -31,6 +31,10 @@ export type NetworkStatusData = {
   publicFeedDiscoveryJoined?: boolean
   feedTopicHex?: string | null
   recommendedBoundary?: string | null
+  network?: any
+  startupTiming?: any
+  doctor?: any
+  directPeerDial?: any
 }
 
 export type PlatformLifecycleEvent =


### PR DESCRIPTION
## Summary
- Raise Electrobun desktop Hyperswarm parallelism and add bounded peer-pool discovery refreshes.
- Remove the Electrobun blob media proxy so playback streams directly from the backend blob server with CORS and range support.
- Forward full backend swarm diagnostics from the desktop worker and add focused regressions.
- Defer Corestore/RocksDB cache compaction until playback is idle so storage cleanup does not contend with blob-server range reads.
- Fix changed-file lint findings in the existing PR files so CI can pass before merge.

## Root Cause
- Cache cleanup stopped awaiting compaction, but still kicked off `storage.compact()` immediately in the background. That avoided a blocked RPC response, but the compaction still competed with subsequent video streaming reads on the same Corestore storage.

## Test Plan
- [x] packages/backend/node_modules/.bin/brittle packages/backend/test/clear-cache-stall-regression.test.mjs packages/backend/test/seeding-storage-accounting.test.mjs packages/backend/test/storage-quota-api.test.mjs
- [x] npm run lint:changed
- [x] node --test packages/backend/test/storage-startup-regression.test.mjs
- [x] node --check packages/backend/src/seeding.js
- [x] node --check packages/app/src/bun/index.ts
- [x] git diff --check
- [x] node --test packages/app/tests/electrobun-latency-regression.test.mjs packages/app/tests/native-backend-startup-regression.test.mjs packages/backend/test/storage-startup-regression.test.mjs packages/backend/test/swarm-desktop-tuning.test.mjs
- [x] node --test packages/backend/test/video-range-http.test.mjs
- [x] npm run typecheck --prefix packages/platform