### PR TITLE
Fix offloaded archive resume playback

### DIFF
--- a/packages/backend/src/api/media-graph.js
+++ b/packages/backend/src/api/media-graph.js
@@ -7,6 +7,7 @@ import { preparePlaybackSource } from '../playback/source-preparation.js'
 import { isPlaybackErrorCode, playbackErrorMessage, playbackErrorRetry } from '../playback/errors.js'
 import { parseBlobRef } from '../blob-utils.js'
 import { isArtworkRendition, normalizeAssetCoreRefV2 } from '../assets/rendition.js'
+import { ASSET_BLOCK_SIZE } from '../assets/static-core.js'
 import b4a from 'b4a'
 
 const DEFAULT_PAGE_LIMIT = 50
@@ -887,10 +888,18 @@ export function createMediaGraphApi(options = {}) {
     let index = blob.blockOffset
     let offset = 0
     if (start > 0) {
-      const seek = await core.seek(Number(blob.byteOffset || 0) + start)
-      if (!seek) throw new Error('rendition start byte is unavailable')
-      index = seek[0]
-      offset = seek[1] || 0
+      const canonicalStaticBlob = blob.blockOffset === 0 &&
+        blob.byteOffset === 0 &&
+        blob.blockLength === Math.ceil(blob.byteLength / ASSET_BLOCK_SIZE)
+      if (canonicalStaticBlob) {
+        index = Math.floor(start / ASSET_BLOCK_SIZE)
+        offset = start % ASSET_BLOCK_SIZE
+      } else {
+        const seek = await core.seek(Number(blob.byteOffset || 0) + start)
+        if (!seek) throw new Error('rendition start byte is unavailable')
+        index = seek[0]
+        offset = seek[1] || 0
+      }
     }
     const blockEnd = blob.blockOffset + blob.blockLength
     while (remaining > 0 && index < blockEnd) {

--- a/packages/backend/src/video-range-http.js
+++ b/packages/backend/src/video-range-http.js
@@ -17,6 +17,7 @@ import {
   prioritizeBlobServerRangeRequest,
   publishBlobPlayheadProgress,
 } from './blob-range-priority.js'
+import { ASSET_BLOCK_SIZE } from './assets/static-core.js'
 import { markPlaybackTiming } from './playback-timing.js'
 
 // A player that issues one open-ended `bytes=N-` request streams the whole
@@ -140,9 +141,26 @@ async function writeResponseChunk(res, chunk, signal) {
   if (ok === false) await waitForResponseDrain(res, signal)
 }
 
+function isCanonicalStaticBlob(blob) {
+  return blob?.blockOffset === 0 &&
+    blob?.byteOffset === 0 &&
+    blob?.blockLength === Math.ceil(blob.byteLength / ASSET_BLOCK_SIZE)
+}
+
 async function resolveStartPosition(core, blob, start) {
   if (start === 0) {
     return { index: blob.blockOffset, offset: 0 }
+  }
+
+  // Static publication assets use canonical 256 KiB blocks. Their data can be
+  // restored from object storage while inner Merkle tree nodes are absent.
+  // Hypercore.seek() waits for a peer in that state even though the exact data
+  // block is locally restorable. Map this committed canonical layout directly.
+  if (isCanonicalStaticBlob(blob)) {
+    return {
+      index: blob.blockOffset + Math.floor(start / ASSET_BLOCK_SIZE),
+      offset: start % ASSET_BLOCK_SIZE,
+    }
   }
 
   const absoluteByteOffset = Number(blob.byteOffset || 0) + start
@@ -363,11 +381,6 @@ export async function serveVideoRangeHttpRequest(deps, req, res) {
   let cancelled = false
 
   try {
-    try {
-      await prioritizeBlobServerRangeRequest(blobServer, req)
-    } catch (err) {
-      console.log('[Storage] Video range priority failed:', err?.message || err)
-    }
 
     core = await blobServer._getCore(ref.key, {
       key: ref.key,
@@ -410,8 +423,27 @@ export async function serveVideoRangeHttpRequest(deps, req, res) {
     }
 
     const syncRange = getPrioritizedBlobDownloadRange(ref.blob, byteRange, { readAheadBytes: 0 })
-    await syncVideoRangeRemoteLength(core, syncRange?.start ?? ref.blob.blockOffset)
+    const startBlock = syncRange?.start ?? ref.blob.blockOffset
+    let startBlockAvailable = false
+    try {
+      startBlockAvailable = Boolean(await core.get(startBlock, { wait: false }))
+    } catch { /* remote acquisition below can still satisfy the request */ }
 
+    if (startBlockAvailable) {
+      console.log('[Storage] Video range HTTP start block: local or restored', JSON.stringify(summarizeVideoRangePeerSync(core)))
+      publishBlobPlayheadProgress({
+        keyHex: ref.key?.toString('hex'),
+        blob: ref.blob,
+        blockIndex: startBlock,
+      })
+    } else {
+      try {
+        await prioritizeBlobServerRangeRequest(blobServer, req)
+      } catch (err) {
+        console.log('[Storage] Video range priority failed:', err?.message || err)
+      }
+      await syncVideoRangeRemoteLength(core, startBlock)
+    }
     const wroteAll = await writeBlobRange({
       core,
       blob: ref.blob,

--- a/packages/backend/src/video-range-http.js
+++ b/packages/backend/src/video-range-http.js
@@ -344,7 +344,7 @@ async function serveStaticAssetRangeHttpRequest(deps, req, res, marker) {
   } catch (error) {
     if (controller.signal.aborted || error?.name === 'AbortError' || res.writableEnded || res.destroyed) return true
     if (res.headersSent) {
-      try { res.destroy?.(error) } catch {}
+      try { res.destroy?.(error) } catch { /* response is already closed */ }
       return true
     }
     return endBoundedStaticResponse(req, res, 503, entry.coreRef.byteLength, 'verified static source unavailable')

--- a/packages/backend/test/upload-playback-support.test.mjs
+++ b/packages/backend/test/upload-playback-support.test.mjs
@@ -278,6 +278,9 @@ test('acquired static publications sign the complete readable core range', async
   const chunks = []
   for await (const chunk of opened.read({ start: 0, length: 16 })) chunks.push(Buffer.from(chunk))
   assert.deepEqual(Buffer.concat(chunks), sourceBytes.subarray(0, 16))
+  const resumed = []
+  for await (const chunk of opened.read({ start: 512, length: 16 })) resumed.push(Buffer.from(chunk))
+  assert.deepEqual(Buffer.concat(resumed), sourceBytes.subarray(512, 528))
   await opened.close()
   await written.core.close()
 })

--- a/packages/backend/test/video-range-http.test.mjs
+++ b/packages/backend/test/video-range-http.test.mjs
@@ -93,6 +93,7 @@ test('serveVideoRangeHttpRequest writes 206 headers before waiting for Hypercore
   const calls = []
   const { key, req } = makeRangeRequest()
   let resolveFirstBlock = null
+  let firstBlockReadPending = true
 
   const core = {
     opened: true,
@@ -105,7 +106,8 @@ test('serveVideoRangeHttpRequest writes 206 headers before waiting for Hypercore
     },
     async get(index) {
       calls.push(['get', index])
-      if (index === 0) {
+      if (index === 0 && firstBlockReadPending) {
+        firstBlockReadPending = false
         await new Promise((resolve) => {
           resolveFirstBlock = resolve
         })
@@ -155,6 +157,53 @@ test('serveVideoRangeHttpRequest writes 206 headers before waiting for Hypercore
   t.alike(calls.filter((call) => call[0] === 'write'), [['write', 'cd'], ['write', 'ef']])
   t.ok(res.writableEnded, 'response ends after the requested range is written')
   t.ok(calls.some((call) => call[0] === '_getCore' && call[1] === key.toString('hex') && call[2] === true))
+  t.absent(calls.some((call) => call[0] === 'download'), 'restorable local data does not enter peer download')
+})
+
+test('serveVideoRangeHttpRequest maps canonical offloaded assets without Hypercore seek', async (t) => {
+  t.teardown(() => releaseAllPrioritizedBlobRanges())
+  const calls = []
+  const blockSize = 256 * 1024
+  const blob = {
+    blockOffset: 0,
+    blockLength: 2,
+    byteOffset: 0,
+    byteLength: 2 * blockSize,
+  }
+  const { req } = makeRangeRequest({
+    blob,
+    range: `bytes=${blockSize + 2}-${blockSize + 5}`,
+  })
+  const core = {
+    peers: [],
+    opened: true,
+    async ready() {},
+    async seek() {
+      calls.push(['seek'])
+      throw new Error('offloaded tree cannot seek without a peer')
+    },
+    async get(index, options = {}) {
+      calls.push(['get', index, options])
+      return Buffer.alloc(blockSize, index === 0 ? 65 : 66)
+    },
+    download(options) {
+      calls.push(['download', options])
+      return { done: () => Promise.resolve(), destroy: () => {} }
+    },
+    close() {},
+  }
+  const blobServer = {
+    token: 'test-token',
+    async _getCore() { return core },
+  }
+  const res = new MockResponse(calls)
+
+  const handled = await serveVideoRangeHttpRequest({ blobServer }, req, res)
+
+  t.is(handled, true)
+  t.alike(calls.filter((call) => call[0] === 'write'), [['write', 'BBBB']])
+  t.absent(calls.some((call) => call[0] === 'seek'), 'canonical byte range does not need missing inner tree nodes')
+  t.absent(calls.some((call) => call[0] === 'download'), 'restorable canonical block does not wait for a peer')
 })
 
 test('serveVideoRangeHttpRequest syncs remote length near the requested seek range', async (t) => {
@@ -189,8 +238,9 @@ test('serveVideoRangeHttpRequest syncs remote length near the requested seek ran
       calls.push(['seek', byteOffset])
       return [100, 0]
     },
-    async get(index) {
-      calls.push(['get', index])
+    async get(index, options = {}) {
+      calls.push(['get', index, options])
+      if (options.wait === false) return null
       return Buffer.from('wxyz')
     },
     download(options) {

--- a/packages/cli/src/companion/contracts.js
+++ b/packages/cli/src/companion/contracts.js
@@ -25,7 +25,7 @@ const CANDIDATE_REF = /^[A-Za-z0-9_-]{43}$/
 const KIND = new Set(['movie', 'episode'])
 const CANONICAL_NAMESPACE = /^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$/
 const SEARCH_FIELDS = new Set(['namespace', 'identifier', 'kind', 'season', 'episode', 'title', 'year', 'limit', 'cursor'])
-const OPEN_FIELDS = new Set(['candidateRef', 'publicationId', 'renditionId'])
+const OPEN_FIELDS = new Set(['candidateRef', 'publicationId', 'renditionId', 'startOffsetSeconds', 'durationSeconds'])
 const ACQUISITION_FIELDS = new Set(['idempotencyKey', 'request'])
 const SOURCE_GRANT_FIELDS = new Set(['grant'])
 const ACQUISITION_LIST_FIELDS = new Set(['cursor', 'limit', 'states'])
@@ -104,6 +104,13 @@ function positiveIntegerText (value, field, maximum = Number.MAX_SAFE_INTEGER) {
   const number = Number(value)
   if (!Number.isSafeInteger(number) || number > maximum) throw new CompanionContractError(400, 'INVALID_FIELD', `Invalid ${field}`, field)
   return number
+}
+function boundedSeconds (value, field, { positive = false } = {}) {
+  if (typeof value !== 'number' || !Number.isFinite(value) ||
+      (positive ? value <= 0 : value < 0) || value > 7 * 24 * 60 * 60) {
+    throw new CompanionContractError(400, 'INVALID_FIELD', `Invalid ${field}`, field)
+  }
+  return value
 }
 
 function optionalQueryValue (values, field) {
@@ -338,10 +345,17 @@ export function decodeOpenStreamBody (body) {
   if (hasCandidate) {
     return { candidateRef: boundedString(value.candidateRef, 'candidateRef', 64, { pattern: CANDIDATE_REF }) }
   }
-  return {
+  const result = {
     publicationId: boundedString(value.publicationId, 'publicationId', 128, { pattern: ID }),
     renditionId: boundedString(value.renditionId, 'renditionId', 128, { pattern: ID })
   }
+  if (value.startOffsetSeconds !== undefined) {
+    result.startOffsetSeconds = boundedSeconds(value.startOffsetSeconds, 'startOffsetSeconds')
+  }
+  if (value.durationSeconds !== undefined) {
+    result.durationSeconds = boundedSeconds(value.durationSeconds, 'durationSeconds', { positive: true })
+  }
+  return result
 }
 
 function inspectBoundedValue (value, {

--- a/packages/cli/src/service.js
+++ b/packages/cli/src/service.js
@@ -1067,7 +1067,7 @@ async function buildRelayService({
               runtime.verifiedQueryView?.getPublication?.({ publicationId }))
             const pubPublisherId = pub?.publisherId || pub?.body?.publisherId || null
             if (pubPublisherId && pubPublisherId === localPublisherId) isLocalPublication = true
-          } catch {}
+          } catch { /* absent publication remains non-local */ }
         }
         if (isLocalPublication && runtime.retractPublication) {
           try {

--- a/packages/cli/src/service.js
+++ b/packages/cli/src/service.js
@@ -44,8 +44,11 @@ function createProviderMachineService(runtime, options = {}) {
   const provider = runtime?.provider
   if (!provider) return null
   const warming = new Set()
-  async function warmPublishedCandidate(candidate) {
-    const key = `${candidate.publicationId}:${candidate.renditionId}`
+  async function warmPublishedCandidate(candidate, options = {}) {
+    const requestedStart = Number.isSafeInteger(options.byteStart) && options.byteStart >= 0
+      ? options.byteStart
+      : null
+    const key = `${candidate.publicationId}:${candidate.renditionId}:${requestedStart ?? 'startup'}`
     if (warming.has(key) || typeof runtime.api?.openMediaRendition !== 'function') return
     warming.add(key)
     const controller = new AbortController()
@@ -59,10 +62,16 @@ function createProviderMachineService(runtime, options = {}) {
         signal: controller.signal
       })
       if (!opened?.success || typeof opened.read !== 'function') return
-      const headLength = Math.min(opened.byteLength, 16 * 1024 * 1024)
-      const tailLength = Math.min(opened.byteLength - headLength, 4 * 1024 * 1024)
-      const ranges = [{ start: 0, length: headLength }]
-      if (tailLength > 0) ranges.push({ start: opened.byteLength - tailLength, length: tailLength })
+      let ranges
+      if (requestedStart !== null && requestedStart < opened.byteLength) {
+        const length = Math.min(opened.byteLength - requestedStart, 4 * 1024 * 1024)
+        ranges = [{ start: requestedStart, length }]
+      } else {
+        const headLength = Math.min(opened.byteLength, 16 * 1024 * 1024)
+        const tailLength = Math.min(opened.byteLength - headLength, 4 * 1024 * 1024)
+        ranges = [{ start: 0, length: headLength }]
+        if (tailLength > 0) ranges.push({ start: opened.byteLength - tailLength, length: tailLength })
+      }
       await Promise.all(ranges.map(async range => {
         for await (const _chunk of opened.read({ ...range, signal: controller.signal })) {
           if (controller.signal.aborted) break
@@ -205,13 +214,27 @@ function createProviderMachineService(runtime, options = {}) {
         asset
       }
     },
-    async openPublication({ publicationId, renditionId, signal, localTransport = false } = {}) {
+    async openPublication({
+      publicationId,
+      renditionId,
+      startOffsetSeconds = 0,
+      durationSeconds = 0,
+      signal,
+      localTransport = false
+    } = {}) {
       if (!localTransport || typeof runtime.api?.openMediaRenditionUrl !== 'function') {
         const error = new Error('Deterministic publication playback requires a local protected transport')
         error.code = 'LOCAL_TRANSPORT_REQUIRED'
         throw error
       }
       const opened = await runtime.api.openMediaRenditionUrl({ publicationId, renditionId, signal })
+      if (opened?.success && Number.isFinite(startOffsetSeconds) && startOffsetSeconds > 0 &&
+          Number.isFinite(durationSeconds) && durationSeconds > 0 && Number.isSafeInteger(opened.byteLength) &&
+          opened.byteLength > 0) {
+        const fraction = Math.min(1, startOffsetSeconds / durationSeconds)
+        const byteStart = Math.min(opened.byteLength - 1, Math.floor(opened.byteLength * fraction))
+        await warmPublishedCandidate({ publicationId, renditionId }, { byteStart })
+      }
       if (!opened?.success) {
         const error = new Error(opened?.error || 'Verified rendition is unavailable')
         error.code = opened?.errorCode || 'PROVIDER_STREAM_UNAVAILABLE'

--- a/packages/cli/test/companion-stream-capability.test.mjs
+++ b/packages/cli/test/companion-stream-capability.test.mjs
@@ -312,13 +312,16 @@ test('local stream open returns the loopback Hypercore blob URL without a media 
   })
 
   const opened = await router.dispatch(request('POST', '/api/v2/streams/open', {
-    body: b4a.from('{"publicationId":"pub-1","renditionId":"rend-1"}'),
+    body: b4a.from('{"publicationId":"pub-1","renditionId":"rend-1","startOffsetSeconds":968.4,"durationSeconds":1320}'),
     serverState: { transport: 'unix' }
   }))
 
   t.is(opened.statusCode, 200)
   t.is(opened.body.url, blobUrl)
-  t.alike([openedInput.publicationId, openedInput.renditionId, openedInput.localTransport], ['pub-1', 'rend-1', true])
+  t.alike(
+    [openedInput.publicationId, openedInput.renditionId, openedInput.startOffsetSeconds, openedInput.durationSeconds, openedInput.localTransport],
+    ['pub-1', 'rend-1', 968.4, 1320, true]
+  )
   t.is(capabilities.size, 0, 'blob playback does not retain a companion media capability')
 })
 

--- a/packages/cli/test/companion-stream-capability.test.mjs
+++ b/packages/cli/test/companion-stream-capability.test.mjs
@@ -301,7 +301,7 @@ test('local stream open returns the loopback Hypercore blob URL without a media 
           mimeType: 'video/mp4',
           capability: null,
           expiresAt: NOW + 60_000,
-          etag: '\"asset-asset-1\"',
+          etag: '"asset-asset-1"',
           url: blobUrl
         }
       }

--- a/packages/cli/test/service-universal.test.mjs
+++ b/packages/cli/test/service-universal.test.mjs
@@ -429,3 +429,56 @@ test('verified catalog rows receive playable candidate references from exact sea
   })
   await service.close()
 })
+
+test('deterministic publication open warms the requested resume byte range', async (t) => {
+  const storagePath = mkdtempSync(join(tmpdir(), 'peartube-cli-resume-warm-'))
+  t.teardown(() => rmSync(storagePath, { recursive: true, force: true }))
+  const calls = []
+  const runtime = fakeRuntime(calls)
+  runtime.api.openMediaRenditionUrl = async () => ({
+    success: true,
+    publicationId: 'publication-1',
+    renditionId: 'rendition-1',
+    assetId: 'asset-1',
+    byteLength: 1000,
+    contentType: 'video/mp4',
+    url: 'http://127.0.0.1:9000/blob'
+  })
+  runtime.api.openMediaRendition = async () => ({
+    success: true,
+    byteLength: 1000,
+    async * read(range) {
+      calls.push(['warm-range', { start: range.start, length: range.length }])
+      yield b4a.alloc(range.length)
+    },
+    async close() {}
+  })
+  let companionService = null
+  const config = configFor(storagePath)
+  config.companion = { ...(config.companion || {}), enabled: true }
+  const service = await createRelayService({
+    config,
+    logger,
+    runtimeFactory: async () => runtime,
+    companionServerFactory: async ({ service: liveService }) => {
+      companionService = liveService
+      return { async start() {}, async close() {} }
+    },
+    writeStatusFile: async () => {},
+    setIntervalFn: () => ({ unref: noop }),
+    clearIntervalFn: noop
+  })
+  await service.start()
+
+  const opened = await companionService.openPublication({
+    publicationId: 'publication-1',
+    renditionId: 'rendition-1',
+    startOffsetSeconds: 25,
+    durationSeconds: 100,
+    localTransport: true
+  })
+
+  t.is(opened.url, 'http://127.0.0.1:9000/blob')
+  t.alike(calls.find(([name]) => name === 'warm-range')?.[1], { start: 250, length: 750 })
+  await service.close()
+})


### PR DESCRIPTION
## Problem
Offloaded static publications could restore data blocks from S3 but still stall on middle/resume ranges because Hypercore byte seek waited for unavailable inner tree nodes and a nonexistent peer. Search warming also prepared only the head and tail, not the requested resume position.

## Changes
- Map canonical static byte ranges directly by the committed 256 KiB block layout.
- Probe object-restorable blocks before starting peer download.
- Accept bounded resume time and duration fields on deterministic companion stream open.
- Warm a bounded 4 MiB window at the derived resume byte position.
- Keep legacy and remote noncanonical blobs on the existing peer-seek path.

## Verification
- Focused offload, video range, companion, service, and upload playback tests pass.
- Cold President Curtis S01E06 resume: open plus warm 2.359 s; previous failing range returned HTTP 206 with 1,024 bytes in 7 ms.