### PR TITLE
fix(cast): bind mDNS discovery to 0.0.0.0:5353 so Chromecast responses are received

### DIFF
--- a/packages/app/tests/ci-workflow-split-regression.test.mjs
+++ b/packages/app/tests/ci-workflow-split-regression.test.mjs
@@ -98,22 +98,24 @@ test('tagged Android releases build arm64 and x86 APKs', () => {
   )
 })
 
-test('pull requests run desktop tests but skip app build/packaging jobs', () => {
+test('pull requests skip the desktop app build but exercise the mobile build', () => {
   const buildDesktop = readFile('.github/workflows/build-desktop.yml')
 
-  // App build/packaging jobs must be gated off on pull requests.
+  // The desktop app build/packaging job must be gated off on pull requests.
   assert.match(
     buildDesktop,
     /electrobun-desktop-build:\s*\n\s*if:\s*\$\{\{\s*github\.event_name != 'pull_request'\s*\}\}/,
     'electrobun-desktop-build (app build) should not run on pull requests',
   )
 
-  // Mobile app builds already never run on pull requests (push/dispatch only).
+  // build-mobile intentionally runs on pull_request (path-filtered) so the
+  // Android build is exercised on PRs — see the "run Build Mobile on
+  // pull_request" change. Publishing still lives in separate release workflows.
   const buildMobile = readFile('.github/workflows/build-mobile.yml')
-  assert.doesNotMatch(
+  assert.match(
     buildMobile,
     /^\s*pull_request:/m,
-    'build-mobile should not be triggered by pull requests',
+    'build-mobile should run on pull requests to exercise the mobile build',
   )
 })
 

--- a/packages/backend/src/cast/discovery.js
+++ b/packages/backend/src/cast/discovery.js
@@ -292,12 +292,62 @@ export class DeviceDiscoverer extends EventEmitter {
 
     const localIp = await this._resolveLocalIPv4()
     if (localIp) {
-      console.log('[Discovery] Using LAN interface for multicast:', localIp)
+      console.log('[Discovery] Joining multicast on LAN interface:', localIp)
     } else {
-      console.warn('[Discovery] Could not determine LAN IPv4; multicast may use the wrong interface')
+      console.warn('[Discovery] Could not determine LAN IPv4; joining multicast on the default interface')
     }
 
+    // mDNS responders send their answers — and the periodic *unsolicited*
+    // announcements Cast devices emit — to the multicast group 224.0.0.251 on
+    // UDP port 5353. To receive them the socket MUST bind 0.0.0.0:5353:
+    //
+    //  - Binding a *specific unicast* interface address (the previous "bind to
+    //    Wi-Fi" attempt) makes the kernel drop inbound multicast, because the
+    //    datagram's destination is the group address, not our unicast address.
+    //    The interface is selected by the multicast membership join instead.
+    //  - Binding an *ephemeral* port only ever caught a legacy one-shot unicast
+    //    reply (RFC 6762 §6.7), never the multicast announcements — so the
+    //    picker stayed empty whenever a device didn't unicast back.
+    //
+    // Fall back to an ephemeral port if 5353 can't be bound (some other mDNS
+    // stack may already hold it without SO_REUSEPORT); legacy unicast replies
+    // still work there.
+    const bindTargets = [
+      { port: MDNS_PORT, host: '0.0.0.0' },
+      { port: 0, host: '0.0.0.0' },
+    ]
+
+    let lastErr = null
+    for (const target of bindTargets) {
+      try {
+        await this._bindMdnsSocket(dgram, target, localIp)
+        return
+      } catch (err) {
+        lastErr = err
+        console.warn('[Discovery] mDNS bind ' + target.host + ':' + target.port + ' failed:', err?.message)
+        // Tear the failed socket down before retrying on the next target.
+        if (this._socket) {
+          try { this._socket.close() } catch {}
+          this._socket = null
+        }
+        if (this._queryInterval) {
+          clearInterval(this._queryInterval)
+          this._queryInterval = null
+        }
+      }
+    }
+
+    throw (lastErr || new Error('Failed to bind mDNS socket'))
+  }
+
+  /**
+   * Create and bind a fresh mDNS socket to the given target, joining the
+   * multicast group on the resolved LAN interface once it is listening.
+   * Resolves when listening, rejects on bind/socket error.
+   */
+  _bindMdnsSocket(dgram, target, localIp) {
     return new Promise((resolve, reject) => {
+      let settled = false
       try {
         console.log('[Discovery] Creating UDP socket...')
         try {
@@ -313,8 +363,12 @@ export class DeviceDiscoverer extends EventEmitter {
 
         this._socket.on('error', (err) => {
           console.error('[Discovery] Socket error:', err.message)
-          this._stopMdns()
-          reject(err)
+          if (!settled) {
+            settled = true
+            reject(err)
+          } else {
+            this._stopMdns()
+          }
         })
 
         this._socket.on('message', (msg, rinfo) => {
@@ -325,6 +379,8 @@ export class DeviceDiscoverer extends EventEmitter {
           const addr = this._socket.address()
           console.log('[Discovery] mDNS socket listening on', addr?.address || '?', 'port', addr?.port || 'unknown')
 
+          // Join the group on the LAN interface so multicast is delivered from
+          // the right NIC on multi-homed hosts (phones with Wi-Fi + cellular).
           this._joinMulticast(localIp)
 
           // Send initial queries
@@ -337,18 +393,19 @@ export class DeviceDiscoverer extends EventEmitter {
             }
           }, 5000)
 
-          resolve()
+          if (!settled) {
+            settled = true
+            resolve()
+          }
         })
 
-        // Bind to the resolved LAN interface so multicast queries egress on
-        // Wi-Fi (not cellular/VPN) and unicast responses come back to us.
-        // Fall back to 0.0.0.0 when the interface is unknown.
-        const bindHost = localIp || '0.0.0.0'
-        console.log('[Discovery] Binding to ' + bindHost + ':0...')
-        this._socket.bind(0, bindHost)
+        console.log('[Discovery] Binding to ' + target.host + ':' + target.port + '...')
+        this._socket.bind(target.port, target.host)
       } catch (err) {
-        console.error('[Discovery] Failed to start mDNS:', err.message)
-        reject(err)
+        if (!settled) {
+          settled = true
+          reject(err)
+        }
       }
     })
   }

--- a/packages/backend/src/cast/discovery.js
+++ b/packages/backend/src/cast/discovery.js
@@ -327,7 +327,7 @@ export class DeviceDiscoverer extends EventEmitter {
         console.warn('[Discovery] mDNS bind ' + target.host + ':' + target.port + ' failed:', err?.message)
         // Tear the failed socket down before retrying on the next target.
         if (this._socket) {
-          try { this._socket.close() } catch {}
+          try { this._socket.close() } catch { /* best-effort teardown */ }
           this._socket = null
         }
         if (this._queryInterval) {
@@ -538,11 +538,11 @@ export class DeviceDiscoverer extends EventEmitter {
         if (innerSocket && typeof innerSocket.dropMembership === 'function') {
           innerSocket.dropMembership(MDNS_ADDRESS)
         }
-      } catch (e) {}
+      } catch (e) { /* best-effort: group may not have been joined */ }
 
       try {
         this._socket.close()
-      } catch (e) {}
+      } catch (e) { /* best-effort: socket may already be closed */ }
 
       this._socket = null
     }

--- a/packages/backend/test/cast-discovery-interface-regression.test.mjs
+++ b/packages/backend/test/cast-discovery-interface-regression.test.mjs
@@ -11,11 +11,13 @@ const discoverySource = fs.readFileSync(
   'utf8',
 )
 
-// Regression: on Android (and any multi-homed host) the mDNS query must
-// egress on the Wi-Fi interface and the multicast group must be joined on
-// that same interface. Binding 0.0.0.0 sent the _googlecast._tcp query out
-// the wrong NIC (cellular/VPN), so no Chromecast ever responded and the
-// device picker stayed empty.
+// Regression: on Android (and any multi-homed host) the mDNS socket must be
+// able to *receive* the multicast answers/announcements Cast devices send to
+// 224.0.0.251:5353. Binding a specific unicast interface address makes the
+// kernel drop inbound multicast (destination is the group, not our address),
+// and binding an ephemeral port only ever caught a one-shot unicast reply — so
+// the device picker stayed empty. The socket must bind 0.0.0.0:5353 and select
+// the interface via the multicast membership join instead.
 
 test('discovery resolves the LAN IPv4 before binding the mDNS socket', () => {
   assert.match(discoverySource, /_resolveLocalIPv4\s*\(/, 'helper that resolves the LAN interface should exist')
@@ -23,10 +25,12 @@ test('discovery resolves the LAN IPv4 before binding the mDNS socket', () => {
   assert.match(discoverySource, /const localIp = await this\._resolveLocalIPv4\(\)/, '_startMdns should resolve the interface before binding')
 })
 
-test('discovery binds to the resolved interface and falls back to 0.0.0.0', () => {
-  assert.match(discoverySource, /const bindHost = localIp \|\| '0\.0\.0\.0'/, 'bind host should prefer the LAN IP and fall back to 0.0.0.0')
-  assert.match(discoverySource, /this\._socket\.bind\(0, bindHost\)/, 'socket should bind to the resolved host')
-  assert.doesNotMatch(discoverySource, /this\._socket\.bind\(0, '0\.0\.0\.0'\)/, 'socket should no longer hard-code 0.0.0.0')
+test('discovery binds 0.0.0.0 on the mDNS port so multicast responses arrive', () => {
+  assert.match(discoverySource, /\{ port: MDNS_PORT, host: '0\.0\.0\.0' \}/, 'primary bind target should be 0.0.0.0:5353')
+  assert.match(discoverySource, /\{ port: 0, host: '0\.0\.0\.0' \}/, 'should fall back to an ephemeral 0.0.0.0 port')
+  assert.match(discoverySource, /this\._socket\.bind\(target\.port, target\.host\)/, 'socket should bind to the chosen target')
+  assert.doesNotMatch(discoverySource, /bind\(0, bindHost\)/, 'socket must not bind to the unicast LAN IP (breaks multicast reception)')
+  assert.doesNotMatch(discoverySource, /const bindHost = localIp/, 'bind host must not be derived from the unicast LAN IP')
 })
 
 test('discovery joins the multicast group on the LAN interface', () => {


### PR DESCRIPTION
## Problem

Chromecast discovery still returned no devices after the earlier "bind mDNS discovery to the Wi-Fi interface" change (#494). The device picker stayed empty.

## Root cause

The mDNS socket in `packages/backend/src/cast/discovery.js` was set up so it could not reliably **receive** Cast responses:

1. **Bound to the interface's unicast IP** (`bind(0, localIp)`, from #494). On Linux/Android, a UDP socket bound to a specific unicast address has inbound **multicast dropped** by the kernel — the datagram's destination is the group address `224.0.0.251`, not our unicast address. The `addMembership` join takes effect, but packets are never delivered to the socket. So #494 actually broke the multicast receive path it was trying to help.
2. **Bound to an ephemeral port**, so the only thing that could arrive was a legacy one-shot *unicast* reply (RFC 6762 §6.7) — never the multicast answers on port 5353, nor the periodic unsolicited announcements Cast devices emit. Whenever a device didn't unicast back, discovery found nothing.

## Fix

Bind `0.0.0.0:5353` with `reuseAddress`, and select the interface via the multicast **membership join** instead of the socket bind — the standard mDNS receive setup, and the only one workable within udx-native's API (it exposes `addMembership(group, iface)` but no `IP_MULTICAST_IF`). Falls back to an ephemeral `0.0.0.0` port when 5353 can't be bound, where legacy unicast replies still work. The bind is factored into `_bindMdnsSocket` so each fallback attempt gets a fresh socket.

## Scope / caveat

This fixes the **receive** path, which is the concrete broken piece. It does not force outbound queries onto a specific NIC on a multi-homed phone — udx-native has no `IP_MULTICAST_IF` to set the egress interface, and forcing it isn't worth a larger send-socket rework here. Reception now works via the multicast announcements Cast devices emit and answers triggered by any client on the LAN. (On Android, receiving multicast at all may additionally require a native `MulticastLock`; out of scope for this change.)

## Tests

- Updated `packages/backend/test/cast-discovery-interface-regression.test.mjs` to assert the corrected setup (bind `0.0.0.0:5353`, interface chosen via membership join, no unicast-IP bind). All 5 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBwYnNWAwVLoNUcHXX2SrW)_