### PR TITLE
ci: align Android release artifact memory limits

### DIFF
--- a/.github/workflows/build-mobile.yml
+++ b/.github/workflows/build-mobile.yml
@@ -100,6 +100,16 @@ jobs:
         working-directory: packages/app
         run: npm run android:prebuild
 
+      - name: Configure release Gradle memory
+        shell: bash
+        run: |
+          mkdir -p "$HOME/.gradle"
+          printf '%s\n' \
+            'org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=1024m -Dfile.encoding=UTF-8' \
+            'org.gradle.workers.max=2' \
+            'kotlin.daemon.jvmargs=-Xmx1536m' \
+            >> "$HOME/.gradle/gradle.properties"
+
       - name: Build release APKs
         working-directory: packages/app/android
         run: ./gradlew assembleRelease --no-daemon


### PR DESCRIPTION
## Problem
Post-merge [Build Mobile34652924603](https://github.com/ayooooo123/peartube/actions/runs/34652924603) failed at `:app:minifyReleaseWithR8` with Java heap exhaustion. Gradle also reported exhausted512MiB metaspace and a2GiB heap. Android debug and iOS passed.

## Change
Reuse the resource configuration already used by `.github/workflows/release-android.yml`:4GiB Gradle heap,1GiB metaspace, two Gradle workers and1536MiB Kotlin daemon heap. Apply it only to `android-release-artifacts`, immediately before the unchanged `assembleRelease --no-daemon` command.

Exactly one workflow file, ten added lines. R8 minification, artifact upload, validation, timeouts, app source and dependency versions are unchanged. Local documentation and generated agent state remain excluded.

## Evidence
- All13 dependency-free workflow regression tests pass.
- The actual setup shell ran in an isolated HOME, preserved existing preferences, and wrote the intended resource limits. This is not APK-build proof.
- Bounded Astra/max source recheck reports no remaining findings; same-model review of Main-authored corrections, not independent-model certification.
- Published head: `c022c8f7a4c332b6f9dc60fbc292da99d7c7dbb2`.

## Acceptance
Require successful real Android release-artifact CI and all applicable PR checks before a normal merge. The post-merge mobile gate remains open until the corrected main workflow succeeds; no blind retry, minifier disable or check bypass.


## Verified PR result
All seven checks passed for c022c8f7a4c332b6f9dc60fbc292da99d7c7dbb2: [Fast CI](https://github.com/ayooooo123/peartube/actions/runs/34660814256) and [Build Mobile](https://github.com/ayooooo123/peartube/actions/runs/34660814204). R8 executed rather than being marked cached/up-to-date/skipped, Gradle reported BUILD SUCCESSFUL, and the [Android release artifact](https://github.com/ayooooo123/peartube/actions/runs/34660814204/artifacts/10288070796) uploaded successfully (209208950 bytes). Corrected-main workflow acceptance is still required after merge.


## Corrected-main acceptance
Merged normally as `0dbc34876fff08effd1eeb6a36abe1dadfa3f899`, with the exact accepted tree. [Main Fast CI](https://github.com/ayooooo123/peartube/actions/runs/34662784331) and [Main Build Mobile](https://github.com/ayooooo123/peartube/actions/runs/34662784332) completed successfully, all seven jobs passing. R8 executed again and Gradle reported BUILD SUCCESSFUL; four release APK files were uploaded as [artifact10288408776](https://github.com/ayooooo123/peartube/actions/runs/34662784332/artifacts/10288408776),209208946 bytes. The post-merge release-build gate is now closed. No minifier disable, validation weakening or merge bypass.
