### PR TITLE
Add permissionless media CDN UI surfaces

### DIFF
--- a/packages/app/app/(tabs)/index.tsx
+++ b/packages/app/app/(tabs)/index.tsx
@@ -9,6 +9,7 @@ import { Feather } from '@expo/vector-icons'
 import { useApp, colors } from '../_layout'
 import { VideoCard } from '../../components/video'
 import { EpisodeCard, EPISODE_CARD_WIDTH, HeroFeatureCard, MediaPosterCard, MEDIA_POSTER_CARD_WIDTH, MediaRail } from '@/components/media'
+import { encodeMediaEntityRouteParam, getMediaEntityRouteId } from '@/components/media/MediaEntityDetailScreen'
 import type { VideoData } from '@peartube/core'
 import { CastHeaderButton } from '@/components/cast'
 import { useVideoPlayerActions } from '@/lib/VideoPlayerContext'
@@ -22,7 +23,7 @@ import { formatTimeAgo } from '@/lib/formatters'
 import { makeVideoUrlCacheKey, setCachedVideoUrl } from '@/lib/video-url-cache'
 import { getDesktopVideoGridColumns } from '@/lib/video-layout'
 import { chunkHomeFeedRows, getVirtualizedHomeFeedRows } from '@/lib/home-feed-virtualization'
