### PR TITLE
Cast: multi-interface mDNS discovery + FCast receiver support

### DIFF
--- a/packages/app/backend/mobile-cast.mjs
+++ b/packages/app/backend/mobile-cast.mjs
@@ -30,6 +30,25 @@ const CAST_PROXY_TTL_MS = 8 * 60 * 60 * 1000
 
 const CAST_LOCALHOSTS = new Set(['127.0.0.1', 'localhost', '0.0.0.0', '::1'])
 
+/**
+ * Map an internal device object onto the HRPC wire shape.
+ *
+ * The @peartube/cast-device schema names the protocol field `castProtocol`
+ * (required) while the cast stack uses `protocol` internally. Encoding a
+ * device without `castProtocol` makes compact-encoding throw, which silently
+ * killed deviceFound events and crashed castGetDevices responses — so every
+ * device that crosses the RPC boundary must go through this mapping.
+ */
+function toWireCastDevice(device) {
+  return {
+    id: device.id,
+    name: device.name,
+    host: device.host,
+    port: device.port,
+    castProtocol: device.protocol || 'chromecast',
+  }
+}
+
 let activeCastTranscodeId = null
 let activeCastSourceKey = null
 let castStallMonitor = null
@@ -285,14 +304,10 @@ async function loadCastContext() {
 
       castContext.on('deviceFound', (device) => {
         try {
-          rpc?.eventCastDeviceFound?.({ device: {
-            id: device.id,
-            name: device.name,
-            host: device.host,
-            port: device.port,
-            protocol: device.protocol,
-          }})
-        } catch {}
+          rpc?.eventCastDeviceFound?.({ device: toWireCastDevice(device) })
+        } catch (err) {
+          console.warn('[Backend] eventCastDeviceFound failed:', err?.message)
+        }
       })
 
       castContext.on('deviceLost', (deviceId) => {
@@ -734,9 +749,7 @@ async function loadCastContext() {
     if (!castContext) return { devices: [] }
     try {
       const devices = castContext.getDevices()
-      return { devices: devices.map((d) => ({
-        id: d.id, name: d.name, host: d.host, port: d.port, protocol: d.protocol,
-      })) }
+      return { devices: devices.map(toWireCastDevice) }
     } catch {
       return { devices: [] }
     }
@@ -748,11 +761,9 @@ async function loadCastContext() {
     try {
       const ctx = getCastContext()
       const device = ctx.addManualDevice({
-        name: r.name, host: r.host, port: r.port, protocol: r.protocol || 'chromecast',
+        name: r.name, host: r.host, port: r.port, protocol: r.castProtocol || r.protocol || 'chromecast',
       })
-      return { success: true, device: {
-        id: device.id, name: device.name, host: device.host, port: device.port, protocol: device.protocol,
-      } }
+      return { success: true, device: toWireCastDevice(device) }
     } catch (err) {
       return { success: false, error: err?.message }
     }
@@ -783,7 +794,7 @@ async function loadCastContext() {
       setCastActive(true)
       return device ? {
         success: true,
-        device: { id: device.id, name: device.name, host: device.host, port: device.port, protocol: device.protocol },
+        device: toWireCastDevice(device),
       } : { success: true }
     } catch (err) {
       return { success: false, error: normalizeErrorMessage(err, 'Cannot connect to Chromecast device') }

--- a/packages/app/components/cast/DevicePickerModal.tsx
+++ b/packages/app/components/cast/DevicePickerModal.tsx
@@ -1,7 +1,7 @@
 /**
  * DevicePickerModal - Modal to select cast devices
  *
- * Shows available Chromecast devices on the network.
+ * Shows available Chromecast and FCast devices on the network.
  * Also allows adding devices manually by IP address.
  */
 
@@ -53,8 +53,11 @@ export function DevicePickerModal({
   const [manualName, setManualName] = useState('')
   const [manualHost, setManualHost] = useState('')
   const [manualPort, setManualPort] = useState('')
-  const manualProtocol = 'chromecast'
+  const [manualProtocol, setManualProtocol] = useState<'chromecast' | 'fcast'>('chromecast')
   const [isAdding, setIsAdding] = useState(false)
+
+  const manualProtocolLabel = manualProtocol === 'fcast' ? 'FCast' : 'Chromecast'
+  const manualDefaultPort = manualProtocol === 'fcast' ? 46899 : 8009
 
   const sortedDevices = (() => {
     const list = Array.isArray(devices) ? [...devices] : []
@@ -75,7 +78,7 @@ export function DevicePickerModal({
     try {
       const port = manualPort ? parseInt(manualPort, 10) : undefined
       const device = await onAddManualDevice(
-        manualName.trim() || `Chromecast @ ${manualHost}`,
+        manualName.trim() || `${manualProtocolLabel} @ ${manualHost}`,
         manualHost.trim(),
         port,
         manualProtocol
@@ -231,7 +234,7 @@ export function DevicePickerModal({
                 />
                 <TextInput
                   style={[styles.input, styles.inputPort]}
-                  placeholder="Port"
+                  placeholder={`${manualDefaultPort}`}
                   placeholderTextColor={colors.textMuted}
                   value={manualPort}
                   onChangeText={setManualPort}
@@ -239,7 +242,27 @@ export function DevicePickerModal({
                 />
               </View>
 
-              <Text style={styles.manualHint}>Protocol: Chromecast</Text>
+              <View style={styles.protocolRow}>
+                {(['chromecast', 'fcast'] as const).map((protocol) => (
+                  <Pressable
+                    key={protocol}
+                    style={[
+                      styles.protocolButton,
+                      manualProtocol === protocol && styles.protocolButtonActive,
+                    ]}
+                    onPress={() => setManualProtocol(protocol)}
+                    accessibilityRole="button"
+                    accessibilityLabel={`Use ${protocol === 'fcast' ? 'FCast' : 'Chromecast'} protocol`}
+                  >
+                    <Text style={[
+                      styles.protocolText,
+                      manualProtocol === protocol && styles.protocolTextActive,
+                    ]}>
+                      {protocol === 'fcast' ? 'FCast' : 'Chromecast'}
+                    </Text>
+                  </Pressable>
+                ))}
+              </View>
 
               <Pressable
                 style={[styles.addButton, !manualHost.trim() && styles.addButtonDisabled]}

--- a/packages/app/lib/cast/useCast.shared.ts
+++ b/packages/app/lib/cast/useCast.shared.ts
@@ -19,7 +19,7 @@ export interface CastDevice {
   name: string
   host: string
   port: number
-  protocol: 'chromecast'
+  protocol: 'chromecast' | 'fcast'
 }
 
 export interface CastPlaybackState {
@@ -76,6 +76,22 @@ export interface UseCastReturn {
 }
 
 type ConnectedDeviceListener = (device: CastDevice | null) => void
+
+/**
+ * Normalize a device object arriving over RPC. The HRPC wire schema names the
+ * protocol field `castProtocol`; the app API uses `protocol`. Accept both so
+ * devices survive the boundary regardless of which side produced them.
+ */
+function normalizeCastDevice(raw: any): CastDevice | null {
+  if (!raw?.id) return null
+  return {
+    id: raw.id,
+    name: raw.name || raw.id,
+    host: raw.host || '',
+    port: typeof raw.port === 'number' ? raw.port : 0,
+    protocol: (raw.protocol || raw.castProtocol || 'chromecast') as CastDevice['protocol'],
+  }
+}
 
 const sharedConnection = {
   connectedDevice: null as CastDevice | null,
@@ -211,7 +227,7 @@ export function useCast(options: UseCastOptions = {}): UseCastReturn {
     if (!platformEvents?.onCastDeviceFound) return
 
     const handleDeviceFound = (data: any) => {
-      const device = data?.device ?? data
+      const device = normalizeCastDevice(data?.device ?? data)
       if (!device?.id) return
       setDevices(prev => {
         const idx = prev.findIndex(d => d.id === device.id)
@@ -331,7 +347,7 @@ export function useCast(options: UseCastOptions = {}): UseCastReturn {
       // Load current devices
       const result = await rpc.castGetDevices({})
       if (result?.devices) {
-        setDevices(result.devices)
+        setDevices(result.devices.map(normalizeCastDevice).filter(Boolean) as CastDevice[])
       }
     } catch (err) {
       console.error('[useCast] startDiscovery failed:', err)
@@ -371,9 +387,10 @@ export function useCast(options: UseCastOptions = {}): UseCastReturn {
         protocol: protocol || 'chromecast'
       })
 
-      if (result?.success && result?.device) {
-        setDevices(prev => [...prev, result.device])
-        return result.device
+      const added = result?.success ? normalizeCastDevice(result?.device) : null
+      if (added) {
+        setDevices(prev => [...prev.filter(d => d.id !== added.id), added])
+        return added
       }
       return null
     } catch (err) {
@@ -418,12 +435,13 @@ export function useCast(options: UseCastOptions = {}): UseCastReturn {
       }
 
       if (result?.success) {
-        let device = result?.device || devices.find((d: CastDevice) => d.id === deviceId) || null
+        let device = normalizeCastDevice(result?.device) || devices.find((d: CastDevice) => d.id === deviceId) || null
         if (!device) {
           const refreshed = await rpc.castGetDevices({})
           if (refreshed?.devices) {
-            setDevices(refreshed.devices)
-            device = refreshed.devices.find((d: CastDevice) => d.id === deviceId) || null
+            const normalized = refreshed.devices.map(normalizeCastDevice).filter(Boolean) as CastDevice[]
+            setDevices(normalized)
+            device = normalized.find((d: CastDevice) => d.id === deviceId) || null
           }
         }
         if (!device) {

--- a/packages/app/tests/fcast-cast-wire-regression.test.mjs
+++ b/packages/app/tests/fcast-cast-wire-regression.test.mjs
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const appRoot = path.resolve(__dirname, '..')
+const repoRoot = path.resolve(appRoot, '..', '..')
+
+function readAppFile(relativePath) {
+  return fs.readFileSync(path.join(appRoot, relativePath), 'utf8')
+}
+
+function readRepoFile(relativePath) {
+  return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8')
+}
+
+// The @peartube/cast-device HRPC schema names the protocol field
+// `castProtocol` (required) while the app and cast stack use `protocol`.
+// Sending a device keyed `protocol` makes compact-encoding throw, which
+// silently dropped deviceFound events and crashed castGetDevices responses —
+// so every device that crosses the RPC boundary must be mapped on the way
+// out (toWireCastDevice) and normalized on the way in (normalizeCastDevice).
+// FCast support depends on this: without it the protocol never round-trips
+// and every device degrades to chromecast.
+
+test('mobile backend maps devices onto the wire shape (castProtocol)', () => {
+  const source = readAppFile('backend/mobile-cast.mjs')
+  assert.match(source, /function toWireCastDevice\(/)
+  assert.match(source, /castProtocol: device\.protocol \|\| 'chromecast'/)
+  assert.match(source, /eventCastDeviceFound\?\.\(\{ device: toWireCastDevice\(device\) \}\)/)
+  assert.match(source, /devices\.map\(toWireCastDevice\)/)
+  assert.match(source, /r\.castProtocol \|\| r\.protocol \|\| 'chromecast'/, 'manual add should read the wire field first')
+  assert.doesNotMatch(source, /device: \{[^}]*protocol: device\.protocol/, 'no raw protocol-keyed device may cross the RPC boundary')
+})
+
+test('desktop worker maps devices onto the wire shape (castProtocol)', () => {
+  const source = readAppFile('workers/desktop/index.ts')
+  assert.match(source, /function toWireCastDevice\(/)
+  assert.match(source, /castProtocol: d\.protocol \|\| 'chromecast'/)
+  assert.match(source, /eventCastDeviceFound\?\.\(\{ device: toWireCastDevice\(d\) \}\)/)
+  assert.match(source, /getDevices\(\)\.map\(toWireCastDevice\)/)
+  assert.match(source, /r\.castProtocol \|\| r\.protocol \|\| 'chromecast'/)
+})
+
+test('useCast normalizes inbound devices from either field name', () => {
+  const source = readAppFile('lib/cast/useCast.shared.ts')
+  assert.match(source, /function normalizeCastDevice\(/)
+  assert.match(source, /raw\.protocol \|\| raw\.castProtocol \|\| 'chromecast'/)
+  assert.match(source, /normalizeCastDevice\(data\?\.device \?\? data\)/, 'deviceFound events should be normalized')
+  assert.match(source, /result\.devices\.map\(normalizeCastDevice\)/, 'castGetDevices results should be normalized')
+  assert.match(source, /protocol: 'chromecast' \| 'fcast'/, 'CastDevice type should include fcast')
+})
+
+test('platform RPC wrappers send castProtocol for manual devices', () => {
+  for (const file of ['rpc.native.ts', 'rpc.web.ts']) {
+    const source = readRepoFile(path.join('packages/platform/src', file))
+    assert.match(
+      source,
+      /castAddManualDevice\(\{ \.\.\.req, castProtocol: req\.protocol \}\)/,
+      `${file} should map protocol onto the castProtocol wire field`,
+    )
+  }
+})
+
+test('desktop worker proxies non-chromecast (fcast) sources onto the LAN', () => {
+  const source = readAppFile('workers/desktop/index.ts')
+  assert.match(
+    source,
+    /\} else \{\s*\n(?:\s*\/\/[^\n]*\n)*\s*try \{ await ensureCastProxyServer\(\); const pu = await createCastProxyUrl\(deviceHost, requestedUrl\)/,
+    'non-chromecast castPlay should route through the cast proxy',
+  )
+})
+
+test('device picker offers the FCast protocol for manual devices', () => {
+  const source = readAppFile('components/cast/DevicePickerModal.tsx')
+  assert.match(source, /useState<'chromecast' \| 'fcast'>\('chromecast'\)/)
+  assert.match(source, /\['chromecast', 'fcast'\] as const/)
+  assert.match(source, /manualProtocol === 'fcast' \? 46899 : 8009/)
+})

--- a/packages/app/workers/desktop/index.ts
+++ b/packages/app/workers/desktop/index.ts
@@ -345,10 +345,17 @@ function buildTranscodeCacheKey(url: string): string | null {
   } catch { return null }
 }
 
+// The @peartube/cast-device wire schema names the protocol field `castProtocol`
+// (required); the cast stack uses `protocol` internally. Devices crossing the
+// RPC boundary must be mapped or compact-encoding throws and the message is lost.
+function toWireCastDevice(d: any) {
+  return { id: d.id, name: d.name, host: d.host, port: d.port, castProtocol: d.protocol || 'chromecast' }
+}
+
 function getCastContext(): any {
   if (!castContext && CastContext) {
     castContext = new CastContext()
-    castContext.on('deviceFound', (d: any) => { try { rpc?.eventCastDeviceFound?.({ device: { id: d.id, name: d.name, host: d.host, port: d.port, protocol: d.protocol } }) } catch {} })
+    castContext.on('deviceFound', (d: any) => { try { rpc?.eventCastDeviceFound?.({ device: toWireCastDevice(d) }) } catch (e: any) { console.warn('[Worker] eventCastDeviceFound failed:', e?.message) } })
     castContext.on('deviceLost', (id: string) => { try { rpc?.eventCastDeviceLost?.({ deviceId: id }) } catch {} })
     castContext.on('playbackStateChanged', (state: string) => {
       if (state === 'stopped' || state === 'idle' || state === 'disconnected' || state === 'error') { activeCastSourceKey = null; if (activeCastTranscodeId) castSessionsWithLoadSent.delete(activeCastTranscodeId) }
@@ -800,9 +807,9 @@ B.pickImageFile = async () => { const r = await pickImageFile(); return { filePa
 B.castAvailable = async () => { await loadCastContext(); return { available: CastContext !== null, error: castLoadError } }
 B.castStartDiscovery = async () => { await loadCastContext(); if (!CastContext) return { success: false, error: castLoadError || 'not available' }; try { await getCastContext().startDiscovery(); return { success: true } } catch (e: any) { return { success: false, error: e?.message } } }
 B.castStopDiscovery = async () => { if (!castContext) return { success: true }; try { castContext.stopDiscovery(); return { success: true } } catch (e: any) { return { success: false, error: e?.message } } }
-B.castGetDevices = async () => { if (!castContext) return { devices: [] }; try { return { devices: castContext.getDevices().map((d: any) => ({ id: d.id, name: d.name, host: d.host, port: d.port, protocol: d.protocol })) } } catch { return { devices: [] } } }
-B.castAddManualDevice = async (r: any) => { await loadCastContext(); if (!CastContext) return { success: false, error: 'not available' }; try { const d = getCastContext().addManualDevice({ name: r.name, host: r.host, port: r.port, protocol: r.protocol || 'chromecast' }); return { success: true, device: { id: d.id, name: d.name, host: d.host, port: d.port, protocol: d.protocol } } } catch (e: any) { return { success: false, error: e?.message } } }
-B.castConnect = async (r: any) => { await loadCastContext(); if (!CastContext) return { success: false, error: 'not available' }; const c = getCastContext(); try { const devices = c.getDevices?.() || []; const dev = devices.find((d: any) => d.id === r.deviceId); await c.connect(r.deviceId); return dev ? { success: true, device: { id: dev.id, name: dev.name, host: dev.host, port: dev.port, protocol: dev.protocol } } : { success: true } } catch (e: any) { return { success: false, error: e?.message } } }
+B.castGetDevices = async () => { if (!castContext) return { devices: [] }; try { return { devices: castContext.getDevices().map(toWireCastDevice) } } catch { return { devices: [] } } }
+B.castAddManualDevice = async (r: any) => { await loadCastContext(); if (!CastContext) return { success: false, error: 'not available' }; try { const d = getCastContext().addManualDevice({ name: r.name, host: r.host, port: r.port, protocol: r.castProtocol || r.protocol || 'chromecast' }); return { success: true, device: toWireCastDevice(d) } } catch (e: any) { return { success: false, error: e?.message } } }
+B.castConnect = async (r: any) => { await loadCastContext(); if (!CastContext) return { success: false, error: 'not available' }; const c = getCastContext(); try { const devices = c.getDevices?.() || []; const dev = devices.find((d: any) => d.id === r.deviceId); await c.connect(r.deviceId); return dev ? { success: true, device: toWireCastDevice(dev) } : { success: true } } catch (e: any) { return { success: false, error: e?.message } } }
 B.castDisconnect = async () => { if (!castContext) return { success: true }; try { await castContext.disconnect(); castProxySessions.clear(); if (activeCastTranscodeId) { castSessionsWithLoadSent.delete(activeCastTranscodeId); castTranscoder.stopCastTranscode(activeCastTranscodeId); transcodeSessions.delete(activeCastTranscodeId); activeCastTranscodeId = null; activeCastSourceKey = null } return { success: true } } catch (e: any) { return { success: false, error: e?.message } } }
 B.castPause = async () => { if (!castContext?.isConnected()) return { success: false, error: 'Not connected' }; try { await castContext.pause(); return { success: true } } catch (e: any) { return { success: false, error: e?.message } } }
 B.castResume = async () => { if (!castContext?.isConnected()) return { success: false, error: 'Not connected' }; try { await castContext.resume(); return { success: true } } catch (e: any) { return { success: false, error: e?.message } } }
@@ -847,6 +854,11 @@ B.castPlay = async (r: any) => {
         if (!usedDirect) { try { await ensureCastProxyServer(); const pu = await createCastProxyUrl(deviceHost, r.url); if (pu) url = pu } catch {} }
         if (!usedDirect) { try { const p = new URL(r.url); if (CAST_LOCALHOSTS.has(p.hostname)) { const ip = await getLocalIPv4ForTarget(deviceHost); if (ip) url = rewriteUrlHost(r.url, ip) } } catch {} }
       }
+    } else {
+      // FCast (and other non-Chromecast) receivers play the original file
+      // directly, but the source URL points at the local blob server — serve
+      // it through the LAN-reachable cast proxy so the receiver can fetch it.
+      try { await ensureCastProxyServer(); const pu = await createCastProxyUrl(deviceHost, requestedUrl); if (pu) url = pu } catch (e: any) { console.warn('[Worker] Cast proxy for', protocol, 'failed, using direct URL:', e?.message) }
     }
     try { await castContext.stop(); await new Promise(resolve => setTimeout(resolve, 200)) } catch {}
     const prev = activeCastTranscodeId

--- a/packages/backend/src/cast/discovery.js
+++ b/packages/backend/src/cast/discovery.js
@@ -12,6 +12,9 @@ import { EventEmitter } from 'bare-events'
 // mDNS multicast address and port
 export const MDNS_ADDRESS = '224.0.0.251'
 export const MDNS_PORT = 5353
+// RFC 6762 §11: mDNS packets SHOULD be sent with IP TTL 255. Some responders
+// drop queries with a lower TTL, and the kernel default for multicast is 1.
+export const MDNS_TTL = 255
 
 // Service types
 export const ServiceType = {
@@ -55,6 +58,7 @@ function encodeName(name) {
 function decodeName(buffer, offset, message) {
   const parts = []
   let jumped = false
+  let jumps = 0
   let originalOffset = offset
 
   while (offset < buffer.length) {
@@ -67,6 +71,8 @@ function decodeName(buffer, offset, message) {
 
     // Check for compression pointer (starts with 11xxxxxx)
     if ((len & 0xc0) === 0xc0) {
+      // Guard against malformed packets whose pointers form a loop.
+      if (++jumps > 32) break
       if (!jumped) {
         originalOffset = offset + 2
       }
@@ -217,43 +223,57 @@ export class DeviceDiscoverer extends EventEmitter {
     this._devices = new Map()
     this._manualDevices = new Map()
     this._socket = null
+    this._txSockets = new Map() // iface IPv4 -> query socket bound to it
     this._queryInterval = null
     this._localIp = undefined
+    this._localIps = undefined
   }
 
   /**
-   * Best-effort resolve this host's LAN IPv4 address.
+   * Best-effort enumerate ALL of this host's usable LAN IPv4 addresses.
    *
-   * Multicast must egress (and the group must be joined) on the correct
-   * interface. Phones in particular have several interfaces at once
-   * (wlan0, rmnet/cellular, virtual VPN, ...). If the query goes out the
-   * wrong interface — e.g. cellular instead of Wi-Fi — it never reaches the
-   * Chromecast and no response is ever received, so devices never appear.
+   * Multicast must be joined — and queries must egress — on the correct
+   * interface, but on a multi-homed host we cannot reliably guess which one
+   * that is: phones have wlan0 + rmnet/cellular + VPN at once, desktops have
+   * ethernet + Wi-Fi + docker/VM bridges. Guessing a single interface (the
+   * previous behaviour) silently picked a bridge or the wrong NIC and
+   * discovery went dark. So we operate on every candidate interface instead.
    *
-   * Returns null when it cannot be determined, in which case callers fall
-   * back to binding 0.0.0.0 (the previous behaviour).
+   * Wi-Fi-looking interfaces (wlan0/en0) are ordered first so the preferred
+   * address (used for logging / single-address callers) stays stable.
    */
-  async _resolveLocalIPv4() {
-    if (this._localIp !== undefined) return this._localIp
-    this._localIp = null
+  async _resolveLocalIPv4s() {
+    if (this._localIps !== undefined) return this._localIps
+    this._localIps = []
     try {
       const mod = await import('udx-native')
       const UDX = (mod && mod.default) ? mod.default : mod
       const udx = new UDX()
-      let fallback = null
+      const preferred = []
+      const rest = []
       for (const iface of udx.networkInterfaces()) {
         if (iface.family !== 4 || iface.internal) continue
+        const host = iface.host
+        if (!host || host.startsWith('127.') || host.startsWith('169.254.')) continue
         // Prefer the well-known Wi-Fi interface names where we can tell.
-        if (iface.name === 'wlan0' || iface.name === 'en0') {
-          this._localIp = iface.host
-          return this._localIp
-        }
-        if (!fallback) fallback = iface.host
+        if (iface.name === 'wlan0' || iface.name === 'en0') preferred.push(host)
+        else rest.push(host)
       }
-      this._localIp = fallback
+      this._localIps = [...new Set([...preferred, ...rest])]
     } catch {
-      this._localIp = null
+      this._localIps = []
     }
+    return this._localIps
+  }
+
+  /**
+   * Best-effort resolve this host's preferred LAN IPv4 address (first usable
+   * interface, Wi-Fi first). Returns null when it cannot be determined.
+   */
+  async _resolveLocalIPv4() {
+    if (this._localIp !== undefined) return this._localIp
+    const ips = await this._resolveLocalIPv4s()
+    this._localIp = ips.length > 0 ? ips[0] : null
     return this._localIp
   }
 
@@ -290,11 +310,12 @@ export class DeviceDiscoverer extends EventEmitter {
       throw new Error('bare-dgram not available: ' + e.message)
     }
 
+    const localIps = await this._resolveLocalIPv4s()
     const localIp = await this._resolveLocalIPv4()
     if (localIp) {
-      console.log('[Discovery] Joining multicast on LAN interface:', localIp)
+      console.log('[Discovery] LAN IPv4 interfaces:', localIps.join(', '))
     } else {
-      console.warn('[Discovery] Could not determine LAN IPv4; joining multicast on the default interface')
+      console.warn('[Discovery] Could not determine any LAN IPv4; using the default interface only')
     }
 
     // mDNS responders send their answers — and the periodic *unsolicited*
@@ -320,7 +341,7 @@ export class DeviceDiscoverer extends EventEmitter {
     let lastErr = null
     for (const target of bindTargets) {
       try {
-        await this._bindMdnsSocket(dgram, target, localIp)
+        await this._bindMdnsSocket(dgram, target, localIps)
         return
       } catch (err) {
         lastErr = err
@@ -342,10 +363,10 @@ export class DeviceDiscoverer extends EventEmitter {
 
   /**
    * Create and bind a fresh mDNS socket to the given target, joining the
-   * multicast group on the resolved LAN interface once it is listening.
+   * multicast group on every resolved LAN interface once it is listening.
    * Resolves when listening, rejects on bind/socket error.
    */
-  _bindMdnsSocket(dgram, target, localIp) {
+  _bindMdnsSocket(dgram, target, localIps) {
     return new Promise((resolve, reject) => {
       let settled = false
       try {
@@ -379,9 +400,14 @@ export class DeviceDiscoverer extends EventEmitter {
           const addr = this._socket.address()
           console.log('[Discovery] mDNS socket listening on', addr?.address || '?', 'port', addr?.port || 'unknown')
 
-          // Join the group on the LAN interface so multicast is delivered from
-          // the right NIC on multi-homed hosts (phones with Wi-Fi + cellular).
-          this._joinMulticast(localIp)
+          // Join the group on every LAN interface so multicast is delivered
+          // no matter which NIC the Chromecast is reachable on (phones with
+          // Wi-Fi + cellular, desktops with ethernet + Wi-Fi + bridges).
+          this._joinMulticast(localIps)
+
+          // Per-interface query sockets: steer query egress out each NIC and
+          // catch unicast (QU) replies even where multicast RX is filtered.
+          this._startTxSockets(dgram, localIps)
 
           // Send initial queries
           this._sendQueries()
@@ -411,30 +437,37 @@ export class DeviceDiscoverer extends EventEmitter {
   }
 
   /**
-   * Join the mDNS multicast group on the given interface.
+   * Join the mDNS multicast group on every given interface.
    *
    * udx-native's underlying socket exposes addMembership(address[, iface]).
    * Passing the interface address makes the kernel deliver multicast
    * responses arriving on that NIC — without it, a multi-homed device can
    * join on the wrong interface and never see Chromecast announcements.
+   * Joining on all interfaces means we no longer have to guess which NIC
+   * shares a subnet with the Chromecast.
    */
-  _joinMulticast(localIp) {
+  _joinMulticast(localIps) {
     try {
       const innerSocket = this._socket?._socket
-      if (innerSocket && typeof innerSocket.addMembership === 'function') {
-        if (localIp) {
-          try {
-            innerSocket.addMembership(MDNS_ADDRESS, localIp)
-            console.log('[Discovery] Joined multicast group', MDNS_ADDRESS, 'on', localIp)
-            return
-          } catch (ifaceErr) {
-            console.warn('[Discovery] Interface-scoped multicast join failed, retrying default:', ifaceErr.message)
-          }
-        }
-        innerSocket.addMembership(MDNS_ADDRESS)
-        console.log('[Discovery] Joined multicast group', MDNS_ADDRESS)
-      } else {
+      if (!innerSocket || typeof innerSocket.addMembership !== 'function') {
         console.warn('[Discovery] Multicast not supported, relying on unicast responses')
+        return
+      }
+
+      let joined = 0
+      for (const localIp of (localIps || [])) {
+        try {
+          innerSocket.addMembership(MDNS_ADDRESS, localIp)
+          joined++
+          console.log('[Discovery] Joined multicast group', MDNS_ADDRESS, 'on', localIp)
+        } catch (ifaceErr) {
+          console.warn('[Discovery] Multicast join failed on', localIp + ':', ifaceErr.message)
+        }
+      }
+
+      if (joined === 0) {
+        innerSocket.addMembership(MDNS_ADDRESS)
+        console.log('[Discovery] Joined multicast group', MDNS_ADDRESS, 'on the default interface')
       }
     } catch (e) {
       // Multicast join is optional - we can still send queries and receive
@@ -444,24 +477,106 @@ export class DeviceDiscoverer extends EventEmitter {
   }
 
   /**
-   * Send mDNS queries for Chromecast
+   * Bind one query socket per LAN interface.
+   *
+   * Two reasons these exist alongside the main 0.0.0.0:5353 socket:
+   *
+   *  1. TX egress: udx-native has no IP_MULTICAST_IF, so multicast sent from
+   *     the wildcard socket follows the default route — on a phone that can
+   *     be cellular/VPN and the query never reaches the Chromecast. Sending
+   *     from a socket bound to an interface's own address makes the kernel
+   *     route the multicast query out THAT interface (Linux/Android resolve
+   *     the output device from the source address for multicast).
+   *  2. Unicast replies: our queries set the QU bit, so responders may reply
+   *     unicast to the query's source address:port. That lands on these
+   *     sockets directly, which keeps discovery alive on networks (common
+   *     mesh/enterprise APs) that filter downstream multicast entirely.
+   */
+  _startTxSockets(dgram, localIps) {
+    for (const ip of (localIps || [])) {
+      if (this._txSockets.has(ip)) continue
+      try {
+        let sock
+        try {
+          sock = dgram.createSocket({ type: 'udp4', reuseAddress: true })
+        } catch {
+          sock = dgram.createSocket('udp4')
+        }
+        sock.on('error', (err) => {
+          console.warn('[Discovery] Query socket error on', ip + ':', err?.message)
+          if (this._txSockets.get(ip) === sock) this._txSockets.delete(ip)
+          try { sock.close() } catch { /* best-effort teardown */ }
+        })
+        sock.on('message', (msg, rinfo) => {
+          this._handleMessage(msg, rinfo)
+        })
+        sock.bind(0, ip)
+        this._txSockets.set(ip, sock)
+        console.log('[Discovery] Query socket bound on', ip)
+      } catch (err) {
+        console.warn('[Discovery] Could not bind query socket on', ip + ':', err?.message)
+      }
+    }
+  }
+
+  /**
+   * Send one query buffer from one socket, with the mDNS-standard IP TTL
+   * where the inner udx socket allows it (the bare-dgram wrapper cannot set
+   * a TTL, and the kernel default multicast TTL of 1 is dropped by some
+   * responders that expect 255 per RFC 6762 §11).
+   */
+  async _sendQuery(socket, query) {
+    const inner = socket?._socket
+    if (inner && typeof inner.send === 'function') {
+      await inner.send(query, MDNS_PORT, MDNS_ADDRESS, MDNS_TTL)
+      return
+    }
+    await socket.send(query, 0, query.length, MDNS_PORT, MDNS_ADDRESS)
+  }
+
+  /**
+   * Send mDNS queries for Chromecast from the main socket and from every
+   * per-interface query socket.
    */
   async _sendQueries() {
     if (!this._socket) return
 
-    try {
-      const queries = [
-        buildQuery(ServiceType.CHROMECAST, true),
-        buildQuery(ServiceType.CHROMECAST, false),
-      ]
+    const queries = [
+      buildQuery(ServiceType.CHROMECAST, true),
+      buildQuery(ServiceType.CHROMECAST, false),
+    ]
 
-      for (const query of queries) {
-        await this._socket.send(query, 0, query.length, MDNS_PORT, MDNS_ADDRESS)
+    let sent = 0
+
+    for (const query of queries) {
+      try {
+        await this._sendQuery(this._socket, query)
+        sent++
+      } catch (err) {
+        console.warn('[Discovery] Error sending query on main socket:', err?.message)
       }
+    }
 
-      console.log('[Discovery] Sent mDNS queries to', MDNS_ADDRESS + ':' + MDNS_PORT)
-    } catch (err) {
-      console.warn('[Discovery] Error sending queries:', err.message)
+    for (const [ip, sock] of [...this._txSockets]) {
+      for (const query of queries) {
+        try {
+          await this._sendQuery(sock, query)
+          sent++
+        } catch (err) {
+          // An interface that cannot route multicast (cellular, downed VPN)
+          // fails on every tick — drop its socket instead of spamming warnings.
+          console.warn('[Discovery] Dropping query socket on', ip + ':', err?.message)
+          this._txSockets.delete(ip)
+          try { sock.close() } catch { /* best-effort teardown */ }
+          break
+        }
+      }
+    }
+
+    if (sent > 0) {
+      console.log('[Discovery] Sent', sent, 'mDNS queries to', MDNS_ADDRESS + ':' + MDNS_PORT)
+    } else {
+      console.warn('[Discovery] No mDNS queries could be sent')
     }
   }
 
@@ -536,7 +651,10 @@ export class DeviceDiscoverer extends EventEmitter {
       try {
         const innerSocket = this._socket._socket
         if (innerSocket && typeof innerSocket.dropMembership === 'function') {
-          innerSocket.dropMembership(MDNS_ADDRESS)
+          for (const localIp of (this._localIps || [])) {
+            try { innerSocket.dropMembership(MDNS_ADDRESS, localIp) } catch { /* not joined on this iface */ }
+          }
+          try { innerSocket.dropMembership(MDNS_ADDRESS) } catch { /* not joined on the default iface */ }
         }
       } catch (e) { /* best-effort: group may not have been joined */ }
 
@@ -547,8 +665,14 @@ export class DeviceDiscoverer extends EventEmitter {
       this._socket = null
     }
 
-    // Re-resolve the interface on the next start in case the network changed.
+    for (const sock of this._txSockets.values()) {
+      try { sock.close() } catch { /* best-effort: socket may already be closed */ }
+    }
+    this._txSockets.clear()
+
+    // Re-resolve the interfaces on the next start in case the network changed.
     this._localIp = undefined
+    this._localIps = undefined
   }
 
   /**

--- a/packages/backend/src/cast/discovery.js
+++ b/packages/backend/src/cast/discovery.js
@@ -1,10 +1,11 @@
 /**
  * Device Discovery via mDNS
  *
- * Discovers Chromecast devices on the local network using mDNS.
+ * Discovers cast devices on the local network using mDNS.
  *
  * Service types:
  * - _googlecast._tcp.local. - Chromecast devices
+ * - _fcast._tcp.local.      - FCast receivers (https://fcast.org)
  */
 
 import { EventEmitter } from 'bare-events'
@@ -18,7 +19,14 @@ export const MDNS_TTL = 255
 
 // Service types
 export const ServiceType = {
-  CHROMECAST: '_googlecast._tcp.local.'
+  CHROMECAST: '_googlecast._tcp.local.',
+  FCAST: '_fcast._tcp.local.'
+}
+
+// Default connect port per protocol (Chromecast: TLS 8009, FCast: TCP 46899)
+const DEFAULT_PROTOCOL_PORTS = {
+  chromecast: 8009,
+  fcast: 46899
 }
 
 // DNS record types
@@ -541,10 +549,13 @@ export class DeviceDiscoverer extends EventEmitter {
   async _sendQueries() {
     if (!this._socket) return
 
-    const queries = [
-      buildQuery(ServiceType.CHROMECAST, true),
-      buildQuery(ServiceType.CHROMECAST, false),
-    ]
+    // One QU (unicast-reply) and one QM (multicast-reply) query per service
+    // type — receivers vary in which they answer.
+    const queries = []
+    for (const serviceName of Object.values(ServiceType)) {
+      queries.push(buildQuery(serviceName, true))
+      queries.push(buildQuery(serviceName, false))
+    }
 
     let sent = 0
 
@@ -593,9 +604,11 @@ export class DeviceDiscoverer extends EventEmitter {
 
       for (const record of allRecords) {
         if (record.type === DNS_TYPE.PTR) {
-          const isChromecast = record.name.includes('_googlecast._tcp')
+          const serviceProtocol = record.name.includes('_googlecast._tcp')
+            ? 'chromecast'
+            : (record.name.includes('_fcast._tcp') ? 'fcast' : null)
 
-          if (isChromecast) {
+          if (serviceProtocol) {
             // Find corresponding SRV and A records
             const instanceName = record.ptr
             const srvRecord = allRecords.find(r => r.type === DNS_TYPE.SRV && r.name === instanceName)
@@ -610,7 +623,7 @@ export class DeviceDiscoverer extends EventEmitter {
             if (srvRecord && aRecord) {
               const host = aRecord.address
               const port = srvRecord.port
-              const protocol = 'chromecast'
+              const protocol = serviceProtocol
               const id = `${host}:${port}`
 
               // Extract friendly name from TXT record or instance name
@@ -698,13 +711,13 @@ export class DeviceDiscoverer extends EventEmitter {
    * @param {Object} options
    * @param {string} options.name - Device name
    * @param {string} options.host - IP address or hostname
-   * @param {number} [options.port] - Port number (default: 8009 for chromecast)
-   * @param {string} [options.protocol='chromecast'] - Protocol type
+   * @param {number} [options.port] - Port number (default: 8009 for chromecast, 46899 for fcast)
+   * @param {string} [options.protocol='chromecast'] - Protocol type ('chromecast' | 'fcast')
    * @returns {Object} The device info
    */
   addManualDevice(options) {
     const protocol = options.protocol || 'chromecast'
-    const port = options.port || 8009
+    const port = options.port || DEFAULT_PROTOCOL_PORTS[protocol] || 8009
     const id = `${options.host}:${port}`
 
     const device = {

--- a/packages/backend/src/cast/fcast-protocol.js
+++ b/packages/backend/src/cast/fcast-protocol.js
@@ -1,0 +1,125 @@
+/**
+ * FCast wire protocol codec (https://fcast.org)
+ *
+ * FCast is an open casting protocol used by FUTO / Grayjay receivers.
+ * Transport is a plain TCP connection (default port 46899). Every message is:
+ *
+ *   [ 4 bytes  little-endian uint32: length of the REST of the message ]
+ *   [ 1 byte   opcode                                                  ]
+ *   [ length-1 bytes UTF-8 JSON body (optional; some opcodes are bare) ]
+ *
+ * This module is dependency-free (global Buffer only) so it runs unchanged
+ * under both Bare and Node, and the framing can be unit-tested directly.
+ */
+
+export const FCAST_PORT = 46899
+
+// Protocol version we advertise. v2 receivers reply to Ping and include
+// duration/speed in PlaybackUpdate; v1 receivers simply ignore the
+// version/ping opcodes they don't know.
+export const FCAST_PROTOCOL_VERSION = 2
+
+export const Opcode = {
+  NONE: 0,
+  PLAY: 1,
+  PAUSE: 2,
+  RESUME: 3,
+  STOP: 4,
+  SEEK: 5,
+  PLAYBACK_UPDATE: 6,
+  VOLUME_UPDATE: 7,
+  SET_VOLUME: 8,
+  PLAYBACK_ERROR: 9,
+  SET_SPEED: 10,
+  VERSION: 11,
+  PING: 12,
+  PONG: 13
+}
+
+// Receiver playback state values carried in PlaybackUpdate.
+export const PlaybackState = {
+  IDLE: 0,
+  PLAYING: 1,
+  PAUSED: 2
+}
+
+// Matches the reference implementation's MAXIMUM_PACKET_LENGTH. Anything
+// larger is a corrupt stream or a hostile peer.
+export const MAX_MESSAGE_LENGTH = 32000
+
+const HEADER_LENGTH = 4
+
+/**
+ * Encode one FCast message.
+ *
+ * @param {number} opcode
+ * @param {Object} [body] - JSON-serializable body; omit for bare opcodes
+ * @returns {Buffer}
+ */
+export function encodeMessage(opcode, body) {
+  const json = body === undefined || body === null ? null : JSON.stringify(body)
+  const jsonBuf = json ? Buffer.from(json, 'utf8') : null
+  const bodyLength = jsonBuf ? jsonBuf.length : 0
+
+  const message = Buffer.alloc(HEADER_LENGTH + 1 + bodyLength)
+  message.writeUInt32LE(1 + bodyLength, 0)
+  message[HEADER_LENGTH] = opcode
+  if (jsonBuf) jsonBuf.copy(message, HEADER_LENGTH + 1)
+  return message
+}
+
+/**
+ * Incremental decoder for the FCast byte stream. Feed it socket chunks in
+ * any fragmentation; it returns fully framed messages as they complete.
+ *
+ * @example
+ * const decoder = new FCastDecoder()
+ * socket.on('data', (chunk) => {
+ *   for (const msg of decoder.push(chunk)) handle(msg.opcode, msg.body)
+ * })
+ */
+export class FCastDecoder {
+  constructor() {
+    this._buffer = Buffer.alloc(0)
+  }
+
+  /**
+   * @param {Buffer} chunk
+   * @returns {{opcode: number, body: Object|null}[]} completed messages
+   * @throws {Error} on an invalid frame length (treat as fatal for the connection)
+   */
+  push(chunk) {
+    this._buffer = this._buffer.length === 0 ? Buffer.from(chunk) : Buffer.concat([this._buffer, chunk])
+
+    const messages = []
+
+    while (this._buffer.length >= HEADER_LENGTH) {
+      const length = this._buffer.readUInt32LE(0)
+
+      if (length < 1 || length > MAX_MESSAGE_LENGTH) {
+        throw new Error(`Invalid FCast message length: ${length}`)
+      }
+
+      if (this._buffer.length < HEADER_LENGTH + length) break
+
+      const opcode = this._buffer[HEADER_LENGTH]
+      const bodyBuf = this._buffer.slice(HEADER_LENGTH + 1, HEADER_LENGTH + length)
+      this._buffer = this._buffer.slice(HEADER_LENGTH + length)
+
+      let body = null
+      if (bodyBuf.length > 0) {
+        try {
+          body = JSON.parse(bodyBuf.toString('utf8'))
+        } catch {
+          body = null // tolerate malformed bodies; opcode alone is still useful
+        }
+      }
+
+      messages.push({ opcode, body })
+    }
+
+    return messages
+  }
+}
+
+export default { FCAST_PORT, FCAST_PROTOCOL_VERSION, Opcode, PlaybackState, MAX_MESSAGE_LENGTH, encodeMessage, FCastDecoder }

--- a/packages/backend/src/cast/fcast.js
+++ b/packages/backend/src/cast/fcast.js
@@ -1,0 +1,543 @@
+/**
+ * FCast Device Implementation (https://fcast.org)
+ *
+ * FCast receivers (FUTO / Grayjay ecosystem) accept a plain TCP connection on
+ * port 46899 and exchange length-prefixed JSON messages — see
+ * ./fcast-protocol.js for the wire format. Unlike Chromecast there is no TLS,
+ * no protobuf, no app launch handshake and no media session: once connected,
+ * a single Play message starts playback and the receiver streams
+ * PlaybackUpdate messages back.
+ *
+ * Receivers are full media players (ExoPlayer / AVPlayer / mpv), so PearTube
+ * plays the original file directly — no cast transcode pipeline needed.
+ *
+ * Exposes the same surface as ChromecastDevice so CastContext can drive
+ * either interchangeably: connect/disconnect/isConnected, play/pause/resume/
+ * stop/seek/setVolume, getPlaybackState, and the events connectionStateChanged,
+ * playbackStateChanged, timeChanged, durationChanged, volumeChanged, error.
+ */
+
+import { EventEmitter } from 'bare-events'
+import tcp from 'bare-tcp'
+import {
+  FCAST_PORT,
+  FCAST_PROTOCOL_VERSION,
+  Opcode,
+  PlaybackState,
+  encodeMessage,
+  FCastDecoder
+} from './fcast-protocol.js'
+
+export { FCAST_PORT }
+
+const PING_INTERVAL = 5000
+// Receivers speaking protocol v1 never answer Ping and may be silent while
+// idle, so only declare the connection dead after a long quiet period.
+const SILENCE_TIMEOUT = 60000
+const LOCALHOST_HOSTS = new Set(['127.0.0.1', 'localhost', '0.0.0.0', '::1'])
+
+function mapPlaybackState(state) {
+  switch (state) {
+    case PlaybackState.PLAYING:
+      return 'playing'
+    case PlaybackState.PAUSED:
+      return 'paused'
+    case PlaybackState.IDLE:
+    default:
+      return 'idle'
+  }
+}
+
+async function getLocalIPv4(targetHost) {
+  let targetPrefix = null
+  if (typeof targetHost === 'string') {
+    const parts = targetHost.split('.')
+    if (parts.length === 4) {
+      targetPrefix = parts.slice(0, 3).join('.')
+    }
+  }
+
+  try {
+    const mod = await import('udx-native')
+    const UDX = (mod && mod.default) ? mod.default : mod
+    const udx = new UDX()
+    let fallback = null
+
+    for (const iface of udx.networkInterfaces()) {
+      if (iface.family !== 4 || iface.internal) continue
+      if (targetPrefix && iface.host.startsWith(`${targetPrefix}.`)) {
+        return iface.host
+      }
+      if (iface.name === 'en0' || iface.name === 'wlan0') return iface.host
+      if (!fallback) fallback = iface.host
+    }
+
+    return fallback
+  } catch {
+    return null
+  }
+}
+
+function rewriteUrlHost(url, host) {
+  try {
+    const parsed = new URL(url)
+    parsed.hostname = host
+    return parsed.toString()
+  } catch {
+    return url
+  }
+}
+
+/**
+ * FCastDevice - Handles communication with an FCast receiver
+ */
+export class FCastDevice extends EventEmitter {
+  constructor(deviceInfo) {
+    super()
+    this.deviceInfo = deviceInfo
+    this._connected = false
+    this._connectPromise = null
+    this._socket = null
+    this._socketHandlers = null
+    this._decoder = new FCastDecoder()
+    this._pingTimer = null
+    this._lastInboundAt = 0
+    this._receiverVersion = null
+    this._playWaiter = null
+
+    this._state = {
+      state: 'idle',
+      currentTime: 0,
+      duration: 0,
+      volume: 1.0
+    }
+  }
+
+  /**
+   * Connect to the FCast receiver
+   */
+  async connect(timeout = 5000) {
+    if (this._connected) return
+    if (this._connectPromise) return this._connectPromise
+
+    this.emit('connectionStateChanged', 'connecting')
+
+    this._connectPromise = new Promise((resolve, reject) => {
+      let settled = false
+
+      const finishResolve = () => {
+        if (settled) return
+        settled = true
+        clearTimeout(timer)
+        this._connectPromise = null
+        resolve()
+      }
+
+      const finishReject = (err) => {
+        if (settled) return
+        settled = true
+        clearTimeout(timer)
+        this._connectPromise = null
+        this._teardown()
+        this.emit('connectionStateChanged', 'error')
+        reject(err)
+      }
+
+      const timer = setTimeout(() => {
+        finishReject(new Error('FCast connection timeout'))
+      }, Math.max(1000, timeout))
+
+      let socket
+      try {
+        socket = tcp.createConnection(this.deviceInfo.port || FCAST_PORT, this.deviceInfo.host)
+      } catch (err) {
+        finishReject(err)
+        return
+      }
+      this._socket = socket
+
+      const onConnect = () => {
+        this._connected = true
+        this._lastInboundAt = Date.now()
+        this.emit('connectionStateChanged', 'connected')
+        try {
+          this._send(Opcode.VERSION, { version: FCAST_PROTOCOL_VERSION })
+        } catch { /* best-effort: v1 receivers ignore it anyway */ }
+        this._startPing()
+        finishResolve()
+      }
+
+      const onData = (data) => {
+        this._handleData(data)
+      }
+
+      const onError = (err) => {
+        if (!settled) {
+          finishReject(err)
+          return
+        }
+        this._handleDisconnect(err)
+      }
+
+      const onClose = () => {
+        if (!settled) {
+          finishReject(new Error('FCast connection closed'))
+          return
+        }
+        this._handleDisconnect()
+      }
+
+      this._socketHandlers = { onConnect, onData, onError, onClose }
+      socket.on('connect', onConnect)
+      socket.on('data', onData)
+      socket.on('error', onError)
+      socket.on('close', onClose)
+    })
+
+    return this._connectPromise
+  }
+
+  /**
+   * Disconnect from the receiver
+   */
+  async disconnect() {
+    const wasConnected = this._connected
+    this._teardown()
+    if (wasConnected) {
+      this.emit('connectionStateChanged', 'disconnected')
+    }
+  }
+
+  /**
+   * Check if connected
+   */
+  isConnected() {
+    return this._connected
+  }
+
+  /**
+   * Play media
+   *
+   * @param {Object} options
+   * @param {string} options.url - Media URL
+   * @param {string} [options.contentType] - MIME type (FCast "container")
+   * @param {number} [options.time] - Start position in seconds
+   * @param {number} [options.volume] - Volume 0.0-1.0
+   * @param {number} [options.speed] - Playback speed
+   * @param {Object} [options.headers] - Request headers for the media URL
+   * @param {number} [options.startTimeoutMs] - How long to wait for playback to start
+   */
+  async play(options) {
+    if (!this._connected) {
+      throw new Error('Not connected')
+    }
+
+    let mediaUrl = options.url
+    try {
+      const parsed = new URL(mediaUrl)
+      if (LOCALHOST_HOSTS.has(parsed.hostname)) {
+        const localIp = await getLocalIPv4(this.deviceInfo.host)
+        if (localIp) {
+          mediaUrl = rewriteUrlHost(mediaUrl, localIp)
+          console.log('[FCast] Rewriting media URL host to', localIp)
+        }
+      }
+    } catch { /* not a parseable URL — send as-is */ }
+
+    const body = {
+      container: options.contentType || 'video/mp4',
+      url: mediaUrl,
+      time: Number.isFinite(options?.time) ? Math.max(0, Number(options.time)) : 0,
+      speed: Number.isFinite(options?.speed) && options.speed > 0 ? Number(options.speed) : 1
+    }
+    if (options.headers && typeof options.headers === 'object') {
+      body.headers = options.headers
+    }
+
+    console.log('[FCast] PLAY', { host: this.deviceInfo?.host, container: body.container, time: body.time })
+
+    this._send(Opcode.PLAY, body)
+    this._state.state = 'loading'
+    this.emit('playbackStateChanged', 'loading')
+
+    if (Number.isFinite(options?.volume)) {
+      try {
+        this._send(Opcode.SET_VOLUME, { volume: Math.max(0, Math.min(1, Number(options.volume))) })
+      } catch { /* volume is cosmetic; never fail play over it */ }
+    }
+
+    await this._waitForPlaybackStart(options?.startTimeoutMs)
+  }
+
+  _waitForPlaybackStart(timeoutMs = 30000) {
+    const immediate = this._state?.state
+    if (immediate === 'playing' || immediate === 'paused') return Promise.resolve(immediate)
+
+    return new Promise((resolve, reject) => {
+      let timer = null
+
+      const cleanup = () => {
+        if (timer) {
+          clearTimeout(timer)
+          timer = null
+        }
+        if (this._playWaiter === waiter) this._playWaiter = null
+      }
+
+      const waiter = {
+        resolve: (state) => {
+          cleanup()
+          resolve(state)
+        },
+        reject: (err) => {
+          cleanup()
+          reject(err)
+        }
+      }
+
+      timer = setTimeout(() => {
+        waiter.reject(new Error('Timed out waiting for FCast playback to start'))
+      }, Math.max(3000, Number(timeoutMs) || 30000))
+
+      this._playWaiter = waiter
+    })
+  }
+
+  /**
+   * Pause playback
+   */
+  async pause() {
+    if (!this._connected) throw new Error('Not connected')
+    this._send(Opcode.PAUSE)
+  }
+
+  /**
+   * Resume playback
+   */
+  async resume() {
+    if (!this._connected) throw new Error('Not connected')
+    this._send(Opcode.RESUME)
+  }
+
+  /**
+   * Stop playback
+   */
+  async stop() {
+    if (!this._connected) throw new Error('Not connected')
+    this._send(Opcode.STOP)
+    this._state.state = 'stopped'
+    this.emit('playbackStateChanged', 'stopped')
+  }
+
+  /**
+   * Seek to position (seconds)
+   */
+  async seek(time) {
+    if (!this._connected) throw new Error('Not connected')
+    this._send(Opcode.SEEK, { time: Math.max(0, Number(time) || 0) })
+  }
+
+  /**
+   * Set volume (0.0 - 1.0)
+   */
+  async setVolume(volume) {
+    if (!this._connected) throw new Error('Not connected')
+    const level = Math.max(0, Math.min(1, Number(volume) || 0))
+    this._send(Opcode.SET_VOLUME, { volume: level })
+    this._state.volume = level
+    this.emit('volumeChanged', level)
+  }
+
+  /**
+   * Set playback speed
+   */
+  async setSpeed(speed) {
+    if (!this._connected) throw new Error('Not connected')
+    this._send(Opcode.SET_SPEED, { speed: Math.max(0.25, Number(speed) || 1) })
+  }
+
+  /**
+   * Get current playback state
+   */
+  getPlaybackState() {
+    return { ...this._state }
+  }
+
+  _send(opcode, body) {
+    const socket = this._socket
+    if (!socket || socket.destroyed) {
+      throw new Error('FCast socket closed')
+    }
+    socket.write(encodeMessage(opcode, body))
+  }
+
+  _startPing() {
+    if (this._pingTimer) return
+    this._pingTimer = setInterval(() => {
+      if (!this._connected || !this._socket) return
+      if (Date.now() - this._lastInboundAt > SILENCE_TIMEOUT) {
+        const err = new Error('FCast receiver silent for ' + Math.round(SILENCE_TIMEOUT / 1000) + 's')
+        this.emit('error', err)
+        this._handleDisconnect(err)
+        return
+      }
+      try {
+        this._send(Opcode.PING)
+      } catch { /* socket teardown races the timer; close handler owns cleanup */ }
+    }, PING_INTERVAL)
+  }
+
+  _stopPing() {
+    if (this._pingTimer) {
+      clearInterval(this._pingTimer)
+      this._pingTimer = null
+    }
+  }
+
+  _handleData(data) {
+    this._lastInboundAt = Date.now()
+
+    let messages
+    try {
+      messages = this._decoder.push(data)
+    } catch (err) {
+      // Framing is corrupt — the stream cannot recover.
+      this.emit('error', err)
+      this._handleDisconnect(err)
+      return
+    }
+
+    for (const message of messages) {
+      try {
+        this._handleMessage(message)
+      } catch (err) {
+        console.warn('[FCast] Failed to handle message:', err?.message)
+      }
+    }
+  }
+
+  _handleMessage({ opcode, body }) {
+    switch (opcode) {
+      case Opcode.PLAYBACK_UPDATE:
+        this._handlePlaybackUpdate(body || {})
+        break
+
+      case Opcode.VOLUME_UPDATE: {
+        const volume = Number(body?.volume)
+        if (Number.isFinite(volume) && this._state.volume !== volume) {
+          this._state.volume = volume
+          this.emit('volumeChanged', volume)
+        }
+        break
+      }
+
+      case Opcode.PLAYBACK_ERROR: {
+        const message = typeof body?.message === 'string' && body.message
+          ? body.message
+          : 'FCast receiver reported a playback error'
+        const err = new Error(message)
+        if (this._playWaiter) {
+          this._playWaiter.reject(err)
+        } else {
+          this.emit('error', err)
+        }
+        break
+      }
+
+      case Opcode.VERSION: {
+        const version = Number(body?.version)
+        if (Number.isFinite(version)) {
+          this._receiverVersion = version
+          console.log('[FCast] Receiver protocol version:', version)
+        }
+        break
+      }
+
+      case Opcode.PING:
+        try {
+          this._send(Opcode.PONG)
+        } catch { /* socket teardown races inbound pings */ }
+        break
+
+      case Opcode.PONG:
+      case Opcode.NONE:
+        break
+
+      default:
+        // Future opcodes (playlists, events, ...) — ignore.
+        break
+    }
+  }
+
+  _handlePlaybackUpdate(update) {
+    const time = Number(update.time)
+    if (Number.isFinite(time) && time >= 0) {
+      this._state.currentTime = time
+      this.emit('timeChanged', time)
+    }
+
+    const duration = Number(update.duration)
+    if (Number.isFinite(duration) && duration > 0 && this._state.duration !== duration) {
+      this._state.duration = duration
+      this.emit('durationChanged', duration)
+    }
+
+    if (update.state !== undefined) {
+      const nextState = mapPlaybackState(Number(update.state))
+
+      if (this._playWaiter && (nextState === 'playing' || nextState === 'paused')) {
+        this._playWaiter.resolve(nextState)
+      }
+
+      // While a Play is in flight the receiver may still report idle for its
+      // previous (stopped) media — don't clobber our 'loading' state with it.
+      const suppressIdle = nextState === 'idle' && this._state.state === 'loading'
+
+      if (!suppressIdle && this._state.state !== nextState) {
+        this._state.state = nextState
+        this.emit('playbackStateChanged', nextState)
+      }
+    }
+  }
+
+  _handleDisconnect(err) {
+    if (!this._connected && !this._socket) return
+    const wasConnected = this._connected
+    this._teardown(err)
+    if (wasConnected) {
+      this.emit('connectionStateChanged', 'disconnected')
+    }
+  }
+
+  _teardown(err) {
+    this._connected = false
+    this._stopPing()
+
+    if (this._playWaiter) {
+      this._playWaiter.reject(err || new Error('FCast connection closed'))
+    }
+
+    const socket = this._socket
+    if (socket) {
+      this._socket = null
+      const handlers = this._socketHandlers
+      this._socketHandlers = null
+      if (handlers && socket.off) {
+        try {
+          socket.off('connect', handlers.onConnect)
+          socket.off('data', handlers.onData)
+          socket.off('error', handlers.onError)
+          socket.off('close', handlers.onClose)
+        } catch { /* best-effort detach */ }
+      }
+      try {
+        socket.destroy()
+      } catch { /* socket may already be destroyed */ }
+    }
+
+    this._decoder = new FCastDecoder()
+    this._state = { state: 'idle', currentTime: 0, duration: 0, volume: this._state.volume }
+  }
+}
+
+export default FCastDevice

--- a/packages/backend/src/cast/index.js
+++ b/packages/backend/src/cast/index.js
@@ -1,19 +1,22 @@
 /**
- * PearTube Cast - Chromecast sender SDK for Bare/Pear runtime
+ * PearTube Cast - casting sender SDK for Bare/Pear runtime
  *
- * Implements the Chromecast protocol (TLS + protobuf on port 8009) for casting
- * media to receiver devices.
+ * Implements the Chromecast protocol (TLS + protobuf on port 8009) and the
+ * FCast protocol (plain TCP + JSON on port 46899, https://fcast.org) for
+ * casting media to receiver devices.
  */
 
 import { EventEmitter } from 'bare-events'
 import { ChromecastDevice } from './chromecast.js'
+import { FCastDevice } from './fcast.js'
 import { DeviceDiscoverer } from './discovery.js'
 
 /**
  * Protocol types supported
  */
 export const ProtocolType = {
-  CHROMECAST: 'chromecast'
+  CHROMECAST: 'chromecast',
+  FCAST: 'fcast'
 }
 
 /**
@@ -46,7 +49,7 @@ export const PlaybackState = {
  * @property {string} name - Human-readable device name
  * @property {string} host - IP address or hostname
  * @property {number} port - Port number
- * @property {string} protocol - Protocol type ('chromecast')
+ * @property {string} protocol - Protocol type ('chromecast' | 'fcast')
  */
 
 /**
@@ -144,9 +147,12 @@ export class CastContext extends EventEmitter {
   /**
    * Create a device instance from DeviceInfo
    * @param {DeviceInfo} deviceInfo
-   * @returns {ChromecastDevice}
+   * @returns {ChromecastDevice|FCastDevice}
    */
   createDevice(deviceInfo) {
+    if (deviceInfo?.protocol === ProtocolType.FCAST) {
+      return new FCastDevice(deviceInfo)
+    }
     return new ChromecastDevice(deviceInfo)
   }
 
@@ -387,6 +393,7 @@ export class CastContext extends EventEmitter {
 
 // Export classes
 export { ChromecastDevice } from './chromecast.js'
+export { FCastDevice } from './fcast.js'
 export { DeviceDiscoverer } from './discovery.js'
 
 // Default export

--- a/packages/backend/test/cast-discovery-interface-regression.test.mjs
+++ b/packages/backend/test/cast-discovery-interface-regression.test.mjs
@@ -25,6 +25,14 @@ test('discovery resolves the LAN IPv4 before binding the mDNS socket', () => {
   assert.match(discoverySource, /const localIp = await this\._resolveLocalIPv4\(\)/, '_startMdns should resolve the interface before binding')
 })
 
+test('discovery enumerates ALL usable LAN IPv4 interfaces, not a single guess', () => {
+  assert.match(discoverySource, /_resolveLocalIPv4s\s*\(/, 'helper that resolves every LAN interface should exist')
+  assert.match(discoverySource, /const localIps = await this\._resolveLocalIPv4s\(\)/, '_startMdns should resolve all interfaces')
+  // Link-local and loopback addresses must be filtered out so a bridge or
+  // stale interface cannot shadow the real LAN NIC.
+  assert.match(discoverySource, /169\.254\./, 'link-local addresses should be excluded')
+})
+
 test('discovery binds 0.0.0.0 on the mDNS port so multicast responses arrive', () => {
   assert.match(discoverySource, /\{ port: MDNS_PORT, host: '0\.0\.0\.0' \}/, 'primary bind target should be 0.0.0.0:5353')
   assert.match(discoverySource, /\{ port: 0, host: '0\.0\.0\.0' \}/, 'should fall back to an ephemeral 0.0.0.0 port')
@@ -33,14 +41,28 @@ test('discovery binds 0.0.0.0 on the mDNS port so multicast responses arrive', (
   assert.doesNotMatch(discoverySource, /const bindHost = localIp/, 'bind host must not be derived from the unicast LAN IP')
 })
 
-test('discovery joins the multicast group on the LAN interface', () => {
+test('discovery joins the multicast group on every LAN interface', () => {
   assert.match(discoverySource, /_joinMulticast\s*\(/, 'multicast join should be its own helper')
+  assert.match(discoverySource, /for \(const localIp of \(localIps \|\| \[\]\)\)/, 'join should iterate every resolved interface')
   assert.match(discoverySource, /addMembership\(MDNS_ADDRESS, localIp\)/, 'join should pass the interface address when known')
   assert.match(discoverySource, /addMembership\(MDNS_ADDRESS\)/, 'join should fall back to a default-interface join')
 })
 
-test('discovery re-resolves the interface after stopping (network may change)', () => {
+test('discovery sends queries from per-interface sockets so egress + QU replies work', () => {
+  // udx-native has no IP_MULTICAST_IF; the only way to steer the query out a
+  // specific NIC is a socket bound to that NIC's address. Those sockets also
+  // receive unicast (QU) replies on networks that filter downstream multicast.
+  assert.match(discoverySource, /_startTxSockets\s*\(/, 'per-interface query socket setup should exist')
+  assert.match(discoverySource, /sock\.bind\(0, ip\)/, 'query sockets should bind an ephemeral port on the interface address')
+  assert.match(discoverySource, /sock\.on\('message'/, 'query sockets must receive unicast QU replies')
+  assert.match(discoverySource, /MDNS_TTL = 255/, 'queries should be sent with the RFC 6762 IP TTL of 255')
+  assert.match(discoverySource, /inner\.send\(query, MDNS_PORT, MDNS_ADDRESS, MDNS_TTL\)/, 'send should use the inner udx socket TTL parameter')
+})
+
+test('discovery re-resolves the interfaces after stopping (network may change)', () => {
   assert.match(discoverySource, /this\._localIp = undefined/, 'cached interface should be cleared so a restart re-resolves it')
+  assert.match(discoverySource, /this\._localIps = undefined/, 'cached interface list should be cleared so a restart re-resolves it')
+  assert.match(discoverySource, /this\._txSockets\.clear\(\)/, 'per-interface query sockets should be torn down on stop')
 })
 
 test('discovery pairs the A record with the SRV target when several devices answer', () => {

--- a/packages/backend/test/fcast-protocol.test.mjs
+++ b/packages/backend/test/fcast-protocol.test.mjs
@@ -1,0 +1,136 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import {
+  FCAST_PORT,
+  FCAST_PROTOCOL_VERSION,
+  Opcode,
+  PlaybackState,
+  MAX_MESSAGE_LENGTH,
+  encodeMessage,
+  FCastDecoder,
+} from '../src/cast/fcast-protocol.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+test('fcast constants match the published protocol', () => {
+  assert.equal(FCAST_PORT, 46899)
+  assert.equal(FCAST_PROTOCOL_VERSION, 2)
+  assert.equal(Opcode.PLAY, 1)
+  assert.equal(Opcode.PAUSE, 2)
+  assert.equal(Opcode.RESUME, 3)
+  assert.equal(Opcode.STOP, 4)
+  assert.equal(Opcode.SEEK, 5)
+  assert.equal(Opcode.PLAYBACK_UPDATE, 6)
+  assert.equal(Opcode.VOLUME_UPDATE, 7)
+  assert.equal(Opcode.SET_VOLUME, 8)
+  assert.equal(Opcode.PLAYBACK_ERROR, 9)
+  assert.equal(Opcode.SET_SPEED, 10)
+  assert.equal(Opcode.VERSION, 11)
+  assert.equal(Opcode.PING, 12)
+  assert.equal(Opcode.PONG, 13)
+  assert.equal(PlaybackState.IDLE, 0)
+  assert.equal(PlaybackState.PLAYING, 1)
+  assert.equal(PlaybackState.PAUSED, 2)
+})
+
+test('encodeMessage frames a JSON body with a little-endian length header', () => {
+  const body = { container: 'video/mp4', url: 'http://192.168.1.5:8080/v.mp4', time: 0, speed: 1 }
+  const message = encodeMessage(Opcode.PLAY, body)
+  const json = Buffer.from(JSON.stringify(body), 'utf8')
+
+  assert.equal(message.readUInt32LE(0), 1 + json.length, 'length covers opcode + body')
+  assert.equal(message[4], Opcode.PLAY)
+  assert.deepEqual(message.slice(5), json)
+})
+
+test('encodeMessage frames bare opcodes with length 1', () => {
+  const message = encodeMessage(Opcode.PING)
+  assert.equal(message.length, 5)
+  assert.equal(message.readUInt32LE(0), 1)
+  assert.equal(message[4], Opcode.PING)
+})
+
+test('decoder reassembles messages across arbitrary chunk boundaries', () => {
+  const stream = Buffer.concat([
+    encodeMessage(Opcode.VERSION, { version: 2 }),
+    encodeMessage(Opcode.PLAYBACK_UPDATE, { time: 12.5, duration: 300, state: 1, speed: 1 }),
+    encodeMessage(Opcode.PONG),
+  ])
+
+  // Feed the stream one byte at a time — the worst possible fragmentation.
+  const decoder = new FCastDecoder()
+  const messages = []
+  for (let i = 0; i < stream.length; i++) {
+    messages.push(...decoder.push(stream.slice(i, i + 1)))
+  }
+
+  assert.equal(messages.length, 3)
+  assert.deepEqual(messages[0], { opcode: Opcode.VERSION, body: { version: 2 } })
+  assert.deepEqual(messages[1], { opcode: Opcode.PLAYBACK_UPDATE, body: { time: 12.5, duration: 300, state: 1, speed: 1 } })
+  assert.deepEqual(messages[2], { opcode: Opcode.PONG, body: null })
+})
+
+test('decoder handles multiple messages arriving in one chunk', () => {
+  const chunk = Buffer.concat([
+    encodeMessage(Opcode.PING),
+    encodeMessage(Opcode.VOLUME_UPDATE, { volume: 0.5 }),
+  ])
+  const messages = new FCastDecoder().push(chunk)
+  assert.equal(messages.length, 2)
+  assert.equal(messages[0].opcode, Opcode.PING)
+  assert.deepEqual(messages[1].body, { volume: 0.5 })
+})
+
+test('decoder rejects invalid frame lengths instead of buffering forever', () => {
+  const zero = Buffer.alloc(4) // length 0 is invalid (opcode byte is mandatory)
+  assert.throws(() => new FCastDecoder().push(zero), /Invalid FCast message length/)
+
+  const huge = Buffer.alloc(4)
+  huge.writeUInt32LE(MAX_MESSAGE_LENGTH + 1, 0)
+  assert.throws(() => new FCastDecoder().push(huge), /Invalid FCast message length/)
+})
+
+test('decoder tolerates malformed JSON bodies', () => {
+  const bad = Buffer.from('{nope', 'utf8')
+  const frame = Buffer.alloc(4 + 1 + bad.length)
+  frame.writeUInt32LE(1 + bad.length, 0)
+  frame[4] = Opcode.PLAYBACK_UPDATE
+  bad.copy(frame, 5)
+
+  const messages = new FCastDecoder().push(frame)
+  assert.equal(messages.length, 1)
+  assert.equal(messages[0].opcode, Opcode.PLAYBACK_UPDATE)
+  assert.equal(messages[0].body, null)
+})
+
+// --- Integration wiring (source-level, same style as the discovery tests:
+// the cast modules import bare-* packages and cannot be loaded under node) ---
+
+const readSource = (rel) => fs.readFileSync(path.join(__dirname, '..', 'src', 'cast', rel), 'utf8')
+
+test('discovery queries and recognizes the _fcast._tcp service', () => {
+  const discoverySource = readSource('discovery.js')
+  assert.match(discoverySource, /FCAST: '_fcast\._tcp\.local\.'/, 'FCast mDNS service type should be declared')
+  assert.match(discoverySource, /Object\.values\(ServiceType\)/, 'queries should cover every service type')
+  assert.match(discoverySource, /_fcast\._tcp'\) \? 'fcast'/, 'PTR answers should map the fcast service to the fcast protocol')
+  assert.match(discoverySource, /fcast: 46899/, 'manual fcast devices should default to port 46899')
+})
+
+test('cast context routes fcast devices to FCastDevice', () => {
+  const indexSource = readSource('index.js')
+  assert.match(indexSource, /FCAST: 'fcast'/, 'ProtocolType should declare fcast')
+  assert.match(indexSource, /ProtocolType\.FCAST\)[\s\S]{0,40}new FCastDevice\(deviceInfo\)/, 'createDevice should branch to FCastDevice')
+  assert.match(indexSource, /export \{ FCastDevice \} from '\.\/fcast\.js'/, 'FCastDevice should be re-exported')
+})
+
+test('fcast device speaks the protocol through the shared codec', () => {
+  const fcastSource = readSource('fcast.js')
+  assert.match(fcastSource, /from '\.\/fcast-protocol\.js'/, 'device should use the shared codec')
+  assert.match(fcastSource, /tcp\.createConnection\(this\.deviceInfo\.port \|\| FCAST_PORT, this\.deviceInfo\.host\)/, 'device should connect over plain TCP on the fcast port')
+  assert.match(fcastSource, /Opcode\.VERSION, \{ version: FCAST_PROTOCOL_VERSION \}/, 'device should advertise its protocol version on connect')
+  assert.match(fcastSource, /Opcode\.PONG/, 'device should answer receiver pings')
+})

--- a/packages/platform/src/rpc.native.ts
+++ b/packages/platform/src/rpc.native.ts
@@ -1322,7 +1322,8 @@ export const rpc = {
   },
 
   async castAddManualDevice(req: { name: string; host: string; port?: number; protocol?: string }): Promise<{ success: boolean; device?: { id: string; name: string; host: string; port: number; protocol: string }; error?: string | null }> {
-    return ensureRPC().castAddManualDevice(req);
+    // Wire schema names the field castProtocol; keep the public API on `protocol`.
+    return ensureRPC().castAddManualDevice({ ...req, castProtocol: req.protocol });
   },
 
   async castConnect(req: { deviceId: string }): Promise<{ success: boolean; error?: string | null }> {

--- a/packages/platform/src/rpc.web.ts
+++ b/packages/platform/src/rpc.web.ts
@@ -651,7 +651,8 @@ export const rpc = {
   },
 
   async castAddManualDevice(req: { name: string; host: string; port?: number; protocol?: string }): Promise<{ success: boolean; device?: { id: string; name: string; host: string; port: number; protocol: string }; error?: string | null }> {
-    return ensureRPC().castAddManualDevice(req);
+    // Wire schema names the field castProtocol; keep the public API on `protocol`.
+    return ensureRPC().castAddManualDevice({ ...req, castProtocol: req.protocol });
   },
 
   async castConnect(req: { deviceId: string }): Promise<{ success: boolean; error?: string | null }> {

--- a/packages/spec/test/cast-device-wire.test.mjs
+++ b/packages/spec/test/cast-device-wire.test.mjs
@@ -1,0 +1,64 @@
+import test from 'brittle'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+const { getEncoding } = require('../spec/hrpc/messages.js')
+const c = require('compact-encoding')
+
+// The @peartube/cast-device schema names its protocol field `castProtocol`,
+// while the cast stack (backend handlers, useCast, UI) uses `protocol`.
+// Devices crossing the RPC boundary MUST be mapped to `castProtocol` — a
+// device object carrying only `protocol` makes compact-encoding throw, which
+// silently drops deviceFound events and crashes castGetDevices responses.
+// The senders map via toWireCastDevice(); these tests pin the wire contract.
+
+const wireDevice = {
+  id: '192.168.1.99:46899',
+  name: 'FCast-LIVINGROOM',
+  host: '192.168.1.99',
+  port: 46899,
+  castProtocol: 'fcast',
+}
+
+test('cast-device round-trips castProtocol (fcast) through the wire codec', (t) => {
+  const enc = getEncoding('@peartube/cast-device')
+  const decoded = c.decode(enc, c.encode(enc, wireDevice))
+  t.is(decoded.castProtocol, 'fcast')
+  t.is(decoded.port, 46899)
+  t.is(decoded.host, '192.168.1.99')
+})
+
+test('event-cast-device-found and cast-get-devices-response carry devices', (t) => {
+  const eventEnc = getEncoding('@peartube/event-cast-device-found')
+  const event = c.decode(eventEnc, c.encode(eventEnc, { device: wireDevice }))
+  t.is(event.device.castProtocol, 'fcast')
+
+  const listEnc = getEncoding('@peartube/cast-get-devices-response')
+  const list = c.decode(listEnc, c.encode(listEnc, { devices: [wireDevice, { ...wireDevice, id: 'a:8009', castProtocol: 'chromecast' }] }))
+  t.is(list.devices.length, 2)
+  t.is(list.devices[0].castProtocol, 'fcast')
+  t.is(list.devices[1].castProtocol, 'chromecast')
+})
+
+test('a device keyed `protocol` (not castProtocol) fails to encode — senders must map it', (t) => {
+  const enc = getEncoding('@peartube/cast-device')
+  const internalDevice = { id: 'a:8009', name: 'TV', host: '1.2.3.4', port: 8009, protocol: 'chromecast' }
+  // Manual try/catch: brittle's t.exception intentionally lets TypeError escape.
+  let threw = false
+  try {
+    c.encode(enc, internalDevice)
+  } catch {
+    threw = true
+  }
+  t.ok(threw, 'encoding an unmapped device must throw')
+})
+
+test('cast-add-manual-device-request carries the optional castProtocol', (t) => {
+  const enc = getEncoding('@peartube/cast-add-manual-device-request')
+  const decoded = c.decode(enc, c.encode(enc, { name: 'Shield', host: '10.0.0.9', port: 46899, castProtocol: 'fcast' }))
+  t.is(decoded.castProtocol, 'fcast')
+
+  // Omitted castProtocol decodes as null (backend then defaults to chromecast)
+  const bare = c.decode(enc, c.encode(enc, { name: 'TV', host: '10.0.0.8' }))
+  t.is(bare.castProtocol, null)
+})


### PR DESCRIPTION
## Summary

Two pieces of cast work on this branch:

### 1. Discovery on every LAN interface (`9d6c852`)

Chromecast discovery still returned no devices after #498. That fix made multicast *reception* possible, but the transmit side had gaps: queries egressed on a single guessed interface (on hosts with docker/VM bridges the guess was often the bridge), the group was joined on only that guess, and there was no per-interface unicast-reply path for networks that filter downstream multicast.

Discovery now enumerates all usable IPv4 interfaces (skipping loopback + link-local), joins the multicast group on each, and binds one ephemeral query socket per interface — steering query egress out every NIC and catching unicast (QU) replies where multicast RX is filtered. Queries go out with the RFC 6762 IP TTL of 255 via the inner udx socket, and DNS name decompression is hardened against pointer loops. Interfaces re-resolve on stop/start so Wi-Fi roams and VPN toggles pick up the new topology.

### 2. FCast receiver support (`f4661a1`)

Adds the [FCast protocol](https://fcast.org) (FUTO/Grayjay receivers) as a second casting target:

- `cast/fcast-protocol.js` — dependency-free wire codec (4-byte LE length + opcode + JSON, protocol v2) with an incremental frame decoder; unit-tested under plain node.
- `cast/fcast.js` — `FCastDevice` over `bare-tcp` port 46899 with the same surface/events as `ChromecastDevice`: version exchange on connect, ping/pong keepalive with a 60s silence cutoff, PlaybackUpdate → state/time/duration mapping, PlaybackError rejecting an in-flight play, localhost→LAN URL rewrite.
- Discovery queries/parses `_fcast._tcp.local` alongside `_googlecast._tcp.local`; manual fcast devices default to port 46899.
- `CastContext.createDevice` routes by protocol; the desktop worker proxies non-Chromecast sources through the LAN-reachable cast proxy (FCast receivers play the original file — no transcode pipeline).
- Device picker gains a Chromecast/FCast toggle for manual adds.

**Includes a latent wire-format fix FCast depends on:** the `@peartube/cast-device` HRPC schema names its field `castProtocol` (required), but every sender passed `protocol` — compact-encoding throws on the missing string, silently dropping `deviceFound` events and crashing `castGetDevices`/`castConnect`/`castAddManualDevice` responses whenever a device crossed the RPC boundary (verified against the real generated codec + bare-rpc stack). Backends now map devices through `toWireCastDevice()`, the app normalizes inbound devices from either field name, and the platform RPC wrappers put the manual-add protocol on the `castProtocol` wire field.

## Testing

- 51 assertions across repo suites: FCast codec unit tests (framing across chunk boundaries, invalid lengths, malformed bodies), spec-level cast-device wire round-trips (fcast + chromecast) pinning that unmapped devices fail to encode, and source regressions for the discovery behavior, boundary mappings, and picker toggle.
- Functional harnesses with stubbed `bare-dgram`/`udx-native`/`bare-tcp`: multi-interface join + per-NIC query sockets + TTL-255 queries; Chromecast and FCast devices parsed from realistic mDNS PTR/SRV/TXT/A answers on both multicast and unicast paths; full FCastDevice session (connect/version/ping/play/updates/controls/teardown); playback-error and connect-timeout paths; HRPC client/server round-trip of the fixed device flows; port-5353-in-use fallback; stop/restart cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ky2WxcgCvbWs5aGCVS1FAL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ky2WxcgCvbWs5aGCVS1FAL)_