### PR TITLE
Fix thumbnail regression: don't discard valid inline thumbnails when blob refs exist

### DIFF
--- a/packages/app/app/(tabs)/index.tsx
+++ b/packages/app/app/(tabs)/index.tsx
@@ -17,7 +17,7 @@ import { fonts } from '@/lib/typography'
 import * as watchHistoryStore from '@/lib/watch-history'
 import { resumeWatchEntry } from '@/lib/playback-resume'
 import { usePlatform } from '@/lib/PlatformProvider'
-import { fetchThumbnailUrlWithRetry, getRenderableThumbnailUrl, hasThumbnailBlobRef } from '@/lib/thumbnail'
+import { fetchThumbnailUrlWithRetry, getRenderableThumbnailUrl } from '@/lib/thumbnail'
 import { formatTimeAgo } from '@/lib/formatters'
 import { makeVideoUrlCacheKey, setCachedVideoUrl } from '@/lib/video-url-cache'
 import { getDesktopVideoGridColumns } from '@/lib/video-layout'
@@ -458,10 +458,12 @@ export default function HomeScreen() {
   useEffect(() => {
     if (!ready || isPear) return
     const missing = feedVideos.filter((v) => {
-      const cacheKey = v.channelKey && v.id ? `${v.channelKey}:${v.id}` : ''
-      return v.channelKey && v.id && !thumbnailCache[cacheKey] && (
-        hasThumbnailBlobRef(v) || (!v.thumbnailUrl && !(v as any).thumbnail)
-      )
+      if (!v.channelKey || !v.id) return false
+      const cacheKey = `${v.channelKey}:${v.id}`
+      // Missing = nothing renders yet: no resolved cache URL and no usable inline
+      // URL (a remote http(s)/data: thumbnail already paints; a stale loopback URL
+      // or bare blob refs need a fresh HRPC resolve).
+      return !getRenderableThumbnailUrl(v, thumbnailCache[cacheKey])
     })
     if (missing.length === 0) {
       thumbnailResweepAttemptsRef.current = 0

--- a/packages/app/lib/renderable-thumbnail-url.mjs
+++ b/packages/app/lib/renderable-thumbnail-url.mjs
@@ -1,0 +1,46 @@
+// Pure thumbnail-URL selection shared by the native feed/discover screens.
+// Kept in plain .mjs (like feed-thumbnail-resolve-key.mjs) so the behavior can be
+// unit-tested directly without transpiling the .ts wrapper.
+
+const LOOPBACK_THUMBNAIL_URL_RE = /^https?:\/\/(?:127\.0\.0\.1|localhost)(?::\d+)?\//i
+
+// A loopback blob-server URL is valid only for the backend process/port that
+// minted it — after a restart (new port) or on another device it points at
+// nothing. Such a URL must never be reused directly; it has to be re-resolved
+// through a fresh HRPC call for the current process.
+export function isLoopbackThumbnailUrl(value) {
+  return typeof value === 'string' && LOOPBACK_THUMBNAIL_URL_RE.test(value)
+}
+
+export function hasThumbnailBlobRef(video) {
+  return Boolean(video?.thumbnailBlobId && video?.thumbnailBlobsCoreKey)
+}
+
+export function getInlineThumbnailUrl(video) {
+  const value = video?.thumbnailUrl || video?.thumbnail || null
+  return typeof value === 'string' && value.length > 0 ? value : null
+}
+
+// Pick the URL to hand the <Image> loader for a feed/rail card.
+//
+// Order of preference:
+//  1. A freshly-resolved current-process URL from the thumbnail cache.
+//  2. A process-independent inline URL — a remote http(s) thumbnail (archived /
+//     imported videos) or a self-contained data: URL. These render no matter
+//     which backend process is alive, so prefer them even when blob refs exist.
+//     (Regression guard: previously any video WITH blob refs discarded its inline
+//     URL and forced a flaky blob resolve, so archived cards went blank while
+//     blob-only cards rendered — "some load, others don't".)
+//  3. Otherwise nothing: either there is no inline URL, or the only inline URL is
+//     a stale loopback blob-server URL that must never paint. When blob refs are
+//     present an HRPC resolve fills the cache (path 1) on a later pass.
+export function getRenderableThumbnailUrl(video, cachedUrl, opts = { native: true }) {
+  if (cachedUrl) return cachedUrl
+
+  const inlineUrl = getInlineThumbnailUrl(video)
+  if (opts && opts.native === false) return inlineUrl
+
+  if (inlineUrl && !isLoopbackThumbnailUrl(inlineUrl)) return inlineUrl
+
+  return null
+}

--- a/packages/app/lib/thumbnail.ts
+++ b/packages/app/lib/thumbnail.ts
@@ -37,34 +37,16 @@ const READY_TIMEOUT_MS = 1_500
 const READY_RETRY_DELAY_MS = 250
 
 const THUMBNAIL_ATTEMPTS = 3
-const LOOPBACK_THUMBNAIL_URL_RE = /^https?:\/\/(?:127\.0\.0\.1|localhost)(?::\d+)?\//i
 
-export function isLoopbackThumbnailUrl(value: unknown): value is string {
-  return typeof value === 'string' && LOOPBACK_THUMBNAIL_URL_RE.test(value)
-}
-
-export function hasThumbnailBlobRef(video: any): boolean {
-  return Boolean(video?.thumbnailBlobId && video?.thumbnailBlobsCoreKey)
-}
-
-export function getInlineThumbnailUrl(video: any): string | null {
-  const value = video?.thumbnailUrl || video?.thumbnail || null
-  return typeof value === 'string' && value.length > 0 ? value : null
-}
-
-export function getRenderableThumbnailUrl(video: any, cachedUrl?: string | null, opts: { native?: boolean } = { native: true }): string | null {
-  if (cachedUrl) return cachedUrl
-
-  const inlineUrl = getInlineThumbnailUrl(video)
-  if (opts.native === false) return inlineUrl
-
-  // Native loopback blob-server URLs are valid only for the backend process/port
-  // that created them. If blob refs are present, force a fresh HRPC resolve and
-  // render only the current-process URL from the thumbnail cache.
-  if (hasThumbnailBlobRef(video)) return null
-
-  return inlineUrl && !isLoopbackThumbnailUrl(inlineUrl) ? inlineUrl : null
-}
+// Pure URL-selection helpers live in a plain .mjs sibling so their behavior can
+// be unit-tested directly. Re-exported here so existing importers of
+// '@/lib/thumbnail' are unaffected.
+export {
+  isLoopbackThumbnailUrl,
+  hasThumbnailBlobRef,
+  getInlineThumbnailUrl,
+  getRenderableThumbnailUrl,
+} from './renderable-thumbnail-url.mjs'
 
 // The backend handler can legitimately spend up to 1.5s on a bounded network
 // wait (plus channel/bee lookups) before answering, and on Android cold start

--- a/packages/app/tests/renderable-thumbnail-url.test.mjs
+++ b/packages/app/tests/renderable-thumbnail-url.test.mjs
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  getRenderableThumbnailUrl,
+  isLoopbackThumbnailUrl,
+} from '../lib/renderable-thumbnail-url.mjs'
+
+test('a resolved cache URL always wins', () => {
+  const url = getRenderableThumbnailUrl(
+    { thumbnailBlobId: 'blob', thumbnailBlobsCoreKey: 'core' },
+    'http://127.0.0.1:5000/current-process.jpg',
+  )
+  assert.equal(url, 'http://127.0.0.1:5000/current-process.jpg')
+})
+
+test('regression: a remote inline thumbnail renders even when blob refs are present', () => {
+  // Archived/imported videos carry a real remote thumbnail AND blob refs. The
+  // buggy version discarded the inline URL whenever blob refs existed, forcing a
+  // flaky blob resolve and leaving those cards blank ("some load, others don't").
+  const url = getRenderableThumbnailUrl({
+    thumbnail: 'https://i.ytimg.com/vi/abc/hqdefault.jpg',
+    thumbnailBlobId: 'blob',
+    thumbnailBlobsCoreKey: 'core',
+  })
+  assert.equal(url, 'https://i.ytimg.com/vi/abc/hqdefault.jpg')
+})
+
+test('regression: a self-contained data: thumbnail renders even with blob refs', () => {
+  const dataUrl = 'data:image/jpeg;base64,/9j/4AAQSkZJRg=='
+  const url = getRenderableThumbnailUrl({
+    thumbnailUrl: dataUrl,
+    thumbnailBlobId: 'blob',
+    thumbnailBlobsCoreKey: 'core',
+  })
+  assert.equal(url, dataUrl)
+})
+
+test('a stale loopback inline URL is never painted directly', () => {
+  // Only the freshly-resolved cache URL is safe; a persisted loopback URL points
+  // at a dead port/process, so render nothing until an HRPC resolve fills cache.
+  assert.ok(isLoopbackThumbnailUrl('http://127.0.0.1:5000/old.jpg'))
+  const url = getRenderableThumbnailUrl({
+    thumbnailUrl: 'http://127.0.0.1:5000/old.jpg',
+    thumbnailBlobId: 'blob',
+    thumbnailBlobsCoreKey: 'core',
+  })
+  assert.equal(url, null)
+})
+
+test('blob-only videos with no inline URL wait for the cache resolve', () => {
+  const url = getRenderableThumbnailUrl({
+    thumbnailBlobId: 'blob',
+    thumbnailBlobsCoreKey: 'core',
+  })
+  assert.equal(url, null)
+})
+
+test('non-native callers keep the raw inline URL (including loopback)', () => {
+  const url = getRenderableThumbnailUrl(
+    { thumbnailUrl: 'http://127.0.0.1:5000/old.jpg' },
+    null,
+    { native: false },
+  )
+  assert.equal(url, 'http://127.0.0.1:5000/old.jpg')
+})


### PR DESCRIPTION
Some feed cards rendered thumbnails while others stayed on the placeholder.
Regression came from getRenderableThumbnailUrl: once a video had thumbnail
blob refs it returned null for *any* inline URL, forcing a fresh HRPC blob
resolve. Archived/imported videos carry a perfectly valid remote http(s)
thumbnail (or a self-contained data: URL) alongside blob refs, so those cards
went blank while blob-only cards still rendered — "some load, others don't".

Prefer a process-independent inline URL (remote http(s) or data:) even when
blob refs are present. Only a loopback blob-server URL — valid solely for the
port/process that minted it — is still rejected and re-resolved through the
thumbnail cache, so stale loopback URLs never paint.

- Extract the pure URL-selection helpers into renderable-thumbnail-url.mjs so
  the behavior is directly unit-testable (mirrors feed-thumbnail-resolve-key.mjs);
  thumbnail.ts re-exports them, importers unchanged.
- Simplify the home-feed re-sweep filter to "nothing renders yet" using the same
  helper, so cards already showing an inline thumbnail aren't needlessly refetched.
- Add renderable-thumbnail-url.test.mjs covering the regression cases.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HwFwQqYVsMK3UHkzNfDT2S