-import { buildMediaHubSections, getMediaHubPlaybackKey } from '@/lib/media-hub'
+import { buildMediaHubSections, getMediaHubPlayableSourceItem, getMediaHubPlaybackKey } from '@/lib/media-hub'
 import {
   getFeedPreviewVideos,
   getFeedVideoHydrationMode,
@@ -99,6 +100,8 @@ type HomeFeedListItem =
   | { type: 'movies' }
   | { type: 'shows' }
   | { type: 'new-episodes' }
+  | { type: 'collections' }
+  | { type: 'creators' }
   | { type: 'music-creators' }
   | { type: 'discover-header' }
   | { type: 'discover-loading' }
@@ -912,13 +915,7 @@ export default function HomeScreen() {
   }, [rpc, loadAndPlayVideo])
 
   const getMediaHubSourceItem = useCallback((item: any) => {
-    const source = item?.item && typeof item.item === 'object' && !Array.isArray(item.item) ? item.item : item
-    if (!source || typeof source !== 'object' || Array.isArray(source)) return source
-    const id = source?.id || source?.videoId || item?.id || item?.videoId
-    const channelKey = source?.channelKey || source?.driveKey || item?.channelKey || item?.driveKey
-    const publicBeeKey = source?.publicBeeKey || item?.publicBeeKey || undefined
-    if (source.id === id && source.channelKey === channelKey && source.publicBeeKey === publicBeeKey) return source
-    return { ...source, id, channelKey, publicBeeKey }
+    return getMediaHubPlayableSourceItem(item)
   }, [])
 
   const playMediaHubItem = useCallback((item: any) => {
@@ -931,6 +928,18 @@ export default function HomeScreen() {
     if (!channelKey) return
     router.push({ pathname: '/channel/[key]', params: { key: channelKey, publicBeeKey: source?.publicBeeKey || item?.publicBeeKey || undefined } })
   }, [getMediaHubSourceItem, router])
+
+  const openMediaEntityPage = useCallback((item: any, entityType: 'media' | 'collection' | 'creator' = 'media') => {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) return
+    const pathname = entityType === 'collection' ? '/collection/[id]' : entityType === 'creator' ? '/creator/[id]' : '/media/[id]'
+    router.push({
+      pathname: pathname as any,
+      params: {
+        id: encodeURIComponent(getMediaEntityRouteId(item)),
+        item: encodeMediaEntityRouteParam(item),
+      },
+    })
+  }, [router])
 
   // Legacy: Play video in overlay only (used by mini player expansion)
   const playVideoInOverlay = useCallback(async (video: VideoData) => {
@@ -1112,6 +1121,8 @@ export default function HomeScreen() {
     if (mediaHub.movies.items.length > 0) items.push({ type: 'movies' })
     if (mediaHub.shows.items.length > 0) items.push({ type: 'shows' })
     if (mediaHub.newEpisodes.items.length > 0) items.push({ type: 'new-episodes' })
+    if (mediaHub.collections.items.length > 0) items.push({ type: 'collections' })
+    if (mediaHub.creators.items.length > 0) items.push({ type: 'creators' })
     if (mediaHub.musicAndCreators.items.length > 0) items.push({ type: 'music-creators' })
     items.push({ type: 'discover-header' })
     if ((feedLoading || loadingFeedVideos) && feedVideos.length === 0) {
@@ -1208,6 +1219,7 @@ export default function HomeScreen() {
             peers={displayPeers}
             onPress={() => playMediaHubItem(hero)}
             onChannelPress={() => openMediaHubChannel(hero)}
+            onDetailsPress={() => openMediaEntityPage(hero, 'media')}
           />
         </View>
       )
@@ -1276,6 +1288,36 @@ export default function HomeScreen() {
           itemWidth={EPISODE_CARD_WIDTH}
           renderItem={({ item: mediaItem }: ListRenderItemInfo<any>) => (
             <EpisodeCard item={mediaItem} onPress={() => playMediaHubItem(mediaItem)} />
+          )}
+        />
+      )
+    }
+
+    if (item.type === 'collections') {
+      return (
+        <MediaRail
+          title={mediaHub.collections.title}
+          subtitle={mediaHub.collections.subtitle}
+          data={mediaHub.collections.items}
+          keyExtractor={(mediaItem: any) => getMediaHubPlaybackKey(mediaItem)}
+          itemWidth={MEDIA_POSTER_CARD_WIDTH}
+          renderItem={({ item: mediaItem }: ListRenderItemInfo<any>) => (
+            <MediaPosterCard item={mediaItem} onPress={() => openMediaEntityPage(mediaItem, 'collection')} />
+          )}
+        />
+      )
+    }
+
+    if (item.type === 'creators') {
+      return (
+        <MediaRail
+          title={mediaHub.creators.title}
+          subtitle={mediaHub.creators.subtitle}
+          data={mediaHub.creators.items}
+          keyExtractor={(mediaItem: any) => getMediaHubPlaybackKey(mediaItem)}
+          itemWidth={MEDIA_POSTER_CARD_WIDTH}
+          renderItem={({ item: mediaItem }: ListRenderItemInfo<any>) => (
+            <MediaPosterCard item={mediaItem} onPress={() => openMediaEntityPage(mediaItem, 'creator')} />
           )}
         />
       )
@@ -1542,6 +1584,7 @@ export default function HomeScreen() {
     loadingFeedVideos,
     mediaHub,
     openMediaHubChannel,
+    openMediaEntityPage,
     playMediaHubItem,
     refreshFeed,
     refreshMyVideos,

--- a/packages/app/app/(tabs)/index.web.tsx
+++ b/packages/app/app/(tabs)/index.web.tsx
@@ -41,7 +41,8 @@ import { mergePreviewFeedVideos, mergeHydratedFeedVideos, shouldRenderFeedVideo 
 import { getFeedThumbnailResolveKey } from '@/lib/feed-thumbnail-resolve-key.mjs'
 import { getWatchPageKey, shouldUseMseBackendForWatch } from '@/lib/watch-page-mse-backend-mode.mjs'
 import { consumeStagedWebChannelPlayback } from '@/lib/channel-playback-handoff.js'
-import { buildMediaHubSections } from '@/lib/media-hub'
+import { getMediaHubPlayableSourceItem, buildMediaHubSections } from '@/lib/media-hub'
+import { MediaEntityDetailScreen, encodeMediaEntityRouteParam, getMediaEntityRouteId } from '@/components/media/MediaEntityDetailScreen'
 
 // Check if running on Pear desktop
 const isPear = typeof window !== 'undefined' && (
@@ -108,7 +109,13 @@ interface HomeRoute {
   type: 'home'
 }
 
-type Route = WatchRoute | ChannelRoute | HomeRoute
+interface EntityRoute {
+  type: 'media' | 'collection' | 'creator'
+  entityId: string
+  item?: string
+}
+
+type Route = WatchRoute | ChannelRoute | EntityRoute | HomeRoute
 
 function parseHash(hash: string): Route {
   const normalized = hash.replace(/^#\/?/, '') || ''
@@ -126,6 +133,13 @@ function parseHash(hash: string): Route {
       publicBeeKey: safeDecodeURIComponent(params.get('publicBeeKey') || ''),
     }
   }
+  if ((parts[0] === 'media' || parts[0] === 'collection' || parts[0] === 'creator') && parts[1]) {
+    return {
+      type: parts[0],
+      entityId: safeDecodeURIComponent(parts[1]),
+      item: params.get('item') || undefined,
+    }
+  }
   return { type: 'home' }
 }
 
@@ -139,44 +153,150 @@ function safeDecodeURIComponent(value: string): string {
 
 
 function getMediaHubSource(item: any): any {
-  return item?.item && typeof item.item === 'object' ? item.item : item
+  if (item?.selectedSource && typeof item.selectedSource === 'object' && !Array.isArray(item.selectedSource)) return item.selectedSource
+  if (item?.item?.selectedSource && typeof item.item.selectedSource === 'object' && !Array.isArray(item.item.selectedSource)) return item.item.selectedSource
+  return item?.item && typeof item.item === 'object' && !Array.isArray(item.item) ? item.item : item
 }
 
-function getMediaHubArtwork(item: any): string | null {
+function mediaHubString(...values: any[]): string | null {
+  for (const value of values) {
+    if (typeof value === 'string' && value.length > 0) return value
+  }
+  return null
+}
+
+function mediaHubNumber(...values: any[]): number | null {
+  for (const value of values) {
+    if (typeof value === 'number' && Number.isFinite(value) && value > 0) return value
+  }
+  return null
+}
+
+function getMediaHubArtwork(item: any, intent: 'hero' | 'poster' | 'episode' | 'card' = 'card'): string | null {
   const source = getMediaHubSource(item)
-  return item?.thumbnailUrl || item?.thumbnail || source?.thumbnailUrl || source?.thumbnail || null
+  const choices = intent === 'hero'
+    ? [item?.backdropUrl, source?.backdropUrl, item?.posterUrl, source?.posterUrl, item?.stillUrl, source?.stillUrl, item?.thumbnailUrl, item?.thumbnail, source?.thumbnailUrl, source?.thumbnail]
+    : intent === 'poster'
+      ? [item?.posterUrl, source?.posterUrl, item?.thumbnailUrl, item?.thumbnail, source?.thumbnailUrl, source?.thumbnail, item?.stillUrl, source?.stillUrl, item?.backdropUrl, source?.backdropUrl]
+      : [item?.stillUrl, source?.stillUrl, item?.thumbnailUrl, item?.thumbnail, source?.thumbnailUrl, source?.thumbnail, item?.backdropUrl, source?.backdropUrl, item?.posterUrl, source?.posterUrl]
+  return mediaHubString(...choices)
 }
 
 function getMediaHubTitle(item: any): string {
   const source = getMediaHubSource(item)
-  return item?.title || source?.title || 'Untitled'
+  return mediaHubString(item?.title, source?.title, source?.preferredMetadata?.title, source?.name) || 'Untitled media'
 }
 
 function getMediaHubSubtitle(item: any): string {
   const source = getMediaHubSource(item)
-  return item?.subtitle || item?.channelName || source?.channelName || source?.channel?.name || 'PearTube network media'
+  return mediaHubString(item?.subtitle, item?.creatorName, item?.sourceProviderName, item?.publisherName, item?.channelName, source?.subtitle, source?.creatorName, source?.sourceProviderName, source?.publisherName, source?.channelName, source?.channel?.name) || 'Resolved from your PearTube media graph'
 }
 
 function getMediaHubTimestamp(item: any): number | string | null {
   const source = getMediaHubSource(item)
-  return item?.createdAt || source?.uploadedAt || source?.createdAt || source?.updatedAt || null
+  return item?.createdAt || item?.publishedAt || source?.uploadedAt || source?.createdAt || source?.updatedAt || null
 }
 
 function getMediaHubDuration(item: any): number | null {
   const source = getMediaHubSource(item)
-  const duration = item?.duration || item?.durationSec || source?.duration || source?.durationSec
-  return typeof duration === 'number' && Number.isFinite(duration) && duration > 0 ? duration : null
+  return mediaHubNumber(item?.duration, item?.durationSec, source?.duration, source?.durationSec)
+}
+
+function getMediaHubEpisodeLabel(item: any): string | null {
+  const source = getMediaHubSource(item)
+  const season = item?.seasonNumber ?? source?.seasonNumber ?? item?.classification?.season ?? source?.classification?.season
+  const episode = item?.episodeNumber ?? source?.episodeNumber ?? item?.classification?.episode ?? source?.classification?.episode
+  if (Number.isSafeInteger(season) && Number.isSafeInteger(episode)) return `S${String(season).padStart(2, '0')} E${String(episode).padStart(2, '0')}`
+  return mediaHubString(item?.episodeLabel, source?.episodeLabel)
+}
+
+function getMediaHubBadge(item: any): string {
+  const source = getMediaHubSource(item)
+  const formatted = formatContentBadge(source) || formatContentBadge(item)
+  const kind = mediaHubString(item?.contentKind, item?.mediaKind, source?.contentKind, source?.mediaKind, item?.classification?.type, source?.classification?.type)
+  const entityKind = mediaHubString(item?.entityKind, source?.entityKind)
+  if (kind === 'movie') return 'Movie'
+  if (kind === 'episode' || kind === 'tv') return getMediaHubEpisodeLabel(item) || 'TV Episode'
+  if (kind === 'song' || kind === 'music') return 'Music'
+  if (kind === 'season' || kind === 'album' || kind === 'playlist' || kind === 'collection' || entityKind === 'collection') return 'Collection'
+  if (kind === 'creator' || entityKind === 'agent') return 'Creator'
+  if (formatted) return formatted
+  return 'Work'
+}
+
+function getMediaHubSourceSummary(item: any): string {
+  const sourceCount = Number.isSafeInteger(item?.sourceCount) ? item.sourceCount : Array.isArray(item?.sources) ? item.sources.length : 0
+  if (sourceCount > 1) return `${sourceCount} sources`
+  return mediaHubString(item?.sourceProviderName, item?.publisherName, item?.channelName, getMediaHubSource(item)?.publisherName, getMediaHubSource(item)?.channelName) || '1 source'
+}
+
+function getMediaHubArchiveSummary(item: any): string | null {
+  const status = mediaHubString(item?.archiveStatus, item?.availabilityStatus, getMediaHubSource(item)?.archiveStatus, getMediaHubSource(item)?.availabilityStatus)
+  if (!status) return null
+  if (status === 'local' || status === 'complete-local') return 'Local copy'
+  if (status === 'cached' || status === 'retained') return 'Retained nearby'
+  if (status === 'pledged' || status === 'archived') return 'Archive evidence'
+  if (status === 'unavailable' || status === 'missing') return 'Missing source'
+  return status
 }
 
 function getMediaHubMeta(item: any): string {
   const parts = []
-  const badge = formatContentBadge(getMediaHubSource(item))
+  const badge = getMediaHubBadge(item)
   const duration = getMediaHubDuration(item)
   const timestamp = getMediaHubTimestamp(item)
+  const sourceSummary = getMediaHubSourceSummary(item)
   if (badge) parts.push(badge)
   if (duration) parts.push(formatDuration(duration))
+  if (sourceSummary) parts.push(sourceSummary)
   if (timestamp) parts.push(formatTimeAgo(timestamp))
   return parts.join(' • ')
+}
+
+function hashMediaHubTitle(title: string): number {
+  let hash = 0
+  for (let i = 0; i < title.length; i += 1) hash = ((hash << 5) - hash + title.charCodeAt(i)) | 0
+  return Math.abs(hash)
+}
+
+function getMediaHubFallbackGradient(item: any): string {
+  const title = getMediaHubTitle(item)
+  const gradients = [
+    'linear-gradient(135deg, #18230f 0%, #0b0f0d 46%, #5d2f12 100%)',
+    'linear-gradient(135deg, #071a2f 0%, #111118 48%, #4c1d95 100%)',
+    'linear-gradient(135deg, #2f1111 0%, #100f0d 48%, #8a5a10 100%)',
+    'linear-gradient(135deg, #09251f 0%, #0b0d12 45%, #14532d 100%)',
+    'linear-gradient(135deg, #241432 0%, #08090d 52%, #365314 100%)',
+  ]
+  return gradients[hashMediaHubTitle(title) % gradients.length]
+}
+
+function getMediaHubInitials(item: any): string {
+  return getMediaHubTitle(item)
+    .replace(/\.[a-z0-9]{2,5}$/i, '')
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase())
+    .join('') || 'PT'
+}
+
+function hasMediaGraphEvidence(item: any): boolean {
+  return Boolean(item?.localEntityId || item?.publicationId || item?.renditionId || item?.provenance?.length || item?.conflicts?.length || item?.sourceCount > 1)
+}
+
+function MediaFallbackArtwork({ item, variant = 'card' }: { item: any, variant?: 'hero' | 'poster' | 'card' }) {
+  const style = variant === 'hero'
+    ? styles.mediaHeroImagePlaceholder
+    : variant === 'poster'
+      ? styles.mediaPosterPlaceholder
+      : styles.mediaCardPlaceholder
+  return (
+    <div style={{ ...style, background: getMediaHubFallbackGradient(item) }}>
+      <span style={styles.mediaFallbackInitials}>{getMediaHubInitials(item)}</span>
+      <span style={styles.mediaFallbackBadge}>{getMediaHubBadge(item)}</span>
+    </div>
+  )
 }
 
 interface DesktopMediaHeroProps {
@@ -189,23 +309,29 @@ interface DesktopMediaHeroProps {
 }
 
 function DesktopMediaHero({ item, peerCount, isRefreshing, onItemPress, onChannelPress, onRefresh }: DesktopMediaHeroProps) {
-  const artwork = getMediaHubArtwork(item)
+  const heroArtwork = getMediaHubArtwork(item, 'hero')
+  const posterArtwork = getMediaHubArtwork(item, 'poster')
   const hasItem = !!item
+  const archiveSummary = hasItem ? getMediaHubArchiveSummary(item) : null
 
   return (
     <section style={styles.mediaHero}>
+      {heroArtwork ? <img src={heroArtwork} alt="" style={styles.mediaHeroBackdropImage} /> : null}
+      <div style={styles.mediaHeroBackdropWash} />
       <div style={styles.mediaHeroCopy}>
-        <div style={styles.mediaKicker}>PEARTUBE MEDIA COCKPIT</div>
-        <h1 style={styles.mediaHeroTitle}>{hasItem ? getMediaHubTitle(item) : 'Your network media library'}</h1>
+        <div style={styles.mediaKicker}>PERMISSIONLESS MEDIA CDN</div>
+        <h1 style={styles.mediaHeroTitle}>{hasItem ? getMediaHubTitle(item) : 'A media graph, not a feed'}</h1>
         <p style={styles.mediaHeroSubtitle}>
           {hasItem
             ? getMediaHubSubtitle(item)
-            : 'Movies, shows, music, channels, and seeded media from the swarm in one desktop-native home.'}
+            : 'Works, episodes, albums, creators, publications, and archive evidence resolved into one local streaming library without a central catalog owner.'}
         </p>
         <div style={styles.mediaHeroMetaRow}>
-          <span style={styles.mediaHeroPill}>Generic media CDN</span>
-          <span style={styles.mediaHeroPill}>{peerCount > 0 ? `${peerCount} peers nearby` : 'P2P swarm ready'}</span>
-          {hasItem && getMediaHubMeta(item) ? <span style={styles.mediaHeroPill}>{getMediaHubMeta(item)}</span> : null}
+          <span style={styles.mediaHeroPillStrong}>{hasItem ? getMediaHubBadge(item) : 'Entity graph'}</span>
+          <span style={styles.mediaHeroPill}>{peerCount > 0 ? `${peerCount} peers connected` : 'Scoped swarms ready'}</span>
+          <span style={styles.mediaHeroPill}>{hasItem ? getMediaHubSourceSummary(item) : 'Publisher + asset topics'}</span>
+          {archiveSummary ? <span style={styles.mediaHeroPill}>{archiveSummary}</span> : null}
+          {hasItem && Array.isArray(item?.conflicts) && item.conflicts.length > 0 ? <span style={styles.mediaHeroPillWarn}>{item.conflicts.length} conflict{item.conflicts.length === 1 ? '' : 's'}</span> : null}
         </div>
         <div style={styles.mediaHeroActions}>
           <button
@@ -214,21 +340,124 @@ function DesktopMediaHero({ item, peerCount, isRefreshing, onItemPress, onChanne
             style={styles.mediaPrimaryButton}
             disabled={!hasItem && isRefreshing}
           >
-            {hasItem ? 'Play featured' : isRefreshing ? 'Refreshing…' : 'Refresh swarm'}
+            {hasItem ? '▶ Play selected source' : isRefreshing ? 'Refreshing…' : 'Refresh network'}
           </button>
           {hasItem ? (
             <button type="button" onClick={() => onChannelPress(item)} style={styles.mediaSecondaryButton}>
-              Open channel
+              Open source channel
             </button>
           ) : null}
         </div>
       </div>
       <div style={styles.mediaHeroArtwork}>
-        {artwork ? (
-          <img src={artwork} alt="" style={styles.mediaHeroImage} />
+        {posterArtwork ? (
+          <img src={posterArtwork} alt="" style={styles.mediaHeroPosterImage} />
         ) : (
-          <div style={styles.mediaHeroImagePlaceholder}>PT</div>
+          <MediaFallbackArtwork item={item} variant="hero" />
         )}
+      </div>
+    </section>
+  )
+}
+
+interface DesktopMediaStatsProps {
+  sections: any
+  peerCount: number
+}
+
+function DesktopMediaStats({ sections, peerCount }: DesktopMediaStatsProps) {
+  const stats = [
+    { label: 'Works', value: sections?.allItems?.length || 0, detail: 'resolved playable items' },
+    { label: 'Collections', value: sections?.collections?.items?.length || 0, detail: 'seasons, albums, sets' },
+    { label: 'Creators', value: sections?.creators?.items?.length || 0, detail: 'agents + roles' },
+    { label: 'Sources', value: (sections?.allItems || []).reduce((total: number, item: any) => total + (Number.isSafeInteger(item.sourceCount) ? item.sourceCount : 1), 0), detail: 'publications/renditions' },
+    { label: 'Swarm', value: peerCount, detail: peerCount === 1 ? 'peer nearby' : 'peers nearby' },
+  ]
+  return (
+    <section style={styles.mediaStatsGrid} aria-label="PearTube permissionless media CDN overview">
+      {stats.map((stat) => (
+        <div key={stat.label} style={styles.mediaStatCard}>
+          <span style={styles.mediaStatValue}>{stat.value}</span>
+          <span style={styles.mediaStatLabel}>{stat.label}</span>
+          <span style={styles.mediaStatDetail}>{stat.detail}</span>
+        </div>
+      ))}
+    </section>
+  )
+}
+
+function getDesktopEvidenceSources(item: any): any[] {
+  if (!item) return []
+  if (Array.isArray(item.sources) && item.sources.length > 0) return item.sources
+  const selected = getMediaHubSource(item)
+  const alternates = Array.isArray(item.alternateSources) ? item.alternateSources : []
+  return [selected, ...alternates].filter((source) => source && typeof source === 'object')
+}
+
+function desktopEvidenceLabel(source: any, index: number): string {
+  return mediaHubString(source?.publisherName, source?.sourceProviderName, source?.channelName, source?.publisherId, source?.channelKey, `Source ${index + 1}`) || `Source ${index + 1}`
+}
+
+function desktopEvidenceId(source: any): string {
+  return mediaHubString(source?.publicationId, source?.renditionId, source?.videoId, source?.id, source?.path) || 'publication claim'
+}
+
+function desktopEvidenceStatus(source: any): string {
+  const status = mediaHubString(source?.archiveStatus, source?.availabilityStatus, source?.retentionStatus)
+  if (source?.localComplete || status === 'local' || status === 'complete-local') return 'local'
+  if (source?.cached || status === 'cached' || status === 'retained') return 'cached'
+  if (source?.available || status === 'available' || status === 'online') return 'available'
+  return status || 'claim'
+}
+
+function DesktopMediaEvidencePanel({ item }: { item: any }) {
+  if (!item) return null
+  const sources = getDesktopEvidenceSources(item)
+  const provenance = Array.isArray(item.provenance) ? item.provenance : []
+  const conflicts = Array.isArray(item.conflicts) ? item.conflicts : []
+  const archive = getMediaHubArchiveSummary(item) || 'No archive evidence yet'
+
+  return (
+    <section style={styles.mediaEvidenceGrid} aria-label="Media graph evidence">
+      <div style={styles.mediaEvidenceCard}>
+        <div style={styles.mediaEvidenceKicker}>SourceSelector</div>
+        <h3 style={styles.mediaEvidenceTitle}>Playable publications</h3>
+        <div style={styles.mediaEvidenceList}>
+          {sources.length === 0 ? <p style={styles.mediaEvidenceEmpty}>No alternate sources attached yet.</p> : sources.slice(0, 4).map((source, index) => (
+            <div key={desktopEvidenceId(source) + index} style={styles.mediaEvidenceRow}>
+              <div style={styles.mediaEvidenceRowMain}>
+                <span style={styles.mediaEvidenceRowTitle}>{desktopEvidenceLabel(source, index)}</span>
+                <span style={styles.mediaEvidenceRowMeta}>{desktopEvidenceId(source)}</span>
+              </div>
+              <span style={styles.mediaEvidenceStatus}>{desktopEvidenceStatus(source)}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div style={styles.mediaEvidenceCard}>
+        <div style={styles.mediaEvidenceKicker}>ProvenancePanel</div>
+        <h3 style={styles.mediaEvidenceTitle}>Publisher claims</h3>
+        <div style={styles.mediaEvidenceList}>
+          {provenance.length === 0 ? <p style={styles.mediaEvidenceEmpty}>{item.localEntityId || 'Legacy source metadata only'}</p> : provenance.slice(0, 4).map((entry: any, index: number) => (
+            <div key={(entry.publicationId || entry.renditionId || entry.role || 'claim') + index} style={styles.mediaEvidenceRow}>
+              <div style={styles.mediaEvidenceRowMain}>
+                <span style={styles.mediaEvidenceRowTitle}>{entry.role || 'claim'}</span>
+                <span style={styles.mediaEvidenceRowMeta}>{mediaHubString(entry.publisherName, entry.publisherId, entry.publicationId, entry.renditionId) || 'unsigned claim'}</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div style={styles.mediaEvidenceCard}>
+        <div style={styles.mediaEvidenceKicker}>ArchiveStatus</div>
+        <h3 style={styles.mediaEvidenceTitle}>{archive}</h3>
+        <p style={styles.mediaEvidenceEmpty}>{sources.length > 0 ? `${sources.length} source${sources.length === 1 ? '' : 's'} can satisfy this entity.` : 'No source claims attached yet.'}</p>
+        {conflicts.length > 0 ? (
+          <div style={styles.mediaConflictInline}>
+            <div style={styles.mediaEvidenceKicker}>ConflictNotice</div>
+            <p style={styles.mediaEvidenceEmpty}>{conflicts.length} unresolved metadata conflict{conflicts.length === 1 ? '' : 's'}</p>
+          </div>
+        ) : null}
       </div>
     </section>
   )
@@ -244,6 +473,7 @@ interface DesktopMediaRailProps {
 function DesktopMediaRail({ rail, variant = 'poster', onItemPress, onChannelPress }: DesktopMediaRailProps) {
   const items = Array.isArray(rail?.items) ? rail.items : []
   if (items.length === 0) return null
+  const limit = rail.limit || (variant === 'poster' ? 12 : 14)
 
   return (
     <section style={styles.mediaRailSection}>
@@ -252,18 +482,23 @@ function DesktopMediaRail({ rail, variant = 'poster', onItemPress, onChannelPres
           <h2 style={styles.mediaRailTitle}>{rail.title}</h2>
           {rail.subtitle ? <p style={styles.mediaRailSubtitle}>{rail.subtitle}</p> : null}
         </div>
-        <span style={styles.mediaRailCount}>{items.length} items</span>
+        <span style={styles.mediaRailCount}>{items.length} in graph</span>
       </div>
       <div style={styles.mediaRailScroller}>
-        {items.slice(0, rail.limit || 14).map((item: any, index: number) => {
-          const artwork = getMediaHubArtwork(item)
+        {items.slice(0, limit).map((item: any, index: number) => {
+          const artwork = getMediaHubArtwork(item, variant === 'poster' ? 'poster' : 'episode')
           const progress = typeof item?.progress === 'number' ? Math.max(0, Math.min(1, item.progress)) : 0
           const cardStyle = variant === 'episode' ? styles.mediaEpisodeCard : styles.mediaPosterCard
+          const artworkStyle = variant === 'episode' ? styles.mediaEpisodeArtwork : styles.mediaPosterArtwork
+          const archiveSummary = getMediaHubArchiveSummary(item)
+          const graphEvidence = hasMediaGraphEvidence(item)
           return (
-            <article key={item.playbackKey || item.id || index} style={cardStyle}>
+            <article key={item.playbackKey || item.localEntityId || item.id || index} style={cardStyle}>
               <button type="button" onClick={() => onItemPress(item)} style={styles.mediaCardButton}>
-                <div style={styles.mediaCardArtwork}>
-                  {artwork ? <img src={artwork} alt="" style={styles.mediaCardImage} /> : <div style={styles.mediaCardPlaceholder}>PT</div>}
+                <div style={artworkStyle}>
+                  {artwork ? <img src={artwork} alt="" style={styles.mediaCardImage} /> : <MediaFallbackArtwork item={item} variant={variant === 'poster' ? 'poster' : 'card'} />}
+                  <span style={styles.mediaCardBadge}>{getMediaHubBadge(item)}</span>
+                  <div style={styles.mediaCardScrim} />
                   {progress > 0 ? (
                     <div style={styles.mediaProgressTrack}>
                       <div style={{ ...styles.mediaProgressFill, width: `${Math.round(progress * 100)}%` }} />
@@ -273,11 +508,16 @@ function DesktopMediaRail({ rail, variant = 'poster', onItemPress, onChannelPres
                 <div style={styles.mediaCardBody}>
                   <div style={styles.mediaCardTitle}>{getMediaHubTitle(item)}</div>
                   <div style={styles.mediaCardSubtitle}>{getMediaHubSubtitle(item)}</div>
-                  {getMediaHubMeta(item) ? <div style={styles.mediaCardMeta}>{getMediaHubMeta(item)}</div> : null}
+                  <div style={styles.mediaCardMeta}>{getMediaHubMeta(item)}</div>
+                  <div style={styles.mediaCardSignalRow}>
+                    <span style={graphEvidence ? styles.mediaSignalPillActive : styles.mediaSignalPill}>provenance</span>
+                    {archiveSummary ? <span style={styles.mediaSignalPill}>{archiveSummary}</span> : null}
+                    {Array.isArray(item?.conflicts) && item.conflicts.length > 0 ? <span style={styles.mediaSignalPillWarn}>conflict</span> : null}
+                  </div>
                 </div>
               </button>
               <button type="button" onClick={() => onChannelPress(item)} style={styles.mediaChannelButton}>
-                Channel
+                Source channel
               </button>
             </article>
           )
@@ -2238,6 +2478,8 @@ export default function HomeScreen() {
     mediaHubSections.movies,
     mediaHubSections.shows,
     mediaHubSections.newEpisodes,
+    mediaHubSections.collections,
+    mediaHubSections.creators,
     mediaHubSections.musicAndCreators,
     mediaHubSections.recentlySeeded,
     mediaHubSections.yourLibrary,
@@ -2577,19 +2819,7 @@ export default function HomeScreen() {
 
 
   const getMediaHubSourceItem = useCallback((item: any): VideoData => {
-    const source = getMediaHubSource(item) || {}
-    const id = source?.id || source?.videoId || item?.id || item?.videoId
-    const channelKey = source?.channelKey || item?.channelKey || source?.driveKey || item?.driveKey || identity?.driveKey || ''
-    const publicBeeKey = source?.publicBeeKey || item?.publicBeeKey || null
-    return {
-      ...source,
-      id,
-      channelKey,
-      publicBeeKey,
-      title: source?.title || item?.title || 'Untitled',
-      thumbnailUrl: source?.thumbnailUrl || item?.thumbnailUrl || source?.thumbnail || item?.thumbnail || null,
-      thumbnail: source?.thumbnail || item?.thumbnail || source?.thumbnailUrl || item?.thumbnailUrl || null,
-    }
+    return getMediaHubPlayableSourceItem(item, { fallbackChannelKey: identity?.driveKey || '' }) as VideoData
   }, [identity?.driveKey])
 
   const playMediaHubItem = useCallback((item: any) => {
@@ -2606,6 +2836,13 @@ export default function HomeScreen() {
       ? `#/channel/${encodeURIComponent(channelKey)}?publicBeeKey=${encodeURIComponent(publicBeeKey)}`
       : '#/channel/' + encodeURIComponent(channelKey)
   }, [feedEntries, getMediaHubSourceItem])
+
+  const openMediaEntityPage = useCallback((item: any, entityType: 'media' | 'collection' | 'creator' = 'media') => {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) return
+    const id = getMediaEntityRouteId(item)
+    const encodedItem = encodeMediaEntityRouteParam(item)
+    window.location.hash = `#/${entityType}/${encodeURIComponent(id)}?item=${encodedItem}`
+  }, [])
 
   const onRefresh = useCallback(async () => {
     setRefreshing(true)
@@ -2639,6 +2876,22 @@ export default function HomeScreen() {
         <p style={styles.loadingText}>
           {!ready ? 'Starting P2P network...' : 'Loading...'}
         </p>
+      </div>
+    )
+  }
+
+  // On Pear desktop with media entity route, render the inspectable entity detail surface
+  if (isPear && (currentRoute.type === 'media' || currentRoute.type === 'collection' || currentRoute.type === 'creator')) {
+    return (
+      <div style={styles.container}>
+        <MediaEntityDetailScreen
+          type={currentRoute.type}
+          routeId={currentRoute.entityId}
+          itemParam={currentRoute.item}
+          onBack={() => {
+            window.location.hash = ''
+          }}
+        />
       </div>
     )
   }
@@ -2745,12 +2998,18 @@ export default function HomeScreen() {
               onChannelPress={openMediaHubChannel}
               onRefresh={refreshFeed}
             />
+            <DesktopMediaStats sections={mediaHubSections} peerCount={peerCount} />
+            <DesktopMediaEvidencePanel item={mediaHubSections.featured.item} />
             {desktopMediaRails.map((rail: any) => (
               <DesktopMediaRail
                 key={rail.id}
                 rail={rail}
                 variant={rail.id === 'new-episodes' || rail.id === 'continue-watching' ? 'episode' : 'poster'}
-                onItemPress={playMediaHubItem}
+                onItemPress={(item: any) => {
+                  if (rail.id === 'collections') openMediaEntityPage(item, 'collection')
+                  else if (rail.id === 'creators') openMediaEntityPage(item, 'creator')
+                  else playMediaHubItem(item)
+                }}
                 onChannelPress={openMediaHubChannel}
               />
             ))}
@@ -2870,24 +3129,46 @@ export default function HomeScreen() {
 
 const styles: Record<string, React.CSSProperties> = {
   mediaCockpitShell: {
+    position: 'relative',
     display: 'flex',
     flexDirection: 'column',
-    gap: 28,
-    marginBottom: 36,
+    gap: 30,
+    marginBottom: 42,
+    padding: '4px 0 0 0',
   },
   mediaHero: {
+    position: 'relative',
     display: 'grid',
-    gridTemplateColumns: 'minmax(0, 1.35fr) minmax(280px, 0.65fr)',
-    gap: 28,
-    minHeight: 360,
-    borderRadius: 28,
-    padding: 32,
-    border: `1px solid ${colors.border}`,
-    background: 'radial-gradient(circle at 10% 10%, rgba(163,230,53,0.28), transparent 32%), linear-gradient(135deg, rgba(20,24,20,0.98), rgba(6,8,7,0.98))',
-    boxShadow: '0 28px 80px rgba(0,0,0,0.36)',
+    gridTemplateColumns: 'minmax(0, 1.45fr) minmax(230px, 0.55fr)',
+    gap: 30,
+    minHeight: 430,
+    borderRadius: 34,
+    padding: 36,
+    border: '1px solid rgba(255,255,255,0.12)',
+    background: 'linear-gradient(135deg, #060807 0%, #0b0f0d 48%, #11170f 100%)',
+    boxShadow: '0 32px 120px rgba(0,0,0,0.52)',
     overflow: 'hidden',
+    isolation: 'isolate',
+  },
+  mediaHeroBackdropImage: {
+    position: 'absolute',
+    inset: 0,
+    width: '100%',
+    height: '100%',
+    objectFit: 'cover',
+    opacity: 0.42,
+    filter: 'saturate(1.15) contrast(1.08)',
+    zIndex: 0,
+  },
+  mediaHeroBackdropWash: {
+    position: 'absolute',
+    inset: 0,
+    background: 'radial-gradient(circle at 76% 18%, rgba(163,230,53,0.20), transparent 34%), linear-gradient(90deg, rgba(4,6,5,0.98) 0%, rgba(5,7,6,0.86) 42%, rgba(5,7,6,0.40) 100%), linear-gradient(0deg, rgba(5,7,6,0.88), rgba(5,7,6,0.18))',
+    zIndex: 1,
   },
   mediaHeroCopy: {
+    position: 'relative',
+    zIndex: 2,
     display: 'flex',
     flexDirection: 'column',
     justifyContent: 'center',
@@ -2895,76 +3176,106 @@ const styles: Record<string, React.CSSProperties> = {
   },
   mediaKicker: {
     color: colors.primary,
-    fontSize: 12,
-    fontWeight: 800,
-    letterSpacing: 2,
+    fontSize: 11,
+    fontWeight: 900,
+    letterSpacing: 3,
     textTransform: 'uppercase',
-    marginBottom: 14,
+    marginBottom: 16,
   },
   mediaHeroTitle: {
     color: colors.text,
-    fontSize: 54,
-    lineHeight: 1.02,
-    letterSpacing: -1.8,
-    margin: '0 0 16px 0',
-    maxWidth: 760,
+    fontSize: 64,
+    lineHeight: 0.96,
+    letterSpacing: -2.6,
+    margin: '0 0 18px 0',
+    maxWidth: 860,
+    textShadow: '0 18px 60px rgba(0,0,0,0.45)',
   },
   mediaHeroSubtitle: {
-    color: colors.textMuted,
+    color: 'rgba(245,245,239,0.78)',
     fontSize: 18,
-    lineHeight: '28px',
+    lineHeight: '29px',
     margin: 0,
-    maxWidth: 720,
+    maxWidth: 780,
   },
   mediaHeroMetaRow: {
     display: 'flex',
     flexWrap: 'wrap',
     gap: 10,
-    marginTop: 22,
+    marginTop: 24,
   },
   mediaHeroPill: {
     borderRadius: 999,
-    border: `1px solid ${colors.border}`,
-    backgroundColor: 'rgba(255,255,255,0.06)',
-    color: colors.text,
+    border: '1px solid rgba(255,255,255,0.14)',
+    backgroundColor: 'rgba(255,255,255,0.075)',
+    color: 'rgba(245,245,239,0.88)',
     fontSize: 12,
-    fontWeight: 700,
+    fontWeight: 800,
+    padding: '8px 12px',
+    backdropFilter: 'blur(14px)',
+  },
+  mediaHeroPillStrong: {
+    borderRadius: 999,
+    border: '1px solid rgba(163,230,53,0.45)',
+    backgroundColor: 'rgba(163,230,53,0.16)',
+    color: colors.primary,
+    fontSize: 12,
+    fontWeight: 900,
+    padding: '8px 12px',
+    backdropFilter: 'blur(14px)',
+  },
+  mediaHeroPillWarn: {
+    borderRadius: 999,
+    border: '1px solid rgba(251,191,36,0.45)',
+    backgroundColor: 'rgba(251,191,36,0.14)',
+    color: '#fde68a',
+    fontSize: 12,
+    fontWeight: 900,
     padding: '8px 12px',
   },
   mediaHeroActions: {
     display: 'flex',
     gap: 12,
-    marginTop: 28,
+    marginTop: 30,
   },
   mediaPrimaryButton: {
     border: 'none',
     borderRadius: 999,
-    backgroundColor: colors.primary,
+    background: `linear-gradient(135deg, ${colors.primary}, #d9f99d)`,
     color: '#081008',
+    cursor: 'pointer',
+    fontSize: 15,
+    fontWeight: 900,
+    letterSpacing: -0.1,
+    padding: '14px 24px',
+    boxShadow: '0 18px 42px rgba(163,230,53,0.24)',
+  },
+  mediaSecondaryButton: {
+    borderRadius: 999,
+    border: '1px solid rgba(255,255,255,0.18)',
+    backgroundColor: 'rgba(255,255,255,0.09)',
+    color: colors.text,
     cursor: 'pointer',
     fontSize: 15,
     fontWeight: 800,
     padding: '13px 20px',
-  },
-  mediaSecondaryButton: {
-    borderRadius: 999,
-    border: `1px solid ${colors.border}`,
-    backgroundColor: 'rgba(255,255,255,0.08)',
-    color: colors.text,
-    cursor: 'pointer',
-    fontSize: 15,
-    fontWeight: 700,
-    padding: '12px 18px',
+    backdropFilter: 'blur(16px)',
   },
   mediaHeroArtwork: {
     position: 'relative',
-    minHeight: 280,
+    zIndex: 2,
+    alignSelf: 'center',
+    justifySelf: 'center',
+    width: 'min(100%, 290px)',
+    aspectRatio: '2 / 3',
     borderRadius: 24,
     overflow: 'hidden',
-    border: `1px solid ${colors.border}`,
-    backgroundColor: 'rgba(255,255,255,0.05)',
+    border: '1px solid rgba(255,255,255,0.18)',
+    backgroundColor: 'rgba(255,255,255,0.06)',
+    boxShadow: '0 30px 80px rgba(0,0,0,0.52)',
+    transform: 'rotate(1.3deg)',
   },
-  mediaHeroImage: {
+  mediaHeroPosterImage: {
     width: '100%',
     height: '100%',
     objectFit: 'cover',
@@ -2972,68 +3283,197 @@ const styles: Record<string, React.CSSProperties> = {
   },
   mediaHeroImagePlaceholder: {
     height: '100%',
-    minHeight: 280,
+    minHeight: 320,
     display: 'flex',
+    flexDirection: 'column',
     alignItems: 'center',
     justifyContent: 'center',
+    gap: 14,
     color: colors.primary,
-    fontSize: 64,
+    padding: 18,
+  },
+  mediaStatsGrid: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(5, minmax(0, 1fr))',
+    gap: 12,
+  },
+  mediaStatCard: {
+    minHeight: 98,
+    borderRadius: 22,
+    padding: 18,
+    border: '1px solid rgba(255,255,255,0.10)',
+    background: 'linear-gradient(180deg, rgba(255,255,255,0.075), rgba(255,255,255,0.032))',
+    boxShadow: '0 18px 48px rgba(0,0,0,0.20)',
+  },
+  mediaStatValue: {
+    display: 'block',
+    color: colors.text,
+    fontSize: 30,
+    lineHeight: '32px',
     fontWeight: 900,
-    letterSpacing: -4,
-    background: 'linear-gradient(135deg, rgba(163,230,53,0.22), rgba(255,255,255,0.04))',
+    letterSpacing: -1,
+  },
+  mediaStatLabel: {
+    display: 'block',
+    color: colors.text,
+    fontSize: 13,
+    fontWeight: 850,
+    marginTop: 9,
+  },
+  mediaStatDetail: {
+    display: 'block',
+    color: colors.textMuted,
+    fontSize: 12,
+    marginTop: 3,
+  },
+  mediaEvidenceGrid: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+    gap: 14,
+  },
+  mediaEvidenceCard: {
+    minHeight: 170,
+    borderRadius: 24,
+    padding: 18,
+    border: '1px solid rgba(255,255,255,0.10)',
+    background: 'linear-gradient(180deg, rgba(255,255,255,0.070), rgba(255,255,255,0.030))',
+    boxShadow: '0 18px 54px rgba(0,0,0,0.18)',
+  },
+  mediaEvidenceKicker: {
+    color: colors.primary,
+    fontSize: 10,
+    fontWeight: 900,
+    letterSpacing: 1.5,
+    textTransform: 'uppercase',
+  },
+  mediaEvidenceTitle: {
+    color: colors.text,
+    fontSize: 18,
+    lineHeight: '22px',
+    fontWeight: 900,
+    letterSpacing: -0.3,
+    margin: '6px 0 0 0',
+  },
+  mediaEvidenceList: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 9,
+    marginTop: 14,
+  },
+  mediaEvidenceRow: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 10,
+    borderRadius: 14,
+    border: '1px solid rgba(255,255,255,0.08)',
+    backgroundColor: 'rgba(255,255,255,0.045)',
+    padding: '10px 11px',
+  },
+  mediaEvidenceRowMain: {
+    minWidth: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 2,
+  },
+  mediaEvidenceRowTitle: {
+    color: colors.text,
+    fontSize: 13,
+    fontWeight: 850,
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  },
+  mediaEvidenceRowMeta: {
+    color: colors.textMuted,
+    fontSize: 11,
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  },
+  mediaEvidenceStatus: {
+    flexShrink: 0,
+    color: colors.primary,
+    borderRadius: 999,
+    border: '1px solid rgba(163,230,53,0.26)',
+    backgroundColor: 'rgba(163,230,53,0.08)',
+    padding: '5px 8px',
+    fontSize: 10,
+    fontWeight: 900,
+    textTransform: 'uppercase',
+  },
+  mediaEvidenceEmpty: {
+    color: colors.textMuted,
+    fontSize: 12,
+    lineHeight: '18px',
+    margin: '12px 0 0 0',
+  },
+  mediaConflictInline: {
+    marginTop: 16,
+    borderRadius: 16,
+    border: '1px solid rgba(251,191,36,0.26)',
+    backgroundColor: 'rgba(251,191,36,0.08)',
+    padding: 12,
   },
   mediaRailSection: {
     display: 'flex',
     flexDirection: 'column',
-    gap: 14,
+    gap: 15,
   },
   mediaRailHeader: {
     display: 'flex',
     alignItems: 'flex-end',
     justifyContent: 'space-between',
     gap: 16,
+    paddingRight: 4,
   },
   mediaRailTitle: {
     color: colors.text,
-    fontSize: 24,
-    fontWeight: 800,
-    letterSpacing: -0.4,
+    fontSize: 26,
+    fontWeight: 900,
+    letterSpacing: -0.8,
     margin: 0,
   },
   mediaRailSubtitle: {
-    color: colors.textMuted,
+    color: 'rgba(245,245,239,0.55)',
     fontSize: 13,
-    margin: '5px 0 0 0',
+    margin: '6px 0 0 0',
   },
   mediaRailCount: {
     color: colors.textMuted,
     fontSize: 12,
-    fontWeight: 700,
-    padding: '6px 10px',
+    fontWeight: 800,
+    padding: '7px 11px',
     borderRadius: 999,
-    border: `1px solid ${colors.border}`,
+    border: '1px solid rgba(255,255,255,0.10)',
+    backgroundColor: 'rgba(255,255,255,0.045)',
   },
   mediaRailScroller: {
     display: 'flex',
-    gap: 16,
+    gap: 18,
     overflowX: 'auto',
-    padding: '2px 0 12px 0',
+    padding: '4px 0 16px 0',
+    scrollSnapType: 'x proximity',
   },
   mediaPosterCard: {
-    width: 214,
-    minWidth: 214,
-    borderRadius: 18,
-    backgroundColor: colors.bgSecondary,
-    border: `1px solid ${colors.border}`,
+    width: 190,
+    minWidth: 190,
+    borderRadius: 20,
+    background: 'linear-gradient(180deg, rgba(255,255,255,0.072), rgba(255,255,255,0.028))',
+    border: '1px solid rgba(255,255,255,0.10)',
     overflow: 'hidden',
+    boxShadow: '0 20px 46px rgba(0,0,0,0.25)',
+    scrollSnapAlign: 'start',
   },
   mediaEpisodeCard: {
-    width: 300,
-    minWidth: 300,
-    borderRadius: 18,
-    backgroundColor: colors.bgSecondary,
-    border: `1px solid ${colors.border}`,
+    width: 344,
+    minWidth: 344,
+    borderRadius: 20,
+    background: 'linear-gradient(180deg, rgba(255,255,255,0.072), rgba(255,255,255,0.028))',
+    border: '1px solid rgba(255,255,255,0.10)',
     overflow: 'hidden',
+    boxShadow: '0 20px 46px rgba(0,0,0,0.25)',
+    scrollSnapAlign: 'start',
   },
   mediaCardButton: {
     width: '100%',
@@ -3043,11 +3483,25 @@ const styles: Record<string, React.CSSProperties> = {
     cursor: 'pointer',
     textAlign: 'left',
   },
+  mediaPosterArtwork: {
+    position: 'relative',
+    width: '100%',
+    aspectRatio: '2 / 3',
+    backgroundColor: '#050706',
+    overflow: 'hidden',
+  },
+  mediaEpisodeArtwork: {
+    position: 'relative',
+    width: '100%',
+    aspectRatio: '16 / 9',
+    backgroundColor: '#050706',
+    overflow: 'hidden',
+  },
   mediaCardArtwork: {
     position: 'relative',
     width: '100%',
-    aspectRatio: '16 / 10',
-    backgroundColor: colors.bg,
+    aspectRatio: '16 / 9',
+    backgroundColor: '#050706',
     overflow: 'hidden',
   },
   mediaCardImage: {
@@ -3055,27 +3509,74 @@ const styles: Record<string, React.CSSProperties> = {
     height: '100%',
     objectFit: 'cover',
     display: 'block',
+    transform: 'scale(1.01)',
+  },
+  mediaCardScrim: {
+    position: 'absolute',
+    inset: 0,
+    background: 'linear-gradient(180deg, rgba(0,0,0,0.02) 40%, rgba(0,0,0,0.46) 100%)',
+    pointerEvents: 'none',
   },
   mediaCardPlaceholder: {
     height: '100%',
     display: 'flex',
+    flexDirection: 'column',
     alignItems: 'center',
     justifyContent: 'center',
+    gap: 10,
     color: colors.primary,
-    fontSize: 28,
-    fontWeight: 900,
-    background: 'linear-gradient(135deg, rgba(163,230,53,0.18), rgba(255,255,255,0.04))',
+    padding: 16,
   },
-  mediaCardBody: {
-    padding: 12,
+  mediaPosterPlaceholder: {
+    height: '100%',
     display: 'flex',
     flexDirection: 'column',
-    gap: 5,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 10,
+    color: colors.primary,
+    padding: 16,
+  },
+  mediaFallbackInitials: {
+    fontSize: 42,
+    fontWeight: 950,
+    letterSpacing: -2,
+    color: 'rgba(245,245,239,0.95)',
+    textShadow: '0 14px 40px rgba(0,0,0,0.55)',
+  },
+  mediaFallbackBadge: {
+    borderRadius: 999,
+    border: '1px solid rgba(255,255,255,0.18)',
+    color: 'rgba(245,245,239,0.78)',
+    backgroundColor: 'rgba(0,0,0,0.22)',
+    fontSize: 11,
+    fontWeight: 850,
+    padding: '6px 9px',
+  },
+  mediaCardBadge: {
+    position: 'absolute',
+    top: 10,
+    left: 10,
+    zIndex: 2,
+    borderRadius: 999,
+    backgroundColor: 'rgba(0,0,0,0.62)',
+    border: '1px solid rgba(255,255,255,0.18)',
+    color: 'rgba(245,245,239,0.92)',
+    fontSize: 11,
+    fontWeight: 850,
+    padding: '5px 8px',
+    backdropFilter: 'blur(12px)',
+  },
+  mediaCardBody: {
+    padding: 13,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 6,
   },
   mediaCardTitle: {
     color: colors.text,
     fontSize: 14,
-    fontWeight: 800,
+    fontWeight: 850,
     lineHeight: '18px',
     display: '-webkit-box',
     WebkitLineClamp: 2,
@@ -3083,7 +3584,7 @@ const styles: Record<string, React.CSSProperties> = {
     overflow: 'hidden',
   },
   mediaCardSubtitle: {
-    color: colors.textMuted,
+    color: 'rgba(245,245,239,0.58)',
     fontSize: 12,
     lineHeight: '16px',
     whiteSpace: 'nowrap',
@@ -3091,9 +3592,42 @@ const styles: Record<string, React.CSSProperties> = {
     textOverflow: 'ellipsis',
   },
   mediaCardMeta: {
-    color: colors.textMuted,
+    color: 'rgba(245,245,239,0.46)',
     fontSize: 11,
-    fontWeight: 700,
+    fontWeight: 800,
+  },
+  mediaCardSignalRow: {
+    display: 'flex',
+    gap: 6,
+    flexWrap: 'wrap',
+    marginTop: 3,
+  },
+  mediaSignalPill: {
+    borderRadius: 999,
+    border: '1px solid rgba(255,255,255,0.10)',
+    color: 'rgba(245,245,239,0.52)',
+    backgroundColor: 'rgba(255,255,255,0.035)',
+    fontSize: 10,
+    fontWeight: 850,
+    padding: '4px 7px',
+  },
+  mediaSignalPillActive: {
+    borderRadius: 999,
+    border: '1px solid rgba(163,230,53,0.32)',
+    color: colors.primary,
+    backgroundColor: 'rgba(163,230,53,0.10)',
+    fontSize: 10,
+    fontWeight: 850,
+    padding: '4px 7px',
+  },
+  mediaSignalPillWarn: {
+    borderRadius: 999,
+    border: '1px solid rgba(251,191,36,0.32)',
+    color: '#fde68a',
+    backgroundColor: 'rgba(251,191,36,0.10)',
+    fontSize: 10,
+    fontWeight: 850,
+    padding: '4px 7px',
   },
   mediaProgressTrack: {
     position: 'absolute',
@@ -3102,20 +3636,22 @@ const styles: Record<string, React.CSSProperties> = {
     bottom: 0,
     height: 4,
     backgroundColor: 'rgba(255,255,255,0.18)',
+    zIndex: 3,
   },
   mediaProgressFill: {
     height: '100%',
     backgroundColor: colors.primary,
+    boxShadow: '0 0 18px rgba(163,230,53,0.65)',
   },
   mediaChannelButton: {
-    margin: '0 12px 12px 12px',
-    border: `1px solid ${colors.border}`,
+    margin: '0 13px 13px 13px',
+    border: '1px solid rgba(255,255,255,0.10)',
     borderRadius: 999,
-    backgroundColor: 'rgba(255,255,255,0.04)',
+    backgroundColor: 'rgba(255,255,255,0.045)',
     color: colors.textMuted,
     cursor: 'pointer',
     fontSize: 12,
-    fontWeight: 700,
+    fontWeight: 800,
     padding: '7px 10px',
   },
   container: {

--- a/packages/app/app/collection/[id].tsx
+++ b/packages/app/app/collection/[id].tsx
@@ -1,0 +1,5 @@
+import { MediaEntityDetailScreen } from '@/components/media/MediaEntityDetailScreen'
+
+export default function CollectionEntityRoute() {
+  return <MediaEntityDetailScreen type="collection" />
+}

--- a/packages/app/app/creator/[id].tsx
+++ b/packages/app/app/creator/[id].tsx
@@ -1,0 +1,5 @@
+import { MediaEntityDetailScreen } from '@/components/media/MediaEntityDetailScreen'
+
+export default function CreatorEntityRoute() {
+  return <MediaEntityDetailScreen type="creator" />
+}

--- a/packages/app/app/media/[id].tsx
+++ b/packages/app/app/media/[id].tsx
@@ -1,0 +1,5 @@
+import { MediaEntityDetailScreen } from '@/components/media/MediaEntityDetailScreen'
+
+export default function MediaEntityRoute() {
+  return <MediaEntityDetailScreen type="media" />
+}

--- a/packages/app/components/media/ArchiveStatus.tsx
+++ b/packages/app/components/media/ArchiveStatus.tsx
@@ -1,0 +1,125 @@
+import { memo } from 'react'
+import { StyleSheet, Text, View } from 'react-native'
+import { Ionicons } from '@expo/vector-icons'
+import { colors } from '@/lib/colors'
+import { fonts } from '@/lib/typography'
+import type { MediaCockpitItem } from './HeroFeatureCard'
+
+function pickString(...values: Array<unknown>): string | null {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim().length > 0) return value.trim()
+  }
+  return null
+}
+
+function archiveLabel(status: string | null): string {
+  if (status === 'local' || status === 'complete-local') return 'Local copy complete'
+  if (status === 'cached' || status === 'retained') return 'Retained nearby'
+  if (status === 'pledged') return 'Archive pledged'
+  if (status === 'archived') return 'Archive evidence available'
+  if (status === 'partial') return 'Partial source available'
+  if (status === 'missing' || status === 'unavailable') return 'Source currently missing'
+  if (status) return status
+  return 'No archive evidence yet'
+}
+
+function archiveTone(status: string | null): 'good' | 'warn' | 'muted' {
+  if (status === 'local' || status === 'complete-local' || status === 'cached' || status === 'retained' || status === 'archived') return 'good'
+  if (status === 'partial' || status === 'pledged') return 'warn'
+  return 'muted'
+}
+
+export interface ArchiveStatusProps {
+  item: MediaCockpitItem & Record<string, any>
+}
+
+function ArchiveStatusComponent({ item }: ArchiveStatusProps) {
+  const selectedSource = item?.selectedSource || item?.item?.selectedSource || null
+  const status = pickString(item?.archiveStatus, item?.availabilityStatus, selectedSource?.archiveStatus, selectedSource?.availabilityStatus)
+  const tone = archiveTone(status)
+  const sourceCount = typeof item?.sourceCount === 'number' ? item.sourceCount : Array.isArray(item?.sources) ? item.sources.length : 0
+
+  return (
+    <View style={[styles.card, tone === 'good' ? styles.cardGood : tone === 'warn' ? styles.cardWarn : null]}>
+      <View style={styles.headerRow}>
+        <View style={[styles.iconWrap, tone === 'good' ? styles.iconGood : tone === 'warn' ? styles.iconWarn : styles.iconMuted]}>
+          <Ionicons name={tone === 'good' ? 'shield-checkmark' : tone === 'warn' ? 'alert-circle' : 'cloud-offline'} color={tone === 'good' ? colors.primary : tone === 'warn' ? '#fde68a' : colors.textMuted} size={17} />
+        </View>
+        <View style={styles.copy}>
+          <Text style={styles.kicker}>Archive status</Text>
+          <Text style={styles.title}>{archiveLabel(status)}</Text>
+        </View>
+      </View>
+      <Text style={styles.detail}>
+        {sourceCount > 0 ? `${sourceCount} source${sourceCount === 1 ? '' : 's'} known for this entity.` : 'No source claims are attached to this entity yet.'}
+      </Text>
+    </View>
+  )
+}
+
+export const ArchiveStatus = memo(ArchiveStatusComponent)
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: 20,
+    borderWidth: 1,
+    borderColor: colors.glassBorder,
+    backgroundColor: colors.bgElevated,
+    padding: 16,
+  },
+  cardGood: {
+    borderColor: 'rgba(163,230,53,0.32)',
+    backgroundColor: 'rgba(163,230,53,0.08)',
+  },
+  cardWarn: {
+    borderColor: 'rgba(251,191,36,0.30)',
+    backgroundColor: 'rgba(251,191,36,0.08)',
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  iconWrap: {
+    width: 38,
+    height: 38,
+    borderRadius: 19,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+  },
+  iconGood: {
+    borderColor: 'rgba(163,230,53,0.36)',
+    backgroundColor: 'rgba(163,230,53,0.10)',
+  },
+  iconWarn: {
+    borderColor: 'rgba(251,191,36,0.34)',
+    backgroundColor: 'rgba(251,191,36,0.10)',
+  },
+  iconMuted: {
+    borderColor: colors.glassBorder,
+    backgroundColor: 'rgba(255,255,255,0.04)',
+  },
+  copy: {
+    flex: 1,
+  },
+  kicker: {
+    color: colors.textMuted,
+    fontSize: 11,
+    fontWeight: '800',
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+  },
+  title: {
+    color: colors.text,
+    fontFamily: fonts.headingMedium,
+    fontSize: 16,
+    marginTop: 2,
+  },
+  detail: {
+    color: colors.textMuted,
+    fontSize: 13,
+    lineHeight: 18,
+    marginTop: 12,
+  },
+})

--- a/packages/app/components/media/ConflictNotice.tsx
+++ b/packages/app/components/media/ConflictNotice.tsx
@@ -1,0 +1,113 @@
+import { memo } from 'react'
+import { StyleSheet, Text, View } from 'react-native'
+import { Ionicons } from '@expo/vector-icons'
+import { colors } from '@/lib/colors'
+import { fonts } from '@/lib/typography'
+import type { MediaCockpitItem } from './HeroFeatureCard'
+
+function asArray(value: unknown): Array<any> {
+  return Array.isArray(value) ? value : []
+}
+
+function conflictLabel(conflict: any, index: number): string {
+  const field = typeof conflict?.field === 'string' ? conflict.field : typeof conflict?.claimType === 'string' ? conflict.claimType : null
+  const reason = typeof conflict?.reason === 'string' ? conflict.reason : typeof conflict?.message === 'string' ? conflict.message : null
+  if (field && reason) return `${field}: ${reason}`
+  if (field) return `${field} claim conflict`
+  if (reason) return reason
+  return `Metadata claim conflict ${index + 1}`
+}
+
+export interface ConflictNoticeProps {
+  item: MediaCockpitItem & Record<string, any>
+}
+
+function ConflictNoticeComponent({ item }: ConflictNoticeProps) {
+  const conflicts = asArray(item?.conflicts)
+  if (conflicts.length === 0) return null
+
+  return (
+    <View style={styles.card}>
+      <View style={styles.headerRow}>
+        <View style={styles.iconWrap}>
+          <Ionicons name="warning" color="#fde68a" size={18} />
+        </View>
+        <View style={styles.copy}>
+          <Text style={styles.kicker}>Conflict notice</Text>
+          <Text style={styles.title}>{conflicts.length} unresolved metadata claim{conflicts.length === 1 ? '' : 's'}</Text>
+        </View>
+      </View>
+      <View style={styles.list}>
+        {conflicts.slice(0, 4).map((conflict, index) => (
+          <View key={conflict?.claimId || conflict?.id || index} style={styles.row}>
+            <Text style={styles.bullet}>!</Text>
+            <Text style={styles.rowText}>{conflictLabel(conflict, index)}</Text>
+          </View>
+        ))}
+      </View>
+    </View>
+  )
+}
+
+export const ConflictNotice = memo(ConflictNoticeComponent)
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: 20,
+    borderWidth: 1,
+    borderColor: 'rgba(251,191,36,0.30)',
+    backgroundColor: 'rgba(251,191,36,0.08)',
+    padding: 16,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  iconWrap: {
+    width: 38,
+    height: 38,
+    borderRadius: 19,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderColor: 'rgba(251,191,36,0.34)',
+    backgroundColor: 'rgba(251,191,36,0.10)',
+  },
+  copy: {
+    flex: 1,
+  },
+  kicker: {
+    color: '#fde68a',
+    fontSize: 11,
+    fontWeight: '800',
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+  },
+  title: {
+    color: colors.text,
+    fontFamily: fonts.headingMedium,
+    fontSize: 16,
+    marginTop: 2,
+  },
+  list: {
+    gap: 8,
+    marginTop: 12,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 8,
+  },
+  bullet: {
+    color: '#fde68a',
+    fontWeight: '900',
+    lineHeight: 18,
+  },
+  rowText: {
+    flex: 1,
+    color: colors.textMuted,
+    fontSize: 13,
+    lineHeight: 18,
+  },
+})

--- a/packages/app/components/media/EpisodeCard.tsx
+++ b/packages/app/components/media/EpisodeCard.tsx
@@ -14,22 +14,44 @@ export interface EpisodeCardProps {
   progress?: number | null
 }
 
+function pickString(...values: Array<unknown>): string | null {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim().length > 0) return value.trim()
+  }
+  return null
+}
+
+function getBadge(item: MediaCockpitItem): string | null {
+  const formatted = formatContentBadge(item)
+  const kind = pickString(item.contentKind, item.classification?.type)
+  if (kind === 'movie') return 'Movie'
+  if (kind === 'episode' || kind === 'tv') return 'Episode'
+  if (kind === 'season' || kind === 'album' || kind === 'collection') return 'Collection'
+  if (kind === 'song' || kind === 'music') return 'Music'
+  return formatted || (item.localEntityId ? 'Work' : null)
+}
+
+function getArtwork(item: MediaCockpitItem): string | null {
+  return pickString(item.stillUrl, item.thumbnailUrl, item.thumbnail, item.backdropUrl, item.posterUrl)
+}
+
+function getSubtitle(item: MediaCockpitItem): string | null {
+  return pickString(item.subtitle, item.creatorName, item.sourceProviderName, item.publisherName, item.channelName, item.channel?.name)
+}
+
+function getSignal(item: MediaCockpitItem): string | null {
+  if (typeof item.sourceCount === 'number' && item.sourceCount > 1) return `${item.sourceCount} sources`
+  const archiveStatus = pickString(item.archiveStatus, item.availabilityStatus)
+  if (archiveStatus === 'local' || archiveStatus === 'complete-local') return 'local copy'
+  if (archiveStatus === 'cached' || archiveStatus === 'retained') return 'retained'
+  if (item.publicationId || item.localEntityId) return 'provenance'
+  return pickString(item.sourceProviderName, item.publisherName)
+}
+
 function EpisodeCardComponent({ item, onPress, progress }: EpisodeCardProps) {
-  const title = typeof item.title === 'string' && item.title.trim().length > 0 ? item.title : 'Untitled episode'
-  const subtitle = typeof item.subtitle === 'string' && item.subtitle.trim().length > 0
-    ? item.subtitle
-    : typeof item.channelName === 'string' && item.channelName.trim().length > 0
-      ? item.channelName
-      : typeof item.channel?.name === 'string' && item.channel.name.trim().length > 0
-        ? item.channel.name
-        : typeof item.creatorName === 'string' && item.creatorName.trim().length > 0
-          ? item.creatorName
-          : null
-  const thumbnailUrl = typeof item.thumbnailUrl === 'string' && item.thumbnailUrl.trim().length > 0
-    ? item.thumbnailUrl
-    : typeof item.thumbnail === 'string' && item.thumbnail.trim().length > 0
-      ? item.thumbnail
-      : null
+  const title = pickString(item.title) || 'Untitled episode'
+  const subtitle = getSubtitle(item)
+  const thumbnailUrl = getArtwork(item)
   const duration = typeof item.duration === 'number' && item.duration > 0
     ? item.duration
     : typeof item.durationSec === 'number' && item.durationSec > 0
@@ -37,7 +59,9 @@ function EpisodeCardComponent({ item, onPress, progress }: EpisodeCardProps) {
       : undefined
   const rawProgress = typeof progress === 'number' ? progress : 0
   const normalizedProgress = rawProgress > 1 ? 1 : rawProgress > 0 ? rawProgress : 0
-  const badge = formatContentBadge(item)
+  const badge = getBadge(item)
+  const signal = getSignal(item)
+  const conflictCount = Array.isArray(item.conflicts) ? item.conflicts.length : 0
 
   return (
     <Pressable
@@ -48,6 +72,8 @@ function EpisodeCardComponent({ item, onPress, progress }: EpisodeCardProps) {
     >
       <View style={styles.thumbnailFrame}>
         <ThumbnailImage thumbnailUrl={thumbnailUrl} duration={duration} channelInitial={title.charAt(0).toUpperCase()} style={styles.thumbnail} />
+        <View pointerEvents="none" style={styles.thumbnailScrim} />
+        {badge ? <Text style={styles.frameBadge} numberOfLines={1}>{badge}</Text> : null}
         {normalizedProgress > 0 ? (
           <View style={styles.progressTrack} pointerEvents="none">
             <View style={[styles.progressFill, { width: `${Math.round(normalizedProgress * 100)}%` }]} />
@@ -57,7 +83,8 @@ function EpisodeCardComponent({ item, onPress, progress }: EpisodeCardProps) {
       <View style={styles.copy}>
         <View style={styles.metaRow}>
           {badge ? <Text style={styles.badge} numberOfLines={1}>{badge}</Text> : null}
-          {item.category ? <Text style={styles.meta} numberOfLines={1}>{item.category}</Text> : null}
+          {signal ? <Text style={styles.meta} numberOfLines={1}>{signal}</Text> : null}
+          {conflictCount > 0 ? <Text style={styles.metaWarn} numberOfLines={1}>conflict</Text> : null}
         </View>
         <Text style={styles.title} numberOfLines={2}>{title}</Text>
         {subtitle ? <Text style={styles.subtitle} numberOfLines={1}>{subtitle}</Text> : null}
@@ -85,6 +112,28 @@ const styles = StyleSheet.create({
   },
   thumbnail: {
     borderRadius: 0,
+  },
+  thumbnailScrim: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    height: 58,
+    backgroundColor: 'rgba(0,0,0,0.32)',
+  },
+  frameBadge: {
+    position: 'absolute',
+    left: 9,
+    bottom: 8,
+    maxWidth: '70%',
+    color: colors.onPrimary,
+    backgroundColor: colors.primary,
+    borderRadius: 999,
+    overflow: 'hidden',
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    fontSize: 10,
+    fontWeight: '800',
   },
   progressTrack: {
     position: 'absolute',
@@ -120,6 +169,13 @@ const styles = StyleSheet.create({
     color: colors.textMuted,
     fontSize: 10,
     fontWeight: '700',
+    textTransform: 'uppercase',
+    letterSpacing: 0.3,
+  },
+  metaWarn: {
+    color: '#fde68a',
+    fontSize: 10,
+    fontWeight: '800',
     textTransform: 'uppercase',
     letterSpacing: 0.3,
   },

--- a/packages/app/components/media/HeroFeatureCard.tsx
+++ b/packages/app/components/media/HeroFeatureCard.tsx
@@ -19,6 +19,18 @@ export interface MediaCockpitItem {
   } | null
   thumbnailUrl?: string | null
   thumbnail?: string | null
+  posterUrl?: string | null
+  backdropUrl?: string | null
+  stillUrl?: string | null
+  sourceCount?: number | null
+  sourceProviderName?: string | null
+  publisherName?: string | null
+  archiveStatus?: string | null
+  availabilityStatus?: string | null
+  conflicts?: Array<unknown> | null
+  provenance?: Array<unknown> | null
+  localEntityId?: string | null
+  publicationId?: string | null
   duration?: number | null
   durationSec?: number | null
   contentKind?: string | null
@@ -36,34 +48,69 @@ export interface HeroFeatureCardProps {
   peers?: number | null
   onPress: () => void
   onChannelPress?: () => void
+  onDetailsPress?: () => void
 }
 
 
-function HeroFeatureCardComponent({ item, peers, onPress, onChannelPress }: HeroFeatureCardProps) {
+function pickString(...values: Array<unknown>): string | null {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim().length > 0) return value.trim()
+  }
+  return null
+}
+
+function getEntityBadge(item: MediaCockpitItem): string | null {
+  const formatted = formatContentBadge(item)
+  const kind = pickString(item.contentKind, item.classification?.type)
+  if (kind === 'movie') return 'Movie'
+  if (kind === 'episode' || kind === 'tv') return 'Episode'
+  if (kind === 'season' || kind === 'album' || kind === 'collection') return 'Collection'
+  if (kind === 'song' || kind === 'music') return 'Music'
+  return formatted || (item.localEntityId ? 'Work' : null)
+}
+
+function getArtwork(item: MediaCockpitItem): string | null {
+  return pickString(item.backdropUrl, item.posterUrl, item.stillUrl, item.thumbnailUrl, item.thumbnail)
+}
+
+function getSourceSummary(item: MediaCockpitItem): string {
+  if (typeof item.sourceCount === 'number' && item.sourceCount > 1) return `${item.sourceCount} sources`
+  return pickString(item.sourceProviderName, item.publisherName, item.channelName, item.channel?.name) || '1 source'
+}
+
+function getArchiveSummary(item: MediaCockpitItem): string | null {
+  const status = pickString(item.archiveStatus, item.availabilityStatus)
+  if (!status) return null
+  if (status === 'local' || status === 'complete-local') return 'Local copy'
+  if (status === 'cached' || status === 'retained') return 'Retained nearby'
+  if (status === 'pledged' || status === 'archived') return 'Archive evidence'
+  if (status === 'unavailable' || status === 'missing') return 'Missing source'
+  return status
+}
+
+function HeroFeatureCardComponent({ item, peers, onPress, onChannelPress, onDetailsPress }: HeroFeatureCardProps) {
   if (!item) return null
 
-  const title = typeof item.title === 'string' && item.title.trim().length > 0 ? item.title : 'Featured media'
-  const subtitle = typeof item.subtitle === 'string' && item.subtitle.trim().length > 0
-    ? item.subtitle
-    : typeof item.channelName === 'string' && item.channelName.trim().length > 0
-      ? item.channelName
-      : typeof item.channel?.name === 'string' && item.channel.name.trim().length > 0
-        ? item.channel.name
-        : typeof item.creatorName === 'string' && item.creatorName.trim().length > 0
-          ? item.creatorName
-          : null
-  const badge = formatContentBadge(item)
-  const thumbnailUrl = typeof item.thumbnailUrl === 'string' && item.thumbnailUrl.trim().length > 0
-    ? item.thumbnailUrl
-    : typeof item.thumbnail === 'string' && item.thumbnail.trim().length > 0
-      ? item.thumbnail
-      : null
+  const title = pickString(item.title) || 'Featured media'
+  const subtitle = pickString(
+    item.subtitle,
+    item.creatorName,
+    item.sourceProviderName,
+    item.publisherName,
+    item.channelName,
+    item.channel?.name,
+  )
+  const badge = getEntityBadge(item)
+  const thumbnailUrl = getArtwork(item)
   const duration = typeof item.duration === 'number' && item.duration > 0
     ? item.duration
     : typeof item.durationSec === 'number' && item.durationSec > 0
       ? item.durationSec
       : undefined
   const channelInitial = title.charAt(0).toUpperCase()
+  const archiveSummary = getArchiveSummary(item)
+  const conflictCount = Array.isArray(item.conflicts) ? item.conflicts.length : 0
+  const hasProvenance = Boolean(item.localEntityId || item.publicationId || (Array.isArray(item.provenance) && item.provenance.length > 0))
 
   return (
     <Pressable
@@ -77,7 +124,7 @@ function HeroFeatureCardComponent({ item, peers, onPress, onChannelPress }: Hero
         <View pointerEvents="none" style={styles.scrimTop} />
         <View pointerEvents="none" style={styles.scrimBottom} />
         <View style={styles.mediaTopRow}>
-          <Text style={styles.kicker} numberOfLines={1}>Featured from the swarm</Text>
+          <Text style={styles.kicker} numberOfLines={1}>Permissionless media CDN</Text>
           <NetworkStatusPill peers={peers} tone={peers && peers > 0 ? 'live' : 'ready'} />
         </View>
       </View>
@@ -85,21 +132,32 @@ function HeroFeatureCardComponent({ item, peers, onPress, onChannelPress }: Hero
       <View style={styles.body}>
         <View style={styles.metaRow}>
           {badge ? <Text style={styles.badge} numberOfLines={1}>{badge}</Text> : null}
-          {item.category ? <Text style={styles.meta} numberOfLines={1}>{item.category}</Text> : null}
+          <Text style={styles.meta} numberOfLines={1}>{getSourceSummary(item)}</Text>
+          {archiveSummary ? <Text style={styles.meta} numberOfLines={1}>{archiveSummary}</Text> : null}
         </View>
         <Text style={styles.title} numberOfLines={2}>{title}</Text>
         {subtitle ? (
           onChannelPress ? (
-            <Pressable onPress={onChannelPress} hitSlop={8} accessibilityRole="button" accessibilityLabel={`Open ${subtitle}`}>
+            <Pressable onPress={onChannelPress} hitSlop={8} accessibilityRole="button" accessibilityLabel={`Open publisher for ${title}`}>
               <Text style={[styles.subtitle, styles.subtitleAction]} numberOfLines={1}>{subtitle}</Text>
             </Pressable>
           ) : (
             <Text style={styles.subtitle} numberOfLines={1}>{subtitle}</Text>
           )
         ) : null}
+        <View style={styles.signalRow}>
+          {onDetailsPress ? (
+            <Pressable onPress={onDetailsPress} hitSlop={8} accessibilityRole="button" accessibilityLabel={`Open media evidence for ${title}`}>
+              <Text style={hasProvenance ? styles.signalActive : styles.signal} numberOfLines={1}>provenance</Text>
+            </Pressable>
+          ) : (
+            <Text style={hasProvenance ? styles.signalActive : styles.signal} numberOfLines={1}>provenance</Text>
+          )}
+          {conflictCount > 0 ? <Text style={styles.signalWarn} numberOfLines={1}>{conflictCount} conflict{conflictCount === 1 ? '' : 's'}</Text> : null}
+        </View>
         <View style={styles.playButton}>
           <Ionicons name="play" size={16} color={colors.onPrimary} />
-          <Text style={styles.playText}>Play</Text>
+          <Text style={styles.playText}>Play selected source</Text>
         </View>
       </View>
     </Pressable>
@@ -210,6 +268,54 @@ const styles = StyleSheet.create({
   },
   subtitleAction: {
     color: colors.swarm,
+  },
+  signalRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: 6,
+    marginTop: 10,
+  },
+  signal: {
+    color: colors.textMuted,
+    borderWidth: 1,
+    borderColor: colors.glassBorder,
+    borderRadius: 999,
+    overflow: 'hidden',
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    fontSize: 10,
+    fontWeight: '800',
+    textTransform: 'uppercase',
+    letterSpacing: 0.3,
+  },
+  signalActive: {
+    color: colors.primary,
+    borderWidth: 1,
+    borderColor: 'rgba(163,230,53,0.35)',
+    backgroundColor: 'rgba(163,230,53,0.10)',
+    borderRadius: 999,
+    overflow: 'hidden',
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    fontSize: 10,
+    fontWeight: '800',
+    textTransform: 'uppercase',
+    letterSpacing: 0.3,
+  },
+  signalWarn: {
+    color: '#fde68a',
+    borderWidth: 1,
+    borderColor: 'rgba(251,191,36,0.32)',
+    backgroundColor: 'rgba(251,191,36,0.10)',
+    borderRadius: 999,
+    overflow: 'hidden',
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    fontSize: 10,
+    fontWeight: '800',
+    textTransform: 'uppercase',
+    letterSpacing: 0.3,
   },
   playButton: {
     alignSelf: 'flex-start',

--- a/packages/app/components/media/MediaEntityDetailScreen.tsx
+++ b/packages/app/components/media/MediaEntityDetailScreen.tsx
@@ -1,0 +1,433 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native'
+import { Ionicons } from '@expo/vector-icons'
+import { useLocalSearchParams, useRouter } from 'expo-router'
+import { colors } from '@/lib/colors'
+import { fonts } from '@/lib/typography'
+import { ThumbnailImage } from '@/components/video/ThumbnailImage'
+import { ArchiveStatus } from './ArchiveStatus'
+import { ConflictNotice } from './ConflictNotice'
+import { ProvenancePanel } from './ProvenancePanel'
+import { SourceSelector } from './SourceSelector'
+import type { MediaCockpitItem } from './HeroFeatureCard'
+
+function firstParam(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value
+}
+
+function decodeMaybe(value: string): string {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}
+
+function decodeItem(value: string | string[] | undefined): (MediaCockpitItem & Record<string, any>) | null {
+  const raw = firstParam(value)
+  if (!raw) return null
+  try {
+    const parsed = JSON.parse(decodeMaybe(raw))
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+function asArray(value: unknown): Array<any> {
+  return Array.isArray(value) ? value : []
+}
+
+function pickString(...values: Array<unknown>): string | null {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim().length > 0) return value.trim()
+  }
+  return null
+}
+
+function sourceIdentityKey(source: any): string {
+  return [
+    source?.publicationId,
+    source?.renditionId,
+    source?.playbackKey,
+    source?.id,
+    source?.videoId,
+    source?.path,
+  ].filter((value) => typeof value === 'string' && value.trim().length > 0).join(':')
+}
+
+function candidateSourcesForItem(item: Record<string, any>): Array<any> {
+  const sources = asArray(item.sources)
+  if (sources.length > 0) return sources
+  return [item.selectedSource, ...asArray(item.alternateSources)].filter((source) => source && typeof source === 'object' && !Array.isArray(source))
+}
+
+function pageTitleFor(type: MediaEntityDetailType): string {
+  if (type === 'collection') return 'Collection'
+  if (type === 'creator') return 'Creator'
+  return 'Media work'
+}
+
+function routeFallbackTitle(type: MediaEntityDetailType, id: string | undefined): string {
+  const label = pageTitleFor(type)
+  return id ? `${label} ${decodeMaybe(id)}` : label
+}
+
+function fallbackItemForRoute(type: MediaEntityDetailType, routeId: string | undefined): MediaCockpitItem & Record<string, any> {
+  const decodedId = routeId ? decodeMaybe(routeId) : `${type}:unresolved`
+  return {
+    id: decodedId,
+    localEntityId: decodedId,
+    entityKind: type === 'creator' ? 'agent' : type,
+    contentKind: type,
+    title: routeFallbackTitle(type, routeId),
+    subtitle: 'Resolver id available; full media graph payload has not been hydrated in this route yet.',
+    sourceCount: 0,
+    sources: [],
+    alternateSources: [],
+    provenance: [{ role: 'route-resolver-id', entityId: decodedId }],
+    conflicts: [],
+    items: [],
+    missingMembers: [],
+    contributions: [],
+    completeness: type === 'collection' ? { known: 0, missing: 0, hasTrustedStructure: false } : null,
+    item: { localEntityId: decodedId, entityKind: type, resolverPending: true },
+  }
+}
+
+function applySelectedSource(item: MediaCockpitItem & Record<string, any>, selectedSource: any | null): MediaCockpitItem & Record<string, any> {
+  if (!selectedSource) return item
+  const sources = candidateSourcesForItem(item)
+  const selectedKey = sourceIdentityKey(selectedSource)
+  const alternateSources = sources.filter((source) => sourceIdentityKey(source) !== selectedKey)
+  const sourceProviderName = pickString(selectedSource.sourceProviderName, selectedSource.publisherName, selectedSource.channelName, item.sourceProviderName, item.publisherName)
+  return {
+    ...item,
+    selectedSource,
+    alternateSources,
+    sourceProviderName,
+    publisherName: sourceProviderName || item.publisherName,
+    channelKey: pickString(selectedSource.channelKey, selectedSource.publisherId, item.channelKey),
+    driveKey: pickString(selectedSource.driveKey, selectedSource.channelKey, item.driveKey),
+    videoId: pickString(selectedSource.videoId, selectedSource.publicationId, item.videoId),
+    path: pickString(selectedSource.path, item.path),
+    publicBeeKey: pickString(selectedSource.publicBeeKey, item.publicBeeKey),
+    publicationId: pickString(selectedSource.publicationId, item.publicationId),
+    renditionId: pickString(selectedSource.renditionId, item.renditionId),
+    playbackKey: pickString(selectedSource.playbackKey, item.playbackKey),
+    archiveStatus: pickString(selectedSource.archiveStatus, selectedSource.retentionStatus, item.archiveStatus),
+    availabilityStatus: pickString(selectedSource.availabilityStatus, item.availabilityStatus),
+    item: { ...item.item, selectedSource, alternateSources },
+  }
+}
+
+function CollectionStructurePanel({ item }: { item: Record<string, any> }) {
+  const members = asArray(item.items || item.members || item.collectionItems)
+  const missingMembers = asArray(item.missingMembers || item.missingSlots)
+  const completeness = item.completeness && typeof item.completeness === 'object' ? item.completeness : {}
+  return (
+    <View style={styles.detailCard}>
+      <Text style={styles.kicker}>Collection structure</Text>
+      <Text style={styles.detailTitle}>Known works, missing slots, and completeness</Text>
+      <View style={styles.summaryRow}>
+        <Text style={styles.summaryPill}>{members.length} known</Text>
+        <Text style={styles.summaryPill}>{missingMembers.length} missing</Text>
+        <Text style={completeness.hasTrustedStructure ? styles.summaryPill : styles.mutedPill}>{completeness.hasTrustedStructure ? 'trusted structure' : 'untrusted structure'}</Text>
+      </View>
+      {members.length > 0 ? members.slice(0, 6).map((member, index) => (
+        <Text key={`member-${index}`} style={styles.detailLine} numberOfLines={1}>{pickString(member?.title, member?.name, member?.workId, member?.id, `Member ${index + 1}`)}</Text>
+      )) : <Text style={styles.detailMuted}>No member claims are attached to this collection payload.</Text>}
+      {missingMembers.length > 0 ? (
+        <View style={styles.subsection}>
+          <Text style={styles.detailLabel}>Missing member claims</Text>
+          {missingMembers.slice(0, 6).map((member, index) => (
+            <Text key={`missing-${index}`} style={styles.detailLine} numberOfLines={1}>{pickString(member?.title, member?.reason, member?.workId, member?.id, `Missing slot ${index + 1}`)}</Text>
+          ))}
+        </View>
+      ) : null}
+    </View>
+  )
+}
+
+function CreatorContributionsPanel({ item }: { item: Record<string, any> }) {
+  const contributions = asArray(item.contributions || item.creatorRoles)
+  return (
+    <View style={styles.detailCard}>
+      <Text style={styles.kicker}>Creator graph</Text>
+      <Text style={styles.detailTitle}>Role attribution and publisher claims</Text>
+      <View style={styles.summaryRow}>
+        <Text style={styles.summaryPill}>{contributions.length} contribution{contributions.length === 1 ? '' : 's'}</Text>
+        {typeof item.sourcePublisherCount === 'number' ? <Text style={styles.summaryPill}>{item.sourcePublisherCount} publisher{item.sourcePublisherCount === 1 ? '' : 's'}</Text> : null}
+      </View>
+      {contributions.length > 0 ? contributions.slice(0, 8).map((entry, index) => (
+        <Text key={`contribution-${index}`} style={styles.detailLine} numberOfLines={1}>
+          {pickString(entry?.role, 'creator')} · {pickString(entry?.name, entry?.agentId, entry?.publisherName, `Contributor ${index + 1}`)}
+        </Text>
+      )) : <Text style={styles.detailMuted}>No creator contribution claims are attached to this payload yet.</Text>}
+    </View>
+  )
+}
+
+export type MediaEntityDetailType = 'media' | 'collection' | 'creator'
+
+export interface MediaEntityDetailScreenProps {
+  type: MediaEntityDetailType
+  routeId?: string
+  itemParam?: string | string[]
+  onBack?: () => void
+}
+
+export function encodeMediaEntityRouteParam(item: MediaCockpitItem & Record<string, any>): string {
+  return encodeURIComponent(JSON.stringify(item))
+}
+
+export function getMediaEntityRouteId(item: MediaCockpitItem & Record<string, any>): string {
+  const selectedSource = item?.selectedSource || item?.item?.selectedSource || null
+  return pickString(
+    item?.localEntityId,
+    item?.id,
+    item?.videoId,
+    selectedSource?.publicationId,
+    selectedSource?.renditionId,
+    selectedSource?.videoId,
+    selectedSource?.id,
+    'entity',
+  ) || 'entity'
+}
+
+export function MediaEntityDetailScreen({ type, routeId: routeIdProp, itemParam, onBack }: MediaEntityDetailScreenProps) {
+  const params = useLocalSearchParams()
+  const router = useRouter()
+  const routeId = routeIdProp || firstParam(params.id)
+  const itemQueryParam = itemParam ?? params.item
+  const decodedItem = useMemo(() => decodeItem(itemQueryParam), [itemQueryParam])
+  const baseItem = useMemo(() => decodedItem || fallbackItemForRoute(type, routeId), [decodedItem, routeId, type])
+  const [selectedSourceKey, setSelectedSourceKey] = useState<string | null>(null)
+
+  useEffect(() => {
+    setSelectedSourceKey(null)
+  }, [params.item, routeId, type])
+
+  const selectedOverride = useMemo(() => {
+    if (!selectedSourceKey) return null
+    return asArray(baseItem.sources).find((source) => sourceIdentityKey(source) === selectedSourceKey) || null
+  }, [baseItem, selectedSourceKey])
+  const item = useMemo(() => applySelectedSource(baseItem, selectedOverride), [baseItem, selectedOverride])
+  const title = pickString(item?.title, item?.preferredMetadata?.title, item?.name, routeFallbackTitle(type, routeId)) || pageTitleFor(type)
+  const subtitle = pickString(item?.subtitle, item?.creatorName, item?.sourceProviderName, item?.publisherName, item?.channelName, item?.channel?.name)
+  const artwork = pickString(item?.backdropUrl, item?.posterUrl, item?.stillUrl, item?.thumbnailUrl, item?.thumbnail)
+  const duration = typeof item?.duration === 'number' && item.duration > 0
+    ? item.duration
+    : typeof item?.durationSec === 'number' && item.durationSec > 0
+      ? item.durationSec
+      : undefined
+  const sourceCount = typeof item?.sourceCount === 'number' ? item.sourceCount : Array.isArray(item?.sources) ? item.sources.length : 0
+
+  return (
+    <View style={styles.root}>
+      <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
+        <Pressable onPress={onBack || (() => router.back())} accessibilityRole="button" accessibilityLabel="Go back" style={styles.backButton}>
+          <Ionicons name="chevron-back" color={colors.text} size={18} />
+          <Text style={styles.backText}>Back</Text>
+        </Pressable>
+
+        <View style={styles.hero}>
+          <View style={styles.artworkFrame}>
+            <ThumbnailImage thumbnailUrl={artwork} duration={duration} channelInitial={title.charAt(0).toUpperCase()} style={styles.artwork} />
+          </View>
+          <View style={styles.heroCopy}>
+            <Text style={styles.kicker}>{pageTitleFor(type)}</Text>
+            <Text style={styles.title}>{title}</Text>
+            {subtitle ? <Text style={styles.subtitle}>{subtitle}</Text> : null}
+            <View style={styles.chipRow}>
+              <Text style={styles.chip}>{sourceCount > 0 ? `${sourceCount} source${sourceCount === 1 ? '' : 's'}` : 'resolver id'}</Text>
+              {item?.localEntityId ? <Text style={styles.chip}>entity id</Text> : null}
+              {decodedItem ? null : <Text style={styles.warnChip}>payload pending</Text>}
+              {Array.isArray(item?.conflicts) && item.conflicts.length > 0 ? <Text style={styles.warnChip}>conflicts</Text> : null}
+            </View>
+          </View>
+        </View>
+
+        <View style={styles.panels}>
+          <ArchiveStatus item={item} />
+          <ConflictNotice item={item} />
+          <SourceSelector item={item} onSelectSource={(source) => setSelectedSourceKey(sourceIdentityKey(source))} />
+          <ProvenancePanel item={item} />
+          {type === 'collection' ? <CollectionStructurePanel item={item} /> : null}
+          {type === 'creator' ? <CreatorContributionsPanel item={item} /> : null}
+        </View>
+      </ScrollView>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: colors.bg,
+  },
+  content: {
+    paddingHorizontal: 20,
+    paddingTop: 18,
+    paddingBottom: 40,
+    gap: 18,
+  },
+  backButton: {
+    alignSelf: 'flex-start',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    borderWidth: 1,
+    borderColor: colors.glassBorder,
+    backgroundColor: colors.bgElevated,
+    borderRadius: 999,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+  },
+  backText: {
+    color: colors.text,
+    fontWeight: '800',
+  },
+  hero: {
+    borderRadius: 28,
+    overflow: 'hidden',
+    borderWidth: 1,
+    borderColor: colors.glassBorder,
+    backgroundColor: colors.bgElevated,
+  },
+  artworkFrame: {
+    height: 210,
+    backgroundColor: colors.bgSecondary,
+  },
+  artwork: {
+    width: '100%',
+    height: '100%',
+    borderRadius: 0,
+  },
+  heroCopy: {
+    padding: 18,
+  },
+  kicker: {
+    color: colors.primary,
+    fontSize: 11,
+    fontWeight: '900',
+    letterSpacing: 0.7,
+    textTransform: 'uppercase',
+  },
+  title: {
+    color: colors.text,
+    fontFamily: fonts.heading,
+    fontSize: 28,
+    lineHeight: 33,
+    marginTop: 8,
+  },
+  subtitle: {
+    color: colors.textMuted,
+    fontSize: 14,
+    lineHeight: 20,
+    marginTop: 8,
+  },
+  chipRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    marginTop: 14,
+  },
+  chip: {
+    color: colors.primary,
+    borderWidth: 1,
+    borderColor: 'rgba(163,230,53,0.26)',
+    backgroundColor: 'rgba(163,230,53,0.08)',
+    borderRadius: 999,
+    overflow: 'hidden',
+    paddingHorizontal: 9,
+    paddingVertical: 5,
+    fontSize: 11,
+    fontWeight: '900',
+    textTransform: 'uppercase',
+  },
+  warnChip: {
+    color: '#fde68a',
+    borderWidth: 1,
+    borderColor: 'rgba(251,191,36,0.28)',
+    backgroundColor: 'rgba(251,191,36,0.10)',
+    borderRadius: 999,
+    overflow: 'hidden',
+    paddingHorizontal: 9,
+    paddingVertical: 5,
+    fontSize: 11,
+    fontWeight: '900',
+    textTransform: 'uppercase',
+  },
+  panels: {
+    gap: 14,
+  },
+  detailCard: {
+    borderRadius: 20,
+    borderWidth: 1,
+    borderColor: colors.glassBorder,
+    backgroundColor: colors.bgElevated,
+    padding: 16,
+  },
+  detailTitle: {
+    color: colors.text,
+    fontFamily: fonts.headingMedium,
+    fontSize: 16,
+    marginTop: 3,
+  },
+  summaryRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    marginTop: 13,
+    marginBottom: 10,
+  },
+  summaryPill: {
+    color: colors.primary,
+    borderRadius: 999,
+    overflow: 'hidden',
+    borderWidth: 1,
+    borderColor: 'rgba(163,230,53,0.26)',
+    backgroundColor: 'rgba(163,230,53,0.08)',
+    paddingHorizontal: 9,
+    paddingVertical: 5,
+    fontSize: 10,
+    fontWeight: '900',
+    textTransform: 'uppercase',
+  },
+  mutedPill: {
+    color: colors.textMuted,
+    borderRadius: 999,
+    overflow: 'hidden',
+    borderWidth: 1,
+    borderColor: colors.glassBorder,
+    backgroundColor: 'rgba(255,255,255,0.035)',
+    paddingHorizontal: 9,
+    paddingVertical: 5,
+    fontSize: 10,
+    fontWeight: '900',
+    textTransform: 'uppercase',
+  },
+  subsection: {
+    marginTop: 12,
+    gap: 6,
+  },
+  detailLabel: {
+    color: colors.text,
+    fontSize: 12,
+    fontWeight: '900',
+    textTransform: 'uppercase',
+  },
+  detailLine: {
+    color: colors.textMuted,
+    fontSize: 13,
+    lineHeight: 19,
+    marginTop: 5,
+  },
+  detailMuted: {
+    color: colors.textMuted,
+    fontSize: 13,
+    lineHeight: 19,
+    marginTop: 8,
+  },
+})

--- a/packages/app/components/media/MediaPosterCard.tsx
+++ b/packages/app/components/media/MediaPosterCard.tsx
@@ -13,38 +13,63 @@ export interface MediaPosterCardProps {
   onPress: () => void
 }
 
+function pickString(...values: Array<unknown>): string | null {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim().length > 0) return value.trim()
+  }
+  return null
+}
+
+function getBadge(item: MediaCockpitItem): string | null {
+  const formatted = formatContentBadge(item)
+  const kind = pickString(item.contentKind, item.classification?.type)
+  if (kind === 'movie') return 'Movie'
+  if (kind === 'episode' || kind === 'tv') return 'Episode'
+  if (kind === 'season' || kind === 'album' || kind === 'collection') return 'Collection'
+  if (kind === 'song' || kind === 'music') return 'Music'
+  return formatted || (item.localEntityId ? 'Work' : null)
+}
+
+function getArtwork(item: MediaCockpitItem): string | null {
+  return pickString(item.posterUrl, item.thumbnailUrl, item.thumbnail, item.stillUrl, item.backdropUrl)
+}
+
+function getSubtitle(item: MediaCockpitItem): string | null {
+  return pickString(item.subtitle, item.creatorName, item.sourceProviderName, item.publisherName, item.channelName, item.channel?.name)
+}
+
+function getSignal(item: MediaCockpitItem): string | null {
+  if (typeof item.sourceCount === 'number' && item.sourceCount > 1) return `${item.sourceCount} sources`
+  const archiveStatus = pickString(item.archiveStatus, item.availabilityStatus)
+  if (archiveStatus === 'local' || archiveStatus === 'complete-local') return 'local copy'
+  if (archiveStatus === 'cached' || archiveStatus === 'retained') return 'retained'
+  if (item.publicationId || item.localEntityId) return 'provenance'
+  return pickString(item.sourceProviderName, item.publisherName)
+}
+
 function MediaPosterCardComponent({ item, onPress }: MediaPosterCardProps) {
-  const title = typeof item.title === 'string' && item.title.trim().length > 0 ? item.title : 'Untitled media'
-  const subtitle = typeof item.subtitle === 'string' && item.subtitle.trim().length > 0
-    ? item.subtitle
-    : typeof item.channelName === 'string' && item.channelName.trim().length > 0
-      ? item.channelName
-      : typeof item.channel?.name === 'string' && item.channel.name.trim().length > 0
-        ? item.channel.name
-        : typeof item.creatorName === 'string' && item.creatorName.trim().length > 0
-          ? item.creatorName
-          : null
-  const thumbnailUrl = typeof item.thumbnailUrl === 'string' && item.thumbnailUrl.trim().length > 0
-    ? item.thumbnailUrl
-    : typeof item.thumbnail === 'string' && item.thumbnail.trim().length > 0
-      ? item.thumbnail
-      : null
+  const title = pickString(item.title) || 'Untitled media'
+  const subtitle = getSubtitle(item)
+  const thumbnailUrl = getArtwork(item)
   const duration = typeof item.duration === 'number' && item.duration > 0
     ? item.duration
     : typeof item.durationSec === 'number' && item.durationSec > 0
       ? item.durationSec
       : undefined
-  const badge = formatContentBadge(item)
+  const badge = getBadge(item)
+  const signal = getSignal(item)
+  const conflictCount = Array.isArray(item.conflicts) ? item.conflicts.length : 0
 
   return (
     <Pressable
       onPress={onPress}
       accessibilityRole="button"
-      accessibilityLabel={`Play ${title}`}
+      accessibilityLabel={`Open ${title}`}
       style={styles.card}
     >
       <View style={styles.posterFrame}>
         <ThumbnailImage thumbnailUrl={thumbnailUrl} duration={duration} channelInitial={title.charAt(0).toUpperCase()} style={styles.thumbnail} />
+        <View pointerEvents="none" style={styles.posterScrim} />
         {badge ? (
           <View style={styles.badgeWrap} pointerEvents="none">
             <Text style={styles.badge} numberOfLines={1}>{badge}</Text>
@@ -54,6 +79,10 @@ function MediaPosterCardComponent({ item, onPress }: MediaPosterCardProps) {
       <View style={styles.copy}>
         <Text style={styles.title} numberOfLines={2}>{title}</Text>
         {subtitle ? <Text style={styles.subtitle} numberOfLines={1}>{subtitle}</Text> : null}
+        <View style={styles.signalRow}>
+          {signal ? <Text style={styles.signal} numberOfLines={1}>{signal}</Text> : null}
+          {conflictCount > 0 ? <Text style={styles.signalWarn} numberOfLines={1}>conflict</Text> : null}
+        </View>
       </View>
     </Pressable>
   )
@@ -79,6 +108,14 @@ const styles = StyleSheet.create({
     height: '100%',
     aspectRatio: undefined,
     borderRadius: 0,
+  },
+  posterScrim: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    height: 74,
+    backgroundColor: 'rgba(0,0,0,0.34)',
   },
   badgeWrap: {
     position: 'absolute',
@@ -111,5 +148,39 @@ const styles = StyleSheet.create({
     color: colors.textMuted,
     fontSize: 12,
     marginTop: 4,
+  },
+  signalRow: {
+    minHeight: 20,
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: 5,
+    marginTop: 7,
+  },
+  signal: {
+    color: colors.primary,
+    borderWidth: 1,
+    borderColor: 'rgba(163,230,53,0.26)',
+    backgroundColor: 'rgba(163,230,53,0.08)',
+    borderRadius: 999,
+    overflow: 'hidden',
+    paddingHorizontal: 7,
+    paddingVertical: 3,
+    fontSize: 10,
+    fontWeight: '800',
+    textTransform: 'uppercase',
+  },
+  signalWarn: {
+    color: '#fde68a',
+    borderWidth: 1,
+    borderColor: 'rgba(251,191,36,0.28)',
+    backgroundColor: 'rgba(251,191,36,0.10)',
+    borderRadius: 999,
+    overflow: 'hidden',
+    paddingHorizontal: 7,
+    paddingVertical: 3,
+    fontSize: 10,
+    fontWeight: '800',
+    textTransform: 'uppercase',
   },
 })

--- a/packages/app/components/media/ProvenancePanel.tsx
+++ b/packages/app/components/media/ProvenancePanel.tsx
@@ -1,0 +1,135 @@
+import { memo } from 'react'
+import { StyleSheet, Text, View } from 'react-native'
+import { colors } from '@/lib/colors'
+import { fonts } from '@/lib/typography'
+import type { MediaCockpitItem } from './HeroFeatureCard'
+
+function asArray(value: unknown): Array<any> {
+  return Array.isArray(value) ? value : []
+}
+
+function pickString(...values: Array<unknown>): string | null {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim().length > 0) return value.trim()
+  }
+  return null
+}
+
+function provenanceTitle(entry: any, index: number): string {
+  return pickString(entry?.role, entry?.claimType, entry?.source, `claim-${index + 1}`) || `claim-${index + 1}`
+}
+
+function provenanceDetail(entry: any): string {
+  const publisher = pickString(entry?.publisherName, entry?.publisherId, entry?.issuerName)
+  const publication = pickString(entry?.publicationId, entry?.renditionId, entry?.claimId, entry?.id)
+  if (publisher && publication) return `${publisher} · ${publication}`
+  return publisher || publication || 'Unsigned local metadata claim'
+}
+
+export interface ProvenancePanelProps {
+  item: MediaCockpitItem & Record<string, any>
+}
+
+function ProvenancePanelComponent({ item }: ProvenancePanelProps) {
+  const provenance = asArray(item?.provenance)
+  const selectedSource = item?.selectedSource || item?.item?.selectedSource || null
+  const rows = provenance.length > 0
+    ? provenance
+    : selectedSource
+      ? [{ role: 'selected-source', publisherName: selectedSource.publisherName, publicationId: selectedSource.publicationId, renditionId: selectedSource.renditionId }]
+      : []
+
+  return (
+    <View style={styles.card}>
+      <View style={styles.headerRow}>
+        <Text style={styles.kicker}>Publisher claims</Text>
+        <Text style={styles.count}>{rows.length} claim{rows.length === 1 ? '' : 's'}</Text>
+      </View>
+      <Text style={styles.summary}>
+        {pickString(item?.localEntityId, item?.publicationId, selectedSource?.publicationId) || 'No stable entity id attached yet.'}
+      </Text>
+      <View style={styles.list}>
+        {rows.length === 0 ? (
+          <Text style={styles.empty}>This item is still running on legacy feed metadata, so provenance is limited to the playable source.</Text>
+        ) : rows.slice(0, 6).map((entry, index) => (
+          <View key={entry?.claimId || entry?.publicationId || entry?.renditionId || index} style={styles.row}>
+            <View style={styles.dot} />
+            <View style={styles.rowCopy}>
+              <Text style={styles.rowTitle} numberOfLines={1}>{provenanceTitle(entry, index)}</Text>
+              <Text style={styles.rowDetail} numberOfLines={2}>{provenanceDetail(entry)}</Text>
+            </View>
+          </View>
+        ))}
+      </View>
+    </View>
+  )
+}
+
+export const ProvenancePanel = memo(ProvenancePanelComponent)
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: 20,
+    borderWidth: 1,
+    borderColor: colors.glassBorder,
+    backgroundColor: colors.bgElevated,
+    padding: 16,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+  },
+  kicker: {
+    color: colors.text,
+    fontFamily: fonts.headingMedium,
+    fontSize: 16,
+  },
+  count: {
+    color: colors.primary,
+    fontSize: 11,
+    fontWeight: '800',
+    textTransform: 'uppercase',
+  },
+  summary: {
+    color: colors.textMuted,
+    fontSize: 12,
+    marginTop: 8,
+  },
+  list: {
+    gap: 10,
+    marginTop: 14,
+  },
+  row: {
+    flexDirection: 'row',
+    gap: 10,
+  },
+  dot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: colors.primary,
+    marginTop: 5,
+  },
+  rowCopy: {
+    flex: 1,
+  },
+  rowTitle: {
+    color: colors.text,
+    fontSize: 13,
+    fontWeight: '800',
+    textTransform: 'uppercase',
+  },
+  rowDetail: {
+    color: colors.textMuted,
+    fontSize: 12,
+    lineHeight: 17,
+    marginTop: 2,
+  },
+  empty: {
+    color: colors.textMuted,
+    fontSize: 13,
+    lineHeight: 18,
+  },
+})

--- a/packages/app/components/media/SourceSelector.tsx
+++ b/packages/app/components/media/SourceSelector.tsx
@@ -1,0 +1,193 @@
+import { memo } from 'react'
+import { Pressable, StyleSheet, Text, View } from 'react-native'
+import { Ionicons } from '@expo/vector-icons'
+import { colors } from '@/lib/colors'
+import { fonts } from '@/lib/typography'
+import type { MediaCockpitItem } from './HeroFeatureCard'
+
+function asArray(value: unknown): Array<any> {
+  return Array.isArray(value) ? value : []
+}
+
+function pickString(...values: Array<unknown>): string | null {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim().length > 0) return value.trim()
+  }
+  return null
+}
+
+function sourceKey(source: any, index: number): string {
+  const parts = [
+    source?.publicationId,
+    source?.renditionId,
+    source?.playbackKey,
+    source?.id,
+    source?.videoId,
+    source?.path,
+  ].filter((value) => typeof value === 'string' && value.trim().length > 0)
+  return parts.length > 0 ? parts.join(':') : `source-${index}`
+}
+
+function sourceLabel(source: any, index: number): string {
+  return pickString(source?.publisherName, source?.sourceProviderName, source?.channelName, source?.publisherId, source?.channelKey, `Source ${index + 1}`) || `Source ${index + 1}`
+}
+
+function sourceStatus(source: any): string {
+  const status = pickString(source?.archiveStatus, source?.availabilityStatus, source?.retentionStatus)
+  if (source?.localComplete || status === 'local' || status === 'complete-local') return 'local'
+  if (source?.cached || status === 'cached' || status === 'retained') return 'cached'
+  if (source?.available || status === 'available' || status === 'online') return 'available'
+  if (status) return status
+  return 'claim'
+}
+
+export interface SourceSelectorProps {
+  item: MediaCockpitItem & Record<string, any>
+  onSelectSource?: (source: any) => void
+}
+
+function SourceSelectorComponent({ item, onSelectSource }: SourceSelectorProps) {
+  const selectedSource = item?.selectedSource || item?.item?.selectedSource || null
+  const alternateSources = asArray(item?.alternateSources)
+  const allSources = asArray(item?.sources)
+  const sources = allSources.length > 0
+    ? allSources
+    : [selectedSource, ...alternateSources].filter(Boolean)
+
+  return (
+    <View style={styles.card}>
+      <View style={styles.headerRow}>
+        <View>
+          <Text style={styles.kicker}>Source selector</Text>
+          <Text style={styles.title}>Playable publications and renditions</Text>
+        </View>
+        <Text style={styles.count}>{sources.length} source{sources.length === 1 ? '' : 's'}</Text>
+      </View>
+      <View style={styles.list}>
+        {sources.length === 0 ? (
+          <Text style={styles.empty}>No alternate sources are attached yet. PearTube will use the legacy playable item if available.</Text>
+        ) : sources.slice(0, 8).map((source, index) => {
+          const selected = selectedSource && sourceKey(source, index) === sourceKey(selectedSource, index)
+          return (
+            <Pressable
+              key={sourceKey(source, index)}
+              onPress={() => onSelectSource?.(source)}
+              accessibilityRole="button"
+              accessibilityLabel={`Select ${sourceLabel(source, index)}`}
+              style={[styles.row, selected ? styles.rowSelected : null]}
+            >
+              <View style={[styles.radio, selected ? styles.radioSelected : null]}>
+                {selected ? <Ionicons name="checkmark" size={13} color={colors.onPrimary} /> : null}
+              </View>
+              <View style={styles.rowCopy}>
+                <Text style={styles.rowTitle} numberOfLines={1}>{sourceLabel(source, index)}</Text>
+                <Text style={styles.rowDetail} numberOfLines={1}>{pickString(source?.publicationId, source?.renditionId, source?.videoId, source?.path) || 'publication claim'}</Text>
+              </View>
+              <Text style={styles.status}>{sourceStatus(source)}</Text>
+            </Pressable>
+          )
+        })}
+      </View>
+    </View>
+  )
+}
+
+export const SourceSelector = memo(SourceSelectorComponent)
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: 20,
+    borderWidth: 1,
+    borderColor: colors.glassBorder,
+    backgroundColor: colors.bgElevated,
+    padding: 16,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
+    gap: 12,
+  },
+  kicker: {
+    color: colors.primary,
+    fontSize: 11,
+    fontWeight: '900',
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+  },
+  title: {
+    color: colors.text,
+    fontFamily: fonts.headingMedium,
+    fontSize: 16,
+    marginTop: 3,
+  },
+  count: {
+    color: colors.textMuted,
+    fontSize: 11,
+    fontWeight: '800',
+    textTransform: 'uppercase',
+  },
+  list: {
+    gap: 9,
+    marginTop: 14,
+  },
+  empty: {
+    color: colors.textMuted,
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    borderWidth: 1,
+    borderColor: colors.glassBorder,
+    backgroundColor: 'rgba(255,255,255,0.035)',
+    borderRadius: 16,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+  },
+  rowSelected: {
+    borderColor: 'rgba(163,230,53,0.34)',
+    backgroundColor: 'rgba(163,230,53,0.08)',
+  },
+  radio: {
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    borderWidth: 1,
+    borderColor: colors.glassBorder,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  radioSelected: {
+    borderColor: colors.primary,
+    backgroundColor: colors.primary,
+  },
+  rowCopy: {
+    flex: 1,
+  },
+  rowTitle: {
+    color: colors.text,
+    fontSize: 13,
+    fontWeight: '800',
+  },
+  rowDetail: {
+    color: colors.textMuted,
+    fontSize: 12,
+    marginTop: 2,
+  },
+  status: {
+    color: colors.primary,
+    borderRadius: 999,
+    overflow: 'hidden',
+    borderWidth: 1,
+    borderColor: 'rgba(163,230,53,0.26)',
+    backgroundColor: 'rgba(163,230,53,0.08)',
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    fontSize: 10,
+    fontWeight: '900',
+    textTransform: 'uppercase',
+  },
+})

--- a/packages/app/lib/media-entity-graph.js
+++ b/packages/app/lib/media-entity-graph.js
@@ -1,0 +1,564 @@
+import { selectMediaSource } from './media-source-selection.js'
+
+function asArray(value) {
+  return Array.isArray(value) ? value : []
+}
+
+function nonArrayObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function nonEmptyString(value) {
+  return typeof value === 'string' && value.length > 0
+}
+
+function firstNonEmptyString(values, fallback = null) {
+  for (const value of values) {
+    if (nonEmptyString(value)) return value
+  }
+  return fallback
+}
+
+function finiteNumber(value) {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
+function safePositiveNumber(value) {
+  return finiteNumber(value) && value > 0 ? value : null
+}
+
+function metadata(entity) {
+  return nonArrayObject(entity?.preferredMetadata)
+    ? entity.preferredMetadata
+    : nonArrayObject(entity?.metadata)
+      ? entity.metadata
+      : {}
+}
+
+function classification(entity) {
+  return nonArrayObject(entity?.classification)
+    ? entity.classification
+    : nonArrayObject(metadata(entity)?.classification)
+      ? metadata(entity).classification
+      : {}
+}
+
+function normalEntityKind(entity) {
+  const kind = firstNonEmptyString([
+    entity?.entityKind,
+    entity?.kind,
+    entity?.type,
+  ], 'work')
+  if (kind === 'resolved-work') return 'work'
+  if (kind === 'creator') return 'agent'
+  if (kind === 'series' || kind === 'season' || kind === 'album' || kind === 'playlist') return 'collection'
+  return kind
+}
+
+function explicitContentKind(entity) {
+  const meta = metadata(entity)
+  const cls = classification(entity)
+  const kind = firstNonEmptyString([
+    entity?.contentKind,
+    entity?.mediaKind,
+    meta.contentKind,
+    meta.mediaKind,
+    cls.contentKind,
+    cls.type,
+  ], null)
+  if (kind === 'tv') return 'episode'
+  if (kind === 'track') return 'song'
+  return kind
+}
+
+function entityTitle(entity) {
+  const meta = metadata(entity)
+  return firstNonEmptyString([
+    meta.title,
+    meta.name,
+    entity?.title,
+    entity?.name,
+    entity?.label,
+  ], 'Untitled media')
+}
+
+function entitySubtitle(entity, creatorName, sourceProviderName) {
+  const meta = metadata(entity)
+  return firstNonEmptyString([
+    meta.subtitle,
+    entity?.subtitle,
+    meta.seriesTitle,
+    entity?.seriesTitle,
+    meta.albumTitle,
+    entity?.albumTitle,
+    creatorName,
+    sourceProviderName,
+  ], null)
+}
+
+function timestampValue(value) {
+  if (finiteNumber(value)) return value
+  if (!nonEmptyString(value)) return null
+  const parsed = Date.parse(value)
+  return Number.isNaN(parsed) ? null : parsed
+}
+
+function entityCreatedAt(entity) {
+  const meta = metadata(entity)
+  for (const value of [entity?.publishedAt, entity?.uploadedAt, entity?.createdAt, entity?.updatedAt, meta.publishedAt, meta.releaseDate, meta.airDate]) {
+    const timestamp = timestampValue(value)
+    if (timestamp !== null) return value
+  }
+  return null
+}
+
+function roleName(contribution) {
+  return firstNonEmptyString([
+    contribution?.role,
+    contribution?.contributionRole,
+    contribution?.kind,
+  ], 'creator')
+}
+
+function agentName(contribution) {
+  return firstNonEmptyString([
+    contribution?.creditedName,
+    contribution?.agentName,
+    contribution?.name,
+    contribution?.agent?.name,
+    contribution?.agent?.preferredMetadata?.name,
+    contribution?.agent?.preferredMetadata?.title,
+  ], null)
+}
+
+function normalizeContributions(entity) {
+  const raw = [
+    ...asArray(entity?.contributions),
+    ...asArray(entity?.creatorRoles),
+    ...asArray(entity?.contributors),
+  ]
+  const contributions = []
+  const seen = new Set()
+  for (const entry of raw) {
+    if (!nonArrayObject(entry)) continue
+    const name = agentName(entry)
+    if (!nonEmptyString(name)) continue
+    const role = roleName(entry)
+    const key = `${role}:${name}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    contributions.push({
+      role,
+      name,
+      agentId: firstNonEmptyString([entry.agentId, entry.agent?.localEntityId, entry.agent?.id], null),
+      raw: entry,
+    })
+  }
+  const directCreator = firstNonEmptyString([entity?.creatorName, metadata(entity)?.creatorName], null)
+  if (directCreator && !seen.has(`creator:${directCreator}`)) contributions.push({ role: 'creator', name: directCreator, agentId: null, raw: null })
+  return contributions
+}
+
+function normalizeArtworkEntry(entry) {
+  if (!nonArrayObject(entry)) return null
+  const role = firstNonEmptyString([entry.role, entry.kind, entry.purpose, entry.type], 'thumbnail')
+  const url = firstNonEmptyString([entry.url, entry.remoteUrl, entry.thumbnailUrl, entry.uri], null)
+  const blobId = firstNonEmptyString([entry.blobId, entry.assetId], null)
+  const blobsCoreKey = firstNonEmptyString([entry.blobsCoreKey, entry.coreKey], null)
+  if (!url && !(blobId && blobsCoreKey)) return null
+  return {
+    role,
+    url,
+    remoteUrl: url,
+    blobId,
+    blobsCoreKey,
+    mimeType: firstNonEmptyString([entry.mimeType, entry.contentType], null),
+    raw: entry,
+  }
+}
+
+function normalizeArtwork(entity) {
+  const meta = metadata(entity)
+  const entries = []
+  for (const entry of asArray(entity?.artwork)) {
+    const normalized = normalizeArtworkEntry(entry)
+    if (normalized) entries.push(normalized)
+  }
+  for (const entry of asArray(meta.artwork)) {
+    const normalized = normalizeArtworkEntry(entry)
+    if (normalized) entries.push(normalized)
+  }
+  for (const [role, value] of [
+    ['poster', entity?.posterUrl || meta.posterUrl],
+    ['backdrop', entity?.backdropUrl || meta.backdropUrl],
+    ['still', entity?.stillUrl || meta.stillUrl],
+    ['thumbnail', entity?.thumbnailUrl || entity?.thumbnail || meta.thumbnailUrl || meta.thumbnail],
+    ['avatar', entity?.avatarUrl || meta.avatarUrl],
+    ['banner', entity?.bannerUrl || meta.bannerUrl],
+  ]) {
+    if (nonEmptyString(value)) entries.push({ role, url: value, remoteUrl: value, blobId: null, blobsCoreKey: null, mimeType: null, raw: null })
+  }
+  return entries
+}
+
+function artworkUrl(artwork, roles) {
+  for (const role of roles) {
+    for (const entry of artwork) {
+      if (entry.role === role && nonEmptyString(entry.url)) return entry.url
+      if (entry.role === role && nonEmptyString(entry.remoteUrl)) return entry.remoteUrl
+    }
+  }
+  return null
+}
+
+function provenanceClaimKey(entry) {
+  return [
+    entry?.claimId || entry?.id || '',
+    entry?.evidenceId || entry?.evidenceHash || '',
+    entry?.publisherId || '',
+    entry?.publisherName || '',
+    entry?.publicationId || '',
+    entry?.renditionId || '',
+    entry?.role || '',
+    entry?.evidence ? JSON.stringify(entry.evidence) : '',
+  ].join(':')
+}
+
+function mediaSourceMergeKey(source) {
+  return [
+    source?.publicationId || '',
+    source?.renditionId || '',
+    source?.playbackKey || '',
+    source?.id || '',
+    source?.videoId || '',
+    source?.path || '',
+  ].join(':')
+}
+
+function normalizeProvenance(entity, sourceSelection) {
+  const raw = [...asArray(entity?.provenance)]
+  for (const source of sourceSelection.sources) {
+    raw.push({
+      publisherId: source.publisherId,
+      publisherName: source.publisherName,
+      publicationId: source.publicationId,
+      renditionId: source.renditionId,
+      role: 'publication-source',
+    })
+  }
+  const provenance = []
+  const seen = new Set()
+  for (const entry of raw) {
+    if (!nonArrayObject(entry)) continue
+    const key = provenanceClaimKey(entry)
+    if (seen.has(key)) continue
+    seen.add(key)
+    provenance.push(entry)
+  }
+  return provenance
+}
+
+function entityId(entity, index = 0) {
+  const kind = normalEntityKind(entity)
+  const meta = metadata(entity)
+  return firstNonEmptyString([
+    entity?.localEntityId,
+    entity?.entityId,
+    entity?.workId,
+    entity?.collectionId,
+    entity?.agentId,
+    entity?.id,
+    meta.localEntityId,
+    meta.workId,
+  ], `${kind}:legacy:${index}`)
+}
+
+function sourceProviderFromSelection(selection) {
+  return firstNonEmptyString(selection.sources.map((source) => source.publisherName), null)
+}
+
+function normalizeGraphEntity(entity, index = 0, options = {}) {
+  if (!nonArrayObject(entity)) return null
+  const localEntityId = entityId(entity, index)
+  const entityKind = normalEntityKind(entity)
+  const mediaKind = explicitContentKind(entity) || (entityKind === 'collection' ? 'collection' : entityKind === 'agent' ? 'creator' : 'video')
+  const contributions = normalizeContributions(entity)
+  const creatorName = firstNonEmptyString(contributions.map((entry) => entry.name), null)
+  const sourceSelection = selectMediaSource(entity, options.sourcePolicy || {})
+  const sourceProviderName = sourceProviderFromSelection(sourceSelection)
+  const artwork = normalizeArtwork(entity)
+  const title = entityTitle(entity)
+  const selected = sourceSelection.selectedSource
+  const meta = metadata(entity)
+  const cls = classification(entity)
+
+  return {
+    id: localEntityId,
+    localEntityId,
+    entityKind,
+    mediaKind,
+    contentKind: mediaKind,
+    title,
+    subtitle: entitySubtitle(entity, creatorName, sourceProviderName),
+    creatorName,
+    creatorRoles: contributions,
+    publisherName: sourceProviderName,
+    sourceProviderName,
+    sourceCount: sourceSelection.sourceCount,
+    selectedSource: selected,
+    alternateSources: sourceSelection.alternateSources,
+    sources: sourceSelection.sources,
+    provenance: normalizeProvenance(entity, sourceSelection),
+    conflicts: asArray(entity?.conflicts),
+    archiveStatus: entity?.archiveStatus || entity?.retentionStatus || selected?.archiveStatus || null,
+    availabilityStatus: selected?.availabilityStatus || null,
+    artwork,
+    posterUrl: artworkUrl(artwork, ['poster', 'album', 'thumbnail', 'still']),
+    backdropUrl: artworkUrl(artwork, ['backdrop', 'banner', 'still', 'poster', 'thumbnail']),
+    stillUrl: artworkUrl(artwork, ['still', 'thumbnail', 'backdrop', 'poster']),
+    thumbnailUrl: artworkUrl(artwork, ['thumbnail', 'still', 'poster', 'backdrop', 'avatar']),
+    thumbnail: artworkUrl(artwork, ['thumbnail', 'still', 'poster', 'backdrop', 'avatar']),
+    playbackKey: selected?.playbackKey || `${localEntityId}:unavailable`,
+    channelKey: selected?.channelKey || selected?.publisherId || null,
+    driveKey: selected?.driveKey || selected?.channelKey || null,
+    videoId: selected?.videoId || selected?.publicationId || null,
+    path: selected?.path || null,
+    publicBeeKey: selected?.publicBeeKey || null,
+    publicationId: selected?.publicationId || null,
+    renditionId: selected?.renditionId || null,
+    duration: safePositiveNumber(entity?.duration ?? entity?.durationSec ?? meta.duration ?? meta.durationSec) || null,
+    durationSec: safePositiveNumber(entity?.durationSec ?? entity?.duration ?? meta.durationSec ?? meta.duration) || null,
+    seasonNumber: Number.isSafeInteger(entity?.seasonNumber) ? entity.seasonNumber : Number.isSafeInteger(meta.seasonNumber) ? meta.seasonNumber : Number.isSafeInteger(cls.season) ? cls.season : null,
+    episodeNumber: Number.isSafeInteger(entity?.episodeNumber) ? entity.episodeNumber : Number.isSafeInteger(meta.episodeNumber) ? meta.episodeNumber : Number.isSafeInteger(cls.episode) ? cls.episode : null,
+    trackNumber: Number.isSafeInteger(entity?.trackNumber) ? entity.trackNumber : Number.isSafeInteger(meta.trackNumber) ? meta.trackNumber : null,
+    collectionRefs: asArray(entity?.collectionRefs),
+    collections: asArray(entity?.collections),
+    createdAt: entityCreatedAt(entity),
+    progress: finiteNumber(entity?.progress) ? Math.max(0, Math.min(1, entity.progress)) : 0,
+    item: { ...entity, selectedSource: selected, alternateSources: sourceSelection.alternateSources },
+  }
+}
+
+function mergeArraysByKey(existing, incoming, keyFn) {
+  const seen = new Set(existing.map(keyFn))
+  for (const item of incoming) {
+    const key = keyFn(item)
+    if (seen.has(key)) continue
+    seen.add(key)
+    existing.push(item)
+  }
+}
+
+function mergeProjectedEntity(existing, incoming) {
+  if (!existing.title && incoming.title) existing.title = incoming.title
+  if (!existing.subtitle && incoming.subtitle) existing.subtitle = incoming.subtitle
+  if (!existing.creatorName && incoming.creatorName) existing.creatorName = incoming.creatorName
+  if (!existing.publisherName && incoming.publisherName) existing.publisherName = incoming.publisherName
+  if (!existing.sourceProviderName && incoming.sourceProviderName) existing.sourceProviderName = incoming.sourceProviderName
+  for (const field of ['posterUrl', 'backdropUrl', 'stillUrl', 'thumbnailUrl', 'thumbnail', 'duration', 'durationSec', 'seasonNumber', 'episodeNumber', 'trackNumber', 'archiveStatus', 'availabilityStatus']) {
+    if ((existing[field] === null || existing[field] === undefined || existing[field] === '') && incoming[field] !== null && incoming[field] !== undefined && incoming[field] !== '') existing[field] = incoming[field]
+  }
+  mergeArraysByKey(existing.sources, incoming.sources, mediaSourceMergeKey)
+  mergeArraysByKey(existing.alternateSources, incoming.alternateSources, mediaSourceMergeKey)
+  mergeArraysByKey(existing.provenance, incoming.provenance, provenanceClaimKey)
+  mergeArraysByKey(existing.conflicts, incoming.conflicts, (entry) => entry.claimId || entry.id || JSON.stringify(entry))
+  mergeArraysByKey(existing.artwork, incoming.artwork, (entry) => [entry.role, entry.url, entry.blobId, entry.blobsCoreKey].join(':'))
+  mergeArraysByKey(existing.creatorRoles, incoming.creatorRoles, (entry) => `${entry.role}:${entry.name}`)
+  const reselection = selectMediaSource({ sources: existing.sources })
+  const selected = reselection.selectedSource
+  existing.selectedSource = selected
+  existing.alternateSources = reselection.alternateSources
+  existing.sourceCount = reselection.sourceCount
+  existing.playbackKey = selected?.playbackKey || existing.playbackKey
+  existing.publicationId = selected?.publicationId || existing.publicationId
+  existing.renditionId = selected?.renditionId || existing.renditionId
+  if (selected?.publisherName) existing.publisherName = selected.publisherName
+  if (selected?.sourceProviderName || selected?.publisherName) existing.sourceProviderName = selected.sourceProviderName || selected.publisherName
+  if (selected?.availabilityStatus) existing.availabilityStatus = selected.availabilityStatus
+  if (selected?.archiveStatus) existing.archiveStatus = selected.archiveStatus
+  return existing
+}
+
+function collectionMemberKey(member) {
+  if (!nonArrayObject(member)) return JSON.stringify(member)
+  return firstNonEmptyString([
+    member.localEntityId,
+    member.workId,
+    member.entityId,
+    member.id,
+    member.videoId,
+    member.path,
+  ], JSON.stringify(member))
+}
+
+function missingMemberKey(member) {
+  if (!nonArrayObject(member)) return JSON.stringify(member)
+  const position = nonArrayObject(member.position) ? member.position : {}
+  return firstNonEmptyString([
+    member.localEntityId,
+    member.workId,
+    member.entityId,
+    member.id,
+    `${position.season || ''}:${position.episode || ''}:${position.track || ''}:${member.reason || ''}`,
+  ], JSON.stringify(member))
+}
+
+function mergeProjectedCollection(existing, incoming) {
+  mergeProjectedEntity(existing, incoming)
+  mergeArraysByKey(existing.items, incoming.items, collectionMemberKey)
+  mergeArraysByKey(existing.missingMembers, incoming.missingMembers, missingMemberKey)
+  existing.itemCount = Math.max(
+    Number.isSafeInteger(existing.itemCount) ? existing.itemCount : 0,
+    Number.isSafeInteger(incoming.itemCount) ? incoming.itemCount : 0,
+    existing.items.length,
+  )
+  existing.completeness = {
+    itemCount: existing.itemCount,
+    missingCount: existing.missingMembers.length,
+    hasTrustedStructure: Boolean(existing.completeness?.hasTrustedStructure || incoming.completeness?.hasTrustedStructure),
+  }
+  return existing
+}
+
+function legacyVideoToEntity(item, sourceName, index) {
+  if (!nonArrayObject(item)) return null
+  const id = firstNonEmptyString([item.id, item.videoId, item.path], null)
+  const title = firstNonEmptyString([item.title], null)
+  if (!id || !title) return null
+  const channelKey = firstNonEmptyString([item.channelKey, item.driveKey, item.channel?.key], 'local')
+  const publisherName = firstNonEmptyString([item.channelName, item.channel?.name, item.creatorName], null)
+  return normalizeGraphEntity({
+    localEntityId: `legacy:${channelKey}:${id}`,
+    entityKind: 'work',
+    contentKind: item.contentKind || item.classification?.type || 'video',
+    title,
+    subtitle: item.subtitle,
+    creatorName: item.creatorName,
+    posterUrl: item.posterUrl,
+    backdropUrl: item.backdropUrl,
+    stillUrl: item.stillUrl,
+    thumbnailUrl: item.thumbnailUrl || item.thumbnail,
+    thumbnail: item.thumbnail,
+    artwork: asArray(item.artwork),
+    classification: item.classification,
+    category: item.category,
+    profileKind: item.profileKind,
+    seasonNumber: item.seasonNumber,
+    episodeNumber: item.episodeNumber,
+    duration: item.duration || item.durationSec,
+    durationSec: item.durationSec || item.duration,
+    progress: item.progress,
+    publishedAt: item.publishedAt || item.uploadedAt || item.createdAt || item.updatedAt,
+    provenance: [{ role: 'legacy-publication', publisherName, publisherId: channelKey, source: sourceName }],
+    sources: [{ ...item, publisherName, publisherId: channelKey, sourceProviderName: publisherName }],
+  }, index)
+}
+
+function normalizeCollection(entity, index) {
+  const projected = normalizeGraphEntity({ ...entity, entityKind: 'collection' }, index)
+  if (!projected) return null
+  const items = asArray(entity.items || entity.members || entity.collectionItems)
+  const missingMembers = asArray(entity.missingMembers || entity.missingSlots)
+  return {
+    ...projected,
+    itemCount: Number.isSafeInteger(entity.itemCount) ? entity.itemCount : items.length,
+    items,
+    missingMembers,
+    completeness: entity.completeness || {
+      known: items.length,
+      missing: missingMembers.length,
+      hasTrustedStructure: missingMembers.length > 0 && entity.trustedStructure === true,
+    },
+  }
+}
+
+function normalizeAgent(entity, index) {
+  const projected = normalizeGraphEntity({ ...entity, entityKind: 'agent', contentKind: 'creator' }, index)
+  if (!projected) return null
+  return {
+    ...projected,
+    contributions: asArray(entity.contributions),
+    sourcePublisherCount: new Set(asArray(entity.contributions).map((entry) => entry.publisherId || entry.publisherName).filter(Boolean)).size,
+  }
+}
+
+function graphEntityArrays(input = {}) {
+  const mediaGraph = nonArrayObject(input.mediaGraph) ? input.mediaGraph : {}
+  return {
+    entities: [
+      ...asArray(input.mediaEntities),
+      ...asArray(input.resolvedEntities),
+      ...asArray(mediaGraph.entities),
+      ...asArray(mediaGraph.works),
+      ...asArray(input.works),
+    ],
+    collections: [
+      ...asArray(input.collections),
+      ...asArray(mediaGraph.collections),
+    ],
+    agents: [
+      ...asArray(input.agents),
+      ...asArray(input.creators),
+      ...asArray(mediaGraph.agents),
+      ...asArray(mediaGraph.creators),
+    ],
+  }
+}
+
+export function projectMediaEntityGraph(input = {}, options = {}) {
+  const includeLegacy = options.includeLegacy === true
+  const arrays = graphEntityArrays(input)
+  const byEntity = new Map()
+
+  arrays.entities.forEach((entity, index) => {
+    const projected = normalizeGraphEntity(entity, index, options)
+    if (projected === null) return
+    const key = projected.localEntityId
+    if (byEntity.has(key)) mergeProjectedEntity(byEntity.get(key), projected)
+    else byEntity.set(key, projected)
+  })
+
+  if (includeLegacy) {
+    const legacyGroups = [
+      ['feed', input.feedVideos],
+      ['library', input.myVideos],
+      ['recommended', input.recommendedVideos],
+    ]
+    for (const [sourceName, items] of legacyGroups) {
+      asArray(items).forEach((item, index) => {
+        const projected = legacyVideoToEntity(item, sourceName, index)
+        if (projected === null) return
+        const key = projected.localEntityId
+        if (byEntity.has(key)) mergeProjectedEntity(byEntity.get(key), projected)
+        else byEntity.set(key, projected)
+      })
+    }
+  }
+
+  const byCollection = new Map()
+  arrays.collections.forEach((entity, index) => {
+    const projected = normalizeCollection(entity, index)
+    if (projected === null) return
+    const key = projected.localEntityId
+    if (byCollection.has(key)) mergeProjectedCollection(byCollection.get(key), projected)
+    else byCollection.set(key, projected)
+  })
+  const collections = Array.from(byCollection.values())
+  const agents = arrays.agents.map(normalizeAgent).filter((item) => item !== null)
+  const mediaItems = Array.from(byEntity.values())
+  const allItems = [...mediaItems, ...collections, ...agents]
+
+  return {
+    mediaItems,
+    collections,
+    agents,
+    allItems,
+    counts: {
+      works: mediaItems.length,
+      collections: collections.length,
+      agents: agents.length,
+      sources: mediaItems.reduce((total, item) => total + item.sourceCount, 0),
+      conflicts: mediaItems.reduce((total, item) => total + item.conflicts.length, 0),
+    },
+  }
+}

--- a/packages/app/lib/media-hub.js
+++ b/packages/app/lib/media-hub.js
@@ -1,8 +1,11 @@
+import { projectMediaEntityGraph } from './media-entity-graph.js'
+
 const MOVIE_CLASSIFICATION = 'movie'
 const SHOW_CLASSIFICATION = 'tv'
 const EPISODE_KIND = 'episode'
 const MUSIC_CREATOR_KINDS = new Set(['music', 'creator'])
 const MUSIC_CREATOR_TYPES = new Set(['music', 'creator'])
+const COLLECTION_KINDS = new Set(['collection', 'season', 'series', 'album', 'playlist'])
 const MUSIC_CREATOR_CATEGORIES = new Set(['Music', 'music'])
 const CREATOR_PROFILE_KINDS = new Set(['creator'])
 const TIMESTAMP_FIELDS = ['uploadedAt', 'createdAt', 'updatedAt', 'indexedAt', 'addedAt', 'publishedAt']
@@ -126,6 +129,17 @@ function normalizeProgress(item, duration) {
 }
 
 function stableItemKey(item) {
+  const selectedSource = nonArrayObject(item?.selectedSource) ? item.selectedSource : nonArrayObject(item?.item?.selectedSource) ? item.item.selectedSource : null
+  if (selectedSource) {
+    return firstNonEmptyString([
+      selectedSource.videoId,
+      selectedSource.path,
+      selectedSource.publicationId,
+      item?.videoId,
+      item?.path,
+      item?.id,
+    ], null)
+  }
   return firstNonEmptyString([item?.id, item?.videoId, item?.path], null)
 }
 
@@ -160,14 +174,42 @@ function normalizeVideoItem(item, source) {
     channelName: nonEmptyString(item?.channelName) ? item.channelName : null,
     channel: nonArrayObject(item?.channel) ? item.channel : null,
     creatorName: nonEmptyString(item?.creatorName) ? item.creatorName : null,
-    thumbnailUrl: firstNonEmptyString([item?.thumbnailUrl, item?.thumbnail], null),
+    thumbnailUrl: firstNonEmptyString([item?.thumbnailUrl, item?.thumbnail, item?.stillUrl, item?.posterUrl, item?.backdropUrl], null),
     thumbnail: nonEmptyString(item?.thumbnail) ? item.thumbnail : null,
-    contentKind: hasUsefulValue(item?.contentKind) ? item.contentKind : null,
+    posterUrl: firstNonEmptyString([item?.posterUrl, item?.thumbnailUrl, item?.thumbnail], null),
+    backdropUrl: firstNonEmptyString([item?.backdropUrl, item?.stillUrl, item?.posterUrl, item?.thumbnailUrl, item?.thumbnail], null),
+    stillUrl: firstNonEmptyString([item?.stillUrl, item?.thumbnailUrl, item?.thumbnail, item?.posterUrl], null),
+    artwork: Array.isArray(item?.artwork) ? item.artwork.slice() : [],
+    contentKind: hasUsefulValue(item?.contentKind) ? item.contentKind : hasUsefulValue(item?.mediaKind) ? item.mediaKind : null,
+    mediaKind: hasUsefulValue(item?.mediaKind) ? item.mediaKind : hasUsefulValue(item?.contentKind) ? item.contentKind : null,
+    entityKind: hasUsefulValue(item?.entityKind) ? item.entityKind : null,
+    localEntityId: nonEmptyString(item?.localEntityId) ? item.localEntityId : null,
     classification: hasUsefulValue(item?.classification) ? item.classification : null,
     category: hasUsefulValue(item?.category) ? item.category : null,
     profileKind: hasUsefulValue(item?.profileKind) ? item.profileKind : null,
     duration,
     durationSec: positiveDuration(item?.durationSec) ?? null,
+    seasonNumber: Number.isSafeInteger(item?.seasonNumber) ? item.seasonNumber : null,
+    episodeNumber: Number.isSafeInteger(item?.episodeNumber) ? item.episodeNumber : null,
+    trackNumber: Number.isSafeInteger(item?.trackNumber) ? item.trackNumber : null,
+    sourceCount: Number.isSafeInteger(item?.sourceCount) ? item.sourceCount : 0,
+    selectedSource: nonArrayObject(item?.selectedSource) ? item.selectedSource : null,
+    alternateSources: Array.isArray(item?.alternateSources) ? item.alternateSources.slice() : [],
+    sources: Array.isArray(item?.sources) ? item.sources.slice() : [],
+    provenance: Array.isArray(item?.provenance) ? item.provenance.slice() : [],
+    conflicts: Array.isArray(item?.conflicts) ? item.conflicts.slice() : [],
+    archiveStatus: hasUsefulValue(item?.archiveStatus) ? item.archiveStatus : null,
+    availabilityStatus: hasUsefulValue(item?.availabilityStatus) ? item.availabilityStatus : null,
+    publisherName: firstNonEmptyString([item?.publisherName, item?.sourceProviderName], null),
+    sourceProviderName: firstNonEmptyString([item?.sourceProviderName, item?.publisherName], null),
+    publicationId: nonEmptyString(item?.publicationId) ? item.publicationId : null,
+    renditionId: nonEmptyString(item?.renditionId) ? item.renditionId : null,
+    creatorRoles: Array.isArray(item?.creatorRoles) ? item.creatorRoles.slice() : [],
+    items: Array.isArray(item?.items) ? item.items.slice() : [],
+    missingMembers: Array.isArray(item?.missingMembers) ? item.missingMembers.slice() : [],
+    completeness: nonArrayObject(item?.completeness) ? { ...item.completeness } : null,
+    contributions: Array.isArray(item?.contributions) ? item.contributions.slice() : [],
+    sourcePublisherCount: Number.isSafeInteger(item?.sourcePublisherCount) ? item.sourcePublisherCount : null,
     progress: normalizeProgress(item, duration),
     createdAt: firstNonEmptyString([item?.createdAt, item?.publishedAt, item?.updatedAt, item?.indexedAt, item?.addedAt], null),
     item: { ...item },
@@ -242,7 +284,13 @@ function mergeMissingTimestampFields(existing, item) {
 function mergeMissingMediaFields(existing, item) {
   mergeMissingField(existing, item, 'thumbnailUrl')
   mergeMissingField(existing, item, 'thumbnail')
+  mergeMissingField(existing, item, 'posterUrl')
+  mergeMissingField(existing, item, 'backdropUrl')
+  mergeMissingField(existing, item, 'stillUrl')
   mergeMissingField(existing, item, 'contentKind')
+  mergeMissingField(existing, item, 'mediaKind')
+  mergeMissingField(existing, item, 'entityKind')
+  mergeMissingField(existing, item, 'localEntityId')
   mergeMissingClassification(existing, item)
   mergeMissingField(existing, item, 'category')
   mergeMissingField(existing, item, 'profileKind')
@@ -252,6 +300,15 @@ function mergeMissingMediaFields(existing, item) {
   mergeMissingField(existing, item, 'channelName')
   mergeMissingField(existing, item, 'channel')
   mergeMissingField(existing, item, 'creatorName')
+  mergeMissingField(existing, item, 'publisherName')
+  mergeMissingField(existing, item, 'sourceProviderName')
+  mergeMissingField(existing, item, 'publicationId')
+  mergeMissingField(existing, item, 'renditionId')
+  mergeMissingField(existing, item, 'archiveStatus')
+  mergeMissingField(existing, item, 'availabilityStatus')
+  mergeMissingField(existing, item, 'seasonNumber')
+  mergeMissingField(existing, item, 'episodeNumber')
+  mergeMissingField(existing, item, 'trackNumber')
   mergeMissingField(existing, item, 'channelKey')
   mergeMissingField(existing, item, 'driveKey')
   mergeMissingField(existing, item, 'videoId')
@@ -262,6 +319,11 @@ function mergeMissingMediaFields(existing, item) {
   mergeMissingSourceField(existing, item, 'videoId')
   mergeMissingSourceField(existing, item, 'path')
   mergeMissingSourceField(existing, item, 'publicBeeKey')
+  if (Array.isArray(existing.artwork) && existing.artwork.length === 0 && Array.isArray(item.artwork) && item.artwork.length > 0) existing.artwork = item.artwork.slice()
+  if (Array.isArray(existing.provenance) && existing.provenance.length === 0 && Array.isArray(item.provenance) && item.provenance.length > 0) existing.provenance = item.provenance.slice()
+  if (Array.isArray(existing.conflicts) && existing.conflicts.length === 0 && Array.isArray(item.conflicts) && item.conflicts.length > 0) existing.conflicts = item.conflicts.slice()
+  if (Array.isArray(existing.alternateSources) && existing.alternateSources.length === 0 && Array.isArray(item.alternateSources) && item.alternateSources.length > 0) existing.alternateSources = item.alternateSources.slice()
+  if (Array.isArray(existing.creatorRoles) && existing.creatorRoles.length === 0 && Array.isArray(item.creatorRoles) && item.creatorRoles.length > 0) existing.creatorRoles = item.creatorRoles.slice()
   mergeMissingTimestampFields(existing, item)
 }
 
@@ -306,8 +368,14 @@ function isMusicOrCreatorItem(item) {
 function hasFeaturedThumbnail(item) {
   return nonEmptyString(item?.thumbnailUrl)
     || nonEmptyString(item?.thumbnail)
+    || nonEmptyString(item?.posterUrl)
+    || nonEmptyString(item?.backdropUrl)
+    || nonEmptyString(item?.stillUrl)
     || nonEmptyString(item?.item?.thumbnailUrl)
     || nonEmptyString(item?.item?.thumbnail)
+    || nonEmptyString(item?.item?.posterUrl)
+    || nonEmptyString(item?.item?.backdropUrl)
+    || nonEmptyString(item?.item?.stillUrl)
 }
 
 function isBetterFeaturedItem(candidate, selected) {
@@ -342,9 +410,9 @@ function rail(id, title, items, options = {}) {
   const result = {
     id,
     title,
+    subtitle: nonEmptyString(options.subtitle) ? options.subtitle : '',
     items,
   }
-  if (nonEmptyString(options.subtitle)) result.subtitle = options.subtitle
   if (Number.isSafeInteger(options.limit) && options.limit > 0) result.limit = options.limit
   return result
 }
@@ -371,12 +439,68 @@ export function getMediaHubPlaybackKey(item) {
   return `${channelKey}:${itemKey}`
 }
 
+function selectedSourceForPlayback(item) {
+  if (nonArrayObject(item?.selectedSource)) return item.selectedSource
+  if (nonArrayObject(item?.item?.selectedSource)) return item.item.selectedSource
+  return null
+}
+
+export function getMediaHubPlayableSourceItem(item, options = {}) {
+  const selectedSource = selectedSourceForPlayback(item)
+  const rawSelected = nonArrayObject(selectedSource?.raw) ? selectedSource.raw : null
+  const legacySource = !selectedSource && nonArrayObject(item?.item) ? item.item : item
+  const source = selectedSource ? { ...rawSelected, ...selectedSource } : legacySource
+  if (!nonArrayObject(source)) return source
+
+  const id = firstNonEmptyString([
+    source.videoId,
+    source.path,
+    source.id,
+    selectedSource ? null : item?.videoId,
+    selectedSource ? null : item?.id,
+    selectedSource ? null : item?.path,
+  ], null)
+  const channelKey = firstNonEmptyString([
+    source.channelKey,
+    source.driveKey,
+    source.channel?.key,
+    selectedSource ? null : item?.channelKey,
+    selectedSource ? null : item?.driveKey,
+    options.fallbackChannelKey,
+  ], '')
+  const publicBeeKey = firstNonEmptyString([
+    source.publicBeeKey,
+    selectedSource ? null : item?.publicBeeKey,
+    options.publicBeeKey,
+  ], null)
+
+  return {
+    ...source,
+    id,
+    videoId: firstNonEmptyString([source.videoId, id], id),
+    channelKey,
+    driveKey: firstNonEmptyString([source.driveKey, channelKey], channelKey),
+    publicBeeKey,
+    title: firstNonEmptyString([source.title, item?.title], 'Untitled'),
+    thumbnailUrl: firstNonEmptyString([source.thumbnailUrl, item?.thumbnailUrl, source.thumbnail, item?.thumbnail], null),
+    thumbnail: firstNonEmptyString([source.thumbnail, item?.thumbnail, source.thumbnailUrl, item?.thumbnailUrl], null),
+  }
+}
+
 export function isMovieItem(item) {
-  return item?.contentKind === MOVIE_CLASSIFICATION || item?.classification?.type === MOVIE_CLASSIFICATION
+  return item?.contentKind === MOVIE_CLASSIFICATION || item?.mediaKind === MOVIE_CLASSIFICATION || item?.classification?.type === MOVIE_CLASSIFICATION
 }
 
 export function isShowItem(item) {
-  return item?.contentKind === EPISODE_KIND || item?.classification?.type === SHOW_CLASSIFICATION
+  return item?.contentKind === EPISODE_KIND || item?.mediaKind === EPISODE_KIND || item?.contentKind === SHOW_CLASSIFICATION || item?.mediaKind === SHOW_CLASSIFICATION || item?.classification?.type === SHOW_CLASSIFICATION
+}
+
+export function isCollectionItem(item) {
+  return COLLECTION_KINDS.has(item?.entityKind) || COLLECTION_KINDS.has(item?.contentKind) || COLLECTION_KINDS.has(item?.mediaKind)
+}
+
+export function isCreatorItem(item) {
+  return item?.entityKind === 'agent' || item?.contentKind === 'creator' || item?.mediaKind === 'creator' || item?.profileKind === 'creator'
 }
 
 export function buildMediaHubSections(input = {}) {
@@ -385,7 +509,18 @@ export function buildMediaHubSections(input = {}) {
     myVideos = [],
     continueWatching = [],
     recommendedVideos = [],
+    mediaGraph = null,
+    mediaEntities = [],
+    resolvedEntities = [],
+    works = [],
+    collections: graphCollections = [],
+    agents = [],
+    creators: graphCreators = [],
   } = input !== null && typeof input === 'object' && !Array.isArray(input) ? input : {}
+  const graphProjection = projectMediaEntityGraph({ mediaGraph, mediaEntities, resolvedEntities, works, collections: graphCollections, agents, creators: graphCreators }, { includeLegacy: false })
+  const graphItems = mapVideos(graphProjection.mediaItems, 'media-graph')
+  const graphCollectionItems = mapVideos(graphProjection.collections, 'media-graph')
+  const graphAgentItems = mapVideos(graphProjection.agents, 'media-graph')
   const recommendedItems = mapVideos(recommendedVideos, 'recommended')
   const feedItems = mapVideos(feedVideos, 'feed')
   const libraryItems = mapVideos(myVideos, 'library')
@@ -393,12 +528,16 @@ export function buildMediaHubSections(input = {}) {
 
   const feedRailItems = dedupeByPlaybackKey([feedItems])
   const libraryRailItems = dedupeByPlaybackKey([libraryItems])
-  const mediaItems = dedupeByPlaybackKey([recommendedItems, feedItems, libraryItems])
+  const mediaItems = dedupeByPlaybackKey([graphItems, recommendedItems, feedItems, libraryItems])
+  const collectionItems = sortNewest(dedupeByPlaybackKey([graphCollectionItems]))
+  const creatorItems = sortNewest(dedupeByPlaybackKey([graphAgentItems, mediaItems.filter(isCreatorItem)]))
   const allItems = sortNewest(mediaItems)
   const movies = sortNewest(allItems.filter(isMovieItem))
   const shows = sortNewest(allItems.filter(isShowItem))
   const newEpisodes = sortNewest(shows)
-  const musicAndCreators = sortNewest(allItems.filter(isMusicOrCreatorItem))
+  const collections = limitItems(collectionItems, 12)
+  const creators = limitItems(creatorItems, 12)
+  const musicAndCreators = sortNewest(dedupeByPlaybackKey([allItems.filter(isMusicOrCreatorItem), creators]))
   const recentlySeeded = limitItems(sortNewest(feedRailItems), 18)
   const yourLibrary = limitItems(sortNewest(libraryRailItems), 12)
   const featured = selectFeatured(dedupeByPlaybackKey([mediaItems, continueItems]))
@@ -413,6 +552,8 @@ export function buildMediaHubSections(input = {}) {
     movies: rail('movies', 'Movies', movies, { subtitle: 'Feature-length media on your network' }),
     shows: rail('shows', 'Shows', shows, { subtitle: 'Episodes and series from peers' }),
     newEpisodes: rail('new-episodes', 'New episodes', newEpisodes),
+    collections: rail('collections', 'Collections', collections, { subtitle: 'Seasons, albums, playlists, and curated sets from the graph', limit: 12 }),
+    creators: rail('creators', 'Creators', creators, { subtitle: 'Agents and contributors resolved across publishers', limit: 12 }),
     musicAndCreators: rail('music-creators', 'Music & creators', musicAndCreators),
     recentlySeeded: rail('recently-seeded', 'Recently from the swarm', recentlySeeded, { limit: 18 }),
     yourLibrary: rail('your-library', 'Your library', yourLibrary, { limit: 12 }),

--- a/packages/app/lib/media-source-selection.js
+++ b/packages/app/lib/media-source-selection.js
@@ -1,0 +1,230 @@
+function asArray(value) {
+  return Array.isArray(value) ? value : []
+}
+
+function nonArrayObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function nonEmptyString(value) {
+  return typeof value === 'string' && value.length > 0
+}
+
+function firstNonEmptyString(values, fallback = null) {
+  for (const value of values) {
+    if (nonEmptyString(value)) return value
+  }
+  return fallback
+}
+
+function finiteNumber(value) {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
+function truthy(value) {
+  return value === true || value === 'true' || value === 'yes'
+}
+
+function sourceTimestampMs(source) {
+  for (const field of ['lastVerifiedAt', 'observedAt', 'publishedAt', 'uploadedAt', 'createdAt', 'updatedAt']) {
+    const value = source?.[field]
+    if (finiteNumber(value)) return value
+    if (nonEmptyString(value)) {
+      const parsed = Date.parse(value)
+      if (!Number.isNaN(parsed)) return parsed
+    }
+  }
+  return 0
+}
+
+function sourceId(source, fallback = 'source') {
+  return firstNonEmptyString([
+    source?.publicationId,
+    source?.sourceId,
+    source?.manifestId,
+    source?.renditionId,
+    source?.videoId,
+    source?.id,
+    source?.path,
+  ], fallback)
+}
+
+function sourcePublisherName(source) {
+  return firstNonEmptyString([
+    source?.publisherName,
+    source?.sourceProviderName,
+    source?.providerName,
+    source?.publisher?.name,
+    source?.channelName,
+    source?.channel?.name,
+    source?.uploaderName,
+  ], null)
+}
+
+function sourcePublisherId(source) {
+  return firstNonEmptyString([
+    source?.publisherId,
+    source?.issuerIdentityKey,
+    source?.channelKey,
+    source?.driveKey,
+    source?.publicBeeKey,
+    source?.channel?.key,
+  ], null)
+}
+
+function sourceModerationPenalty(source) {
+  const action = source?.moderation?.action || source?.policyDecision?.action || source?.decision
+  if (action === 'blocked' || action === 'hidden' || action === 'not-downloaded') return -1000
+  if (action === 'blurred') return -60
+  return 0
+}
+
+function availabilityScore(source) {
+  const status = source?.availabilityStatus || source?.availability || source?.retentionStatus || source?.archiveStatus
+  if (truthy(source?.localComplete) || truthy(source?.isLocal) || status === 'local' || status === 'complete-local') return 260
+  if (truthy(source?.cached) || truthy(source?.retained) || status === 'cached' || status === 'retained') return 220
+  if (truthy(source?.archived) || status === 'archived' || status === 'pledged') return 170
+  if (truthy(source?.available) || status === 'available' || status === 'online' || status === 'seeded') return 140
+  if (status === 'partial') return 90
+  if (status === 'unavailable' || status === 'missing' || status === 'blocked') return -160
+  return 0
+}
+
+function formatScore(source) {
+  let score = 0
+  if (source?.formatSupported === false) score -= 180
+  if (source?.playbackSupported === false) score -= 180
+  if (source?.verified === true || source?.verificationStatus === 'verified') score += 70
+  if (source?.fingerprintAgreement === true) score += 40
+  if (source?.isPreferred === true || source?.preferred === true) score += 35
+  if (finiteNumber(source?.height)) score += Math.min(45, Math.max(0, source.height / 60))
+  if (finiteNumber(source?.bitrate)) score += Math.min(35, Math.max(0, source.bitrate / 200000))
+  return score
+}
+
+export function normalizeMediaSource(source = {}, entity = {}) {
+  if (!nonArrayObject(source)) return null
+
+  const publicationId = firstNonEmptyString([
+    source.publicationId,
+    source.id,
+    source.manifest?.publicationId,
+    source.publication?.id,
+    source.publication?.publicationId,
+  ], null)
+  const rendition = nonArrayObject(source.rendition) ? source.rendition : nonArrayObject(source.selectedRendition) ? source.selectedRendition : null
+  const renditionId = firstNonEmptyString([
+    source.renditionId,
+    rendition?.renditionId,
+    rendition?.id,
+    source.playbackRenditionId,
+  ], null)
+  const videoId = firstNonEmptyString([source.videoId, source.video?.id, source.item?.videoId], null)
+  const id = firstNonEmptyString([source.id, videoId, publicationId, renditionId, source.path], null)
+  if (!nonEmptyString(id)) return null
+
+  const publisherId = sourcePublisherId(source)
+  const publisherName = sourcePublisherName(source)
+  const channelKey = firstNonEmptyString([source.channelKey, source.driveKey, source.channel?.key, publisherId], null)
+  const playbackItemKey = firstNonEmptyString([videoId, source.path, source.video?.id, renditionId, publicationId, id], 'unknown')
+  const playbackKey = firstNonEmptyString([
+    source.playbackKey,
+    entity?.playbackKey,
+  ], `${channelKey || publisherId || entity?.localEntityId || 'publisher'}:${playbackItemKey}`)
+
+  return {
+    id,
+    publicationId,
+    manifestId: firstNonEmptyString([source.manifestId, source.manifest?.id], null),
+    renditionId,
+    publisherId,
+    publisherName,
+    sourceProviderName: publisherName,
+    channelKey,
+    driveKey: firstNonEmptyString([source.driveKey, source.channelKey], null),
+    videoId,
+    path: firstNonEmptyString([source.path, source.filePath, source.video?.path], null),
+    publicBeeKey: firstNonEmptyString([source.publicBeeKey, source.video?.publicBeeKey], null),
+    playbackKey,
+    availabilityStatus: source.availabilityStatus || source.availability || source.retentionStatus || null,
+    archiveStatus: source.archiveStatus || source.retentionStatus || null,
+    localComplete: !!source.localComplete,
+    cached: !!source.cached,
+    retained: !!source.retained,
+    available: source.available !== false,
+    verified: !!source.verified || source.verificationStatus === 'verified',
+    formatSupported: source.formatSupported !== false,
+    playbackSupported: source.playbackSupported !== false,
+    height: finiteNumber(source.height) ? source.height : finiteNumber(rendition?.height) ? rendition.height : null,
+    bitrate: finiteNumber(source.bitrate) ? source.bitrate : finiteNumber(rendition?.bitrate) ? rendition.bitrate : null,
+    publishedAt: source.publishedAt || source.uploadedAt || source.createdAt || null,
+    provenance: asArray(source.provenance),
+    moderation: source.moderation || source.policyDecision || null,
+    raw: source,
+  }
+}
+
+function collectCandidateSources(entity = {}) {
+  const sources = []
+  for (const field of ['selectedSource', 'preferredSource']) {
+    if (nonArrayObject(entity[field])) sources.push(entity[field])
+  }
+  for (const field of ['sources', 'publicationSources', 'publications', 'alternateSources']) {
+    for (const source of asArray(entity[field])) sources.push(source)
+  }
+  if (nonArrayObject(entity.item)) sources.push(entity.item)
+  if (nonEmptyString(entity.videoId) || nonEmptyString(entity.publicationId) || nonEmptyString(entity.path)) sources.push(entity)
+  return sources
+}
+
+export function scoreMediaSource(source, policy = {}) {
+  if (!nonArrayObject(source)) return Number.NEGATIVE_INFINITY
+  let score = availabilityScore(source) + formatScore(source) + sourceModerationPenalty(source)
+  if (nonEmptyString(policy.preferredPublicationId) && source.publicationId === policy.preferredPublicationId) score += 1000
+  if (nonEmptyString(policy.preferredRenditionId) && source.renditionId === policy.preferredRenditionId) score += 700
+  if (nonEmptyString(policy.preferredPublisherId) && source.publisherId === policy.preferredPublisherId) score += 180
+  if (policy.allowUnavailable === true && (source.availabilityStatus === 'unavailable' || source.availabilityStatus === 'missing')) score += 120
+  score += Math.min(30, sourceTimestampMs(source) / 100000000000)
+  return score
+}
+
+export function selectMediaSource(entity = {}, policy = {}) {
+  const normalized = []
+  const seen = new Set()
+  for (const candidate of collectCandidateSources(entity)) {
+    const source = normalizeMediaSource(candidate, entity)
+    if (source === null) continue
+    const key = [
+      source.publicationId || '',
+      source.renditionId || '',
+      source.playbackKey || '',
+      source.id || '',
+      source.videoId || '',
+      source.path || '',
+    ].join(':')
+    if (seen.has(key)) continue
+    seen.add(key)
+    normalized.push(source)
+  }
+
+  const scored = normalized
+    .map((source, index) => ({ source, index, score: scoreMediaSource(source, policy) }))
+    .sort((left, right) => {
+      if (right.score !== left.score) return right.score - left.score
+      const leftId = sourceId(left.source)
+      const rightId = sourceId(right.source)
+      if (leftId < rightId) return -1
+      if (leftId > rightId) return 1
+      return left.index - right.index
+    })
+
+  const selectedSource = scored[0]?.source || null
+  const alternateSources = scored.slice(1).map(({ source }) => source)
+  return {
+    selectedSource,
+    alternateSources,
+    sources: scored.map(({ source }) => source),
+    sourceCount: scored.length,
+    unavailableReason: selectedSource === null ? 'no-playable-source' : null,
+  }
+}

--- a/packages/app/tests/desktop-media-cockpit-regression.test.mjs
+++ b/packages/app/tests/desktop-media-cockpit-regression.test.mjs
@@ -18,7 +18,19 @@ test('desktop Home imports and renders the media cockpit instead of only the leg
   for (const required of [
     'buildMediaHubSections',
     'DesktopMediaHero',
+    'DesktopMediaStats',
+    'DesktopMediaEvidencePanel',
     'DesktopMediaRail',
+    'PERMISSIONLESS MEDIA CDN',
+    'A media graph, not a feed',
+    'Publisher + asset topics',
+    'getMediaHubSourceSummary',
+    'getMediaHubArchiveSummary',
+    'SourceSelector',
+    'ProvenancePanel',
+    'ConflictNotice',
+    'ArchiveStatus',
+    'MediaFallbackArtwork',
     'mediaHubSections.featured.item',
     'desktopMediaRails.map',
     'playMediaHubItem',
@@ -27,6 +39,7 @@ test('desktop Home imports and renders the media cockpit instead of only the leg
     '<VideoGrid',
     'mediaCockpitShell:',
     'mediaHero:',
+    'mediaEvidenceGrid:',
     'mediaRailSection:',
     'mediaPosterCard:',
   ]) {
@@ -37,10 +50,11 @@ test('desktop Home imports and renders the media cockpit instead of only the leg
 test('desktop media cockpit preserves existing playback, channel, and feed refresh contracts', () => {
   const source = readApp('app/(tabs)/index.web.tsx')
 
+  assert.ok(source.includes('getMediaHubPlayableSourceItem'), 'desktop cockpit should import the shared playable-source adapter')
   assert.match(
     source,
-    /const id = source\?\.id \|\| source\?\.videoId \|\| item\?\.id \|\| item\?\.videoId/,
-    'desktop cockpit playback helper should map videoId-shaped entries into the id shape used by playVideo',
+    /return getMediaHubPlayableSourceItem\(item, \{ fallbackChannelKey: identity\?\.driveKey \|\| '' \}\) as VideoData/,
+    'desktop cockpit playback helper should delegate selected-source unwrapping while preserving desktop fallback channel identity',
   )
   assert.match(
     source,
@@ -55,4 +69,36 @@ test('desktop media cockpit preserves existing playback, channel, and feed refre
   assert.match(source, /await rpc\.refreshFeed\(\{\}\)/, 'feed refresh should keep using the existing desktop feed refresh path')
   assert.doesNotMatch(source, /getContentCatalog\(/, 'desktop cockpit should not add catalog RPC fetches')
   assert.doesNotMatch(source, /getRecommendations/, 'desktop cockpit should not add recommendation RPC fetches')
+})
+
+
+test('desktop cockpit should render inspectable media evidence without new RPC dependencies', () => {
+  const source = readApp('app/(tabs)/index.web.tsx')
+
+  for (const required of [
+    '<DesktopMediaEvidencePanel item={mediaHubSections.featured.item} />',
+    'getDesktopEvidenceSources',
+    'Playable publications',
+    'Publisher claims',
+    'No archive evidence yet',
+    'unresolved metadata conflict',
+  ]) {
+    assert.ok(source.includes(required), `desktop evidence panel should contain ${required}`)
+  }
+  assert.doesNotMatch(source, /getMediaGraph\(/, 'desktop evidence panel should not add a new graph RPC fetch')
+  assert.doesNotMatch(source, /resolveMediaEntity\(/, 'desktop evidence panel should not add a new entity-resolution RPC fetch')
+})
+
+
+test('desktop collection and creator rails route to entity pages while playable rails keep playback', () => {
+  const source = readApp('app/(tabs)/index.web.tsx')
+
+  assert.ok(source.includes('openMediaEntityPage'), 'desktop Home should define entity-page routing for non-playable graph rails')
+  assert.ok(source.includes("interface EntityRoute"), 'desktop hash parser should model entity routes')
+  assert.match(source, /parts\[0\] === 'media' \|\| parts\[0\] === 'collection' \|\| parts\[0\] === 'creator'/, 'desktop hash parser should recognize media, collection, and creator entity hashes')
+  assert.ok(source.includes('<MediaEntityDetailScreen'), 'desktop entity hashes should render the shared entity detail surface')
+  assert.match(source, /if \(rail\.id === 'collections'\) openMediaEntityPage\(item, 'collection'\)/, 'collections rail should open collection entity pages')
+  assert.match(source, /else if \(rail\.id === 'creators'\) openMediaEntityPage\(item, 'creator'\)/, 'creators rail should open creator entity pages')
+  assert.match(source, /else playMediaHubItem\(item\)/, 'playable media rails should keep selected-source playback')
+  assert.match(source, /window\.location\.hash = `#\/\$\{entityType\}\/\$\{encodeURIComponent\(id\)\}\?item=\$\{encodedItem\}`/, 'entity pages should be addressable through hash routes with serialized graph payloads')
 })

--- a/packages/app/tests/media-entity-graph.test.mjs
+++ b/packages/app/tests/media-entity-graph.test.mjs
@@ -1,0 +1,189 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { projectMediaEntityGraph } from '../lib/media-entity-graph.js'
+
+test('collapses duplicate publications into one work with alternate sources and provenance', () => {
+  const graph = projectMediaEntityGraph({
+    resolvedEntities: [
+      {
+        localEntityId: 'work:tmdb-episode:entourage-s1e1',
+        entityKind: 'work',
+        contentKind: 'episode',
+        preferredMetadata: { title: 'Entourage', seriesTitle: 'Entourage' },
+        seasonNumber: 1,
+        episodeNumber: 1,
+        artwork: [{ role: 'still', remoteUrl: 'https://example.test/still.jpg' }],
+        contributions: [{ role: 'director', agentName: 'Pilot Director' }],
+        publications: [
+          { publicationId: 'pub-a', renditionId: 'rend-a', publisherId: 'publisher-a', publisherName: 'Publisher A', availabilityStatus: 'available', verified: true },
+          { publicationId: 'pub-b', renditionId: 'rend-b', publisherId: 'publisher-b', publisherName: 'Publisher B', availabilityStatus: 'available' },
+        ],
+      },
+      {
+        localEntityId: 'work:tmdb-episode:entourage-s1e1',
+        entityKind: 'work',
+        contentKind: 'episode',
+        preferredMetadata: { title: 'Entourage' },
+        publications: [
+          { publicationId: 'pub-c', renditionId: 'rend-c', publisherId: 'publisher-c', publisherName: 'Publisher C', availabilityStatus: 'cached', cached: true },
+        ],
+      },
+    ],
+  })
+
+  assert.equal(graph.mediaItems.length, 1)
+  const episode = graph.mediaItems[0]
+  assert.equal(episode.localEntityId, 'work:tmdb-episode:entourage-s1e1')
+  assert.equal(episode.sourceCount, 3)
+  assert.equal(episode.selectedSource.publicationId, 'pub-c')
+  assert.equal(episode.publisherName, 'Publisher C')
+  assert.equal(episode.sourceProviderName, 'Publisher C')
+  assert.equal(episode.alternateSources.length, 2)
+  assert.equal(episode.provenance.length, 3)
+  assert.equal(episode.stillUrl, 'https://example.test/still.jpg')
+  assert.equal(episode.creatorRoles[0].role, 'director')
+})
+
+test('keeps creator roles distinct from publisher/source-provider attribution', () => {
+  const graph = projectMediaEntityGraph({
+    resolvedEntities: [
+      {
+        localEntityId: 'work:film:1',
+        entityKind: 'work',
+        contentKind: 'movie',
+        preferredMetadata: { title: 'A Film' },
+        contributions: [
+          { role: 'director', agentName: 'Director Person' },
+          { role: 'performer', agentName: 'Lead Actor' },
+        ],
+        publications: [
+          { publicationId: 'pub-archive', publisherId: 'publisher-archive', publisherName: 'Public Archive Mirror', availabilityStatus: 'available' },
+        ],
+      },
+    ],
+  })
+
+  const item = graph.mediaItems[0]
+  assert.equal(item.creatorName, 'Director Person')
+  assert.equal(item.publisherName, 'Public Archive Mirror')
+  assert.deepEqual(item.creatorRoles.map((role) => role.role), ['director', 'performer'])
+})
+
+test('projects partial collections without inventing missing-member truth', () => {
+  const graph = projectMediaEntityGraph({
+    collections: [
+      {
+        localEntityId: 'collection:season:show-x:s1',
+        entityKind: 'collection',
+        contentKind: 'season',
+        preferredMetadata: { title: 'Show X Season 1' },
+        items: [{ localEntityId: 'work:e1' }, { localEntityId: 'work:e3' }],
+        missingMembers: [{ position: { season: 1, episode: 2 }, reason: 'trusted-structure-gap' }],
+        trustedStructure: true,
+      },
+      {
+        localEntityId: 'collection:season:show-x:s1',
+        entityKind: 'collection',
+        contentKind: 'season',
+        preferredMetadata: { title: 'Show X Season 1' },
+        items: [{ localEntityId: 'work:e2' }, { localEntityId: 'work:e3' }],
+        missingMembers: [{ position: { season: 1, episode: 4 }, reason: 'trusted-structure-gap' }],
+      },
+    ],
+  })
+
+  assert.equal(graph.collections.length, 1)
+  assert.equal(graph.collections[0].itemCount, 3)
+  assert.deepEqual(graph.collections[0].items.map((member) => member.localEntityId), ['work:e1', 'work:e3', 'work:e2'])
+  assert.equal(graph.collections[0].missingMembers.length, 2)
+  assert.equal(graph.collections[0].completeness.missingCount, 2)
+  assert.equal(graph.collections[0].completeness.hasTrustedStructure, true)
+})
+
+test('preserves conflict arrays and explicit metadata instead of title parsing', () => {
+  const graph = projectMediaEntityGraph({
+    resolvedEntities: [
+      {
+        localEntityId: 'work:conflict:1',
+        entityKind: 'work',
+        title: 'File.Name.S01E02.1080p.mkv',
+        preferredMetadata: { title: 'Actual Episode Title', contentKind: 'episode' },
+        conflicts: [{ claimId: 'claim-conflict-1', field: 'seasonNumber' }],
+        publications: [{ publicationId: 'pub-1', renditionId: 'rend-1', publisherName: 'Uploader', availabilityStatus: 'available' }],
+      },
+    ],
+  })
+
+  const item = graph.mediaItems[0]
+  assert.equal(item.title, 'Actual Episode Title')
+  assert.equal(item.contentKind, 'episode')
+  assert.equal(item.seasonNumber, null)
+  assert.equal(item.episodeNumber, null)
+  assert.equal(item.conflicts.length, 1)
+})
+
+test('legacy adapter creates attributed publications without claiming global entity truth', () => {
+  const graph = projectMediaEntityGraph({
+    feedVideos: [
+      {
+        id: 'video-1',
+        title: 'Loose Upload',
+        channelKey: 'channel-a',
+        channelName: 'Uploader Channel',
+        thumbnailUrl: 'https://example.test/thumb.jpg',
+      },
+    ],
+  }, { includeLegacy: true })
+
+  assert.equal(graph.mediaItems.length, 1)
+  assert.equal(graph.mediaItems[0].localEntityId, 'legacy:channel-a:video-1')
+  assert.equal(graph.mediaItems[0].publisherName, 'Uploader Channel')
+  assert.equal(graph.mediaItems[0].provenance[0].role, 'legacy-publication')
+  assert.equal(graph.mediaItems[0].thumbnailUrl, 'https://example.test/thumb.jpg')
+})
+
+
+test('does not mark untrusted missing members as trusted collection structure', () => {
+  const graph = projectMediaEntityGraph({
+    collections: [
+      {
+        localEntityId: 'collection:season:untrusted',
+        entityKind: 'collection',
+        contentKind: 'season',
+        preferredMetadata: { title: 'Untrusted Season' },
+        items: [{ localEntityId: 'work:e1' }],
+        missingMembers: [{ position: { season: 1, episode: 2 }, reason: 'peer-claim' }],
+      },
+      {
+        localEntityId: 'collection:season:untrusted',
+        entityKind: 'collection',
+        contentKind: 'season',
+        preferredMetadata: { title: 'Untrusted Season' },
+        missingMembers: [{ position: { season: 1, episode: 3 }, reason: 'peer-claim' }],
+      },
+    ],
+  })
+
+  assert.equal(graph.collections[0].missingMembers.length, 2)
+  assert.equal(graph.collections[0].completeness.hasTrustedStructure, false)
+})
+
+test('preserves distinct provenance evidence claims with the same publisher and rendition', () => {
+  const graph = projectMediaEntityGraph({
+    resolvedEntities: [
+      {
+        localEntityId: 'work:provenance:1',
+        entityKind: 'work',
+        preferredMetadata: { title: 'Provenance Work' },
+        provenance: [
+          { claimId: 'claim-a', publisherId: 'publisher-1', publicationId: 'pub-1', renditionId: 'rend-1', role: 'metadata', evidenceHash: 'hash-a' },
+          { claimId: 'claim-b', publisherId: 'publisher-1', publicationId: 'pub-1', renditionId: 'rend-1', role: 'metadata', evidenceHash: 'hash-b' },
+        ],
+        publications: [{ publicationId: 'pub-1', renditionId: 'rend-1', publisherId: 'publisher-1', publisherName: 'Publisher 1', availabilityStatus: 'available' }],
+      },
+    ],
+  })
+
+  const claimIds = graph.mediaItems[0].provenance.map((entry) => entry.claimId).filter(Boolean).sort()
+  assert.deepEqual(claimIds, ['claim-a', 'claim-b'])
+})

--- a/packages/app/tests/media-hub.test.mjs
+++ b/packages/app/tests/media-hub.test.mjs
@@ -3,6 +3,7 @@ import test from 'node:test'
 
 import {
   buildMediaHubSections,
+  getMediaHubPlayableSourceItem,
   getMediaHubPlaybackKey,
   isMovieItem,
   isShowItem,
@@ -639,3 +640,166 @@ test('deduped playback field backfill survives source item unwrap', () => {
   assert.equal(item.thumbnailUrl, 'https://img.example/backfilled-playback.jpg')
 })
 
+test('playable source helper unwraps selected graph source without using entity id for playback', () => {
+  const item = {
+    id: 'work:movie:network-film',
+    localEntityId: 'work:movie:network-film',
+    title: 'Network Film',
+    channelKey: 'entity-channel-should-not-win',
+    selectedSource: {
+      id: 'publication-id-should-not-win',
+      publicationId: 'publication-id-should-not-win',
+      videoId: 'playable-video-id',
+      channelKey: 'publisher-channel',
+      publicBeeKey: 'public-bee-key',
+      raw: {
+        id: 'raw-upload-id',
+        videoId: 'playable-video-id',
+        channelKey: 'publisher-channel',
+        blobId: 'blob-1',
+        blobsCoreKey: 'blobs-core-1',
+      },
+    },
+  }
+
+  const playable = getMediaHubPlayableSourceItem(item)
+  assert.equal(playable.id, 'playable-video-id')
+  assert.equal(playable.videoId, 'playable-video-id')
+  assert.equal(playable.channelKey, 'publisher-channel')
+  assert.equal(playable.publicBeeKey, 'public-bee-key')
+  assert.equal(playable.blobId, 'blob-1')
+  assert.notEqual(playable.id, item.localEntityId)
+})
+
+test('playable source helper preserves legacy normalized video wrappers', () => {
+  const playable = getMediaHubPlayableSourceItem({
+    id: 'legacy:channel-a:video-a',
+    title: 'Legacy wrapped upload',
+    item: {
+      videoId: 'video-a',
+      channelKey: 'channel-a',
+      publicBeeKey: 'bee-a',
+      thumbnailUrl: 'https://example.test/thumb.jpg',
+    },
+  })
+
+  assert.equal(playable.id, 'video-a')
+  assert.equal(playable.videoId, 'video-a')
+  assert.equal(playable.channelKey, 'channel-a')
+  assert.equal(playable.publicBeeKey, 'bee-a')
+  assert.equal(playable.thumbnailUrl, 'https://example.test/thumb.jpg')
+})
+
+test('media hub renders resolved graph works as unified source-aware media', () => {
+  const sections = buildMediaHubSections({
+    resolvedEntities: [
+      {
+        localEntityId: 'work:movie:network-film',
+        entityKind: 'work',
+        contentKind: 'movie',
+        preferredMetadata: { title: 'Network Film' },
+        artwork: [{ role: 'poster', remoteUrl: 'https://example.test/poster.jpg' }],
+        conflicts: [{ claimId: 'conflict-title' }],
+        publications: [
+          { publicationId: 'pub-a', renditionId: 'rend-a', publisherId: 'publisher-a', publisherName: 'Publisher A', availabilityStatus: 'available' },
+          { publicationId: 'pub-b', renditionId: 'rend-b', publisherId: 'publisher-b', publisherName: 'Publisher B', availabilityStatus: 'cached', cached: true },
+        ],
+      },
+    ],
+  })
+
+  assert.equal(sections.movies.items.length, 1)
+  assert.equal(sections.movies.items[0].title, 'Network Film')
+  assert.equal(sections.movies.items[0].localEntityId, 'work:movie:network-film')
+  assert.equal(sections.movies.items[0].sourceCount, 2)
+  assert.equal(sections.movies.items[0].publicationId, 'pub-b')
+  assert.equal(sections.movies.items[0].posterUrl, 'https://example.test/poster.jpg')
+  assert.equal(sections.movies.items[0].conflicts.length, 1)
+})
+
+test('media hub exposes collection and creator rails from the resolved graph', () => {
+  const sections = buildMediaHubSections({
+    collections: [
+      {
+        localEntityId: 'collection:season:show-x:s1',
+        entityKind: 'collection',
+        contentKind: 'season',
+        preferredMetadata: { title: 'Show X Season 1' },
+        items: [{ localEntityId: 'work:e1' }],
+      },
+    ],
+    agents: [
+      {
+        localEntityId: 'agent:creator:one',
+        entityKind: 'agent',
+        preferredMetadata: { title: 'Creator One' },
+        contributions: [{ publisherId: 'publisher-a', role: 'director' }],
+      },
+    ],
+  })
+
+  assert.equal(sections.collections.title, 'Collections')
+  assert.equal(sections.collections.items[0].title, 'Show X Season 1')
+  assert.equal(sections.creators.title, 'Creators')
+  assert.equal(sections.creators.items[0].title, 'Creator One')
+})
+
+
+
+test('promotes collection and creator graph detail fields into serialized hub cards', () => {
+  const sections = buildMediaHubSections({
+    mediaGraph: {
+      collections: [
+        {
+          localEntityId: 'collection:season:1',
+          entityKind: 'collection',
+          contentKind: 'season',
+          preferredMetadata: { title: 'Season One' },
+          items: [{ localEntityId: 'work:e1', title: 'Episode 1' }],
+          missingMembers: [{ position: { season: 1, episode: 2 }, reason: 'peer claim' }],
+          completeness: { known: 1, missing: 1, hasTrustedStructure: false },
+        },
+      ],
+      creators: [
+        {
+          localEntityId: 'creator:director:1',
+          entityKind: 'agent',
+          contentKind: 'creator',
+          preferredMetadata: { title: 'Director One' },
+          contributions: [{ role: 'director', agentName: 'Director One', publisherId: 'publisher-a' }],
+        },
+      ],
+    },
+  })
+
+  const collection = sections.collections.items[0]
+  assert.equal(collection.items.length, 1)
+  assert.equal(collection.missingMembers.length, 1)
+  assert.equal(collection.completeness.hasTrustedStructure, false)
+
+  const creator = sections.creators.items[0]
+  assert.equal(creator.contributions.length, 1)
+  assert.equal(creator.contributions[0].role, 'director')
+  assert.equal(creator.sourcePublisherCount, 1)
+})
+
+test('dedupes graph media items against legacy playable feed entries by selected source identity', () => {
+  const sections = buildMediaHubSections({
+    mediaGraph: {
+      works: [
+        {
+          localEntityId: 'work:movie:archive-1',
+          entityKind: 'work',
+          contentKind: 'movie',
+          preferredMetadata: { title: 'Archive Movie' },
+          publications: [{ publicationId: 'video-1', renditionId: 'rend-1', channelKey: 'channel-a', videoId: 'video-1', publisherName: 'Publisher', availabilityStatus: 'available' }],
+        },
+      ],
+    },
+    feedVideos: [video({ id: 'video-1', videoId: 'video-1', channelKey: 'channel-a', title: 'Archive Movie duplicate' })],
+  })
+
+  assert.equal(sections.allItems.length, 1)
+  assert.equal(sections.allItems[0].localEntityId, 'work:movie:archive-1')
+  assert.equal(sections.allItems[0].id, 'video-1')
+})

--- a/packages/app/tests/media-source-selection.test.mjs
+++ b/packages/app/tests/media-source-selection.test.mjs
@@ -1,0 +1,87 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { selectMediaSource, normalizeMediaSource, scoreMediaSource } from '../lib/media-source-selection.js'
+
+test('selects playable local or cached source before unavailable publisher source', () => {
+  const entity = {
+    localEntityId: 'work:episode:1',
+    sources: [
+      {
+        publicationId: 'pub-remote',
+        renditionId: 'rend-remote',
+        publisherId: 'publisher-b',
+        publisherName: 'Publisher B',
+        availabilityStatus: 'unavailable',
+        formatSupported: true,
+      },
+      {
+        publicationId: 'pub-local',
+        renditionId: 'rend-local',
+        publisherId: 'publisher-a',
+        publisherName: 'Publisher A',
+        availabilityStatus: 'local',
+        localComplete: true,
+        formatSupported: true,
+      },
+    ],
+  }
+
+  const selection = selectMediaSource(entity)
+
+  assert.equal(selection.selectedSource.publicationId, 'pub-local')
+  assert.equal(selection.alternateSources.length, 1)
+  assert.equal(selection.sourceCount, 2)
+})
+
+test('keeps source-provider identity separate from playback identity', () => {
+  const source = normalizeMediaSource({
+    publicationId: 'publication-1',
+    renditionId: 'rendition-1080p',
+    publisherId: 'publisher-root-1',
+    publisherName: 'Archive Node 7',
+    channelKey: 'legacy-channel',
+    videoId: 'legacy-video',
+  })
+
+  assert.equal(source.publisherId, 'publisher-root-1')
+  assert.equal(source.publisherName, 'Archive Node 7')
+  assert.equal(source.channelKey, 'legacy-channel')
+  assert.equal(source.videoId, 'legacy-video')
+  assert.equal(source.playbackKey, 'legacy-channel:legacy-video')
+})
+
+test('policy can prefer a publication without making unavailable sources silently win', () => {
+  const entity = {
+    sources: [
+      { publicationId: 'preferred', publisherId: 'publisher-a', availabilityStatus: 'unavailable' },
+      { publicationId: 'available', publisherId: 'publisher-b', availabilityStatus: 'available', verified: true },
+    ],
+  }
+
+  const defaultSelection = selectMediaSource(entity)
+  const preferredSelection = selectMediaSource(entity, { preferredPublicationId: 'preferred', allowUnavailable: true })
+
+  assert.equal(defaultSelection.selectedSource.publicationId, 'available')
+  assert.equal(preferredSelection.selectedSource.publicationId, 'preferred')
+})
+
+test('moderation-blocked source receives a hard score penalty', () => {
+  const allowed = scoreMediaSource({ publicationId: 'allowed', availabilityStatus: 'available' })
+  const blocked = scoreMediaSource({ publicationId: 'blocked', availabilityStatus: 'available', moderation: { action: 'blocked' } })
+
+  assert.ok(blocked < allowed - 500)
+})
+
+
+test('preserves multiple renditions for the same publication and lets policy select rendition', () => {
+  const selection = selectMediaSource({
+    sources: [
+      { publicationId: 'pub-shared', renditionId: 'rend-720', videoId: 'video-720', availabilityStatus: 'available' },
+      { publicationId: 'pub-shared', renditionId: 'rend-1080', videoId: 'video-1080', availabilityStatus: 'available' },
+    ],
+  }, { preferredRenditionId: 'rend-1080' })
+
+  assert.equal(selection.sourceCount, 2)
+  assert.equal(selection.selectedSource.renditionId, 'rend-1080')
+  assert.deepEqual(selection.sources.map((source) => source.renditionId).sort(), ['rend-1080', 'rend-720'].sort())
+})

--- a/packages/app/tests/mobile-ui-redesign-regression.test.mjs
+++ b/packages/app/tests/mobile-ui-redesign-regression.test.mjs
@@ -103,6 +103,33 @@ test('media cockpit components stay presentational', () => {
   )
 })
 
+
+test('media cockpit cards surface permissionless media graph signals', () => {
+  const sources = [
+    'components/media/HeroFeatureCard.tsx',
+    'components/media/MediaPosterCard.tsx',
+    'components/media/EpisodeCard.tsx',
+  ].map((componentPath) => readApp(componentPath)).join('\n')
+
+  for (const required of [
+    'posterUrl',
+    'backdropUrl',
+    'stillUrl',
+    'sourceCount',
+    'sourceProviderName',
+    'archiveStatus',
+    'availabilityStatus',
+    'conflicts',
+    'provenance',
+    'localEntityId',
+    'publicationId',
+    'Permissionless media CDN',
+    'Play selected source',
+  ]) {
+    assert.ok(sources.includes(required), `media cockpit cards should surface ${required}`)
+  }
+})
+
 test('mobile home media cockpit preserves playback, channel, and refresh paths', () => {
   const source = readApp('app/(tabs)/index.tsx')
 
@@ -112,6 +139,10 @@ test('mobile home media cockpit preserves playback, channel, and refresh paths',
     'MediaRail',
     'MediaPosterCard',
     'EpisodeCard',
+    "{ type: 'collections' }",
+    "{ type: 'creators' }",
+    'mediaHub.collections.items',
+    'mediaHub.creators.items',
     'getMediaHubSourceItem',
     'playMediaHubItem',
     'rpc.preparePlayback(playbackRequest)',
@@ -127,20 +158,69 @@ test('mobile home media cockpit preserves playback, channel, and refresh paths',
 
 test('mobile home media cockpit playback helper preserves videoId playback identity', () => {
   const source = readApp('app/(tabs)/index.tsx')
+  const mapper = readApp('lib/media-hub.js')
 
+  assert.ok(source.includes('getMediaHubPlayableSourceItem'), 'mobile Home should import the shared playable-source adapter')
   assert.match(
     source,
-    /const id = source\?\.id \|\| source\?\.videoId \|\| item\?\.id \|\| item\?\.videoId/,
-    'media hub playback helper should map normalized or watch-history videoId to playVideo id',
-  )
-  assert.match(
-    source,
-    /return \{ \.\.\.source, id, channelKey, publicBeeKey \}/,
-    'media hub playback helper should return a playback-safe source copy without mutating raw records',
+    /return getMediaHubPlayableSourceItem\(item\)/,
+    'media hub playback helper should delegate normalized source unwrapping to the shared adapter',
   )
   assert.match(
     source,
     /playVideo\(getMediaHubSourceItem\(item\)\)/,
     'media cockpit playback should go through the source normalizer before playVideo',
   )
+  assert.match(
+    mapper,
+    /source\.videoId,[\s\S]*source\.path,[\s\S]*source\.id,[\s\S]*selectedSource \? null : item\?\.videoId/,
+    'shared adapter should prefer selected source video/path/id before legacy item id fallbacks',
+  )
+})
+
+test('Task 18 media entity routes expose inspectable source and provenance panels', () => {
+  const home = readApp('app/(tabs)/index.tsx')
+  const mediaRoute = readApp('app/media/[id].tsx')
+  const collectionRoute = readApp('app/collection/[id].tsx')
+  const creatorRoute = readApp('app/creator/[id].tsx')
+  const detail = readApp('components/media/MediaEntityDetailScreen.tsx')
+  const sourceSelector = readApp('components/media/SourceSelector.tsx')
+  const provenancePanel = readApp('components/media/ProvenancePanel.tsx')
+  const conflictNotice = readApp('components/media/ConflictNotice.tsx')
+  const archiveStatus = readApp('components/media/ArchiveStatus.tsx')
+
+  for (const required of [
+    "openMediaEntityPage(hero, 'media')",
+    "openMediaEntityPage(mediaItem, 'collection')",
+    "openMediaEntityPage(mediaItem, 'creator')",
+    'encodeMediaEntityRouteParam',
+    'getMediaEntityRouteId',
+    "onDetailsPress={() => openMediaEntityPage(hero, 'media')}",
+    'onChannelPress={() => openMediaHubChannel(hero)}',
+  ]) {
+    assert.ok(home.includes(required), `mobile Home should wire entity navigation through ${required}`)
+  }
+  assert.ok(mediaRoute.includes('type="media"'), 'media route should render media entity detail screen')
+  assert.ok(collectionRoute.includes('type="collection"'), 'collection route should render collection entity detail screen')
+  assert.ok(creatorRoute.includes('type="creator"'), 'creator route should render creator entity detail screen')
+  for (const required of [
+    'SourceSelector',
+    'ProvenancePanel',
+    'ConflictNotice',
+    'ArchiveStatus',
+    'useLocalSearchParams',
+    'fallbackItemForRoute',
+    'onSelectSource={(source) => setSelectedSourceKey(sourceIdentityKey(source))}',
+    'candidateSourcesForItem',
+    'fallbackItemForRoute',
+    'CollectionStructurePanel',
+    'CreatorContributionsPanel',
+  ]) {
+    assert.ok(detail.includes(required), `entity detail route should include ${required}`)
+  }
+  assert.ok(sourceSelector.includes('Playable publications and renditions'), 'SourceSelector should expose playable publications')
+  assert.ok(sourceSelector.includes('onPress={() => onSelectSource?.(source)}'), 'SourceSelector should wire source presses to the selected-source callback')
+  assert.ok(provenancePanel.includes('Publisher claims'), 'ProvenancePanel should expose publisher claims')
+  assert.ok(conflictNotice.includes('Conflict notice'), 'ConflictNotice should expose metadata conflicts')
+  assert.ok(archiveStatus.includes('Archive status'), 'ArchiveStatus should expose archive evidence')
 })


### PR DESCRIPTION
## Summary
- add a client-side media entity graph/source selection layer for works, collections, creators, publications, renditions, provenance, conflicts, and archive/source state
- align desktop and mobile Home surfaces with the permissionless media CDN architecture while preserving existing playback/channel/feed refresh paths
- add inspectable media/collection/creator entity routes plus source selector, provenance, conflict, and archive panels

## Verification
- `node --test packages/app/tests/content-catalog.test.mjs packages/app/tests/media-source-selection.test.mjs packages/app/tests/media-entity-graph.test.mjs packages/app/tests/media-hub.test.mjs packages/app/tests/mobile-ui-redesign-regression.test.mjs packages/app/tests/desktop-media-cockpit-regression.test.mjs packages/app/tests/vertical-discovery-regression.test.mjs packages/app/tests/watch-page-mse-backend-mode.test.mjs` — 90/90 pass
- scoped `npx eslint --quiet` on changed app files — exit 0
- changed-file TypeScript diagnostics — 0; broad app `tsc --noEmit` still exits 2 from unrelated existing workspace diagnostics
- `npm run desktop:build --prefix packages/app` — exit 0
- `npx --yes bun packages/app/scripts/smoke-desktop-bundle.mjs` — PASS native addons loaded
- `git diff --check` — exit 0

## Notes
- This is UI/client projection work only; it does not change backend, relay, blob-server, HRPC schema, or protocol contracts.
- OMP read-only review found blockers during development; follow-up fixes were added and covered by regression tests. A final OMP review retry timed out once and then could not run on the fast OpenRouter profile because of account credit limits.